### PR TITLE
Persist dismissed search tip across visits

### DIFF
--- a/frontend/src/components/SearchForm.jsx
+++ b/frontend/src/components/SearchForm.jsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from "react";
 import StoreSelector from "./StoreSelector";
 
+const TIP_DISMISSED_STORAGE_KEY = "search-form-tip-dismissed";
+
 const SearchForm = ({
   searchQuery,
   onQueryChange,
@@ -20,7 +22,17 @@ const SearchForm = ({
 }) => {
   const wrapperRef = useRef(null);
   const [selectedIndex, setSelectedIndex] = useState(-1);
-  const [showTip, setShowTip] = useState(true);
+  const [showTip, setShowTip] = useState(() => {
+    if (typeof window === "undefined") {
+      return true;
+    }
+
+    try {
+      return localStorage.getItem(TIP_DISMISSED_STORAGE_KEY) !== "true";
+    } catch {
+      return true;
+    }
+  });
 
   useEffect(() => {
     function handleClickOutside(event) {
@@ -69,6 +81,16 @@ const SearchForm = ({
         break;
       default:
         break;
+    }
+  };
+
+  const handleDismissTip = () => {
+    setShowTip(false);
+
+    try {
+      localStorage.setItem(TIP_DISMISSED_STORAGE_KEY, "true");
+    } catch {
+      // Ignore storage access failures and keep in-memory state only.
     }
   };
 
@@ -154,13 +176,14 @@ const SearchForm = ({
           >
             <div>
               <span className="text-info-emphasis me-1 fw-semibold">Tip:</span>
-              Selecting fewer stores usually helps GishathFetch finish searching faster and keeps operational costs down.
+              Selecting fewer stores usually helps GishathFetch finish searching
+              faster and keeps operational costs down.
             </div>
             <button
               type="button"
               className="btn-close ms-2"
               aria-label="Dismiss tip"
-              onClick={() => setShowTip(false)}
+              onClick={handleDismissTip}
             />
           </div>
         )}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- persist the search tip dismissal state in `localStorage` using a dedicated key
- initialize `showTip` from storage so dismissed tips stay hidden on later visits
- add a `handleDismissTip` helper that updates both component state and storage with graceful fallback if storage access fails

## Validation
- `npx biome check src/components/SearchForm.jsx`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a99b19a-2c1b-42b4-bd4d-26faefff3856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a99b19a-2c1b-42b4-bd4d-26faefff3856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

