### PR TITLE
Batch Discord search errors into a single alert

### DIFF
--- a/api/controller/search.go
+++ b/api/controller/search.go
@@ -53,6 +53,8 @@ type Card struct {
 
 const binderposMaxConcurrent = 5
 
+var sendDiscordAlert = alert.SendDiscordAlert
+
 func Search(ctx context.Context, input SearchInput) ([]Card, error) {
 	shopNameToLGSMap := initAndMapShops(input.Lgs)
 	return searchShops(ctx, input, shopNameToLGSMap)
@@ -97,6 +99,7 @@ func fetchCardsConcurrently(ctx context.Context, searchString string, shops map[
 	var mu sync.Mutex
 	var errMu sync.Mutex
 	siteErrors := make(map[string]error, len(shops))
+	discordErrorMessages := make([]string, 0, len(shops))
 	binderposGate := make(chan struct{}, binderposMaxConcurrent)
 
 	log.Printf("Start checking shops for [%s]...", searchString)
@@ -107,9 +110,9 @@ func fetchCardsConcurrently(ctx context.Context, searchString string, shops map[
 				if r := recover(); r != nil {
 					errMsg := fmt.Sprintf("Recovered from panic in shop [%s]: %v", shopName, r)
 					log.Println(errMsg)
-					go alert.SendDiscordAlert(errMsg) // Send asynchronously
 					errMu.Lock()
 					siteErrors[shopName] = fmt.Errorf("panic: %v", r)
+					discordErrorMessages = append(discordErrorMessages, errMsg)
 					errMu.Unlock()
 				}
 			}()
@@ -129,7 +132,9 @@ func fetchCardsConcurrently(ctx context.Context, searchString string, shops map[
 				if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 					errMsg := fmt.Sprintf("Error encountered searching [%s] for [%s]: %v", shopName, searchString, err)
 					log.Println(errMsg)
-					go alert.SendDiscordAlert(errMsg)
+					errMu.Lock()
+					discordErrorMessages = append(discordErrorMessages, errMsg)
+					errMu.Unlock()
 				}
 				errMu.Lock()
 				siteErrors[shopName] = err
@@ -147,11 +152,26 @@ func fetchCardsConcurrently(ctx context.Context, searchString string, shops map[
 	}
 
 	wg.Wait()
+	if len(discordErrorMessages) > 0 {
+		go sendDiscordAlert(formatDiscordErrorSummary(searchString, discordErrorMessages))
+	}
 	if len(siteErrors) > 0 {
 		log.Printf("Shops with errors for [%s]: %d", searchString, len(siteErrors))
 	}
 	log.Println("End checking shops...")
 	return cards, siteErrors
+}
+
+func formatDiscordErrorSummary(searchString string, errorMessages []string) string {
+	sortedMessages := append([]string(nil), errorMessages...)
+	sort.Strings(sortedMessages)
+
+	return fmt.Sprintf(
+		"Encountered %d error(s) while searching [%s]:\n%s",
+		len(sortedMessages),
+		searchString,
+		strings.Join(sortedMessages, "\n"),
+	)
 }
 
 func filterAndSortCards(cards []gateway.Card, searchString string, shopNameToHasResultMap map[string]bool) []Card {

--- a/api/controller/search_test.go
+++ b/api/controller/search_test.go
@@ -11,6 +11,8 @@ import (
 	"mtg-price-checker-sg/gateway/gog"
 	"mtg-price-checker-sg/gateway/hideout"
 	"mtg-price-checker-sg/gateway/tefuda"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -344,5 +346,76 @@ func TestFetchCardsConcurrently_BinderposGate(t *testing.T) {
 	_, _ = fetchCardsConcurrently(context.Background(), "Abrade", shops)
 	if atomic.LoadInt32(&maxActiveBinderpos) > binderposMaxConcurrent {
 		t.Fatalf("expected at most %d concurrent binderpos searches, got %d", binderposMaxConcurrent, maxActiveBinderpos)
+	}
+}
+
+func TestFetchCardsConcurrently_CollatesDiscordErrors(t *testing.T) {
+	shops := map[string]gateway.LGS{
+		"ErrorShopA": &MockLGS{
+			SearchFunc: func(ctx context.Context, searchStr string) ([]gateway.Card, error) {
+				return nil, fmt.Errorf("shop A failed")
+			},
+		},
+		"ErrorShopB": &MockLGS{
+			SearchFunc: func(ctx context.Context, searchStr string) ([]gateway.Card, error) {
+				return nil, fmt.Errorf("shop B failed")
+			},
+		},
+		"PanicShop": &MockLGS{
+			SearchFunc: func(ctx context.Context, searchStr string) ([]gateway.Card, error) {
+				panic("shop panic")
+			},
+		},
+	}
+
+	var mu sync.Mutex
+	alertMessages := make([]string, 0, 1)
+	alertDone := make(chan struct{}, 1)
+
+	originalSendDiscordAlert := sendDiscordAlert
+	sendDiscordAlert = func(message string) {
+		mu.Lock()
+		alertMessages = append(alertMessages, message)
+		mu.Unlock()
+		select {
+		case alertDone <- struct{}{}:
+		default:
+		}
+	}
+	t.Cleanup(func() {
+		sendDiscordAlert = originalSendDiscordAlert
+	})
+
+	_, siteErrors := fetchCardsConcurrently(context.Background(), "Abrade", shops)
+	if len(siteErrors) != 3 {
+		t.Fatalf("expected 3 site errors, got %d", len(siteErrors))
+	}
+
+	select {
+	case <-alertDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for collated discord alert")
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(alertMessages) != 1 {
+		t.Fatalf("expected exactly 1 collated alert, got %d", len(alertMessages))
+	}
+
+	got := alertMessages[0]
+	if !strings.Contains(got, "Encountered 3 error(s) while searching [Abrade]:") {
+		t.Fatalf("expected collated summary header, got: %s", got)
+	}
+	if !strings.Contains(got, "Error encountered searching [ErrorShopA] for [Abrade]: shop A failed") {
+		t.Fatalf("expected ErrorShopA details in alert, got: %s", got)
+	}
+	if !strings.Contains(got, "Error encountered searching [ErrorShopB] for [Abrade]: shop B failed") {
+		t.Fatalf("expected ErrorShopB details in alert, got: %s", got)
+	}
+	if !strings.Contains(got, "Recovered from panic in shop [PanicShop]: shop panic") {
+		t.Fatalf("expected PanicShop details in alert, got: %s", got)
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- collate all non-timeout search errors and panic recoveries into a single Discord alert per request
- send the collated alert once after all shops complete instead of sending one message per error
- add deterministic formatting for the collated error payload
- add a controller regression test that verifies multiple shop failures produce exactly one Discord alert containing all error details

## Testing
- `go test ./controller`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c352e7f4-950d-4bde-9442-4d3b5c5ed1f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c352e7f4-950d-4bde-9442-4d3b5c5ed1f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

