### PR TITLE
Preserve direct retry proxy context labeling

### DIFF
--- a/api/gateway/collector.go
+++ b/api/gateway/collector.go
@@ -185,11 +185,23 @@ func registerRequestHandler(c *colly.Collector, leasedDedicatedProxyURL string, 
 		// Keep gzip only. Go's default client does not transparently decode brotli ("br").
 		r.Headers.Set("Accept-Encoding", "gzip")
 		r.Headers.Set("User-Agent", browserUserAgents[rand.IntN(len(browserUserAgents))])
-		if r.Ctx != nil && r.Ctx.Get("last_proxy_url") == "" {
-			r.Ctx.Put("last_proxy_mode", initialProxyMode)
-			r.Ctx.Put("last_proxy_url", initialProxyURL)
-		}
+		seedProxyContextIfMissing(r.Ctx, initialProxyMode, initialProxyURL)
 	})
+}
+
+func seedProxyContextIfMissing(ctx *colly.Context, initialProxyMode, initialProxyURL string) {
+	if ctx == nil {
+		return
+	}
+
+	// Proxy context is considered initialized once mode exists.
+	// Direct mode intentionally uses an empty proxy URL.
+	if ctx.Get("last_proxy_mode") != "" {
+		return
+	}
+
+	ctx.Put("last_proxy_mode", initialProxyMode)
+	ctx.Put("last_proxy_url", initialProxyURL)
 }
 
 func registerScrapedHandler(c *colly.Collector, releaseDedicatedProxy func()) {

--- a/api/gateway/collector_test.go
+++ b/api/gateway/collector_test.go
@@ -346,3 +346,36 @@ func TestVisitWithProxyInfo(t *testing.T) {
 		t.Fatalf("expected proxy context in error, got %q", err)
 	}
 }
+
+func TestSeedProxyContextIfMissing(t *testing.T) {
+	t.Run("initializes mode and url when missing", func(t *testing.T) {
+		ctx := colly.NewContext()
+		seedProxyContextIfMissing(ctx, "dedicated", "http://proxy:8080")
+
+		if got := ctx.Get("last_proxy_mode"); got != "dedicated" {
+			t.Fatalf("expected dedicated mode, got %q", got)
+		}
+		if got := ctx.Get("last_proxy_url"); got != "http://proxy:8080" {
+			t.Fatalf("expected proxy URL to be seeded, got %q", got)
+		}
+	})
+
+	t.Run("does not overwrite direct context with empty url", func(t *testing.T) {
+		ctx := colly.NewContext()
+		ctx.Put("last_proxy_mode", "direct")
+		ctx.Put("last_proxy_url", "")
+
+		seedProxyContextIfMissing(ctx, "shared", "http://shared:8080")
+
+		if got := ctx.Get("last_proxy_mode"); got != "direct" {
+			t.Fatalf("expected direct mode to remain, got %q", got)
+		}
+		if got := ctx.Get("last_proxy_url"); got != "" {
+			t.Fatalf("expected direct mode proxy URL to stay empty, got %q", got)
+		}
+	})
+
+	t.Run("ignores nil context", func(t *testing.T) {
+		seedProxyContextIfMissing(nil, "dedicated", "http://proxy:8080")
+	})
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix proxy-context seeding so direct retries (which intentionally use an empty proxy URL) are not overwritten back to initial proxy mode
- add regression tests to protect direct-context attribution

## Details
- Updated `registerRequestHandler` in `api/gateway/collector.go` to delegate context initialization to `seedProxyContextIfMissing(...)`.
- Added `seedProxyContextIfMissing(...)` which treats proxy context as initialized when `last_proxy_mode` is set (instead of checking `last_proxy_url`).
- This preserves valid `direct` mode context where `last_proxy_url` is expected to be empty.
- Added `TestSeedProxyContextIfMissing` in `api/gateway/collector_test.go` to verify:
  - initial seed works
  - direct mode is not overwritten
  - nil context is safely ignored

## Validation
- existing gateway unit tests cover the new helper and retry/proxy behavior
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b8ed19a-eadf-4b37-a5b8-49f5ecb9da4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b8ed19a-eadf-4b37-a5b8-49f5ecb9da4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

