### PR TITLE
Add store-level errors array to search API response

### DIFF
--- a/api/controller/search.go
+++ b/api/controller/search.go
@@ -51,20 +51,25 @@ type Card struct {
 	ExtraInfo string  `json:"extraInfo"`
 }
 
+type StoreError struct {
+	Store string `json:"store"`
+	Error string `json:"error"`
+}
+
 const binderposMaxConcurrent = 10
 
 var sendDiscordAlert = alert.SendDiscordAlert
 
-func Search(ctx context.Context, input SearchInput) ([]Card, error) {
+func Search(ctx context.Context, input SearchInput) ([]Card, []StoreError, error) {
 	shopNameToLGSMap := initAndMapShops(input.Lgs)
 	return searchShops(ctx, input, shopNameToLGSMap)
 }
 
-func searchShops(ctx context.Context, input SearchInput, shopNameToLGSMap map[string]gateway.LGS) ([]Card, error) {
+func searchShops(ctx context.Context, input SearchInput, shopNameToLGSMap map[string]gateway.LGS) ([]Card, []StoreError, error) {
 	shopNameToHasResultMap := initShopHasResultMap(shopNameToLGSMap)
 
 	if len(shopNameToLGSMap) == 0 {
-		return nil, nil
+		return nil, []StoreError{}, nil
 	}
 
 	realStart := time.Now()
@@ -90,7 +95,7 @@ func searchShops(ctx context.Context, input SearchInput, shopNameToLGSMap map[st
 		log.Printf("Sleeping for [%s]", sleepDuration)
 	}
 
-	return inStockCards, nil
+	return inStockCards, buildStoreErrors(siteErrors), nil
 }
 
 func fetchCardsConcurrently(ctx context.Context, searchString string, shops map[string]gateway.LGS) ([]gateway.Card, map[string]error) {
@@ -183,6 +188,36 @@ func formatDiscordErrorSummary(searchString string, errorMessages []string) stri
 		searchString,
 		strings.Join(formattedLines, "\n"),
 	)
+}
+
+func buildStoreErrors(siteErrors map[string]error) []StoreError {
+	if len(siteErrors) == 0 {
+		return []StoreError{}
+	}
+
+	storeNames := make([]string, 0, len(siteErrors))
+	for storeName := range siteErrors {
+		storeNames = append(storeNames, storeName)
+	}
+	sort.Strings(storeNames)
+
+	storeErrors := make([]StoreError, 0, len(storeNames))
+	for _, storeName := range storeNames {
+		err := siteErrors[storeName]
+		if err == nil {
+			continue
+		}
+		storeErrors = append(storeErrors, StoreError{
+			Store: storeName,
+			Error: err.Error(),
+		})
+	}
+
+	if len(storeErrors) == 0 {
+		return []StoreError{}
+	}
+
+	return storeErrors
 }
 
 func parseSearchErrorMessage(message, searchString string) (shopName, details string, ok bool) {

--- a/api/controller/search_test.go
+++ b/api/controller/search_test.go
@@ -274,9 +274,12 @@ func TestSearchShops(t *testing.T) {
 				}
 			}
 
-			results, err := searchShops(context.Background(), tt.input, mockMap)
+			results, storeErrors, err := searchShops(context.Background(), tt.input, mockMap)
 			if err != nil {
 				t.Fatalf("searchShops returned unexpected error: %v", err)
+			}
+			if len(storeErrors) != 0 {
+				t.Fatalf("expected no store errors, got %d", len(storeErrors))
 			}
 
 			if len(results) != tt.expectedCount {
@@ -287,6 +290,40 @@ func TestSearchShops(t *testing.T) {
 				tt.verifyFunc(t, results)
 			}
 		})
+	}
+}
+
+func TestSearchShops_IncludesStoreErrors(t *testing.T) {
+	shops := map[string]gateway.LGS{
+		"Failing Shop": &MockLGS{
+			SearchFunc: func(ctx context.Context, searchStr string) ([]gateway.Card, error) {
+				return nil, fmt.Errorf("simulated failure")
+			},
+		},
+		"Good Shop": &MockLGS{
+			SearchFunc: func(ctx context.Context, searchStr string) ([]gateway.Card, error) {
+				return []gateway.Card{
+					{Name: searchStr, Price: 1.0, InStock: true, Source: "Good Shop"},
+				}, nil
+			},
+		},
+	}
+
+	results, storeErrors, err := searchShops(context.Background(), SearchInput{SearchString: "Card A"}, shops)
+	if err != nil {
+		t.Fatalf("searchShops returned unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result card, got %d", len(results))
+	}
+	if len(storeErrors) != 1 {
+		t.Fatalf("expected 1 store error, got %d", len(storeErrors))
+	}
+	if storeErrors[0].Store != "Failing Shop" {
+		t.Fatalf("expected store error for 'Failing Shop', got %q", storeErrors[0].Store)
+	}
+	if storeErrors[0].Error != "simulated failure" {
+		t.Fatalf("expected 'simulated failure', got %q", storeErrors[0].Error)
 	}
 }
 

--- a/api/handler/search.go
+++ b/api/handler/search.go
@@ -17,7 +17,8 @@ import (
 )
 
 type WebResponse struct {
-	Data []controller.Card `json:"data"`
+	Data   []controller.Card       `json:"data"`
+	Errors []controller.StoreError `json:"errors"`
 }
 
 var searchFunc = controller.Search
@@ -60,7 +61,7 @@ func Search(ctx context.Context, request events.APIGatewayProxyRequest) (events.
 		lgs = strings.Split(lgsString, ",")
 	}
 
-	inStockCards, err := searchFunc(ctx, controller.SearchInput{
+	inStockCards, storeErrors, err := searchFunc(ctx, controller.SearchInput{
 		SearchString: searchString,
 		Lgs:          lgs,
 	})
@@ -72,6 +73,11 @@ func Search(ctx context.Context, request events.APIGatewayProxyRequest) (events.
 
 	apiRes.StatusCode = http.StatusOK
 	webRes.Data = inStockCards
+	if storeErrors == nil {
+		webRes.Errors = []controller.StoreError{}
+	} else {
+		webRes.Errors = storeErrors
+	}
 
 	return lambdaApiResponse(apiRes, webRes, origin)
 }

--- a/api/handler/search_test.go
+++ b/api/handler/search_test.go
@@ -19,9 +19,11 @@ func Test_Search_Success(t *testing.T) {
 	type args struct {
 		givenAPIGatewayProxyRequest events.APIGatewayProxyRequest
 		mockSearchResponse          []controller.Card
+		mockStoreErrors             []controller.StoreError
 		mockSearchErr               error
 		expStatusCode               int
 		expBodyData                 []controller.Card
+		expBodyErrors               []controller.StoreError
 	}
 	tcs := map[string]args{
 		"success with results": {
@@ -39,6 +41,7 @@ func Test_Search_Success(t *testing.T) {
 			expBodyData: []controller.Card{
 				{Name: "Abrade", Price: 1.5, Source: "Flagship Games", InStock: true},
 			},
+			expBodyErrors: []controller.StoreError{},
 		},
 		"success, no results": {
 			givenAPIGatewayProxyRequest: events.APIGatewayProxyRequest{
@@ -51,6 +54,29 @@ func Test_Search_Success(t *testing.T) {
 			mockSearchErr:      nil,
 			expStatusCode:      http.StatusOK,
 			expBodyData:        nil, // key: "data": null
+			expBodyErrors:      []controller.StoreError{},
+		},
+		"success with store errors": {
+			givenAPIGatewayProxyRequest: events.APIGatewayProxyRequest{
+				QueryStringParameters: map[string]string{
+					"s":   "abrade",
+					"lgs": "Flagship%20Games",
+				},
+			},
+			mockSearchResponse: []controller.Card{
+				{Name: "Abrade", Price: 1.5, Source: "Flagship Games", InStock: true},
+			},
+			mockStoreErrors: []controller.StoreError{
+				{Store: "Flagship Games", Error: "timeout"},
+			},
+			mockSearchErr: nil,
+			expStatusCode: http.StatusOK,
+			expBodyData: []controller.Card{
+				{Name: "Abrade", Price: 1.5, Source: "Flagship Games", InStock: true},
+			},
+			expBodyErrors: []controller.StoreError{
+				{Store: "Flagship Games", Error: "timeout"},
+			},
 		},
 	}
 	for s, tc := range tcs {
@@ -58,8 +84,8 @@ func Test_Search_Success(t *testing.T) {
 			// Setup Mock
 			originalSearchFunc := searchFunc
 			defer func() { searchFunc = originalSearchFunc }()
-			searchFunc = func(_ context.Context, input controller.SearchInput) ([]controller.Card, error) {
-				return tc.mockSearchResponse, tc.mockSearchErr
+			searchFunc = func(_ context.Context, input controller.SearchInput) ([]controller.Card, []controller.StoreError, error) {
+				return tc.mockSearchResponse, tc.mockStoreErrors, tc.mockSearchErr
 			}
 
 			err := os.Setenv("ENV", config.EnvStaging)
@@ -74,6 +100,7 @@ func Test_Search_Success(t *testing.T) {
 			err = json.Unmarshal([]byte(result.Body), &webRes)
 			require.NoError(t, err)
 			require.Equal(t, tc.expBodyData, webRes.Data)
+			require.Equal(t, tc.expBodyErrors, webRes.Errors)
 		})
 	}
 }
@@ -82,8 +109,8 @@ func Test_Search_CORS(t *testing.T) {
 	// Setup Mock
 	originalSearchFunc := searchFunc
 	defer func() { searchFunc = originalSearchFunc }()
-	searchFunc = func(_ context.Context, input controller.SearchInput) ([]controller.Card, error) {
-		return []controller.Card{}, nil
+	searchFunc = func(_ context.Context, input controller.SearchInput) ([]controller.Card, []controller.StoreError, error) {
+		return []controller.Card{}, []controller.StoreError{}, nil
 	}
 
 	err := os.Setenv("ENV", config.EnvStaging)
@@ -164,8 +191,8 @@ func Test_Search_Err(t *testing.T) {
 			// Setup Mock
 			originalSearchFunc := searchFunc
 			defer func() { searchFunc = originalSearchFunc }()
-			searchFunc = func(_ context.Context, input controller.SearchInput) ([]controller.Card, error) {
-				return tc.mockSearchResponse, tc.mockSearchErr
+			searchFunc = func(_ context.Context, input controller.SearchInput) ([]controller.Card, []controller.StoreError, error) {
+				return tc.mockSearchResponse, nil, tc.mockSearchErr
 			}
 
 			err := os.Setenv("ENV", config.EnvStaging)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a `StoreError` contract in the controller with `store` and `error` fields
- return store-level errors from the search controller alongside cards
- include an always-present `errors` array in the search Lambda response payload (`[]` when none)
- update handler and controller tests to cover empty/non-empty store error cases

## API Contract
Successful search responses now include:

```json
{
  "data": [...],
  "errors": [
    { "store": "<store-name>", "error": "<error-message>" }
  ]
}
```

When no store-level failures occur:

```json
{
  "data": [...],
  "errors": []
}
```

## Notes
- no frontend rendering changes are included in this PR
- error responses (non-200) remain unchanged
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc4f6617-5520-4f89-bdbc-73d84d9f22c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc4f6617-5520-4f89-bdbc-73d84d9f22c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

