### PR TITLE
Include proxy context in scraper errors

### DIFF
--- a/api/gateway/agora/search.go
+++ b/api/gateway/agora/search.go
@@ -118,5 +118,5 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 		})
 	})
 
-	return cards, c.Visit(searchURL)
+	return cards, gateway.VisitWithProxyInfo(c, searchURL)
 }

--- a/api/gateway/binderpos/scrap.go
+++ b/api/gateway/binderpos/scrap.go
@@ -111,7 +111,7 @@ func scrapVariant5(ctx context.Context, storeName, baseUrl, searchUrl, searchStr
 		})
 	})
 
-	return cards, c.Visit(searchURL)
+	return cards, gateway.VisitWithProxyInfo(c, searchURL)
 }
 
 // tefuda
@@ -158,7 +158,7 @@ func scrapVariant4(ctx context.Context, storeName, baseUrl, searchUrl, searchStr
 		})
 	})
 
-	return cards, c.Visit(searchURL)
+	return cards, gateway.VisitWithProxyInfo(c, searchURL)
 }
 
 type pagination struct {
@@ -228,7 +228,7 @@ func scrapVariant3(ctx context.Context, storeName, baseUrl, searchUrl, searchStr
 		})
 	})
 
-	return cards, c.Visit(searchURL)
+	return cards, gateway.VisitWithProxyInfo(c, searchURL)
 }
 
 // card affinity
@@ -292,7 +292,7 @@ func scrapVariant2(ctx context.Context, storeName, baseUrl, searchUrl, searchStr
 		})
 	})
 
-	return cards, c.Visit(searchURL)
+	return cards, gateway.VisitWithProxyInfo(c, searchURL)
 }
 
 // cards citadel
@@ -361,7 +361,7 @@ func scrapVariant1(ctx context.Context, storeName, baseUrl, searchUrl, searchStr
 			}
 		})
 	})
-	return cards, c.Visit(searchURL)
+	return cards, gateway.VisitWithProxyInfo(c, searchURL)
 }
 
 func parsePriceAndQuality(priceQualityStr string) (float64, string, error) {

--- a/api/gateway/collector.go
+++ b/api/gateway/collector.go
@@ -7,8 +7,10 @@ import (
 	"math/rand/v2"
 	"mtg-price-checker-sg/gateway/util"
 	"mtg-price-checker-sg/pkg/config"
+	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -207,7 +209,11 @@ func registerRetryErrorHandler(c *colly.Collector, leasedDedicatedProxyURL strin
 		// Colly may call OnError without a full response/request on network/proxy failures.
 		// Guard all dereferences to prevent intermittent panics that bubble up as 500s.
 		if r == nil || r.Ctx == nil || r.Request == nil || r.Request.URL == nil {
-			fmt.Printf("Request failed before response was available: %v\n", err)
+			mode := "unknown"
+			if leasedDedicatedProxyURL != "" {
+				mode = "dedicated"
+			}
+			log.Printf("Request failed before response was available: %v (%s)", err, formatProxyContext(mode, leasedDedicatedProxyURL))
 			releaseDedicatedProxy()
 			return
 		}
@@ -224,17 +230,67 @@ func registerRetryErrorHandler(c *colly.Collector, leasedDedicatedProxyURL strin
 			r.Ctx.Put("last_proxy_url", proxyURL)
 
 			waitDuration := retryDelay(statusCode, retryAfterHeaderValue(r), retries)
-			log.Printf("Retrying %s (attempt=%d status=%d wait=%s proxy_mode=%s)", r.Request.URL, nextRetry, statusCode, waitDuration, proxyMode)
+			log.Printf(
+				"Retrying %s (attempt=%d status=%d wait=%s %s)",
+				r.Request.URL,
+				nextRetry,
+				statusCode,
+				waitDuration,
+				formatProxyContext(proxyMode, proxyURL),
+			)
 			time.Sleep(waitDuration)
 			if retryErr := r.Request.Retry(); retryErr != nil {
-				log.Printf("Retry failed for %s (attempt=%d status=%d): %v", r.Request.URL, nextRetry, statusCode, retryErr)
+				log.Printf(
+					"Retry failed for %s (attempt=%d status=%d): %v (%s)",
+					r.Request.URL,
+					nextRetry,
+					statusCode,
+					retryErr,
+					formatProxyContext(proxyMode, proxyURL),
+				)
 				releaseDedicatedProxy()
 			}
 		} else {
-			log.Printf("Failed after %d retries: %s (status=%d)", maxRetries, r.Request.URL, statusCode)
+			log.Printf(
+				"Failed after %d retries: %s (status=%d %s)",
+				maxRetries,
+				r.Request.URL,
+				statusCode,
+				formatProxyContext(r.Ctx.Get("last_proxy_mode"), r.Ctx.Get("last_proxy_url")),
+			)
 			releaseDedicatedProxy()
 		}
 	})
+}
+
+// VisitWithProxyInfo wraps collector visit errors with the selected proxy context.
+func VisitWithProxyInfo(c *colly.Collector, targetURL string) error {
+	var proxyMu sync.Mutex
+	var lastProxyMode string
+	var lastProxyURL string
+
+	c.OnRequest(func(r *colly.Request) {
+		if r == nil || r.Ctx == nil {
+			return
+		}
+
+		proxyMu.Lock()
+		lastProxyMode = r.Ctx.Get("last_proxy_mode")
+		lastProxyURL = r.Ctx.Get("last_proxy_url")
+		proxyMu.Unlock()
+	})
+
+	err := c.Visit(targetURL)
+	if err == nil {
+		return nil
+	}
+
+	proxyMu.Lock()
+	mode := lastProxyMode
+	proxyURL := lastProxyURL
+	proxyMu.Unlock()
+
+	return fmt.Errorf("%w (%s)", err, formatProxyContext(mode, proxyURL))
 }
 
 // Retry metadata helpers.
@@ -329,6 +385,45 @@ func randomDedicatedProxyURL(avoidProxyURL string) (string, bool) {
 	p := candidates[rand.IntN(len(candidates))]
 	proxyURL, ok := util.BuildDedicatedProxyURL(p)
 	return proxyURL, ok
+}
+
+func formatProxyContext(mode, proxyURL string) string {
+	if mode == "" {
+		mode = "unknown"
+	}
+
+	safeProxy := sanitizeProxyURL(proxyURL)
+	if safeProxy == "" {
+		safeProxy = "none"
+	}
+
+	return fmt.Sprintf("proxy_mode=%s proxy=%s", mode, safeProxy)
+}
+
+func sanitizeProxyURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+
+	parsed, err := url.Parse(raw)
+	if err == nil && parsed.Host != "" {
+		parsed.User = nil
+		parsed.Path = ""
+		parsed.RawPath = ""
+		parsed.RawQuery = ""
+		parsed.Fragment = ""
+		return parsed.String()
+	}
+
+	if at := strings.LastIndex(raw, "@"); at != -1 {
+		if schemeIdx := strings.Index(raw, "://"); schemeIdx != -1 && at > schemeIdx+3 {
+			return raw[:schemeIdx+3] + raw[at+1:]
+		}
+		return raw[at+1:]
+	}
+
+	return raw
 }
 
 func retryDelay(statusCode int, retryAfterHeader string, retries int) time.Duration {

--- a/api/gateway/collector.go
+++ b/api/gateway/collector.go
@@ -7,10 +7,8 @@ import (
 	"math/rand/v2"
 	"mtg-price-checker-sg/gateway/util"
 	"mtg-price-checker-sg/pkg/config"
-	"net/url"
 	"os"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -392,38 +390,45 @@ func formatProxyContext(mode, proxyURL string) string {
 		mode = "unknown"
 	}
 
-	safeProxy := sanitizeProxyURL(proxyURL)
-	if safeProxy == "" {
-		safeProxy = "none"
-	}
-
-	return fmt.Sprintf("proxy_mode=%s proxy=%s", mode, safeProxy)
+	return fmt.Sprintf("proxy_mode=%s proxy=%s", mode, resolveProxyLabel(mode, proxyURL))
 }
 
-func sanitizeProxyURL(raw string) string {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return ""
+func resolveProxyLabel(mode, proxyURL string) string {
+	if proxyURL == "" {
+		return "none"
 	}
 
-	parsed, err := url.Parse(raw)
-	if err == nil && parsed.Host != "" {
-		parsed.User = nil
-		parsed.Path = ""
-		parsed.RawPath = ""
-		parsed.RawQuery = ""
-		parsed.Fragment = ""
-		return parsed.String()
-	}
-
-	if at := strings.LastIndex(raw, "@"); at != -1 {
-		if schemeIdx := strings.Index(raw, "://"); schemeIdx != -1 && at > schemeIdx+3 {
-			return raw[:schemeIdx+3] + raw[at+1:]
+	switch mode {
+	case "direct":
+		return "none"
+	case "shared":
+		if sharedProxyURL := os.Getenv("PROXY_URL"); sharedProxyURL != "" && sharedProxyURL == proxyURL {
+			return "PROXY_URL"
 		}
-		return raw[at+1:]
+		return "shared-configured"
+	case "dedicated":
+		if label := dedicatedProxyEnvLabel(proxyURL); label != "" {
+			return label
+		}
+		return "dedicated-configured"
+	default:
+		return "configured"
+	}
+}
+
+func dedicatedProxyEnvLabel(proxyURL string) string {
+	dedicatedProxies := util.GetDedicatedProxy()
+	for idx, proxy := range dedicatedProxies {
+		candidateURL, ok := util.BuildDedicatedProxyURL(proxy)
+		if !ok {
+			continue
+		}
+		if candidateURL == proxyURL {
+			return fmt.Sprintf("DEDICATED_PROXY_%d", idx+1)
+		}
 	}
 
-	return raw
+	return ""
 }
 
 func retryDelay(statusCode int, retryAfterHeader string, retries int) time.Duration {

--- a/api/gateway/collector_test.go
+++ b/api/gateway/collector_test.go
@@ -1,7 +1,9 @@
 package gateway
 
 import (
+	"context"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -220,4 +222,54 @@ func TestDedicatedProxyURLHelpers(t *testing.T) {
 			t.Fatalf("unexpected proxy url: %q", proxyURL)
 		}
 	})
+}
+
+func TestSanitizeProxyURL(t *testing.T) {
+	t.Run("removes credentials and path query from valid URL", func(t *testing.T) {
+		got := sanitizeProxyURL("http://user:pass@1.1.1.1:8080/path?q=v")
+		if got != "http://1.1.1.1:8080" {
+			t.Fatalf("expected sanitized proxy URL without credentials/path/query, got %q", got)
+		}
+	})
+
+	t.Run("handles URL without credentials", func(t *testing.T) {
+		got := sanitizeProxyURL("http://2.2.2.2:9090")
+		if got != "http://2.2.2.2:9090" {
+			t.Fatalf("expected unchanged host-only URL, got %q", got)
+		}
+	})
+
+	t.Run("handles non URL input by stripping auth section", func(t *testing.T) {
+		got := sanitizeProxyURL("user:pass@3.3.3.3:1234")
+		if got != "3.3.3.3:1234" {
+			t.Fatalf("expected auth section stripped from raw proxy string, got %q", got)
+		}
+	})
+}
+
+func TestFormatProxyContext(t *testing.T) {
+	t.Run("empty mode and proxy default values", func(t *testing.T) {
+		got := formatProxyContext("", "")
+		if got != "proxy_mode=unknown proxy=none" {
+			t.Fatalf("unexpected proxy context: %q", got)
+		}
+	})
+
+	t.Run("includes sanitized proxy URL", func(t *testing.T) {
+		got := formatProxyContext("dedicated", "http://user:pass@4.4.4.4:8080")
+		if got != "proxy_mode=dedicated proxy=http://4.4.4.4:8080" {
+			t.Fatalf("unexpected proxy context: %q", got)
+		}
+	})
+}
+
+func TestVisitWithProxyInfo(t *testing.T) {
+	c := NewOptimizedCollectorNoRetry(context.Background())
+	err := VisitWithProxyInfo(c, "http://[::1")
+	if err == nil {
+		t.Fatalf("expected visit error for malformed URL")
+	}
+	if !strings.Contains(err.Error(), "proxy_mode=") {
+		t.Fatalf("expected proxy context in error, got %q", err)
+	}
 }

--- a/api/gateway/collector_test.go
+++ b/api/gateway/collector_test.go
@@ -224,29 +224,6 @@ func TestDedicatedProxyURLHelpers(t *testing.T) {
 	})
 }
 
-func TestSanitizeProxyURL(t *testing.T) {
-	t.Run("removes credentials and path query from valid URL", func(t *testing.T) {
-		got := sanitizeProxyURL("http://user:pass@1.1.1.1:8080/path?q=v")
-		if got != "http://1.1.1.1:8080" {
-			t.Fatalf("expected sanitized proxy URL without credentials/path/query, got %q", got)
-		}
-	})
-
-	t.Run("handles URL without credentials", func(t *testing.T) {
-		got := sanitizeProxyURL("http://2.2.2.2:9090")
-		if got != "http://2.2.2.2:9090" {
-			t.Fatalf("expected unchanged host-only URL, got %q", got)
-		}
-	})
-
-	t.Run("handles non URL input by stripping auth section", func(t *testing.T) {
-		got := sanitizeProxyURL("user:pass@3.3.3.3:1234")
-		if got != "3.3.3.3:1234" {
-			t.Fatalf("expected auth section stripped from raw proxy string, got %q", got)
-		}
-	})
-}
-
 func TestFormatProxyContext(t *testing.T) {
 	t.Run("empty mode and proxy default values", func(t *testing.T) {
 		got := formatProxyContext("", "")
@@ -255,10 +232,54 @@ func TestFormatProxyContext(t *testing.T) {
 		}
 	})
 
-	t.Run("includes sanitized proxy URL", func(t *testing.T) {
+	t.Run("uses dedicated proxy env label when mapped", func(t *testing.T) {
+		t.Setenv("DEDICATED_PROXY_1", "4.4.4.4|8080|user|pass")
 		got := formatProxyContext("dedicated", "http://user:pass@4.4.4.4:8080")
-		if got != "proxy_mode=dedicated proxy=http://4.4.4.4:8080" {
+		if got != "proxy_mode=dedicated proxy=DEDICATED_PROXY_1" {
 			t.Fatalf("unexpected proxy context: %q", got)
+		}
+	})
+
+	t.Run("uses shared proxy env label", func(t *testing.T) {
+		t.Setenv("PROXY_URL", "http://shared-proxy:8080")
+		got := formatProxyContext("shared", "http://shared-proxy:8080")
+		if got != "proxy_mode=shared proxy=PROXY_URL" {
+			t.Fatalf("unexpected proxy context: %q", got)
+		}
+	})
+}
+
+func TestResolveProxyLabel(t *testing.T) {
+	t.Run("returns none for empty proxy", func(t *testing.T) {
+		if got := resolveProxyLabel("dedicated", ""); got != "none" {
+			t.Fatalf("expected none, got %q", got)
+		}
+	})
+
+	t.Run("matches dedicated env key by URL", func(t *testing.T) {
+		t.Setenv("DEDICATED_PROXY_1", "10.0.0.1|1111|u1|p1")
+		t.Setenv("DEDICATED_PROXY_2", "10.0.0.2|2222|u2|p2")
+		if got := resolveProxyLabel("dedicated", "http://u2:p2@10.0.0.2:2222"); got != "DEDICATED_PROXY_2" {
+			t.Fatalf("expected DEDICATED_PROXY_2, got %q", got)
+		}
+	})
+
+	t.Run("matches shared env key by URL", func(t *testing.T) {
+		t.Setenv("PROXY_URL", "http://shared:3333")
+		if got := resolveProxyLabel("shared", "http://shared:3333"); got != "PROXY_URL" {
+			t.Fatalf("expected PROXY_URL, got %q", got)
+		}
+	})
+
+	t.Run("falls back to mode label when unmapped", func(t *testing.T) {
+		if got := resolveProxyLabel("dedicated", "http://unknown:4444"); got != "dedicated-configured" {
+			t.Fatalf("expected dedicated-configured fallback, got %q", got)
+		}
+		if got := resolveProxyLabel("shared", "http://unknown:5555"); got != "shared-configured" {
+			t.Fatalf("expected shared-configured fallback, got %q", got)
+		}
+		if got := resolveProxyLabel("unknown", "http://unknown:6666"); got != "configured" {
+			t.Fatalf("expected configured fallback, got %q", got)
 		}
 	})
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- keep proxy context in scraper errors/logs but replace raw proxy URLs with labels
- map dedicated proxies to their env var names (`DEDICATED_PROXY_1..5`) when possible
- map shared proxy to `PROXY_URL`
- use safe fallback labels when URL cannot be matched (`dedicated-configured`, `shared-configured`, `configured`)
- continue reporting `none` for direct/no-proxy
- keep `VisitWithProxyInfo` wrapping so surfaced scraper errors carry proxy mode + label

## Testing
- `go test ./gateway`
- `go test ./gateway ./gateway/agora ./gateway/binderpos ./controller ./handler`
- `go test ./...` *(still has existing unrelated failure in `gateway/tcgmarketplace Test_Search`)*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c1eab7b-ee4b-4be4-a5c4-3d34cfe8f5c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c1eab7b-ee4b-4be4-a5c4-3d34cfe8f5c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

