### PR TITLE
Reduce BinderPOS storefront suggestion limit to 8

### DIFF
--- a/api/gateway/binderpos/storefront.go
+++ b/api/gateway/binderpos/storefront.go
@@ -263,7 +263,7 @@ func fetchSuggestProducts(ctx context.Context, client *http.Client, baseURL, sea
 	query := suggestURL.Query()
 	query.Set("q", strings.TrimSpace(searchStr+" mtg"))
 	query.Set("resources[type]", "product")
-	query.Set("resources[limit]", "20")
+	query.Set("resources[limit]", "8")
 	suggestURL.RawQuery = query.Encode()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, suggestURL.String(), nil)

--- a/api/gateway/binderpos/storefront.go
+++ b/api/gateway/binderpos/storefront.go
@@ -264,6 +264,7 @@ func fetchSuggestProducts(ctx context.Context, client *http.Client, baseURL, sea
 	query.Set("q", strings.TrimSpace(searchStr+" mtg"))
 	query.Set("resources[type]", "product")
 	query.Set("resources[limit]", "8")
+	query.Set("resources[options][unavailable_products]", "hide")
 	suggestURL.RawQuery = query.Encode()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, suggestURL.String(), nil)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- reduce BinderPOS storefront suggest query `resources[limit]` from `20` to `8`
- include `resources[options][unavailable_products]=hide` in BinderPOS suggest requests so sold-out products are excluded from suggestions
- reduce per-store request fan-out for BinderPOS API search attempts

## Validation
- `go test -mod=vendor ./gateway/binderpos -run 'TestSearchWithFallback|TestNewHTTPClientWithProxyURL|TestRunWithAttemptTimeout'`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23e85e12-2086-4b86-a355-a3198bf49433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23e85e12-2086-4b86-a355-a3198bf49433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

