### PR TITLE
Show shared proxy URL in error context

### DIFF
--- a/api/gateway/collector.go
+++ b/api/gateway/collector.go
@@ -7,8 +7,10 @@ import (
 	"math/rand/v2"
 	"mtg-price-checker-sg/gateway/util"
 	"mtg-price-checker-sg/pkg/config"
+	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -403,7 +405,9 @@ func resolveProxyLabel(mode, proxyURL string) string {
 		return "none"
 	case "shared":
 		if sharedProxyURL := os.Getenv("PROXY_URL"); sharedProxyURL != "" && sharedProxyURL == proxyURL {
-			return "PROXY_URL"
+			if sanitized := sanitizeProxyURL(proxyURL); sanitized != "" {
+				return sanitized
+			}
 		}
 		return "shared-configured"
 	case "dedicated":
@@ -429,6 +433,32 @@ func dedicatedProxyEnvLabel(proxyURL string) string {
 	}
 
 	return ""
+}
+
+func sanitizeProxyURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+
+	parsed, err := url.Parse(raw)
+	if err == nil && parsed.Host != "" {
+		parsed.User = nil
+		parsed.Path = ""
+		parsed.RawPath = ""
+		parsed.RawQuery = ""
+		parsed.Fragment = ""
+		return parsed.String()
+	}
+
+	if at := strings.LastIndex(raw, "@"); at != -1 {
+		if schemeIdx := strings.Index(raw, "://"); schemeIdx != -1 && at > schemeIdx+3 {
+			return raw[:schemeIdx+3] + raw[at+1:]
+		}
+		return raw[at+1:]
+	}
+
+	return raw
 }
 
 func retryDelay(statusCode int, retryAfterHeader string, retries int) time.Duration {

--- a/api/gateway/collector_test.go
+++ b/api/gateway/collector_test.go
@@ -240,10 +240,10 @@ func TestFormatProxyContext(t *testing.T) {
 		}
 	})
 
-	t.Run("uses shared proxy env label", func(t *testing.T) {
-		t.Setenv("PROXY_URL", "http://shared-proxy:8080")
-		got := formatProxyContext("shared", "http://shared-proxy:8080")
-		if got != "proxy_mode=shared proxy=PROXY_URL" {
+	t.Run("uses sanitized shared proxy URL", func(t *testing.T) {
+		t.Setenv("PROXY_URL", "http://user:pass@shared-proxy:8080/path?q=1")
+		got := formatProxyContext("shared", "http://user:pass@shared-proxy:8080/path?q=1")
+		if got != "proxy_mode=shared proxy=http://shared-proxy:8080" {
 			t.Fatalf("unexpected proxy context: %q", got)
 		}
 	})
@@ -264,10 +264,10 @@ func TestResolveProxyLabel(t *testing.T) {
 		}
 	})
 
-	t.Run("matches shared env key by URL", func(t *testing.T) {
-		t.Setenv("PROXY_URL", "http://shared:3333")
-		if got := resolveProxyLabel("shared", "http://shared:3333"); got != "PROXY_URL" {
-			t.Fatalf("expected PROXY_URL, got %q", got)
+	t.Run("returns sanitized shared proxy URL", func(t *testing.T) {
+		t.Setenv("PROXY_URL", "http://user:pass@shared:3333/path?x=1")
+		if got := resolveProxyLabel("shared", "http://user:pass@shared:3333/path?x=1"); got != "http://shared:3333" {
+			t.Fatalf("expected sanitized shared proxy URL, got %q", got)
 		}
 	})
 
@@ -280,6 +280,29 @@ func TestResolveProxyLabel(t *testing.T) {
 		}
 		if got := resolveProxyLabel("unknown", "http://unknown:6666"); got != "configured" {
 			t.Fatalf("expected configured fallback, got %q", got)
+		}
+	})
+}
+
+func TestSanitizeProxyURL(t *testing.T) {
+	t.Run("removes credentials and path query from valid URL", func(t *testing.T) {
+		got := sanitizeProxyURL("http://user:pass@1.1.1.1:8080/path?q=v")
+		if got != "http://1.1.1.1:8080" {
+			t.Fatalf("expected sanitized proxy URL without credentials/path/query, got %q", got)
+		}
+	})
+
+	t.Run("handles URL without credentials", func(t *testing.T) {
+		got := sanitizeProxyURL("http://2.2.2.2:9090")
+		if got != "http://2.2.2.2:9090" {
+			t.Fatalf("expected unchanged host-only URL, got %q", got)
+		}
+	})
+
+	t.Run("handles non URL input by stripping auth section", func(t *testing.T) {
+		got := sanitizeProxyURL("user:pass@3.3.3.3:1234")
+		if got != "3.3.3.3:1234" {
+			t.Fatalf("expected auth section stripped from raw proxy string, got %q", got)
 		}
 	})
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update proxy context formatting so `shared` mode reports the actual shared proxy URL instead of the literal `PROXY_URL`
- sanitize shared proxy URL before logging/error output (strip credentials, path, query, fragment)
- keep dedicated proxies reported as env labels (`DEDICATED_PROXY_1..5`)
- retain existing fallback labels for unmapped values (`shared-configured`, `dedicated-configured`, `configured`)
- add tests covering sanitized shared URL output and URL sanitization helper behavior

## Testing
- `go test ./gateway`
- `go test ./gateway ./gateway/agora ./gateway/binderpos ./controller ./handler` *(external integration failure observed in `gateway/binderpos Test_StorefrontSupportedGamesEndpoint_ExistsForGreyOgreAndMtgAsia` due to live upstream `https://www.mtg-asia.com` returning 500)*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c1eab7b-ee4b-4be4-a5c4-3d34cfe8f5c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c1eab7b-ee4b-4be4-a5c4-3d34cfe8f5c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

