### PR TITLE
Switch BinderPOS final fallback to direct scraper

### DIFF
--- a/api/gateway/binderpos/scrap.go
+++ b/api/gateway/binderpos/scrap.go
@@ -28,6 +28,10 @@ func (i impl) scrapDedicatedProxy(ctx context.Context, scrapVariant int, storeNa
 	return i.scrapWithCollectorFactory(ctx, scrapVariant, storeName, baseUrl, searchUrl, searchStr, newDedicatedNoRetryCollector)
 }
 
+func (i impl) scrapDirect(ctx context.Context, scrapVariant int, storeName, baseUrl, searchUrl, searchStr string) ([]gateway.Card, error) {
+	return i.scrapWithCollectorFactory(ctx, scrapVariant, storeName, baseUrl, searchUrl, searchStr, newDirectNoRetryCollector)
+}
+
 func (i impl) scrapWithCollectorFactory(
 	ctx context.Context,
 	scrapVariant int,
@@ -52,6 +56,13 @@ func (i impl) scrapWithCollectorFactory(
 func newDedicatedNoRetryCollector(ctx context.Context) *colly.Collector {
 	c := gateway.NewOptimizedCollectorNoRetry(ctx)
 	c.SetRequestTimeout(binderposAttemptTimeout)
+	return c
+}
+
+func newDirectNoRetryCollector(ctx context.Context) *colly.Collector {
+	c := gateway.NewOptimizedCollectorNoRetry(ctx)
+	c.SetRequestTimeout(binderposAttemptTimeout)
+	c.SetProxyFunc(nil)
 	return c
 }
 

--- a/api/gateway/binderpos/storefront.go
+++ b/api/gateway/binderpos/storefront.go
@@ -114,21 +114,25 @@ func searchWithFallback(
 	scrapDirectFn func() ([]gateway.Card, error),
 ) ([]gateway.Card, error) {
 	apiDedicatedCards, apiDedicatedErr := searchAPIDedicatedFn()
+	apiDedicatedErr = annotateAttemptError(1, "api-dedicated", apiDedicatedErr)
 	if len(apiDedicatedCards) > 0 && apiDedicatedErr == nil {
 		return apiDedicatedCards, nil
 	}
 
 	scrapedCards, scrapErr := scrapDedicatedFn()
+	scrapErr = annotateAttemptError(2, "scrap-dedicated", scrapErr)
 	if len(scrapedCards) > 0 && scrapErr == nil {
 		return scrapedCards, nil
 	}
 
 	apiSharedCards, apiSharedErr := searchAPISharedFn()
+	apiSharedErr = annotateAttemptError(3, "api-shared", apiSharedErr)
 	if len(apiSharedCards) > 0 && apiSharedErr == nil {
 		return apiSharedCards, nil
 	}
 
 	scrapedDirectCards, scrapDirectErr := scrapDirectFn()
+	scrapDirectErr = annotateAttemptError(4, "scrap-direct", scrapDirectErr)
 	if len(scrapedDirectCards) > 0 && scrapDirectErr == nil {
 		return scrapedDirectCards, nil
 	}
@@ -147,6 +151,13 @@ func searchWithFallback(
 	}
 
 	return []gateway.Card{}, nil
+}
+
+func annotateAttemptError(attempt int, strategy string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("attempt %d (%s): %w", attempt, strategy, err)
 }
 
 func searchByStorefrontAPIWithClient(ctx context.Context, client *http.Client, scrapVariant int, storeName, baseURL, searchStr string) ([]gateway.Card, error) {

--- a/api/gateway/binderpos/storefront.go
+++ b/api/gateway/binderpos/storefront.go
@@ -67,7 +67,7 @@ func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, 
 		},
 		func() ([]gateway.Card, error) {
 			return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
-				return searchByStorefrontAPIDirect(attemptCtx, scrapVariant, storeName, baseURL, searchStr)
+				return i.scrapDirect(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
 			})
 		},
 	)
@@ -111,7 +111,7 @@ func searchWithFallback(
 	searchAPIDedicatedFn func() ([]gateway.Card, error),
 	scrapDedicatedFn func() ([]gateway.Card, error),
 	searchAPISharedFn func() ([]gateway.Card, error),
-	searchAPIDirectFn func() ([]gateway.Card, error),
+	scrapDirectFn func() ([]gateway.Card, error),
 ) ([]gateway.Card, error) {
 	apiDedicatedCards, apiDedicatedErr := searchAPIDedicatedFn()
 	if len(apiDedicatedCards) > 0 && apiDedicatedErr == nil {
@@ -128,13 +128,13 @@ func searchWithFallback(
 		return apiSharedCards, nil
 	}
 
-	apiDirectCards, apiDirectErr := searchAPIDirectFn()
-	if len(apiDirectCards) > 0 && apiDirectErr == nil {
-		return apiDirectCards, nil
+	scrapedDirectCards, scrapDirectErr := scrapDirectFn()
+	if len(scrapedDirectCards) > 0 && scrapDirectErr == nil {
+		return scrapedDirectCards, nil
 	}
 
-	if apiDirectErr != nil {
-		return apiDirectCards, apiDirectErr
+	if scrapDirectErr != nil {
+		return scrapedDirectCards, scrapDirectErr
 	}
 	if apiSharedErr != nil {
 		return apiSharedCards, apiSharedErr

--- a/api/gateway/binderpos/storefront_fallback_test.go
+++ b/api/gateway/binderpos/storefront_fallback_test.go
@@ -54,26 +54,26 @@ func TestSearchWithFallback(t *testing.T) {
 		}
 	})
 
-	t.Run("falls back to direct api when dedicated api, scraper and shared api fail", func(t *testing.T) {
+	t.Run("falls back to direct scraper when dedicated api, scraper and shared api fail", func(t *testing.T) {
 		cards, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
 			func() ([]gateway.Card, error) { return nil, errors.New("scraper failed") },
 			func() ([]gateway.Card, error) { return nil, errors.New("shared api failed") },
-			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-direct"}}, nil },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-direct"}}, nil },
 		)
 		if err != nil {
 			t.Fatalf("expected nil error, got %v", err)
 		}
-		if len(cards) != 1 || cards[0].Name != "api-direct" {
-			t.Fatalf("expected direct api card, got %+v", cards)
+		if len(cards) != 1 || cards[0].Name != "scrap-direct" {
+			t.Fatalf("expected direct scraper card, got %+v", cards)
 		}
 	})
 
-	t.Run("returns final direct api error when all fail", func(t *testing.T) {
+	t.Run("returns final direct scraper error when all fail", func(t *testing.T) {
 		dedicatedErr := errors.New("dedicated api failed")
 		scrapErr := errors.New("scraper failed")
 		sharedErr := errors.New("shared api failed")
-		directErr := errors.New("direct api failed")
+		directErr := errors.New("direct scraper failed")
 		_, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return nil, dedicatedErr },
 			func() ([]gateway.Card, error) { return nil, scrapErr },
@@ -81,7 +81,7 @@ func TestSearchWithFallback(t *testing.T) {
 			func() ([]gateway.Card, error) { return nil, directErr },
 		)
 		if !errors.Is(err, directErr) {
-			t.Fatalf("expected direct api error, got %v", err)
+			t.Fatalf("expected direct scraper error, got %v", err)
 		}
 	})
 
@@ -98,12 +98,12 @@ func TestSearchWithFallback(t *testing.T) {
 			fail("api-dedicated"),
 			fail("scrap-dedicated"),
 			fail("api-shared"),
-			fail("direct"),
+			fail("scrap-direct"),
 		)
 		if err == nil {
 			t.Fatalf("expected fallback chain to return the final error")
 		}
-		expected := []string{"api-dedicated", "scrap-dedicated", "api-shared", "direct"}
+		expected := []string{"api-dedicated", "scrap-dedicated", "api-shared", "scrap-direct"}
 		if len(sequence) != len(expected) {
 			t.Fatalf("expected %d attempts, got %d (%v)", len(expected), len(sequence), sequence)
 		}

--- a/api/gateway/binderpos/storefront_fallback_test.go
+++ b/api/gateway/binderpos/storefront_fallback_test.go
@@ -83,6 +83,10 @@ func TestSearchWithFallback(t *testing.T) {
 		if !errors.Is(err, directErr) {
 			t.Fatalf("expected direct scraper error, got %v", err)
 		}
+		expectedError := "attempt 4 (scrap-direct): direct scraper failed"
+		if err == nil || err.Error() != expectedError {
+			t.Fatalf("expected final error %q, got %v", expectedError, err)
+		}
 	})
 
 	t.Run("runs attempts in the requested order", func(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- change BinderPOS storefront fallback chain so the last attempt uses direct scraper instead of direct storefront API
- add a direct no-retry collector helper that explicitly runs without proxy
- annotate fallback errors with attempt number and strategy so failures include context like `attempt 4 (scrap-direct): ...`
- update fallback tests to assert the new final attempt behavior, ordering, and error message format

## Testing
- `go test ./gateway/binderpos -run TestSearchWithFallback`
- `go test ./gateway/binderpos/...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73f092c8-f647-41a9-8274-0cfff52678bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73f092c8-f647-41a9-8274-0cfff52678bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

