### PR TITLE
Add BinderPOS storefront API search with feature-flag fallback

### DIFF
--- a/api/gateway/arcanesanctum/search.go
+++ b/api/gateway/arcanesanctum/search.go
@@ -27,7 +27,7 @@ func NewLGS() gateway.LGS {
 }
 
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
-	return s.BinderposGwy.Scrap(ctx,
+	return s.BinderposGwy.Search(ctx,
 		5,
 		s.Name,
 		s.BaseUrl,

--- a/api/gateway/binderpos/new.go
+++ b/api/gateway/binderpos/new.go
@@ -7,6 +7,7 @@ import (
 )
 
 type Gateway interface {
+	Search(ctx context.Context, scrapVariant int, storeName, baseUrl, searchUrl, searchStr string) ([]gateway.Card, error)
 	Scrap(ctx context.Context, scrapVariant int, storeName, baseUrl, searchUrl, searchStr string) ([]gateway.Card, error)
 }
 

--- a/api/gateway/binderpos/storefront.go
+++ b/api/gateway/binderpos/storefront.go
@@ -47,7 +47,7 @@ func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, 
 		return i.Scrap(ctx, scrapVariant, storeName, baseURL, searchURL, searchStr)
 	}
 
-	cards, err := searchByStorefrontAPI(ctx, storeName, baseURL, searchStr)
+	cards, err := searchByStorefrontAPI(ctx, scrapVariant, storeName, baseURL, searchStr)
 	if err != nil || len(cards) == 0 {
 		return i.Scrap(ctx, scrapVariant, storeName, baseURL, searchURL, searchStr)
 	}
@@ -55,7 +55,7 @@ func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, 
 	return cards, nil
 }
 
-func searchByStorefrontAPI(ctx context.Context, storeName, baseURL, searchStr string) ([]gateway.Card, error) {
+func searchByStorefrontAPI(ctx context.Context, scrapVariant int, storeName, baseURL, searchStr string) ([]gateway.Card, error) {
 	client := &http.Client{Timeout: config.PerSiteTimeout}
 
 	products, err := fetchSuggestProducts(ctx, client, baseURL, searchStr)
@@ -90,15 +90,20 @@ func searchByStorefrontAPI(ctx context.Context, storeName, baseURL, searchStr st
 				continue
 			}
 
+			setName := extractSetName(detail.Title)
+			image := buildCardImageURL(product.Image, detail.Title)
 			card := gateway.Card{
-				Name:    strings.TrimSpace(detail.Title),
+				Name:    formatCardName(scrapVariant, detail.Title, variant.Title),
 				Url:     cardURL,
-				Img:     strings.TrimSpace(product.Image),
+				Img:     image,
 				Price:   float64(variant.Price) / 100,
 				InStock: variant.Available,
 				IsFoil:  strings.Contains(strings.ToLower(variant.Title), "foil"),
 				Source:  storeName,
 				Quality: util.MapQuality(quality),
+			}
+			if scrapVariant == 3 && setName != "" {
+				card.ExtraInfo = []string{setName}
 			}
 
 			key := fmt.Sprintf("%s|%.2f|%t", card.Url, card.Price, card.InStock)
@@ -212,10 +217,59 @@ func buildProductURLWithVariant(baseURL, productPath string, variantID int64) (s
 		return "", err
 	}
 
+	u.RawQuery = ""
 	query := u.Query()
 	query.Set("variant", fmt.Sprint(variantID))
 	query.Set("utm_source", config.UtmSource)
 	u.RawQuery = query.Encode()
 
 	return u.String(), nil
+}
+
+func formatCardName(scrapVariant int, productTitle, variantTitle string) string {
+	productTitle = strings.TrimSpace(productTitle)
+	variantTitle = strings.TrimSpace(variantTitle)
+
+	switch scrapVariant {
+	case 2:
+		if variantTitle == "" {
+			return productTitle
+		}
+		return strings.TrimSpace(productTitle + " - " + variantTitle)
+	case 3:
+		return stripTrailingSet(productTitle)
+	default:
+		return productTitle
+	}
+}
+
+func stripTrailingSet(productTitle string) string {
+	title := strings.TrimSpace(productTitle)
+	open := strings.LastIndex(title, "[")
+	close := strings.LastIndex(title, "]")
+	if open >= 0 && close > open && close == len(title)-1 {
+		return strings.TrimSpace(title[:open])
+	}
+	return title
+}
+
+func extractSetName(productTitle string) string {
+	title := strings.TrimSpace(productTitle)
+	open := strings.LastIndex(title, "[")
+	close := strings.LastIndex(title, "]")
+	if open >= 0 && close > open && close == len(title)-1 {
+		return strings.TrimSpace(title[open+1 : close])
+	}
+	return ""
+}
+
+func buildCardImageURL(rawImageURL, cardTitle string) string {
+	img := strings.TrimSpace(rawImageURL)
+	if strings.HasPrefix(img, "//") {
+		return "https:" + img
+	}
+	if strings.HasPrefix(img, "http://") || strings.HasPrefix(img, "https://") {
+		return img
+	}
+	return fmt.Sprintf("https://placehold.co/304x424?text=%s", url.QueryEscape(strings.TrimSpace(cardTitle)))
 }

--- a/api/gateway/binderpos/storefront.go
+++ b/api/gateway/binderpos/storefront.go
@@ -1,0 +1,221 @@
+package binderpos
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"mtg-price-checker-sg/gateway"
+	"mtg-price-checker-sg/gateway/util"
+	"mtg-price-checker-sg/pkg/config"
+)
+
+const storefrontSuggestPath = "/search/suggest.json"
+
+type storefrontSuggestResponse struct {
+	Resources struct {
+		Results struct {
+			Products []storefrontProduct `json:"products"`
+		} `json:"results"`
+	} `json:"resources"`
+}
+
+type storefrontProduct struct {
+	Title string `json:"title"`
+	URL   string `json:"url"`
+	Image string `json:"image"`
+}
+
+type storefrontProductDetail struct {
+	Title    string                   `json:"title"`
+	Variants []storefrontProductStock `json:"variants"`
+}
+
+type storefrontProductStock struct {
+	ID        int64  `json:"id"`
+	Title     string `json:"title"`
+	Available bool   `json:"available"`
+	Price     int    `json:"price"`
+}
+
+func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, searchURL, searchStr string) ([]gateway.Card, error) {
+	if !config.UseBinderposStorefrontAPI() {
+		return i.Scrap(ctx, scrapVariant, storeName, baseURL, searchURL, searchStr)
+	}
+
+	cards, err := searchByStorefrontAPI(ctx, storeName, baseURL, searchStr)
+	if err != nil || len(cards) == 0 {
+		return i.Scrap(ctx, scrapVariant, storeName, baseURL, searchURL, searchStr)
+	}
+
+	return cards, nil
+}
+
+func searchByStorefrontAPI(ctx context.Context, storeName, baseURL, searchStr string) ([]gateway.Card, error) {
+	client := &http.Client{Timeout: config.PerSiteTimeout}
+
+	products, err := fetchSuggestProducts(ctx, client, baseURL, searchStr)
+	if err != nil {
+		return nil, err
+	}
+	if len(products) == 0 {
+		return []gateway.Card{}, nil
+	}
+
+	cards := make([]gateway.Card, 0, len(products)*4)
+	seen := map[string]struct{}{}
+	for _, product := range products {
+		productURL := product.URL
+		if productURL == "" {
+			continue
+		}
+
+		detail, err := fetchProductDetail(ctx, client, baseURL, productURL)
+		if err != nil {
+			continue
+		}
+
+		for _, variant := range detail.Variants {
+			if variant.Price <= 0 {
+				continue
+			}
+
+			quality := strings.TrimSpace(strings.ReplaceAll(variant.Title, "Foil", ""))
+			cardURL, err := buildProductURLWithVariant(baseURL, productURL, variant.ID)
+			if err != nil {
+				continue
+			}
+
+			card := gateway.Card{
+				Name:    strings.TrimSpace(detail.Title),
+				Url:     cardURL,
+				Img:     strings.TrimSpace(product.Image),
+				Price:   float64(variant.Price) / 100,
+				InStock: variant.Available,
+				IsFoil:  strings.Contains(strings.ToLower(variant.Title), "foil"),
+				Source:  storeName,
+				Quality: util.MapQuality(quality),
+			}
+
+			key := fmt.Sprintf("%s|%.2f|%t", card.Url, card.Price, card.InStock)
+			if _, exists := seen[key]; exists {
+				continue
+			}
+			seen[key] = struct{}{}
+			cards = append(cards, card)
+		}
+	}
+
+	return cards, nil
+}
+
+func fetchSuggestProducts(ctx context.Context, client *http.Client, baseURL, searchStr string) ([]storefrontProduct, error) {
+	suggestURL, err := url.Parse(baseURL + storefrontSuggestPath)
+	if err != nil {
+		return nil, err
+	}
+
+	query := suggestURL.Query()
+	query.Set("q", strings.TrimSpace(searchStr+" mtg"))
+	query.Set("resources[type]", "product")
+	query.Set("resources[limit]", "20")
+	suggestURL.RawQuery = query.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, suggestURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "mtg-price-checker-sg-storefront-api")
+
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("storefront suggest request returned status %d", res.StatusCode)
+	}
+
+	var payload storefrontSuggestResponse
+	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+		return nil, err
+	}
+
+	return payload.Resources.Results.Products, nil
+}
+
+func fetchProductDetail(ctx context.Context, client *http.Client, baseURL, productPath string) (*storefrontProductDetail, error) {
+	productJSONURL, err := productPathToJSONURL(baseURL, productPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, productJSONURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "mtg-price-checker-sg-storefront-api")
+
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(res.Body)
+		return nil, fmt.Errorf("product detail request failed status=%d body=%s", res.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var detail storefrontProductDetail
+	if err := json.NewDecoder(res.Body).Decode(&detail); err != nil {
+		return nil, err
+	}
+
+	return &detail, nil
+}
+
+func productPathToJSONURL(baseURL, productPath string) (string, error) {
+	u, err := url.Parse(productPath)
+	if err != nil {
+		return "", err
+	}
+
+	path := strings.TrimSpace(u.Path)
+	if path == "" {
+		return "", fmt.Errorf("missing product path")
+	}
+
+	path = strings.TrimSuffix(path, "/")
+	if !strings.HasSuffix(path, ".js") {
+		path += ".js"
+	}
+
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		return "", err
+	}
+	base.Path = path
+	base.RawQuery = ""
+
+	return base.String(), nil
+}
+
+func buildProductURLWithVariant(baseURL, productPath string, variantID int64) (string, error) {
+	u, err := url.Parse(baseURL + productPath)
+	if err != nil {
+		return "", err
+	}
+
+	query := u.Query()
+	query.Set("variant", fmt.Sprint(variantID))
+	query.Set("utm_source", config.UtmSource)
+	u.RawQuery = query.Encode()
+
+	return u.String(), nil
+}

--- a/api/gateway/binderpos/storefront_api_test.go
+++ b/api/gateway/binderpos/storefront_api_test.go
@@ -1,0 +1,109 @@
+package binderpos
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+var shopifyDomainPattern = regexp.MustCompile(`Shopify\.shop\s*=\s*"([^"]+)"`)
+
+type supportedGame struct {
+	GameID   string `json:"gameId"`
+	GameName string `json:"gameName"`
+}
+
+func Test_StorefrontSupportedGamesEndpoint_ExistsForGreyOgreAndMtgAsia(t *testing.T) {
+	client := &http.Client{Timeout: 20 * time.Second}
+
+	tests := []struct {
+		name     string
+		storeURL string
+	}{
+		{
+			name:     "grey ogre games",
+			storeURL: "https://www.greyogregames.com",
+		},
+		{
+			name:     "mtg asia",
+			storeURL: "https://www.mtg-asia.com",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			shopifyDomain, err := fetchShopifyShopDomain(ctx, client, test.storeURL)
+			require.NoError(t, err)
+			require.NotEmpty(t, shopifyDomain)
+
+			storefrontAPIURL := fmt.Sprintf(
+				"https://portal.binderpos.com/external/shopify/supportedGames?storeUrl=%s",
+				url.QueryEscape(shopifyDomain),
+			)
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, storefrontAPIURL, nil)
+			require.NoError(t, err)
+			req.Header.Set("User-Agent", "mtg-price-checker-sg-integration-test")
+
+			res, err := client.Do(req)
+			require.NoError(t, err)
+			defer res.Body.Close()
+
+			require.Equal(t, http.StatusOK, res.StatusCode)
+			require.Contains(t, strings.ToLower(res.Header.Get("Content-Type")), "application/json")
+
+			var games []supportedGame
+			require.NoError(t, json.NewDecoder(res.Body).Decode(&games))
+			require.NotEmpty(t, games)
+
+			hasMTGGame := false
+			for _, game := range games {
+				if strings.HasPrefix(strings.ToLower(game.GameID), "mtg") {
+					hasMTGGame = true
+					break
+				}
+			}
+			require.True(t, hasMTGGame, "expected BinderPOS supported games to include an mtg* game id")
+		})
+	}
+}
+
+func fetchShopifyShopDomain(ctx context.Context, client *http.Client, storeURL string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, storeURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("User-Agent", "mtg-price-checker-sg-integration-test")
+
+	res, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status %d while loading %s", res.StatusCode, storeURL)
+	}
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return "", err
+	}
+
+	matches := shopifyDomainPattern.FindStringSubmatch(string(body))
+	if len(matches) < 2 || strings.TrimSpace(matches[1]) == "" {
+		return "", fmt.Errorf("shopify domain not found on %s", storeURL)
+	}
+
+	return strings.TrimSpace(matches[1]), nil
+}

--- a/api/gateway/binderpos/storefront_search_test.go
+++ b/api/gateway/binderpos/storefront_search_test.go
@@ -1,0 +1,169 @@
+package binderpos
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/joho/godotenv"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	_ = godotenv.Load("../../.env")
+}
+
+type binderposStoreSearchCase struct {
+	storeName    string
+	baseURL      string
+	searchURL    string
+	scrapVariant int
+	query        string
+}
+
+func Test_SearchByStorefrontAPI_SupportsAllBinderposStores(t *testing.T) {
+	for _, testCase := range binderposStoreSearchCases() {
+		t.Run(testCase.storeName, func(t *testing.T) {
+			cards, err := searchByStorefrontAPI(context.Background(), testCase.storeName, testCase.baseURL, testCase.query)
+			require.NoError(t, err)
+			require.NotEmpty(t, cards)
+
+			for _, card := range cards {
+				require.NotEmpty(t, card.Name)
+				require.NotEmpty(t, card.Url)
+				require.NotEmpty(t, card.Img)
+				require.NotEmpty(t, card.Source)
+				require.Greater(t, card.Price, float64(0))
+			}
+		})
+	}
+}
+
+func Test_SearchByStorefrontAPI_OverlapsLegacyScrapeResults(t *testing.T) {
+	for _, testCase := range binderposStoreSearchCases() {
+		t.Run(testCase.storeName, func(t *testing.T) {
+			storefrontCards, err := searchByStorefrontAPI(context.Background(), testCase.storeName, testCase.baseURL, testCase.query)
+			require.NoError(t, err)
+			require.NotEmpty(t, storefrontCards)
+
+			scrapedCards, err := New().Scrap(
+				context.Background(),
+				testCase.scrapVariant,
+				testCase.storeName,
+				testCase.baseURL,
+				testCase.searchURL,
+				testCase.query,
+			)
+			require.NoError(t, err)
+			require.NotEmpty(t, scrapedCards)
+
+			scrapedNames := make(map[string]struct{}, len(scrapedCards))
+			for _, card := range scrapedCards {
+				scrapedNames[normalizeCardName(card.Name)] = struct{}{}
+			}
+
+			overlapCount := 0
+			for _, card := range storefrontCards {
+				if _, exists := scrapedNames[normalizeCardName(card.Name)]; exists {
+					overlapCount++
+				}
+			}
+
+			// Ensures storefront API and legacy scraping return materially similar search data.
+			require.Greater(t, overlapCount, 0)
+		})
+	}
+}
+
+func binderposStoreSearchCases() []binderposStoreSearchCase {
+	return []binderposStoreSearchCase{
+		{
+			storeName:    "Cards Citadel",
+			baseURL:      "https://cardscitadel.com",
+			searchURL:    "/search?q=*%s*",
+			scrapVariant: 1,
+			query:        "Abrade",
+		},
+		{
+			storeName:    "Card Affinity",
+			baseURL:      "https://card-affinity.com",
+			searchURL:    "/search?q=%s",
+			scrapVariant: 2,
+			query:        "Abrade",
+		},
+		{
+			storeName:    "Cardboard Crack Games",
+			baseURL:      "https://www.cardboardcrackgames.com",
+			searchURL:    "/search?type=product&q=%s",
+			scrapVariant: 2,
+			query:        "Abrade",
+		},
+		{
+			storeName:    "Flagship Games",
+			baseURL:      "https://www.flagshipgames.sg",
+			searchURL:    "/search?type=product&q=%s",
+			scrapVariant: 2,
+			query:        "Abrade",
+		},
+		{
+			storeName:    "Games Haven",
+			baseURL:      "https://www.gameshaventcg.com",
+			searchURL:    "/search?q=%s",
+			scrapVariant: 3,
+			query:        "Abrade",
+		},
+		{
+			storeName:    "Grey Ogre Games",
+			baseURL:      "https://www.greyogregames.com",
+			searchURL:    "/search?q=%s",
+			scrapVariant: 3,
+			query:        "Abrade",
+		},
+		{
+			storeName:    "Hideout",
+			baseURL:      "https://hideoutcg.com",
+			searchURL:    "/search?q=%s",
+			scrapVariant: 3,
+			query:        "Abrade",
+		},
+		{
+			storeName:    "Mana Pro",
+			baseURL:      "https://sg-manapro.com",
+			searchURL:    "/search?type=product&q=%s",
+			scrapVariant: 2,
+			query:        "Abrade",
+		},
+		{
+			storeName:    "MTG Asia",
+			baseURL:      "https://www.mtg-asia.com",
+			searchURL:    "/search?q=%s",
+			scrapVariant: 2,
+			query:        "Abrade",
+		},
+		{
+			storeName:    "OneMtg",
+			baseURL:      "https://onemtg.com.sg",
+			searchURL:    "/search?q=%s",
+			scrapVariant: 2,
+			query:        "Abrade",
+		},
+		{
+			storeName:    "Tefuda",
+			baseURL:      "https://tefudagames.com",
+			searchURL:    "/search?q=%s",
+			scrapVariant: 4,
+			query:        "smothering tithe",
+		},
+		{
+			storeName:    "Arcane Sanctum",
+			baseURL:      "https://arcanesanctumtcg.com",
+			searchURL:    "/search?q=%s",
+			scrapVariant: 5,
+			query:        "signet",
+		},
+	}
+}
+
+func normalizeCardName(name string) string {
+	return strings.ToLower(strings.Join(strings.Fields(strings.TrimSpace(name)), " "))
+}

--- a/api/gateway/binderpos/storefront_search_test.go
+++ b/api/gateway/binderpos/storefront_search_test.go
@@ -24,7 +24,7 @@ type binderposStoreSearchCase struct {
 func Test_SearchByStorefrontAPI_SupportsAllBinderposStores(t *testing.T) {
 	for _, testCase := range binderposStoreSearchCases() {
 		t.Run(testCase.storeName, func(t *testing.T) {
-			cards, err := searchByStorefrontAPI(context.Background(), testCase.storeName, testCase.baseURL, testCase.query)
+			cards, err := searchByStorefrontAPI(context.Background(), testCase.scrapVariant, testCase.storeName, testCase.baseURL, testCase.query)
 			require.NoError(t, err)
 			require.NotEmpty(t, cards)
 
@@ -42,7 +42,7 @@ func Test_SearchByStorefrontAPI_SupportsAllBinderposStores(t *testing.T) {
 func Test_SearchByStorefrontAPI_OverlapsLegacyScrapeResults(t *testing.T) {
 	for _, testCase := range binderposStoreSearchCases() {
 		t.Run(testCase.storeName, func(t *testing.T) {
-			storefrontCards, err := searchByStorefrontAPI(context.Background(), testCase.storeName, testCase.baseURL, testCase.query)
+			storefrontCards, err := searchByStorefrontAPI(context.Background(), testCase.scrapVariant, testCase.storeName, testCase.baseURL, testCase.query)
 			require.NoError(t, err)
 			require.NotEmpty(t, storefrontCards)
 

--- a/api/gateway/cardaffinity/search.go
+++ b/api/gateway/cardaffinity/search.go
@@ -27,7 +27,7 @@ func NewLGS() gateway.LGS {
 }
 
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
-	return s.BinderposGwy.Scrap(ctx,
+	return s.BinderposGwy.Search(ctx,
 		2,
 		s.Name,
 		s.BaseUrl,

--- a/api/gateway/cardboardcrackgames/search.go
+++ b/api/gateway/cardboardcrackgames/search.go
@@ -27,7 +27,7 @@ func NewLGS() gateway.LGS {
 }
 
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
-	return s.BinderposGwy.Scrap(ctx,
+	return s.BinderposGwy.Search(ctx,
 		2,
 		s.Name,
 		s.BaseUrl,

--- a/api/gateway/cardscitadel/search.go
+++ b/api/gateway/cardscitadel/search.go
@@ -27,5 +27,5 @@ func NewLGS() gateway.LGS {
 }
 
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
-	return s.BinderposGwy.Scrap(ctx, 1, s.Name, s.BaseUrl, s.SearchUrl, searchStr)
+	return s.BinderposGwy.Search(ctx, 1, s.Name, s.BaseUrl, s.SearchUrl, searchStr)
 }

--- a/api/gateway/flagship/search.go
+++ b/api/gateway/flagship/search.go
@@ -28,5 +28,5 @@ func NewLGS() gateway.LGS {
 }
 
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
-	return s.BinderposGwy.Scrap(ctx, 2, s.Name, s.BaseUrl, s.SearchUrl, searchStr)
+	return s.BinderposGwy.Search(ctx, 2, s.Name, s.BaseUrl, s.SearchUrl, searchStr)
 }

--- a/api/gateway/gameshaven/search.go
+++ b/api/gateway/gameshaven/search.go
@@ -27,7 +27,7 @@ func NewLGS() gateway.LGS {
 }
 
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
-	return s.BinderposGwy.Scrap(ctx,
+	return s.BinderposGwy.Search(ctx,
 		3,
 		s.Name,
 		s.BaseUrl,

--- a/api/gateway/gog/search.go
+++ b/api/gateway/gog/search.go
@@ -28,5 +28,5 @@ func NewLGS() gateway.LGS {
 }
 
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
-	return s.BinderposGwy.Scrap(ctx, 3, s.Name, s.BaseUrl, s.SearchUrl, searchStr)
+	return s.BinderposGwy.Search(ctx, 3, s.Name, s.BaseUrl, s.SearchUrl, searchStr)
 }

--- a/api/gateway/hideout/search.go
+++ b/api/gateway/hideout/search.go
@@ -27,7 +27,7 @@ func NewLGS() gateway.LGS {
 }
 
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
-	return s.BinderposGwy.Scrap(ctx,
+	return s.BinderposGwy.Search(ctx,
 		3,
 		s.Name,
 		s.BaseUrl,

--- a/api/gateway/manapro/search.go
+++ b/api/gateway/manapro/search.go
@@ -28,5 +28,5 @@ func NewLGS() gateway.LGS {
 }
 
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
-	return s.BinderposGwy.Scrap(ctx, 2, s.Name, s.BaseUrl, s.SearchUrl, searchStr)
+	return s.BinderposGwy.Search(ctx, 2, s.Name, s.BaseUrl, s.SearchUrl, searchStr)
 }

--- a/api/gateway/mtgasia/search.go
+++ b/api/gateway/mtgasia/search.go
@@ -28,5 +28,5 @@ func NewLGS() gateway.LGS {
 }
 
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
-	return s.BinderposGwy.Scrap(ctx, 2, s.Name, s.BaseUrl, s.SearchUrl, searchStr)
+	return s.BinderposGwy.Search(ctx, 2, s.Name, s.BaseUrl, s.SearchUrl, searchStr)
 }

--- a/api/gateway/onemtg/search.go
+++ b/api/gateway/onemtg/search.go
@@ -27,7 +27,7 @@ func NewLGS() gateway.LGS {
 }
 
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
-	return s.BinderposGwy.Scrap(ctx,
+	return s.BinderposGwy.Search(ctx,
 		2,
 		s.Name,
 		s.BaseUrl,

--- a/api/gateway/tefuda/search.go
+++ b/api/gateway/tefuda/search.go
@@ -27,7 +27,7 @@ func NewLGS() gateway.LGS {
 }
 
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
-	return s.BinderposGwy.Scrap(ctx,
+	return s.BinderposGwy.Search(ctx,
 		4,
 		s.Name,
 		s.BaseUrl,

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"os"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -13,7 +15,24 @@ const (
 	EnvLocal         = "local"
 	UseProxy         = true
 	PerSiteTimeout   = 20 * time.Second
+	// UseBinderposStorefrontAPIEnv toggles BinderPOS storefront API search mode.
+	// Default is enabled; set to "false" to force legacy scraping.
+	UseBinderposStorefrontAPIEnv = "USE_BINDERPOS_STOREFRONT_API"
 )
+
+func UseBinderposStorefrontAPI() bool {
+	rawValue := strings.TrimSpace(os.Getenv(UseBinderposStorefrontAPIEnv))
+	if rawValue == "" {
+		return true
+	}
+
+	enabled, err := strconv.ParseBool(rawValue)
+	if err != nil {
+		return true
+	}
+
+	return enabled
+}
 
 func GetAllowedOrigins() []string {
 	if os.Getenv("ENV") == EnvProd {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a new BinderPOS Storefront API search implementation using Shopify predictive search (`/search/suggest.json`) plus product JSON (`/products/<handle>.js`) to build variant-level card results
- add feature toggle `USE_BINDERPOS_STOREFRONT_API` (default **enabled**) in `config`, with automatic fallback to existing scraper implementation when storefront search fails or returns empty
- update all BinderPOS-backed store gateways to call `BinderposGwy.Search(...)` so they use the new API path under toggle control
- align storefront result shaping with each existing scrape variant (naming/image/extra-info behavior) to maintain data compatibility
- add integration tests that:
  - verify storefront API search works for every BinderPOS-backed store in this repo
  - verify storefront results overlap with legacy scraper data for each store/query pair

## Feature toggle
- `USE_BINDERPOS_STOREFRONT_API`
  - unset/empty => `true` (enabled)
  - `false` => force legacy scraping path

## Validation
- `go test ./gateway/binderpos -v` ✅
- `go test ./gateway/...` ⚠️ has unrelated pre-existing failures in non-BinderPOS packages (`gateway/fivemana`, `gateway/tcgmarketplace`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01fbfb21-fd75-49c1-a5fa-2e3825ba9ebb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01fbfb21-fd75-49c1-a5fa-2e3825ba9ebb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

