### PR TITLE
Fix deploy image tagging after buildx build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ deploy-staging: deploy-common docker-tag-staging docker-push-staging lambda-upda
 deploy-common: docker-build aws-login
 
 docker-build:
-	docker buildx build --platform linux/amd64 --provenance=false -t mtg-price-scrapper .
+	docker buildx build --platform linux/amd64 --provenance=false --load -t mtg-price-scrapper .
 
 docker-tag:
 	docker tag mtg-price-scrapper 206363131200.dkr.ecr.ap-southeast-1.amazonaws.com/mtg-price-scrapper:latest


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update `docker-build` in `Makefile` to include `--load`
- ensure the built image (`mtg-price-scrapper`) is available in the local Docker daemon before `docker tag`

## Why
- GitHub runners using the docker-container Buildx driver keep outputs in cache by default
- without `--load`, `docker tag mtg-price-scrapper ...` fails with `No such image`

## Result
- `make deploy` can proceed past `aws-login` and image tagging in GitHub Actions
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e9a2eeed-15ff-45fc-8d56-1280d9292f4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9a2eeed-15ff-45fc-8d56-1280d9292f4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

