### PR TITLE
Fix broken Mox & Lotus card images by using API image_path

### DIFF
--- a/api/gateway/moxandlotus/search.go
+++ b/api/gateway/moxandlotus/search.go
@@ -176,10 +176,6 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 						}.Encode()
 
 						price, _ := strconv.ParseFloat(strings.TrimSpace(cardWithCondition.Price), 64)
-						cardNo, err := strconv.Atoi(card.CardNumber)
-						if err != nil {
-							continue
-						}
 
 						var extraInfo []string
 						var isFoil bool
@@ -191,6 +187,11 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 							extraInfo = append(extraInfo, fmt.Sprintf("[%s]", card.Expansion))
 						}
 
+						imageURL, ok := resolveCardImageURL(card.ExpansionCode, card.CardNumber, card.ImagePath)
+						if !ok {
+							continue
+						}
+
 						cards = append(cards, gateway.Card{
 							Name:      strings.TrimSpace(card.Title),
 							Url:       cleanPageURL.String(),
@@ -198,7 +199,7 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 							IsFoil:    isFoil,
 							Price:     price,
 							Source:    s.Name,
-							Img:       fmt.Sprintf(CardImageURL, card.ExpansionCode, fmt.Sprintf("%03d", cardNo)),
+							Img:       imageURL,
 							Quality:   util.MapQuality(cardWithCondition.Code),
 							ExtraInfo: extraInfo,
 						})
@@ -209,4 +210,20 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 	}
 
 	return cards, nil
+}
+
+func resolveCardImageURL(expansionCode, cardNumber string, imagePath any) (string, bool) {
+	if imageURL, ok := imagePath.(string); ok {
+		imageURL = strings.TrimSpace(imageURL)
+		if imageURL != "" {
+			return imageURL, true
+		}
+	}
+
+	cardNo, err := strconv.Atoi(strings.TrimSpace(cardNumber))
+	if err != nil {
+		return "", false
+	}
+
+	return fmt.Sprintf(CardImageURL, strings.TrimSpace(expansionCode), fmt.Sprintf("%03d", cardNo)), true
 }

--- a/api/gateway/moxandlotus/search_test.go
+++ b/api/gateway/moxandlotus/search_test.go
@@ -24,3 +24,23 @@ func Test_Search(t *testing.T) {
 		}
 	}
 }
+
+func Test_resolveCardImageURL(t *testing.T) {
+	t.Run("uses image path from API when available", func(t *testing.T) {
+		actual, ok := resolveCardImageURL("SOC", "55", "https://d3nmvyqkci0c2u.cloudfront.net/SOC/card-418530-325166.jpg")
+		require.True(t, ok)
+		require.Equal(t, "https://d3nmvyqkci0c2u.cloudfront.net/SOC/card-418530-325166.jpg", actual)
+	})
+
+	t.Run("uses fallback image path when image path is empty", func(t *testing.T) {
+		actual, ok := resolveCardImageURL("SOC", "55", "")
+		require.True(t, ok)
+		require.Equal(t, "https://d3nmvyqkci0c2u.cloudfront.net/SOC/055.png", actual)
+	})
+
+	t.Run("returns empty image when fallback card number is invalid", func(t *testing.T) {
+		actual, ok := resolveCardImageURL("SOC", "invalid", nil)
+		require.False(t, ok)
+		require.Equal(t, "", actual)
+	})
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix Mox & Lotus gateway image resolution to prefer `image_path` from the live products API
- keep the legacy computed CloudFront PNG URL as a fallback when `image_path` is unavailable
- preserve previous behavior by skipping records only when neither source can produce a valid image URL
- add unit tests for `resolveCardImageURL` to cover API image path, fallback path, and invalid fallback inputs

## Root cause
For cards like **Turbulent Fen**, the live API now returns image URLs such as:
- `https://d3nmvyqkci0c2u.cloudfront.net/SOC/card-418530-325166.jpg`

The previous code ignored `image_path` and always built:
- `https://d3nmvyqkci0c2u.cloudfront.net/SOC/055.png`

That legacy `.png` URL currently returns 403, causing broken images in both Mox and lotus live gateway search results.

## Validation
- `go test ./gateway/moxandlotus` ✅
- `go test ./...` ⚠️ existing unrelated failure in `gateway/tcgmarketplace` (`json: cannot unmarshal string into ... []struct ...`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9cfad8cc-1ed2-4b3a-9554-daf4fbb3bf28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9cfad8cc-1ed2-4b3a-9554-daf4fbb3bf28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

