### PR TITLE
Clean up collated search error summary format

### DIFF
--- a/api/controller/search.go
+++ b/api/controller/search.go
@@ -166,12 +166,52 @@ func formatDiscordErrorSummary(searchString string, errorMessages []string) stri
 	sortedMessages := append([]string(nil), errorMessages...)
 	sort.Strings(sortedMessages)
 
+	formattedLines := make([]string, 0, len(sortedMessages))
+	for _, message := range sortedMessages {
+		shopName, details, ok := parseSearchErrorMessage(message, searchString)
+		if ok {
+			formattedLines = append(formattedLines, fmt.Sprintf("- [%s] %s", shopName, details))
+			continue
+		}
+
+		formattedLines = append(formattedLines, fmt.Sprintf("- %s", message))
+	}
+
 	return fmt.Sprintf(
 		"Encountered %d error(s) while searching [%s]:\n%s",
 		len(sortedMessages),
 		searchString,
-		strings.Join(sortedMessages, "\n"),
+		strings.Join(formattedLines, "\n"),
 	)
+}
+
+func parseSearchErrorMessage(message, searchString string) (shopName, details string, ok bool) {
+	const prefix = "Error encountered searching ["
+	if !strings.HasPrefix(message, prefix) {
+		return "", "", false
+	}
+
+	withoutPrefix := strings.TrimPrefix(message, prefix)
+	const shopSuffix = "] for ["
+	shopSuffixIndex := strings.Index(withoutPrefix, shopSuffix)
+	if shopSuffixIndex == -1 {
+		return "", "", false
+	}
+
+	shopName = withoutPrefix[:shopSuffixIndex]
+	withoutShop := withoutPrefix[shopSuffixIndex+len(shopSuffix):]
+
+	searchSuffix := fmt.Sprintf("%s]: ", searchString)
+	if !strings.HasPrefix(withoutShop, searchSuffix) {
+		return "", "", false
+	}
+
+	details = strings.TrimPrefix(withoutShop, searchSuffix)
+	if strings.TrimSpace(details) == "" {
+		return "", "", false
+	}
+
+	return shopName, details, true
 }
 
 func filterAndSortCards(cards []gateway.Card, searchString string, shopNameToHasResultMap map[string]bool) []Card {

--- a/api/controller/search_test.go
+++ b/api/controller/search_test.go
@@ -409,13 +409,34 @@ func TestFetchCardsConcurrently_CollatesDiscordErrors(t *testing.T) {
 	if !strings.Contains(got, "Encountered 3 error(s) while searching [Abrade]:") {
 		t.Fatalf("expected collated summary header, got: %s", got)
 	}
-	if !strings.Contains(got, "Error encountered searching [ErrorShopA] for [Abrade]: shop A failed") {
+	if !strings.Contains(got, "- [ErrorShopA] shop A failed") {
 		t.Fatalf("expected ErrorShopA details in alert, got: %s", got)
 	}
-	if !strings.Contains(got, "Error encountered searching [ErrorShopB] for [Abrade]: shop B failed") {
+	if !strings.Contains(got, "- [ErrorShopB] shop B failed") {
 		t.Fatalf("expected ErrorShopB details in alert, got: %s", got)
 	}
-	if !strings.Contains(got, "Recovered from panic in shop [PanicShop]: shop panic") {
+	if !strings.Contains(got, "- Recovered from panic in shop [PanicShop]: shop panic") {
 		t.Fatalf("expected PanicShop details in alert, got: %s", got)
+	}
+}
+
+func TestFormatDiscordErrorSummary(t *testing.T) {
+	got := formatDiscordErrorSummary("Uro, Titan of Nature's Wrath", []string{
+		"Error encountered searching [Tefuda] for [Uro, Titan of Nature's Wrath]: attempt 4 (scrap-direct): Service Unavailable (proxy_mode=dedicated proxy=DEDICATED_PROXY_5)",
+		"Error encountered searching [Arcane Sanctum] for [Uro, Titan of Nature's Wrath]: attempt 4 (scrap-direct): Service Unavailable (proxy_mode=dedicated proxy=DEDICATED_PROXY_2)",
+		"Recovered from panic in shop [ShopPanic]: panic value",
+	})
+
+	if !strings.Contains(got, "Encountered 3 error(s) while searching [Uro, Titan of Nature's Wrath]:") {
+		t.Fatalf("expected summary header, got: %s", got)
+	}
+	if !strings.Contains(got, "- [Arcane Sanctum] attempt 4 (scrap-direct): Service Unavailable (proxy_mode=dedicated proxy=DEDICATED_PROXY_2)") {
+		t.Fatalf("expected Arcane Sanctum concise line, got: %s", got)
+	}
+	if !strings.Contains(got, "- [Tefuda] attempt 4 (scrap-direct): Service Unavailable (proxy_mode=dedicated proxy=DEDICATED_PROXY_5)") {
+		t.Fatalf("expected Tefuda concise line, got: %s", got)
+	}
+	if !strings.Contains(got, "- Recovered from panic in shop [ShopPanic]: panic value") {
+		t.Fatalf("expected fallback line for non-search error, got: %s", got)
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- clean up collated Discord error summaries to avoid repeating the full `Error encountered searching ... for ...` prefix on every line
- render search failures as concise bullet lines in the form `- [<shop>] <error details>` while keeping non-search errors intact
- add coverage for the new summary format using realistic sample errors

## Testing
- `go test ./controller` (run from `/workspace/api`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da246cf8-1637-4f7d-8fb6-92f0fd958ab2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da246cf8-1637-4f7d-8fb6-92f0fd958ab2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

