### PR TITLE
Increase binderposMaxConcurrent to 10

### DIFF
--- a/api/controller/search.go
+++ b/api/controller/search.go
@@ -51,7 +51,7 @@ type Card struct {
 	ExtraInfo string  `json:"extraInfo"`
 }
 
-const binderposMaxConcurrent = 5
+const binderposMaxConcurrent = 10
 
 var sendDiscordAlert = alert.SendDiscordAlert
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- increase `binderposMaxConcurrent` from `5` to `10` in `api/controller/search.go`
- allow up to 10 concurrent binderpos-backed store searches

## Testing
- `go test ./controller` (run from `api/`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-25328f4c-d7b8-4804-ba7c-ef7711ec9fa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25328f4c-d7b8-4804-ba7c-ef7711ec9fa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

