### PR TITLE
Limit binderpos concurrency and enforce one-active-dedicated-IP per scrape

### DIFF
--- a/api/controller/search.go
+++ b/api/controller/search.go
@@ -51,7 +51,7 @@ type Card struct {
 	ExtraInfo string  `json:"extraInfo"`
 }
 
-const binderposMaxConcurrent = 4
+const binderposMaxConcurrent = 5
 
 func Search(ctx context.Context, input SearchInput) ([]Card, error) {
 	shopNameToLGSMap := initAndMapShops(input.Lgs)

--- a/api/controller/search_test.go
+++ b/api/controller/search_test.go
@@ -8,6 +8,7 @@ import (
 	"mtg-price-checker-sg/gateway/cardaffinity"
 	"mtg-price-checker-sg/gateway/cardscitadel"
 	"mtg-price-checker-sg/gateway/gameshaven"
+	"mtg-price-checker-sg/gateway/gog"
 	"mtg-price-checker-sg/gateway/hideout"
 	"mtg-price-checker-sg/gateway/tefuda"
 	"sync/atomic"
@@ -313,6 +314,8 @@ func TestFetchCardsConcurrently_BinderposGate(t *testing.T) {
 		cardaffinity.StoreName,
 		hideout.StoreName,
 		gameshaven.StoreName,
+		tefuda.StoreName,
+		gog.StoreName,
 	}
 	shops := make(map[string]gateway.LGS, len(binderposShops)+1)
 	for _, name := range binderposShops {

--- a/api/gateway/binderpos/scrap.go
+++ b/api/gateway/binderpos/scrap.go
@@ -69,7 +69,7 @@ func scrapVariant5(ctx context.Context, storeName, baseUrl, searchUrl, searchStr
 	searchURL := buildSafeSearchURL(baseUrl, searchUrl, searchStr+" mtg")
 	var cards []gateway.Card
 
-	c := gateway.NewOptimizedCollector(ctx)
+	c := gateway.NewOptimizedCollectorForBinderpos(ctx)
 
 	c.OnHTML("body", func(e *colly.HTMLElement) {
 		e.ForEach("div.product-grid-container ul.product-grid li", func(_ int, el *colly.HTMLElement) {
@@ -119,7 +119,7 @@ func scrapVariant4(ctx context.Context, storeName, baseUrl, searchUrl, searchStr
 	searchURL := buildSafeSearchURL(baseUrl, searchUrl, searchStr+" mtg")
 	var cards []gateway.Card
 
-	c := gateway.NewOptimizedCollector(ctx)
+	c := gateway.NewOptimizedCollectorForBinderpos(ctx)
 
 	c.OnHTML("body", func(e *colly.HTMLElement) {
 		e.ForEach("div.product-grid-container ul.product-grid li", func(_ int, el *colly.HTMLElement) {
@@ -173,7 +173,7 @@ func scrapVariant3(ctx context.Context, storeName, baseUrl, searchUrl, searchStr
 	var cards []gateway.Card
 	searchURL := buildSafeSearchURL(baseUrl, searchUrl, searchStr+" mtg")
 
-	c := gateway.NewOptimizedCollector(ctx)
+	c := gateway.NewOptimizedCollectorForBinderpos(ctx)
 
 	c.OnHTML("body", func(e *colly.HTMLElement) {
 		// get cards
@@ -241,7 +241,7 @@ func scrapVariant2(ctx context.Context, storeName, baseUrl, searchUrl, searchStr
 	searchURL := buildSafeSearchURL(baseUrl, searchUrl, searchStr+" mtg")
 	var cards []gateway.Card
 
-	c := gateway.NewOptimizedCollector(ctx)
+	c := gateway.NewOptimizedCollectorForBinderpos(ctx)
 
 	c.OnHTML("body", func(e *colly.HTMLElement) {
 		e.ForEach("div", func(_ int, el *colly.HTMLElement) {
@@ -300,7 +300,7 @@ func scrapVariant1(ctx context.Context, storeName, baseUrl, searchUrl, searchStr
 	searchURL := buildSafeSearchURL(baseUrl, searchUrl, searchStr+" mtg")
 	var cards []gateway.Card
 
-	c := gateway.NewOptimizedCollector(ctx)
+	c := gateway.NewOptimizedCollectorForBinderpos(ctx)
 
 	c.OnHTML("div.container", func(e *colly.HTMLElement) {
 		e.ForEach("div.Norm", func(_ int, el *colly.HTMLElement) {

--- a/api/gateway/collector.go
+++ b/api/gateway/collector.go
@@ -9,6 +9,7 @@ import (
 	"mtg-price-checker-sg/pkg/config"
 	"os"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/gocolly/colly/v2"
@@ -24,11 +25,64 @@ var browserUserAgents = []string{
 	"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Edg/135.0.3179.98 Chrome/135.0.0.0 Safari/537.36",
 }
 
+var dedicatedProxyLeases = newDedicatedProxyLeasePool()
+
+type dedicatedProxyLeasePool struct {
+	mu    sync.Mutex
+	cond  *sync.Cond
+	inUse map[string]bool
+}
+
+func newDedicatedProxyLeasePool() *dedicatedProxyLeasePool {
+	pool := &dedicatedProxyLeasePool{
+		inUse: make(map[string]bool),
+	}
+	pool.cond = sync.NewCond(&pool.mu)
+	return pool
+}
+
+func (p *dedicatedProxyLeasePool) acquire(proxyURLs []string) (string, bool) {
+	if len(proxyURLs) == 0 {
+		return "", false
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	for {
+		for _, idx := range rand.Perm(len(proxyURLs)) {
+			proxyURL := proxyURLs[idx]
+			if proxyURL == "" {
+				continue
+			}
+			if !p.inUse[proxyURL] {
+				p.inUse[proxyURL] = true
+				return proxyURL, true
+			}
+		}
+		p.cond.Wait()
+	}
+}
+
+func (p *dedicatedProxyLeasePool) release(proxyURL string) {
+	if proxyURL == "" {
+		return
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.inUse[proxyURL] {
+		delete(p.inUse, proxyURL)
+		p.cond.Signal()
+	}
+}
+
 func NewOptimizedCollector(ctx context.Context) *colly.Collector {
 	c := colly.NewCollector(
 		colly.StdlibContext(ctx),
 	)
-	ConfigureRequestOptimizations(c)
+	configureRequestOptimizations(c, true, false)
 	return c
 }
 
@@ -36,22 +90,46 @@ func NewOptimizedCollectorNoRetry(ctx context.Context) *colly.Collector {
 	c := colly.NewCollector(
 		colly.StdlibContext(ctx),
 	)
-	ConfigureRequestOptimizationsNoRetry(c)
+	configureRequestOptimizations(c, false, false)
+	return c
+}
+
+func NewOptimizedCollectorForBinderpos(ctx context.Context) *colly.Collector {
+	c := colly.NewCollector(
+		colly.StdlibContext(ctx),
+	)
+	configureRequestOptimizations(c, true, true)
 	return c
 }
 
 func ConfigureRequestOptimizations(c *colly.Collector) {
-	configureRequestOptimizations(c, true)
+	configureRequestOptimizations(c, true, false)
 }
 
 func ConfigureRequestOptimizationsNoRetry(c *colly.Collector) {
-	configureRequestOptimizations(c, false)
+	configureRequestOptimizations(c, false, false)
 }
 
-func configureRequestOptimizations(c *colly.Collector, enableRetry bool) {
+func configureRequestOptimizations(c *colly.Collector, enableRetry, enforceDedicatedProxyLease bool) {
 	c.DisableCookies()
 	c.SetRequestTimeout(config.PerSiteTimeout)
-	initialProxyMode, initialProxyURL := applyProxyForRetryAttempt(c, 0, "")
+
+	var leasedDedicatedProxyURL string
+	releaseLeasedDedicatedProxy := func() {}
+	if enforceDedicatedProxyLease && config.UseProxy {
+		if proxyURL, ok := dedicatedProxyLeases.acquire(util.GetDedicatedProxyURLs()); ok {
+			leasedDedicatedProxyURL = proxyURL
+			releaseLeasedDedicatedProxy = func() {
+				dedicatedProxyLeases.release(proxyURL)
+			}
+		}
+	}
+	var releaseOnce sync.Once
+	releaseDedicatedProxy := func() {
+		releaseOnce.Do(releaseLeasedDedicatedProxy)
+	}
+
+	initialProxyMode, initialProxyURL := applyProxyForRetryAttemptWithPinnedDedicated(c, 0, "", leasedDedicatedProxyURL)
 	c.OnRequest(func(r *colly.Request) {
 		// Keep gzip only. Go's default client does not transparently decode brotli ("br").
 		r.Headers.Set("Accept-Encoding", "gzip")
@@ -67,7 +145,14 @@ func configureRequestOptimizations(c *colly.Collector, enableRetry bool) {
 		RandomDelay: 2 * time.Second, // adds 0–2s jitter between matching-domain requests
 	})
 
+	c.OnScraped(func(_ *colly.Response) {
+		releaseDedicatedProxy()
+	})
+
 	if !enableRetry {
+		c.OnError(func(_ *colly.Response, _ error) {
+			releaseDedicatedProxy()
+		})
 		return
 	}
 
@@ -78,6 +163,7 @@ func configureRequestOptimizations(c *colly.Collector, enableRetry bool) {
 		// Guard all dereferences to prevent intermittent panics that bubble up as 500s.
 		if r == nil || r.Ctx == nil || r.Request == nil || r.Request.URL == nil {
 			fmt.Printf("Request failed before response was available: %v\n", err)
+			releaseDedicatedProxy()
 			return
 		}
 
@@ -88,7 +174,7 @@ func configureRequestOptimizations(c *colly.Collector, enableRetry bool) {
 			nextRetry := retries + 1
 			r.Ctx.Put("retries", nextRetry)
 			previousProxyURL := r.Ctx.Get("last_proxy_url")
-			proxyMode, proxyURL := applyProxyForRetryAttempt(c, nextRetry, previousProxyURL)
+			proxyMode, proxyURL := applyProxyForRetryAttemptWithPinnedDedicated(c, nextRetry, previousProxyURL, leasedDedicatedProxyURL)
 			r.Ctx.Put("last_proxy_mode", proxyMode)
 			r.Ctx.Put("last_proxy_url", proxyURL)
 
@@ -101,17 +187,28 @@ func configureRequestOptimizations(c *colly.Collector, enableRetry bool) {
 			time.Sleep(waitDuration)
 			if retryErr := r.Request.Retry(); retryErr != nil {
 				log.Printf("Retry failed for %s (attempt=%d status=%d): %v", r.Request.URL, nextRetry, statusCode, retryErr)
+				releaseDedicatedProxy()
 			}
 		} else {
 			log.Printf("Failed after %d retries: %s (status=%d)", maxRetries, r.Request.URL, statusCode)
+			releaseDedicatedProxy()
 		}
 	})
 }
 
 func applyProxyForRetryAttempt(c *colly.Collector, retryAttempt int, avoidProxyURL string) (string, string) {
+	return applyProxyForRetryAttemptWithPinnedDedicated(c, retryAttempt, avoidProxyURL, "")
+}
+
+func applyProxyForRetryAttemptWithPinnedDedicated(c *colly.Collector, retryAttempt int, avoidProxyURL, pinnedDedicatedProxyURL string) (string, string) {
 	if !config.UseProxy {
 		c.SetProxyFunc(nil)
 		return "direct", ""
+	}
+
+	if pinnedDedicatedProxyURL != "" {
+		c.SetProxy(pinnedDedicatedProxyURL)
+		return "dedicated", pinnedDedicatedProxyURL
 	}
 
 	switch retryAttempt {
@@ -148,9 +245,9 @@ func randomDedicatedProxyURL(avoidProxyURL string) (string, bool) {
 	if avoidProxyURL != "" && len(valid) > 1 {
 		filtered := make([]util.DedicatedProxy, 0, len(valid))
 		for _, p := range valid {
-			proxyURL := fmt.Sprintf("http://%s:%s", p.Host, p.Port)
-			if p.Username != "" || p.Password != "" {
-				proxyURL = fmt.Sprintf("http://%s:%s@%s:%s", p.Username, p.Password, p.Host, p.Port)
+			proxyURL, ok := util.BuildDedicatedProxyURL(p)
+			if !ok {
+				continue
 			}
 			if proxyURL != avoidProxyURL {
 				filtered = append(filtered, p)
@@ -162,11 +259,8 @@ func randomDedicatedProxyURL(avoidProxyURL string) (string, bool) {
 	}
 
 	p := candidates[rand.IntN(len(candidates))]
-	if p.Username != "" || p.Password != "" {
-		return fmt.Sprintf("http://%s:%s@%s:%s", p.Username, p.Password, p.Host, p.Port), true
-	}
-
-	return fmt.Sprintf("http://%s:%s", p.Host, p.Port), true
+	proxyURL, ok := util.BuildDedicatedProxyURL(p)
+	return proxyURL, ok
 }
 
 func retryDelay(statusCode int, retryAfterHeader string, retries int) time.Duration {

--- a/api/gateway/collector_test.go
+++ b/api/gateway/collector_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"mtg-price-checker-sg/gateway/util"
+
 	"github.com/gocolly/colly/v2"
 )
 
@@ -98,6 +100,88 @@ func TestApplyProxyForRetryAttempt(t *testing.T) {
 		}
 		if proxyURL != "" {
 			t.Fatalf("expected empty proxy url, got %q", proxyURL)
+		}
+	})
+}
+
+func TestApplyProxyForRetryAttemptWithPinnedDedicated(t *testing.T) {
+	c := colly.NewCollector()
+	t.Setenv("DEDICATED_PROXY_1", "9.9.9.9|9000|user|pass")
+	t.Setenv("PROXY_URL", "http://shared:8080")
+
+	pinned := "http://pinned:1234"
+	for attempt := 0; attempt <= 3; attempt++ {
+		mode, proxyURL := applyProxyForRetryAttemptWithPinnedDedicated(c, attempt, "", pinned)
+		if mode != "dedicated" {
+			t.Fatalf("expected dedicated mode for pinned proxy on attempt %d, got %q", attempt, mode)
+		}
+		if proxyURL != pinned {
+			t.Fatalf("expected pinned proxy url %q on attempt %d, got %q", pinned, attempt, proxyURL)
+		}
+	}
+}
+
+func TestDedicatedProxyLeasePoolAcquireRelease(t *testing.T) {
+	pool := newDedicatedProxyLeasePool()
+	proxyURLs := []string{"http://a:1", "http://b:2"}
+
+	first, ok := pool.acquire(proxyURLs)
+	if !ok || first == "" {
+		t.Fatalf("expected first acquire to succeed")
+	}
+	second, ok := pool.acquire(proxyURLs)
+	if !ok || second == "" {
+		t.Fatalf("expected second acquire to succeed")
+	}
+	if first == second {
+		t.Fatalf("expected distinct leased proxies, got duplicate %q", first)
+	}
+
+	acquired := make(chan string, 1)
+	go func() {
+		third, ok := pool.acquire(proxyURLs)
+		if ok {
+			acquired <- third
+			return
+		}
+		acquired <- ""
+	}()
+
+	select {
+	case v := <-acquired:
+		t.Fatalf("expected third acquire to block before release, got %q", v)
+	case <-time.After(50 * time.Millisecond):
+		// expected: blocked
+	}
+
+	pool.release(first)
+
+	select {
+	case third := <-acquired:
+		if third != first {
+			t.Fatalf("expected released proxy %q to be re-acquired, got %q", first, third)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("expected third acquire to unblock after release")
+	}
+
+	pool.release(second)
+	pool.release(first)
+}
+
+func TestDedicatedProxyURLHelpers(t *testing.T) {
+	t.Run("build dedicated proxy url", func(t *testing.T) {
+		proxyURL, ok := util.BuildDedicatedProxyURL(util.DedicatedProxy{
+			Host:     "1.1.1.1",
+			Port:     "8080",
+			Username: "user",
+			Password: "pass",
+		})
+		if !ok {
+			t.Fatalf("expected proxy url build to succeed")
+		}
+		if proxyURL != "http://user:pass@1.1.1.1:8080" {
+			t.Fatalf("unexpected proxy url: %q", proxyURL)
 		}
 	})
 }

--- a/api/gateway/util/dedicated_proxy.go
+++ b/api/gateway/util/dedicated_proxy.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"fmt"
 	"os"
 	"strings"
 )
@@ -45,4 +46,28 @@ func GetDedicatedProxy() []DedicatedProxy {
 		parseDedicatedProxy(os.Getenv("DEDICATED_PROXY_4")),
 		parseDedicatedProxy(os.Getenv("DEDICATED_PROXY_5")),
 	}
+}
+
+func BuildDedicatedProxyURL(proxy DedicatedProxy) (string, bool) {
+	if proxy.Host == "" || proxy.Port == "" {
+		return "", false
+	}
+
+	if proxy.Username != "" || proxy.Password != "" {
+		return fmt.Sprintf("http://%s:%s@%s:%s", proxy.Username, proxy.Password, proxy.Host, proxy.Port), true
+	}
+
+	return fmt.Sprintf("http://%s:%s", proxy.Host, proxy.Port), true
+}
+
+func GetDedicatedProxyURLs() []string {
+	proxies := GetDedicatedProxy()
+	proxyURLs := make([]string, 0, len(proxies))
+	for _, proxy := range proxies {
+		proxyURL, ok := BuildDedicatedProxyURL(proxy)
+		if ok {
+			proxyURLs = append(proxyURLs, proxyURL)
+		}
+	}
+	return proxyURLs
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- increase binderpos search concurrency gate from 4 to 5 (`binderposMaxConcurrent = 5`) to match available dedicated IP count
- add dedicated proxy URL helpers in `gateway/util`
- introduce a dedicated-proxy lease pool in `gateway/collector` that ensures one binderpos scrape holds exactly one dedicated proxy and no two binderpos scrapes use the same dedicated proxy at the same time
- add `NewOptimizedCollectorForBinderpos` and switch binderpos scrape variants to use it
- keep existing retry/backoff flow, but pin binderpos retries to the leased dedicated proxy while that scrape is active

## Why
You requested binderpos concurrency to match your 5 IPs and to ensure each IP is only actively used by one scrape at a time.

## Testing
- `go test ./gateway ./gateway/binderpos ./gateway/util ./controller` (pass)
- full `go test ./...` currently has an unrelated existing failure in `gateway/tcgmarketplace` test unmarshalling (not introduced by this change)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6be6006-91a3-48c8-9eb1-d7bca37d6180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6be6006-91a3-48c8-9eb1-d7bca37d6180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

