### PR TITLE
Adjust BinderPOS search proxy strategy ordering

### DIFF
--- a/api/gateway/binderpos/storefront.go
+++ b/api/gateway/binderpos/storefront.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/rand/v2"
 	"net/http"
 	"net/url"
 	"strings"
@@ -56,8 +57,15 @@ func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, 
 }
 
 func searchByStorefrontAPI(ctx context.Context, scrapVariant int, storeName, baseURL, searchStr string) ([]gateway.Card, error) {
-	client := &http.Client{Timeout: config.PerSiteTimeout}
+	client, ok := newDedicatedProxyHTTPClient()
+	if !ok {
+		return nil, fmt.Errorf("no dedicated proxy configured for binderpos storefront api")
+	}
 
+	return searchByStorefrontAPIWithClient(ctx, client, scrapVariant, storeName, baseURL, searchStr)
+}
+
+func searchByStorefrontAPIWithClient(ctx context.Context, client *http.Client, scrapVariant int, storeName, baseURL, searchStr string) ([]gateway.Card, error) {
 	products, err := fetchSuggestProducts(ctx, client, baseURL, searchStr)
 	if err != nil {
 		return nil, err
@@ -116,6 +124,30 @@ func searchByStorefrontAPI(ctx context.Context, scrapVariant int, storeName, bas
 	}
 
 	return cards, nil
+}
+
+func newDedicatedProxyHTTPClient() (*http.Client, bool) {
+	proxyURLs := util.GetDedicatedProxyURLs()
+	if len(proxyURLs) == 0 {
+		return nil, false
+	}
+
+	proxyURL := strings.TrimSpace(proxyURLs[rand.IntN(len(proxyURLs))])
+	if proxyURL == "" {
+		return nil, false
+	}
+
+	parsedProxyURL, err := url.Parse(proxyURL)
+	if err != nil {
+		return nil, false
+	}
+
+	return &http.Client{
+		Timeout: config.PerSiteTimeout,
+		Transport: &http.Transport{
+			Proxy: http.ProxyURL(parsedProxyURL),
+		},
+	}, true
 }
 
 func fetchSuggestProducts(ctx context.Context, client *http.Client, baseURL, searchStr string) ([]storefrontProduct, error) {

--- a/api/gateway/binderpos/storefront.go
+++ b/api/gateway/binderpos/storefront.go
@@ -48,12 +48,17 @@ func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, 
 		return i.Scrap(ctx, scrapVariant, storeName, baseURL, searchURL, searchStr)
 	}
 
-	cards, err := searchByStorefrontAPI(ctx, scrapVariant, storeName, baseURL, searchStr)
-	if err != nil || len(cards) == 0 {
-		return i.Scrap(ctx, scrapVariant, storeName, baseURL, searchURL, searchStr)
-	}
-
-	return cards, nil
+	return searchWithFallback(
+		func() ([]gateway.Card, error) {
+			return searchByStorefrontAPI(ctx, scrapVariant, storeName, baseURL, searchStr)
+		},
+		func() ([]gateway.Card, error) {
+			return i.Scrap(ctx, scrapVariant, storeName, baseURL, searchURL, searchStr)
+		},
+		func() ([]gateway.Card, error) {
+			return searchByStorefrontAPIDirect(ctx, scrapVariant, storeName, baseURL, searchStr)
+		},
+	)
 }
 
 func searchByStorefrontAPI(ctx context.Context, scrapVariant int, storeName, baseURL, searchStr string) ([]gateway.Card, error) {
@@ -63,6 +68,44 @@ func searchByStorefrontAPI(ctx context.Context, scrapVariant int, storeName, bas
 	}
 
 	return searchByStorefrontAPIWithClient(ctx, client, scrapVariant, storeName, baseURL, searchStr)
+}
+
+func searchByStorefrontAPIDirect(ctx context.Context, scrapVariant int, storeName, baseURL, searchStr string) ([]gateway.Card, error) {
+	client := &http.Client{Timeout: config.PerSiteTimeout}
+	return searchByStorefrontAPIWithClient(ctx, client, scrapVariant, storeName, baseURL, searchStr)
+}
+
+func searchWithFallback(
+	searchAPIDedicatedFn func() ([]gateway.Card, error),
+	scrapDedicatedFn func() ([]gateway.Card, error),
+	searchAPIDirectFn func() ([]gateway.Card, error),
+) ([]gateway.Card, error) {
+	apiDedicatedCards, apiDedicatedErr := searchAPIDedicatedFn()
+	if len(apiDedicatedCards) > 0 && apiDedicatedErr == nil {
+		return apiDedicatedCards, nil
+	}
+
+	scrapedCards, scrapErr := scrapDedicatedFn()
+	if len(scrapedCards) > 0 && scrapErr == nil {
+		return scrapedCards, nil
+	}
+
+	apiDirectCards, apiDirectErr := searchAPIDirectFn()
+	if len(apiDirectCards) > 0 && apiDirectErr == nil {
+		return apiDirectCards, nil
+	}
+
+	if apiDirectErr != nil {
+		return apiDirectCards, apiDirectErr
+	}
+	if scrapErr != nil {
+		return scrapedCards, scrapErr
+	}
+	if apiDedicatedErr != nil {
+		return apiDedicatedCards, apiDedicatedErr
+	}
+
+	return []gateway.Card{}, nil
 }
 
 func searchByStorefrontAPIWithClient(ctx context.Context, client *http.Client, scrapVariant int, storeName, baseURL, searchStr string) ([]gateway.Card, error) {

--- a/api/gateway/binderpos/storefront.go
+++ b/api/gateway/binderpos/storefront.go
@@ -44,10 +44,6 @@ type storefrontProductStock struct {
 }
 
 func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, searchURL, searchStr string) ([]gateway.Card, error) {
-	if !config.UseBinderposStorefrontAPI() {
-		return i.Scrap(ctx, scrapVariant, storeName, baseURL, searchURL, searchStr)
-	}
-
 	return searchWithFallback(
 		func() ([]gateway.Card, error) {
 			return searchByStorefrontAPI(ctx, scrapVariant, storeName, baseURL, searchStr)

--- a/api/gateway/binderpos/storefront_fallback_test.go
+++ b/api/gateway/binderpos/storefront_fallback_test.go
@@ -3,14 +3,16 @@ package binderpos
 import (
 	"errors"
 	"testing"
+
+	"mtg-price-checker-sg/gateway"
 )
 
 func TestSearchWithFallback(t *testing.T) {
 	t.Run("returns dedicated api results first", func(t *testing.T) {
 		cards, err := searchWithFallback(
-			func() ([]cardLike, error) { return []cardLike{{Name: "api-dedicated"}}, nil },
-			func() ([]cardLike, error) { return []cardLike{{Name: "scrap"}}, nil },
-			func() ([]cardLike, error) { return []cardLike{{Name: "api-direct"}}, nil },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-dedicated"}}, nil },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap"}}, nil },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-direct"}}, nil },
 		)
 		if err != nil {
 			t.Fatalf("expected nil error, got %v", err)
@@ -22,9 +24,9 @@ func TestSearchWithFallback(t *testing.T) {
 
 	t.Run("falls back to scraper before direct api", func(t *testing.T) {
 		cards, err := searchWithFallback(
-			func() ([]cardLike, error) { return nil, errors.New("dedicated api failed") },
-			func() ([]cardLike, error) { return []cardLike{{Name: "scrap"}}, nil },
-			func() ([]cardLike, error) { return []cardLike{{Name: "api-direct"}}, nil },
+			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap"}}, nil },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-direct"}}, nil },
 		)
 		if err != nil {
 			t.Fatalf("expected nil error, got %v", err)
@@ -36,9 +38,9 @@ func TestSearchWithFallback(t *testing.T) {
 
 	t.Run("falls back to direct api when dedicated api and scraper fail", func(t *testing.T) {
 		cards, err := searchWithFallback(
-			func() ([]cardLike, error) { return nil, errors.New("dedicated api failed") },
-			func() ([]cardLike, error) { return nil, errors.New("scraper failed") },
-			func() ([]cardLike, error) { return []cardLike{{Name: "api-direct"}}, nil },
+			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
+			func() ([]gateway.Card, error) { return nil, errors.New("scraper failed") },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-direct"}}, nil },
 		)
 		if err != nil {
 			t.Fatalf("expected nil error, got %v", err)
@@ -53,16 +55,12 @@ func TestSearchWithFallback(t *testing.T) {
 		scrapErr := errors.New("scraper failed")
 		directErr := errors.New("direct api failed")
 		_, err := searchWithFallback(
-			func() ([]cardLike, error) { return nil, dedicatedErr },
-			func() ([]cardLike, error) { return nil, scrapErr },
-			func() ([]cardLike, error) { return nil, directErr },
+			func() ([]gateway.Card, error) { return nil, dedicatedErr },
+			func() ([]gateway.Card, error) { return nil, scrapErr },
+			func() ([]gateway.Card, error) { return nil, directErr },
 		)
 		if !errors.Is(err, directErr) {
 			t.Fatalf("expected direct api error, got %v", err)
 		}
 	})
-}
-
-type cardLike struct {
-	Name string
 }

--- a/api/gateway/binderpos/storefront_fallback_test.go
+++ b/api/gateway/binderpos/storefront_fallback_test.go
@@ -1,0 +1,68 @@
+package binderpos
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestSearchWithFallback(t *testing.T) {
+	t.Run("returns dedicated api results first", func(t *testing.T) {
+		cards, err := searchWithFallback(
+			func() ([]cardLike, error) { return []cardLike{{Name: "api-dedicated"}}, nil },
+			func() ([]cardLike, error) { return []cardLike{{Name: "scrap"}}, nil },
+			func() ([]cardLike, error) { return []cardLike{{Name: "api-direct"}}, nil },
+		)
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if len(cards) != 1 || cards[0].Name != "api-dedicated" {
+			t.Fatalf("expected dedicated api card, got %+v", cards)
+		}
+	})
+
+	t.Run("falls back to scraper before direct api", func(t *testing.T) {
+		cards, err := searchWithFallback(
+			func() ([]cardLike, error) { return nil, errors.New("dedicated api failed") },
+			func() ([]cardLike, error) { return []cardLike{{Name: "scrap"}}, nil },
+			func() ([]cardLike, error) { return []cardLike{{Name: "api-direct"}}, nil },
+		)
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if len(cards) != 1 || cards[0].Name != "scrap" {
+			t.Fatalf("expected scraper card, got %+v", cards)
+		}
+	})
+
+	t.Run("falls back to direct api when dedicated api and scraper fail", func(t *testing.T) {
+		cards, err := searchWithFallback(
+			func() ([]cardLike, error) { return nil, errors.New("dedicated api failed") },
+			func() ([]cardLike, error) { return nil, errors.New("scraper failed") },
+			func() ([]cardLike, error) { return []cardLike{{Name: "api-direct"}}, nil },
+		)
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if len(cards) != 1 || cards[0].Name != "api-direct" {
+			t.Fatalf("expected direct api card, got %+v", cards)
+		}
+	})
+
+	t.Run("returns final direct api error when all fail", func(t *testing.T) {
+		dedicatedErr := errors.New("dedicated api failed")
+		scrapErr := errors.New("scraper failed")
+		directErr := errors.New("direct api failed")
+		_, err := searchWithFallback(
+			func() ([]cardLike, error) { return nil, dedicatedErr },
+			func() ([]cardLike, error) { return nil, scrapErr },
+			func() ([]cardLike, error) { return nil, directErr },
+		)
+		if !errors.Is(err, directErr) {
+			t.Fatalf("expected direct api error, got %v", err)
+		}
+	})
+}
+
+type cardLike struct {
+	Name string
+}

--- a/api/gateway/binderpos/storefront_search_test.go
+++ b/api/gateway/binderpos/storefront_search_test.go
@@ -2,8 +2,10 @@ package binderpos
 
 import (
 	"context"
+	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/joho/godotenv"
 	"github.com/stretchr/testify/require"
@@ -22,9 +24,10 @@ type binderposStoreSearchCase struct {
 }
 
 func Test_SearchByStorefrontAPI_SupportsAllBinderposStores(t *testing.T) {
+	client := &http.Client{Timeout: 20 * time.Second}
 	for _, testCase := range binderposStoreSearchCases() {
 		t.Run(testCase.storeName, func(t *testing.T) {
-			cards, err := searchByStorefrontAPI(context.Background(), testCase.scrapVariant, testCase.storeName, testCase.baseURL, testCase.query)
+			cards, err := searchByStorefrontAPIWithClient(context.Background(), client, testCase.scrapVariant, testCase.storeName, testCase.baseURL, testCase.query)
 			require.NoError(t, err)
 			require.NotEmpty(t, cards)
 
@@ -40,9 +43,10 @@ func Test_SearchByStorefrontAPI_SupportsAllBinderposStores(t *testing.T) {
 }
 
 func Test_SearchByStorefrontAPI_OverlapsLegacyScrapeResults(t *testing.T) {
+	client := &http.Client{Timeout: 20 * time.Second}
 	for _, testCase := range binderposStoreSearchCases() {
 		t.Run(testCase.storeName, func(t *testing.T) {
-			storefrontCards, err := searchByStorefrontAPI(context.Background(), testCase.scrapVariant, testCase.storeName, testCase.baseURL, testCase.query)
+			storefrontCards, err := searchByStorefrontAPIWithClient(context.Background(), client, testCase.scrapVariant, testCase.storeName, testCase.baseURL, testCase.query)
 			require.NoError(t, err)
 			require.NotEmpty(t, storefrontCards)
 

--- a/api/gateway/collector.go
+++ b/api/gateway/collector.go
@@ -39,14 +39,14 @@ const (
 	// - first retry (attempt 1): dedicated proxy
 	// - second/final retry (attempt 2): direct (no proxy)
 	defaultMaxRetries = 2
-	// Binderpos also uses two retries after the initial request, but with a different first retry path:
-	// - first retry (attempt 1): shared/dynamic PROXY_URL
-	// - second/final retry (attempt 2): direct (no proxy)
+	// Binderpos also uses two retries after the initial request.
+	// Strategy is selected at runtime:
+	// - default: dedicated -> dedicated -> direct
+	// - optional rollback: dedicated -> shared(PROXY_URL) -> direct
 	binderposMaxRetries = defaultMaxRetries
 	// Dedicated (leased or random pool) is used while retryAttempt <= this value (initial request is attempt 0).
 	// First retry = attempt 1 (still dedicated).
-	dedicatedProxyRetryThreshold          = 1
-	binderposDedicatedProxyRetryThreshold = 0
+	dedicatedProxyRetryThreshold = 1
 	// Keep a small reserve so a retry request can still be dispatched before context cancellation.
 	retryExecutionBuffer = 300 * time.Millisecond
 )
@@ -123,8 +123,16 @@ func NewOptimizedCollectorForBinderpos(ctx context.Context) *colly.Collector {
 	c := colly.NewCollector(
 		colly.StdlibContext(ctx),
 	)
-	configureRequestOptimizationsWithDedicatedThreshold(c, true, true, binderposDedicatedProxyRetryThreshold, binderposMaxRetries)
+	configureRequestOptimizationsWithDedicatedThreshold(c, true, true, binderposDedicatedRetryThreshold(), binderposMaxRetries)
 	return c
+}
+
+func binderposDedicatedRetryThreshold() int {
+	if config.UseBinderposSharedProxyFallback() {
+		// Rollback mode keeps shared proxy on retry attempt 1.
+		return 0
+	}
+	return dedicatedProxyRetryThreshold
 }
 
 func ConfigureRequestOptimizations(c *colly.Collector) {

--- a/api/gateway/collector_test.go
+++ b/api/gateway/collector_test.go
@@ -184,31 +184,60 @@ func TestApplyProxyForRetryAttemptWithPinnedDedicated(t *testing.T) {
 }
 
 func TestApplyProxyForRetryAttemptWithPinnedDedicatedBinderpos(t *testing.T) {
-	c := colly.NewCollector()
-	t.Setenv("DEDICATED_PROXY_1", "9.9.9.9|9000|user|pass")
-	t.Setenv("PROXY_URL", "http://shared:8080")
+	t.Run("default strategy uses dedicated then direct", func(t *testing.T) {
+		c := colly.NewCollector()
+		t.Setenv("DEDICATED_PROXY_1", "9.9.9.9|9000|user|pass")
+		t.Setenv("PROXY_URL", "http://shared:8080")
+		t.Setenv("USE_BINDERPOS_SHARED_PROXY_FALLBACK", "false")
 
-	pinned := "http://pinned:1234"
-	mode, proxyURL := applyProxyForRetryAttemptWithPinnedDedicated(c, 0, "", pinned, binderposDedicatedProxyRetryThreshold, binderposMaxRetries)
-	if mode != "dedicated" || proxyURL != pinned {
-		t.Fatalf("expected dedicated on attempt 0, got mode=%q url=%q", mode, proxyURL)
-	}
+		pinned := "http://pinned:1234"
+		mode, proxyURL := applyProxyForRetryAttemptWithPinnedDedicated(c, 0, "", pinned, binderposDedicatedRetryThreshold(), binderposMaxRetries)
+		if mode != "dedicated" || proxyURL != pinned {
+			t.Fatalf("expected dedicated on attempt 0, got mode=%q url=%q", mode, proxyURL)
+		}
 
-	mode, proxyURL = applyProxyForRetryAttemptWithPinnedDedicated(c, 1, "", pinned, binderposDedicatedProxyRetryThreshold, binderposMaxRetries)
-	if mode != "shared" {
-		t.Fatalf("expected PROXY_URL on attempt 1, got mode %q", mode)
-	}
-	if proxyURL != "http://shared:8080" {
-		t.Fatalf("expected shared proxy url on attempt 1, got %q", proxyURL)
-	}
+		mode, proxyURL = applyProxyForRetryAttemptWithPinnedDedicated(c, 1, "", pinned, binderposDedicatedRetryThreshold(), binderposMaxRetries)
+		if mode != "dedicated" || proxyURL != pinned {
+			t.Fatalf("expected dedicated on attempt 1, got mode=%q url=%q", mode, proxyURL)
+		}
 
-	mode, proxyURL = applyProxyForRetryAttemptWithPinnedDedicated(c, 2, "", pinned, binderposDedicatedProxyRetryThreshold, binderposMaxRetries)
-	if mode != "direct" {
-		t.Fatalf("expected direct mode on final retry attempt 2, got %q", mode)
-	}
-	if proxyURL != "" {
-		t.Fatalf("expected empty proxy url on final retry attempt 2, got %q", proxyURL)
-	}
+		mode, proxyURL = applyProxyForRetryAttemptWithPinnedDedicated(c, 2, "", pinned, binderposDedicatedRetryThreshold(), binderposMaxRetries)
+		if mode != "direct" {
+			t.Fatalf("expected direct mode on final retry attempt 2, got %q", mode)
+		}
+		if proxyURL != "" {
+			t.Fatalf("expected empty proxy url on final retry attempt 2, got %q", proxyURL)
+		}
+	})
+
+	t.Run("rollback strategy uses shared fallback", func(t *testing.T) {
+		c := colly.NewCollector()
+		t.Setenv("DEDICATED_PROXY_1", "9.9.9.9|9000|user|pass")
+		t.Setenv("PROXY_URL", "http://shared:8080")
+		t.Setenv("USE_BINDERPOS_SHARED_PROXY_FALLBACK", "true")
+
+		pinned := "http://pinned:1234"
+		mode, proxyURL := applyProxyForRetryAttemptWithPinnedDedicated(c, 0, "", pinned, binderposDedicatedRetryThreshold(), binderposMaxRetries)
+		if mode != "dedicated" || proxyURL != pinned {
+			t.Fatalf("expected dedicated on attempt 0, got mode=%q url=%q", mode, proxyURL)
+		}
+
+		mode, proxyURL = applyProxyForRetryAttemptWithPinnedDedicated(c, 1, "", pinned, binderposDedicatedRetryThreshold(), binderposMaxRetries)
+		if mode != "shared" {
+			t.Fatalf("expected PROXY_URL on attempt 1, got mode %q", mode)
+		}
+		if proxyURL != "http://shared:8080" {
+			t.Fatalf("expected shared proxy url on attempt 1, got %q", proxyURL)
+		}
+
+		mode, proxyURL = applyProxyForRetryAttemptWithPinnedDedicated(c, 2, "", pinned, binderposDedicatedRetryThreshold(), binderposMaxRetries)
+		if mode != "direct" {
+			t.Fatalf("expected direct mode on final retry attempt 2, got %q", mode)
+		}
+		if proxyURL != "" {
+			t.Fatalf("expected empty proxy url on final retry attempt 2, got %q", proxyURL)
+		}
+	})
 }
 
 func TestDedicatedProxyLeasePoolAcquireRelease(t *testing.T) {

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -18,6 +18,10 @@ const (
 	// UseBinderposStorefrontAPIEnv toggles BinderPOS storefront API search mode.
 	// Default is enabled; set to "false" to force legacy scraping.
 	UseBinderposStorefrontAPIEnv = "USE_BINDERPOS_STOREFRONT_API"
+	// UseBinderposSharedProxyFallbackEnv controls BinderPOS scraper retry path.
+	// Default is disabled to use dedicated proxy and then direct. Set to "true"
+	// to restore the previous dedicated -> shared -> direct behavior.
+	UseBinderposSharedProxyFallbackEnv = "USE_BINDERPOS_SHARED_PROXY_FALLBACK"
 )
 
 func UseBinderposStorefrontAPI() bool {
@@ -29,6 +33,20 @@ func UseBinderposStorefrontAPI() bool {
 	enabled, err := strconv.ParseBool(rawValue)
 	if err != nil {
 		return true
+	}
+
+	return enabled
+}
+
+func UseBinderposSharedProxyFallback() bool {
+	rawValue := strings.TrimSpace(os.Getenv(UseBinderposSharedProxyFallbackEnv))
+	if rawValue == "" {
+		return false
+	}
+
+	enabled, err := strconv.ParseBool(rawValue)
+	if err != nil {
+		return false
 	}
 
 	return enabled


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- enforce a strict BinderPOS search sequence at orchestration level:
  1) search API via dedicated proxy
  2) scraper via dedicated proxy
  3) search API direct (no proxy) as final attempt
- remove the `USE_BINDERPOS_STOREFRONT_API` bypass from BinderPOS `Search`, so first attempt is always API via dedicated proxy
- preserve shared proxy rollback logic for scraper retry behavior via `USE_BINDERPOS_SHARED_PROXY_FALLBACK=true`
- keep focused fallback-order unit tests and proxy strategy unit tests

## Validation
- `go test ./gateway/binderpos -run TestSearchWithFallback -count=1`
- `go test ./gateway -run TestApplyProxyForRetryAttemptWithPinnedDedicatedBinderpos -count=1`

## Notes
- network integration tests may intermittently fail due upstream storefront/API availability (e.g. transient 503).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c6cde77f-b7d1-4c91-aa0e-a9e624449f0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6cde77f-b7d1-4c91-aa0e-a9e624449f0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

