### PR TITLE
Swap Advertisement and Patreon link positions

### DIFF
--- a/frontend/src/components/AdComponent.jsx
+++ b/frontend/src/components/AdComponent.jsx
@@ -67,8 +67,14 @@ const AdComponent = ({ variant = "leaderboard" }) => {
       className="ad-large text-center d-print-none d-block d-sm-block w-100"
       style={{ overflow: "hidden" }}
     >
-      <div className="text-secondary mb-2" style={{ fontSize: "11px" }}>
-        Advertisement
+      <div className="text-center mb-2" style={{ fontSize: "11px" }}>
+        <a
+          href="https://www.patreon.com/GishathFetch"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Follow / Support Gishath Fetch on Patreon
+        </a>
       </div>
       <div style={{ minHeight: "90px", overflow: "hidden" }}>
         <ins
@@ -85,14 +91,8 @@ const AdComponent = ({ variant = "leaderboard" }) => {
           data-full-width-responsive={isResponsive ? "true" : undefined}
         ></ins>
       </div>
-      <div className="text-center mt-2" style={{ fontSize: "11px" }}>
-        <a
-          href="https://www.patreon.com/GishathFetch"
-          target="_blank"
-          rel="noreferrer"
-        >
-          Follow / Support Gishath Fetch on Patreon
-        </a>
+      <div className="text-secondary mt-2" style={{ fontSize: "11px" }}>
+        Advertisement
       </div>
     </div>
   );

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -27,8 +27,14 @@ const Footer = ({ cartCount, onShowCart, onShowMap, onShowFaq }) => {
     <>
       {/* Footer / Ads */}
       <div className="ad-large mt-4 pb-5 text-center d-print-none d-block d-sm-block">
-        <div className="text-secondary mb-2" style={{ fontSize: "11px" }}>
-          Advertisement
+        <div className="text-center mb-2" style={{ fontSize: "11px" }}>
+          <a
+            href="https://www.patreon.com/GishathFetch"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Follow / Support Gishath Fetch on Patreon
+          </a>
         </div>
         <div style={{ minHeight: "90px" }}>
           {/* AdSense slot placeholder */}
@@ -39,14 +45,8 @@ const Footer = ({ cartCount, onShowCart, onShowMap, onShowFaq }) => {
             data-ad-slot="6707964257"
           ></ins>
         </div>
-        <div className="text-center mt-2" style={{ fontSize: "11px" }}>
-          <a
-            href="https://www.patreon.com/GishathFetch"
-            target="_blank"
-            rel="noreferrer"
-          >
-            Follow / Support Gishath Fetch on Patreon
-          </a>
+        <div className="text-secondary mt-2" style={{ fontSize: "11px" }}>
+          Advertisement
         </div>
       </div>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- swap the display order of the Patreon support link and the Advertisement label in the footer ad block
- apply the same order change in the reusable ad component for consistency

## Testing
- not run (UI text/order change only)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dfe1b49f-fc8d-4fa1-9f25-9a55ed1a88a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dfe1b49f-fc8d-4fa1-9f25-9a55ed1a88a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

