### PR TITLE
Enhance BinderPOS search fallback strategy

### DIFF
--- a/api/controller/search.go
+++ b/api/controller/search.go
@@ -51,7 +51,7 @@ type Card struct {
 	ExtraInfo string  `json:"extraInfo"`
 }
 
-const binderposMaxConcurrent = 10
+const binderposMaxConcurrent = 5
 
 var sendDiscordAlert = alert.SendDiscordAlert
 

--- a/api/gateway/binderpos/scrap.go
+++ b/api/gateway/binderpos/scrap.go
@@ -17,19 +17,46 @@ import (
 )
 
 func (i impl) Scrap(ctx context.Context, scrapVariant int, storeName, baseUrl, searchUrl, searchStr string) ([]gateway.Card, error) {
+	return i.scrapWithCollectorFactory(ctx, scrapVariant, storeName, baseUrl, searchUrl, searchStr, gateway.NewOptimizedCollectorForBinderpos)
+}
+
+func (i impl) scrapDedicatedProxy(ctx context.Context, scrapVariant int, storeName, baseUrl, searchUrl, searchStr string) ([]gateway.Card, error) {
+	if !dedicatedProxyConfigured() {
+		return nil, fmt.Errorf("no dedicated proxy configured for binderpos scraper")
+	}
+
+	return i.scrapWithCollectorFactory(ctx, scrapVariant, storeName, baseUrl, searchUrl, searchStr, newDedicatedNoRetryCollector)
+}
+
+func (i impl) scrapWithCollectorFactory(
+	ctx context.Context,
+	scrapVariant int,
+	storeName, baseUrl, searchUrl, searchStr string,
+	collectorFactory func(context.Context) *colly.Collector,
+) ([]gateway.Card, error) {
 	switch scrapVariant {
 	case 1:
-		return scrapVariant1(ctx, storeName, baseUrl, searchUrl, searchStr)
+		return scrapVariant1(ctx, storeName, baseUrl, searchUrl, searchStr, collectorFactory)
 	case 2:
-		return scrapVariant2(ctx, storeName, baseUrl, searchUrl, searchStr)
+		return scrapVariant2(ctx, storeName, baseUrl, searchUrl, searchStr, collectorFactory)
 	case 3:
-		return scrapVariant3(ctx, storeName, baseUrl, searchUrl, searchStr)
+		return scrapVariant3(ctx, storeName, baseUrl, searchUrl, searchStr, collectorFactory)
 	case 4:
-		return scrapVariant4(ctx, storeName, baseUrl, searchUrl, searchStr)
+		return scrapVariant4(ctx, storeName, baseUrl, searchUrl, searchStr, collectorFactory)
 	case 5:
-		return scrapVariant5(ctx, storeName, baseUrl, searchUrl, searchStr)
+		return scrapVariant5(ctx, storeName, baseUrl, searchUrl, searchStr, collectorFactory)
 	}
 	return []gateway.Card{}, fmt.Errorf("invalid scrap variant: %d", scrapVariant)
+}
+
+func newDedicatedNoRetryCollector(ctx context.Context) *colly.Collector {
+	c := gateway.NewOptimizedCollectorNoRetry(ctx)
+	c.SetRequestTimeout(binderposAttemptTimeout)
+	return c
+}
+
+func dedicatedProxyConfigured() bool {
+	return len(util.GetDedicatedProxyURLs()) > 0
 }
 
 // buildSafeSearchURL safely constructs the URL using url.URL and url.Values to isolate user string input.
@@ -65,11 +92,11 @@ func buildSafeSearchURL(baseUrl, searchUrlTemplate, searchStr string) string {
 }
 
 // arcane sanctum
-func scrapVariant5(ctx context.Context, storeName, baseUrl, searchUrl, searchStr string) ([]gateway.Card, error) {
+func scrapVariant5(ctx context.Context, storeName, baseUrl, searchUrl, searchStr string, collectorFactory func(context.Context) *colly.Collector) ([]gateway.Card, error) {
 	searchURL := buildSafeSearchURL(baseUrl, searchUrl, searchStr+" mtg")
 	var cards []gateway.Card
 
-	c := gateway.NewOptimizedCollectorForBinderpos(ctx)
+	c := collectorFactory(ctx)
 
 	c.OnHTML("body", func(e *colly.HTMLElement) {
 		e.ForEach("div.product-grid-container ul.product-grid li", func(_ int, el *colly.HTMLElement) {
@@ -115,11 +142,11 @@ func scrapVariant5(ctx context.Context, storeName, baseUrl, searchUrl, searchStr
 }
 
 // tefuda
-func scrapVariant4(ctx context.Context, storeName, baseUrl, searchUrl, searchStr string) ([]gateway.Card, error) {
+func scrapVariant4(ctx context.Context, storeName, baseUrl, searchUrl, searchStr string, collectorFactory func(context.Context) *colly.Collector) ([]gateway.Card, error) {
 	searchURL := buildSafeSearchURL(baseUrl, searchUrl, searchStr+" mtg")
 	var cards []gateway.Card
 
-	c := gateway.NewOptimizedCollectorForBinderpos(ctx)
+	c := collectorFactory(ctx)
 
 	c.OnHTML("body", func(e *colly.HTMLElement) {
 		e.ForEach("div.product-grid-container ul.product-grid li", func(_ int, el *colly.HTMLElement) {
@@ -169,11 +196,11 @@ type pagination struct {
 // games haven
 // gog
 // hideout
-func scrapVariant3(ctx context.Context, storeName, baseUrl, searchUrl, searchStr string) ([]gateway.Card, error) {
+func scrapVariant3(ctx context.Context, storeName, baseUrl, searchUrl, searchStr string, collectorFactory func(context.Context) *colly.Collector) ([]gateway.Card, error) {
 	var cards []gateway.Card
 	searchURL := buildSafeSearchURL(baseUrl, searchUrl, searchStr+" mtg")
 
-	c := gateway.NewOptimizedCollectorForBinderpos(ctx)
+	c := collectorFactory(ctx)
 
 	c.OnHTML("body", func(e *colly.HTMLElement) {
 		// get cards
@@ -237,11 +264,11 @@ func scrapVariant3(ctx context.Context, storeName, baseUrl, searchUrl, searchStr
 // onemtg
 // manapro
 // mtgasia
-func scrapVariant2(ctx context.Context, storeName, baseUrl, searchUrl, searchStr string) ([]gateway.Card, error) {
+func scrapVariant2(ctx context.Context, storeName, baseUrl, searchUrl, searchStr string, collectorFactory func(context.Context) *colly.Collector) ([]gateway.Card, error) {
 	searchURL := buildSafeSearchURL(baseUrl, searchUrl, searchStr+" mtg")
 	var cards []gateway.Card
 
-	c := gateway.NewOptimizedCollectorForBinderpos(ctx)
+	c := collectorFactory(ctx)
 
 	c.OnHTML("body", func(e *colly.HTMLElement) {
 		e.ForEach("div", func(_ int, el *colly.HTMLElement) {
@@ -296,11 +323,11 @@ func scrapVariant2(ctx context.Context, storeName, baseUrl, searchUrl, searchStr
 }
 
 // cards citadel
-func scrapVariant1(ctx context.Context, storeName, baseUrl, searchUrl, searchStr string) ([]gateway.Card, error) {
+func scrapVariant1(ctx context.Context, storeName, baseUrl, searchUrl, searchStr string, collectorFactory func(context.Context) *colly.Collector) ([]gateway.Card, error) {
 	searchURL := buildSafeSearchURL(baseUrl, searchUrl, searchStr+" mtg")
 	var cards []gateway.Card
 
-	c := gateway.NewOptimizedCollectorForBinderpos(ctx)
+	c := collectorFactory(ctx)
 
 	c.OnHTML("div.container", func(e *colly.HTMLElement) {
 		e.ForEach("div.Norm", func(_ int, el *colly.HTMLElement) {

--- a/api/gateway/binderpos/storefront.go
+++ b/api/gateway/binderpos/storefront.go
@@ -8,14 +8,19 @@ import (
 	"math/rand/v2"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
+	"time"
 
 	"mtg-price-checker-sg/gateway"
 	"mtg-price-checker-sg/gateway/util"
 	"mtg-price-checker-sg/pkg/config"
 )
 
-const storefrontSuggestPath = "/search/suggest.json"
+const (
+	storefrontSuggestPath   = "/search/suggest.json"
+	binderposAttemptTimeout = 4 * time.Second
+)
 
 type storefrontSuggestResponse struct {
 	Resources struct {
@@ -46,15 +51,32 @@ type storefrontProductStock struct {
 func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, searchURL, searchStr string) ([]gateway.Card, error) {
 	return searchWithFallback(
 		func() ([]gateway.Card, error) {
-			return searchByStorefrontAPI(ctx, scrapVariant, storeName, baseURL, searchStr)
+			return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
+				return searchByStorefrontAPI(attemptCtx, scrapVariant, storeName, baseURL, searchStr)
+			})
 		},
 		func() ([]gateway.Card, error) {
-			return i.Scrap(ctx, scrapVariant, storeName, baseURL, searchURL, searchStr)
+			return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
+				return i.scrapDedicatedProxy(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
+			})
 		},
 		func() ([]gateway.Card, error) {
-			return searchByStorefrontAPIDirect(ctx, scrapVariant, storeName, baseURL, searchStr)
+			return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
+				return searchByStorefrontAPISharedProxy(attemptCtx, scrapVariant, storeName, baseURL, searchStr)
+			})
+		},
+		func() ([]gateway.Card, error) {
+			return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
+				return searchByStorefrontAPIDirect(attemptCtx, scrapVariant, storeName, baseURL, searchStr)
+			})
 		},
 	)
+}
+
+func runWithAttemptTimeout(ctx context.Context, fn func(context.Context) ([]gateway.Card, error)) ([]gateway.Card, error) {
+	attemptCtx, cancel := context.WithTimeout(ctx, binderposAttemptTimeout)
+	defer cancel()
+	return fn(attemptCtx)
 }
 
 func searchByStorefrontAPI(ctx context.Context, scrapVariant int, storeName, baseURL, searchStr string) ([]gateway.Card, error) {
@@ -67,13 +89,28 @@ func searchByStorefrontAPI(ctx context.Context, scrapVariant int, storeName, bas
 }
 
 func searchByStorefrontAPIDirect(ctx context.Context, scrapVariant int, storeName, baseURL, searchStr string) ([]gateway.Card, error) {
-	client := &http.Client{Timeout: config.PerSiteTimeout}
+	client := &http.Client{Timeout: binderposAttemptTimeout}
+	return searchByStorefrontAPIWithClient(ctx, client, scrapVariant, storeName, baseURL, searchStr)
+}
+
+func searchByStorefrontAPISharedProxy(ctx context.Context, scrapVariant int, storeName, baseURL, searchStr string) ([]gateway.Card, error) {
+	sharedProxyURL := strings.TrimSpace(os.Getenv("PROXY_URL"))
+	if sharedProxyURL == "" {
+		return nil, fmt.Errorf("no shared proxy configured for binderpos storefront api")
+	}
+
+	client, err := newHTTPClientWithProxyURL(sharedProxyURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid shared proxy configured for binderpos storefront api: %w", err)
+	}
+
 	return searchByStorefrontAPIWithClient(ctx, client, scrapVariant, storeName, baseURL, searchStr)
 }
 
 func searchWithFallback(
 	searchAPIDedicatedFn func() ([]gateway.Card, error),
 	scrapDedicatedFn func() ([]gateway.Card, error),
+	searchAPISharedFn func() ([]gateway.Card, error),
 	searchAPIDirectFn func() ([]gateway.Card, error),
 ) ([]gateway.Card, error) {
 	apiDedicatedCards, apiDedicatedErr := searchAPIDedicatedFn()
@@ -86,6 +123,11 @@ func searchWithFallback(
 		return scrapedCards, nil
 	}
 
+	apiSharedCards, apiSharedErr := searchAPISharedFn()
+	if len(apiSharedCards) > 0 && apiSharedErr == nil {
+		return apiSharedCards, nil
+	}
+
 	apiDirectCards, apiDirectErr := searchAPIDirectFn()
 	if len(apiDirectCards) > 0 && apiDirectErr == nil {
 		return apiDirectCards, nil
@@ -93,6 +135,9 @@ func searchWithFallback(
 
 	if apiDirectErr != nil {
 		return apiDirectCards, apiDirectErr
+	}
+	if apiSharedErr != nil {
+		return apiSharedCards, apiSharedErr
 	}
 	if scrapErr != nil {
 		return scrapedCards, scrapErr
@@ -176,17 +221,26 @@ func newDedicatedProxyHTTPClient() (*http.Client, bool) {
 		return nil, false
 	}
 
-	parsedProxyURL, err := url.Parse(proxyURL)
+	client, err := newHTTPClientWithProxyURL(proxyURL)
 	if err != nil {
 		return nil, false
 	}
 
+	return client, true
+}
+
+func newHTTPClientWithProxyURL(proxyURL string) (*http.Client, error) {
+	parsedProxyURL, err := url.Parse(proxyURL)
+	if err != nil {
+		return nil, err
+	}
+
 	return &http.Client{
-		Timeout: config.PerSiteTimeout,
+		Timeout: binderposAttemptTimeout,
 		Transport: &http.Transport{
 			Proxy: http.ProxyURL(parsedProxyURL),
 		},
-	}, true
+	}, nil
 }
 
 func fetchSuggestProducts(ctx context.Context, client *http.Client, baseURL, searchStr string) ([]storefrontProduct, error) {

--- a/api/gateway/binderpos/storefront_fallback_test.go
+++ b/api/gateway/binderpos/storefront_fallback_test.go
@@ -2,6 +2,7 @@ package binderpos
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"mtg-price-checker-sg/gateway"
@@ -12,6 +13,7 @@ func TestSearchWithFallback(t *testing.T) {
 		cards, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-dedicated"}}, nil },
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap"}}, nil },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-shared"}}, nil },
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-direct"}}, nil },
 		)
 		if err != nil {
@@ -26,6 +28,7 @@ func TestSearchWithFallback(t *testing.T) {
 		cards, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap"}}, nil },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-shared"}}, nil },
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-direct"}}, nil },
 		)
 		if err != nil {
@@ -36,10 +39,26 @@ func TestSearchWithFallback(t *testing.T) {
 		}
 	})
 
-	t.Run("falls back to direct api when dedicated api and scraper fail", func(t *testing.T) {
+	t.Run("falls back to shared api before direct api", func(t *testing.T) {
 		cards, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
 			func() ([]gateway.Card, error) { return nil, errors.New("scraper failed") },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-shared"}}, nil },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-direct"}}, nil },
+		)
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if len(cards) != 1 || cards[0].Name != "api-shared" {
+			t.Fatalf("expected shared api card, got %+v", cards)
+		}
+	})
+
+	t.Run("falls back to direct api when dedicated api, scraper and shared api fail", func(t *testing.T) {
+		cards, err := searchWithFallback(
+			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
+			func() ([]gateway.Card, error) { return nil, errors.New("scraper failed") },
+			func() ([]gateway.Card, error) { return nil, errors.New("shared api failed") },
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-direct"}}, nil },
 		)
 		if err != nil {
@@ -53,14 +72,45 @@ func TestSearchWithFallback(t *testing.T) {
 	t.Run("returns final direct api error when all fail", func(t *testing.T) {
 		dedicatedErr := errors.New("dedicated api failed")
 		scrapErr := errors.New("scraper failed")
+		sharedErr := errors.New("shared api failed")
 		directErr := errors.New("direct api failed")
 		_, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return nil, dedicatedErr },
 			func() ([]gateway.Card, error) { return nil, scrapErr },
+			func() ([]gateway.Card, error) { return nil, sharedErr },
 			func() ([]gateway.Card, error) { return nil, directErr },
 		)
 		if !errors.Is(err, directErr) {
 			t.Fatalf("expected direct api error, got %v", err)
+		}
+	})
+
+	t.Run("runs attempts in the requested order", func(t *testing.T) {
+		sequence := make([]string, 0, 4)
+		fail := func(label string) func() ([]gateway.Card, error) {
+			return func() ([]gateway.Card, error) {
+				sequence = append(sequence, label)
+				return nil, fmt.Errorf("%s failed", label)
+			}
+		}
+
+		_, err := searchWithFallback(
+			fail("api-dedicated"),
+			fail("scrap-dedicated"),
+			fail("api-shared"),
+			fail("direct"),
+		)
+		if err == nil {
+			t.Fatalf("expected fallback chain to return the final error")
+		}
+		expected := []string{"api-dedicated", "scrap-dedicated", "api-shared", "direct"}
+		if len(sequence) != len(expected) {
+			t.Fatalf("expected %d attempts, got %d (%v)", len(expected), len(sequence), sequence)
+		}
+		for i := range expected {
+			if sequence[i] != expected[i] {
+				t.Fatalf("attempt %d: expected %q, got %q", i+1, expected[i], sequence[i])
+			}
 		}
 	})
 }

--- a/api/gateway/binderpos/storefront_proxy_client_test.go
+++ b/api/gateway/binderpos/storefront_proxy_client_test.go
@@ -1,0 +1,77 @@
+package binderpos
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"mtg-price-checker-sg/gateway"
+)
+
+func TestNewHTTPClientWithProxyURL(t *testing.T) {
+	t.Run("returns error for invalid proxy URL", func(t *testing.T) {
+		_, err := newHTTPClientWithProxyURL("://invalid-proxy")
+		if err == nil {
+			t.Fatalf("expected invalid proxy URL to return error")
+		}
+	})
+
+	t.Run("builds client with configured proxy and timeout", func(t *testing.T) {
+		client, err := newHTTPClientWithProxyURL("http://user:pass@10.0.0.1:8080")
+		if err != nil {
+			t.Fatalf("expected valid proxy URL, got error %v", err)
+		}
+		if client.Timeout != binderposAttemptTimeout {
+			t.Fatalf("expected timeout %s, got %s", binderposAttemptTimeout, client.Timeout)
+		}
+
+		transport, ok := client.Transport.(*http.Transport)
+		if !ok {
+			t.Fatalf("expected http.Transport, got %T", client.Transport)
+		}
+		if transport.Proxy == nil {
+			t.Fatalf("expected proxy function to be configured")
+		}
+
+		reqURL, err := url.Parse("https://example.com")
+		if err != nil {
+			t.Fatalf("failed to parse request URL: %v", err)
+		}
+		proxyURL, err := transport.Proxy(&http.Request{URL: reqURL})
+		if err != nil {
+			t.Fatalf("expected proxy function to succeed, got %v", err)
+		}
+		if proxyURL == nil || proxyURL.String() != "http://user:pass@10.0.0.1:8080" {
+			t.Fatalf("unexpected proxy URL: %v", proxyURL)
+		}
+	})
+}
+
+func TestRunWithAttemptTimeout(t *testing.T) {
+	t.Run("returns callback result when callback succeeds", func(t *testing.T) {
+		got, err := runWithAttemptTimeout(context.Background(), func(attemptCtx context.Context) ([]gateway.Card, error) {
+			if _, hasDeadline := attemptCtx.Deadline(); !hasDeadline {
+				t.Fatalf("expected attempt context to have deadline")
+			}
+			return []gateway.Card{{Name: "ok"}}, nil
+		})
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if len(got) != 1 || got[0].Name != "ok" {
+			t.Fatalf("expected ok result, got %+v", got)
+		}
+	})
+
+	t.Run("propagates callback error", func(t *testing.T) {
+		wantErr := errors.New("boom")
+		_, err := runWithAttemptTimeout(context.Background(), func(_ context.Context) ([]gateway.Card, error) {
+			return nil, wantErr
+		})
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("expected %v, got %v", wantErr, err)
+		}
+	})
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- enforce BinderPOS storefront search fallback order as:
  1. storefront API via dedicated proxy
  2. scraper via dedicated proxy
  3. storefront API via shared proxy (`PROXY_URL`)
  4. storefront API direct
- add per-attempt timeout capping to keep each fallback stage bounded (`4s` each)
- keep scraper fallback deterministic for step 2 by using a dedicated-proxy-only, no-retry collector path
- add shared proxy storefront API client construction and validation logic
- reduce BinderPOS shop concurrency gate back to `5`

## Testing
- `go test ./gateway/binderpos -run 'TestSearchWithFallback|TestNewHTTPClientWithProxyURL|TestRunWithAttemptTimeout'`
- `go test ./controller -run TestFetchCardsConcurrently_BinderposGate`

## Notes
- full BinderPOS integration tests are environment-dependent and currently flaky in CI/local due to live upstream availability; this change adds deterministic unit coverage around ordering, timeout behavior, and concurrency gating.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1a3497a-2a6b-4bd5-bfd1-f430d2493b9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1a3497a-2a6b-4bd5-bfd1-f430d2493b9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

