### PR TITLE
Add per-domain request pacing with jitter

### DIFF
--- a/api/gateway/binderpos/storefront.go
+++ b/api/gateway/binderpos/storefront.go
@@ -134,7 +134,7 @@ func fetchSuggestProducts(ctx context.Context, client *http.Client, baseURL, sea
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("User-Agent", "mtg-price-checker-sg-storefront-api")
+	req.Header.Set("User-Agent", gateway.RandomBrowserUserAgent())
 	if err := gateway.WaitForDomainRequestSlot(ctx, req.URL); err != nil {
 		return nil, err
 	}
@@ -167,7 +167,7 @@ func fetchProductDetail(ctx context.Context, client *http.Client, baseURL, produ
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("User-Agent", "mtg-price-checker-sg-storefront-api")
+	req.Header.Set("User-Agent", gateway.RandomBrowserUserAgent())
 	if err := gateway.WaitForDomainRequestSlot(ctx, req.URL); err != nil {
 		return nil, err
 	}

--- a/api/gateway/binderpos/storefront.go
+++ b/api/gateway/binderpos/storefront.go
@@ -135,6 +135,9 @@ func fetchSuggestProducts(ctx context.Context, client *http.Client, baseURL, sea
 		return nil, err
 	}
 	req.Header.Set("User-Agent", "mtg-price-checker-sg-storefront-api")
+	if err := gateway.WaitForDomainRequestSlot(ctx, req.URL); err != nil {
+		return nil, err
+	}
 
 	res, err := client.Do(req)
 	if err != nil {
@@ -165,6 +168,9 @@ func fetchProductDetail(ctx context.Context, client *http.Client, baseURL, produ
 		return nil, err
 	}
 	req.Header.Set("User-Agent", "mtg-price-checker-sg-storefront-api")
+	if err := gateway.WaitForDomainRequestSlot(ctx, req.URL); err != nil {
+		return nil, err
+	}
 
 	res, err := client.Do(req)
 	if err != nil {

--- a/api/gateway/collector.go
+++ b/api/gateway/collector.go
@@ -152,10 +152,6 @@ func configureRequestOptimizationsWithDedicatedThreshold(c *colly.Collector, ena
 func applyCollectorDefaults(c *colly.Collector) {
 	c.DisableCookies()
 	c.SetRequestTimeout(config.PerSiteTimeout)
-	c.Limit(&colly.LimitRule{
-		DomainGlob:  "*",
-		RandomDelay: 2 * time.Second, // adds 0-2s jitter between matching-domain requests
-	})
 }
 
 // Dedicated proxy lease lifecycle helpers.
@@ -182,6 +178,14 @@ func leaseDedicatedProxyIfNeeded(enforceDedicatedProxyLease bool) (string, func(
 func registerRequestHandler(c *colly.Collector, leasedDedicatedProxyURL string, dedicatedRetryThreshold, maxRetries int) {
 	initialProxyMode, initialProxyURL := applyProxyForRetryAttemptWithPinnedDedicated(c, 0, "", leasedDedicatedProxyURL, dedicatedRetryThreshold, maxRetries)
 	c.OnRequest(func(r *colly.Request) {
+		if r == nil || r.URL == nil {
+			return
+		}
+		if err := waitForDomainRequestSlot(c.Context, r.URL); err != nil {
+			log.Printf("Skipping request pacing for %s due to context cancellation: %v", r.URL, err)
+			r.Abort()
+			return
+		}
 		// Keep gzip only. Go's default client does not transparently decode brotli ("br").
 		r.Headers.Set("Accept-Encoding", "gzip")
 		r.Headers.Set("User-Agent", browserUserAgents[rand.IntN(len(browserUserAgents))])

--- a/api/gateway/collector.go
+++ b/api/gateway/collector.go
@@ -25,6 +25,13 @@ var browserUserAgents = []string{
 	"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Edg/135.0.3179.98 Chrome/135.0.0.0 Safari/537.36",
 }
 
+func RandomBrowserUserAgent() string {
+	if len(browserUserAgents) == 0 {
+		return "Mozilla/5.0"
+	}
+	return browserUserAgents[rand.IntN(len(browserUserAgents))]
+}
+
 var dedicatedProxyLeases = newDedicatedProxyLeasePool()
 
 const (
@@ -188,7 +195,7 @@ func registerRequestHandler(c *colly.Collector, leasedDedicatedProxyURL string, 
 		}
 		// Keep gzip only. Go's default client does not transparently decode brotli ("br").
 		r.Headers.Set("Accept-Encoding", "gzip")
-		r.Headers.Set("User-Agent", browserUserAgents[rand.IntN(len(browserUserAgents))])
+		r.Headers.Set("User-Agent", RandomBrowserUserAgent())
 		seedProxyContextIfMissing(r.Ctx, initialProxyMode, initialProxyURL)
 	})
 }

--- a/api/gateway/collector_test.go
+++ b/api/gateway/collector_test.go
@@ -379,3 +379,21 @@ func TestSeedProxyContextIfMissing(t *testing.T) {
 		seedProxyContextIfMissing(nil, "dedicated", "http://proxy:8080")
 	})
 }
+
+func TestRandomBrowserUserAgent(t *testing.T) {
+	got := RandomBrowserUserAgent()
+	if strings.TrimSpace(got) == "" {
+		t.Fatalf("expected random browser user-agent to be non-empty")
+	}
+
+	found := false
+	for _, candidate := range browserUserAgents {
+		if got == candidate {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected user-agent to be chosen from browserUserAgents list, got %q", got)
+	}
+}

--- a/api/gateway/domain_rate_limiter.go
+++ b/api/gateway/domain_rate_limiter.go
@@ -1,0 +1,115 @@
+package gateway
+
+import (
+	"context"
+	"math/rand/v2"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	domainRequestMinInterval = 300 * time.Millisecond
+	domainRequestMaxJitter   = 600 * time.Millisecond
+)
+
+var sharedDomainRequestLimiter = newDomainRequestLimiter(domainRequestMinInterval, domainRequestMaxJitter)
+
+type domainRequestLimiter struct {
+	mu          sync.Mutex
+	nextAllowed map[string]time.Time
+	minInterval time.Duration
+	maxJitter   time.Duration
+}
+
+func newDomainRequestLimiter(minInterval, maxJitter time.Duration) *domainRequestLimiter {
+	if minInterval < 0 {
+		minInterval = 0
+	}
+	if maxJitter < 0 {
+		maxJitter = 0
+	}
+
+	return &domainRequestLimiter{
+		nextAllowed: make(map[string]time.Time),
+		minInterval: minInterval,
+		maxJitter:   maxJitter,
+	}
+}
+
+// waitForDomainRequestSlot blocks until the next request for this domain can be made.
+func waitForDomainRequestSlot(ctx context.Context, targetURL *url.URL) error {
+	return sharedDomainRequestLimiter.wait(ctx, targetURL)
+}
+
+// WaitForDomainRequestSlot exposes shared per-domain pacing for non-Colly requests.
+func WaitForDomainRequestSlot(ctx context.Context, targetURL *url.URL) error {
+	return waitForDomainRequestSlot(ctx, targetURL)
+}
+
+func (l *domainRequestLimiter) wait(ctx context.Context, targetURL *url.URL) error {
+	if l == nil || targetURL == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	domain := canonicalDomain(targetURL)
+	if domain == "" {
+		return nil
+	}
+
+	delay, reservedUntil := l.reserveDelay(domain, time.Now())
+	if delay <= 0 {
+		return nil
+	}
+
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		l.rollbackReservation(domain, reservedUntil)
+		return ctx.Err()
+	}
+}
+
+func (l *domainRequestLimiter) reserveDelay(domain string, now time.Time) (time.Duration, time.Time) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	nextAllowed := l.nextAllowed[domain]
+	if nextAllowed.Before(now) {
+		nextAllowed = now
+	}
+
+	jitter := randomDuration(l.maxJitter)
+	reservedUntil := nextAllowed.Add(l.minInterval + jitter)
+	l.nextAllowed[domain] = reservedUntil
+	return nextAllowed.Sub(now), reservedUntil
+}
+
+func (l *domainRequestLimiter) rollbackReservation(domain string, reservedUntil time.Time) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if currentReservation, exists := l.nextAllowed[domain]; exists && currentReservation.Equal(reservedUntil) {
+		l.nextAllowed[domain] = time.Now()
+	}
+}
+
+func canonicalDomain(targetURL *url.URL) string {
+	return strings.ToLower(strings.TrimSpace(targetURL.Hostname()))
+}
+
+func randomDuration(max time.Duration) time.Duration {
+	if max <= 0 {
+		return 0
+	}
+
+	return time.Duration(rand.Int64N(int64(max)))
+}

--- a/api/gateway/domain_rate_limiter_test.go
+++ b/api/gateway/domain_rate_limiter_test.go
@@ -1,0 +1,82 @@
+package gateway
+
+import (
+	"context"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestDomainRequestLimiterWaitSameDomain(t *testing.T) {
+	limiter := newDomainRequestLimiter(40*time.Millisecond, 0)
+	targetURL, err := url.Parse("https://example.com/products")
+	if err != nil {
+		t.Fatalf("failed to parse URL: %v", err)
+	}
+
+	start := time.Now()
+	if err := limiter.wait(context.Background(), targetURL); err != nil {
+		t.Fatalf("first wait returned error: %v", err)
+	}
+	if err := limiter.wait(context.Background(), targetURL); err != nil {
+		t.Fatalf("second wait returned error: %v", err)
+	}
+
+	elapsed := time.Since(start)
+	if elapsed < 35*time.Millisecond {
+		t.Fatalf("expected second request to be delayed, got elapsed=%s", elapsed)
+	}
+}
+
+func TestDomainRequestLimiterWaitDifferentDomains(t *testing.T) {
+	limiter := newDomainRequestLimiter(50*time.Millisecond, 0)
+	firstURL, err := url.Parse("https://example.com/a")
+	if err != nil {
+		t.Fatalf("failed to parse first URL: %v", err)
+	}
+	secondURL, err := url.Parse("https://other.com/b")
+	if err != nil {
+		t.Fatalf("failed to parse second URL: %v", err)
+	}
+
+	start := time.Now()
+	if err := limiter.wait(context.Background(), firstURL); err != nil {
+		t.Fatalf("first wait returned error: %v", err)
+	}
+	if err := limiter.wait(context.Background(), secondURL); err != nil {
+		t.Fatalf("second wait returned error: %v", err)
+	}
+
+	elapsed := time.Since(start)
+	if elapsed >= 35*time.Millisecond {
+		t.Fatalf("expected different domains to avoid throttling delay, got elapsed=%s", elapsed)
+	}
+}
+
+func TestDomainRequestLimiterRollbackOnCancellation(t *testing.T) {
+	limiter := newDomainRequestLimiter(150*time.Millisecond, 0)
+	targetURL, err := url.Parse("https://example.com/items")
+	if err != nil {
+		t.Fatalf("failed to parse URL: %v", err)
+	}
+
+	if err := limiter.wait(context.Background(), targetURL); err != nil {
+		t.Fatalf("first wait returned error: %v", err)
+	}
+
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := limiter.wait(canceledCtx, targetURL); err == nil {
+		t.Fatalf("expected canceled wait to return an error")
+	}
+
+	start := time.Now()
+	if err := limiter.wait(context.Background(), targetURL); err != nil {
+		t.Fatalf("post-cancellation wait returned error: %v", err)
+	}
+	elapsed := time.Since(start)
+
+	if elapsed >= 60*time.Millisecond {
+		t.Fatalf("expected rollback to clear pending reservation, got elapsed=%s", elapsed)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a shared gateway-level per-domain request limiter that spaces outbound requests by a minimum interval plus randomized jitter
- apply the limiter to Colly request flow in `gateway/collector.go` so scraping requests are paced by destination host
- apply the same limiter to BinderPOS storefront API HTTP requests (`fetchSuggestProducts` and `fetchProductDetail`) to reduce burst traffic that can trigger service unavailable responses
- replace fixed BinderPOS storefront `User-Agent` header with randomized browser-like user agents via shared gateway helper (`RandomBrowserUserAgent`)
- add unit tests for limiter behavior: same-domain delay, cross-domain independence, and cancellation rollback
- add unit test to verify randomized user-agent selection comes from the browser user-agent pool

## Testing
- `go test ./gateway`
- `go test ./gateway/binderpos -run TestDoesNotExist`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b56fa3d8-7a4a-4817-894c-90ca876dc6ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b56fa3d8-7a4a-4817-894c-90ca876dc6ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

