### PR TITLE
Fix search submit when default Sol Ring value is shown

### DIFF
--- a/frontend/src/components/SearchForm.jsx
+++ b/frontend/src/components/SearchForm.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import StoreSelector from "./StoreSelector";
+import { DEFAULT_SEARCH_QUERY } from "../constants";
 
 const SearchForm = ({
   searchQuery,
@@ -18,7 +19,6 @@ const SearchForm = ({
   onSelectNone,
   onCloseSuggestions,
 }) => {
-  const PLACEHOLDER_SUGGESTION = "Sol Ring";
   const wrapperRef = useRef(null);
   const [selectedIndex, setSelectedIndex] = useState(-1);
   const [showTip, setShowTip] = useState(true);
@@ -98,11 +98,16 @@ const SearchForm = ({
   };
 
   const displayValue =
-    !isInputFocused && !searchQuery ? PLACEHOLDER_SUGGESTION : searchQuery;
+    !isInputFocused && !searchQuery ? DEFAULT_SEARCH_QUERY : searchQuery;
 
   return (
     <div ref={wrapperRef}>
-      <form id="searchForm" onSubmit={onSearchSubmit}>
+      <form
+        id="searchForm"
+        onSubmit={(e) =>
+          onSearchSubmit(e, { defaultQuery: DEFAULT_SEARCH_QUERY })
+        }
+      >
         <div className="mb-3 position-relative">
           <div className="form-floating">
             {/* biome-ignore lint/a11y/useAriaPropsSupportedByRole: Controlled input behaves like combobox */}

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,6 +1,7 @@
 // --- App Constants ---
 export const PAGE_TITLE =
   "Gishath Fetch: MTG Price Checker for Singapore's LGS";
+export const DEFAULT_SEARCH_QUERY = "Sol Ring";
 
 export const LGS_OPTIONS = [
   "5 Mana",

--- a/frontend/src/hooks/useSearch.js
+++ b/frontend/src/hooks/useSearch.js
@@ -1,5 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { API_BASE_URL, BASE_URL, LGS_OPTIONS } from "../constants";
+import {
+  API_BASE_URL,
+  BASE_URL,
+  DEFAULT_SEARCH_QUERY,
+  LGS_OPTIONS,
+} from "../constants";
 
 // Search configuration constants
 const MIN_SEARCH_LENGTH = 3;
@@ -213,9 +218,16 @@ export default function useSearch() {
     // Note: Search is NOT triggered automatically - user must click Search button or press Enter
   };
 
-  const handleSearchSubmit = (e) => {
+  const handleSearchSubmit = (
+    e,
+    { defaultQuery = DEFAULT_SEARCH_QUERY } = {},
+  ) => {
     if (e) e.preventDefault();
     setShowSuggestions(false);
+
+    const normalizedSearchQuery = searchQuery.trim();
+    const normalizedDefaultQuery = defaultQuery.trim();
+    const queryToSearch = normalizedSearchQuery || normalizedDefaultQuery;
 
     let storesToSearch = selectedStores;
     if (selectedStores.length === 0) {
@@ -231,7 +243,11 @@ export default function useSearch() {
       }
     }
 
-    performSearch(searchQuery, storesToSearch);
+    if (!normalizedSearchQuery && queryToSearch) {
+      setSearchQuery(queryToSearch);
+    }
+
+    performSearch(queryToSearch, storesToSearch);
   };
 
   const toggleStore = (store) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- centralize the default search text as `DEFAULT_SEARCH_QUERY` in shared constants
- pass the default query through `SearchForm` submit handling
- update `useSearch.handleSearchSubmit` to fall back to the default query when the controlled query is empty, and sync state before searching

## Testing
- pending: run frontend checks after opening this PR
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a27b078e-4431-41af-9fbc-7dd1706aadf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a27b078e-4431-41af-9fbc-7dd1706aadf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

