### PR TITLE
Add final direct retry after proxy attempts

### DIFF
--- a/api/gateway/collector.go
+++ b/api/gateway/collector.go
@@ -28,11 +28,15 @@ var browserUserAgents = []string{
 var dedicatedProxyLeases = newDedicatedProxyLeasePool()
 
 const (
-	// Allow two retries after the initial request so the second retry can switch to PROXY_URL.
-	maxRetries = 2
+	// Allow three retries after the initial request.
+	// Retry flow:
+	// - first retry (attempt 1): dedicated proxy
+	// - second retry (attempt 2): shared PROXY_URL
+	// - third/final retry (attempt 3): direct (no proxy)
+	maxRetries = 3
 	// Dedicated (leased or random pool) is used while retryAttempt <= this value (initial request is attempt 0).
-	// First retry = attempt 1 (still dedicated); second retry = attempt 2 (PROXY_URL when set).
-	dedicatedProxyRetryThreshold = 1
+	// First retry = attempt 1 (still dedicated).
+	dedicatedProxyRetryThreshold          = 1
 	binderposDedicatedProxyRetryThreshold = dedicatedProxyRetryThreshold
 )
 
@@ -253,8 +257,17 @@ func isDedicatedRetryAttempt(retryAttempt int, dedicatedRetryThreshold int) bool
 	return retryAttempt <= dedicatedRetryThreshold
 }
 
+func isFinalRetryAttempt(retryAttempt int) bool {
+	return retryAttempt >= maxRetries
+}
+
 func applyProxyForRetryAttemptWithPinnedDedicated(c *colly.Collector, retryAttempt int, avoidProxyURL, pinnedDedicatedProxyURL string, dedicatedRetryThreshold int) (string, string) {
 	if !config.UseProxy {
+		return clearProxy(c)
+	}
+
+	// Final retry is always direct to bypass potentially bad proxy routes.
+	if isFinalRetryAttempt(retryAttempt) {
 		return clearProxy(c)
 	}
 

--- a/api/gateway/collector_test.go
+++ b/api/gateway/collector_test.go
@@ -70,14 +70,14 @@ func TestApplyProxyForRetryAttempt(t *testing.T) {
 		}
 	})
 
-	t.Run("retry 3 uses shared proxy", func(t *testing.T) {
+	t.Run("retry 3 uses direct on final retry", func(t *testing.T) {
 		t.Setenv("PROXY_URL", "http://shared:8080")
 		mode, proxyURL := applyProxyForRetryAttempt(c, 3, "")
-		if mode != "shared" {
-			t.Fatalf("expected shared mode, got %q", mode)
+		if mode != "direct" {
+			t.Fatalf("expected direct mode on final retry, got %q", mode)
 		}
-		if proxyURL != "http://shared:8080" {
-			t.Fatalf("unexpected shared proxy url: %q", proxyURL)
+		if proxyURL != "" {
+			t.Fatalf("expected empty proxy url on final retry, got %q", proxyURL)
 		}
 	})
 
@@ -92,9 +92,9 @@ func TestApplyProxyForRetryAttempt(t *testing.T) {
 		}
 	})
 
-	t.Run("retry 3 falls back to direct without shared proxy", func(t *testing.T) {
+	t.Run("retry 4 remains direct without shared proxy", func(t *testing.T) {
 		_ = os.Unsetenv("PROXY_URL")
-		mode, proxyURL := applyProxyForRetryAttempt(c, 3, "")
+		mode, proxyURL := applyProxyForRetryAttempt(c, 4, "")
 		if mode != "direct" {
 			t.Fatalf("expected direct mode, got %q", mode)
 		}
@@ -120,14 +120,20 @@ func TestApplyProxyForRetryAttemptWithPinnedDedicated(t *testing.T) {
 		}
 	}
 
-	for attempt := 2; attempt <= 3; attempt++ {
-		mode, proxyURL := applyProxyForRetryAttemptWithPinnedDedicated(c, attempt, "", pinned, dedicatedProxyRetryThreshold)
-		if mode != "shared" {
-			t.Fatalf("expected shared mode on attempt %d, got %q", attempt, mode)
-		}
-		if proxyURL != "http://shared:8080" {
-			t.Fatalf("expected shared proxy url on attempt %d, got %q", attempt, proxyURL)
-		}
+	mode, proxyURL := applyProxyForRetryAttemptWithPinnedDedicated(c, 2, "", pinned, dedicatedProxyRetryThreshold)
+	if mode != "shared" {
+		t.Fatalf("expected shared mode on attempt 2, got %q", mode)
+	}
+	if proxyURL != "http://shared:8080" {
+		t.Fatalf("expected shared proxy url on attempt 2, got %q", proxyURL)
+	}
+
+	mode, proxyURL = applyProxyForRetryAttemptWithPinnedDedicated(c, 3, "", pinned, dedicatedProxyRetryThreshold)
+	if mode != "direct" {
+		t.Fatalf("expected direct mode on final retry attempt 3, got %q", mode)
+	}
+	if proxyURL != "" {
+		t.Fatalf("expected empty proxy url on final retry attempt 3, got %q", proxyURL)
 	}
 }
 
@@ -143,14 +149,21 @@ func TestApplyProxyForRetryAttemptWithPinnedDedicatedBinderpos(t *testing.T) {
 			t.Fatalf("expected dedicated on attempt %d, got mode=%q url=%q", attempt, mode, proxyURL)
 		}
 	}
-	for attempt := 2; attempt <= 3; attempt++ {
-		mode, proxyURL := applyProxyForRetryAttemptWithPinnedDedicated(c, attempt, "", pinned, binderposDedicatedProxyRetryThreshold)
-		if mode != "shared" {
-			t.Fatalf("expected PROXY_URL on attempt %d, got mode %q", attempt, mode)
-		}
-		if proxyURL != "http://shared:8080" {
-			t.Fatalf("expected shared proxy url on attempt %d, got %q", attempt, proxyURL)
-		}
+
+	mode, proxyURL := applyProxyForRetryAttemptWithPinnedDedicated(c, 2, "", pinned, binderposDedicatedProxyRetryThreshold)
+	if mode != "shared" {
+		t.Fatalf("expected PROXY_URL on attempt 2, got mode %q", mode)
+	}
+	if proxyURL != "http://shared:8080" {
+		t.Fatalf("expected shared proxy url on attempt 2, got %q", proxyURL)
+	}
+
+	mode, proxyURL = applyProxyForRetryAttemptWithPinnedDedicated(c, 3, "", pinned, binderposDedicatedProxyRetryThreshold)
+	if mode != "direct" {
+		t.Fatalf("expected direct mode on final retry attempt 3, got %q", mode)
+	}
+	if proxyURL != "" {
+		t.Fatalf("expected empty proxy url on final retry attempt 3, got %q", proxyURL)
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- increase retry budget from 2 retries to 3 retries after the initial request
- update proxy selection so the final retry always runs direct (no proxy)
- keep existing proxy sequence before the final retry: dedicated (attempt 1) -> shared `PROXY_URL` (attempt 2)
- update gateway proxy strategy tests for the new attempt-by-attempt behavior

## Testing
- `go test ./gateway`
- `go test ./gateway -run 'TestApplyProxyForRetryAttempt|TestApplyProxyForRetryAttemptWithPinnedDedicated|TestRetryDelay|TestParseRetryAfter'`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f478a890-278c-4e39-9e8d-ee682576d5ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f478a890-278c-4e39-9e8d-ee682576d5ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

