### PR TITLE
Harden BinderPOS storefront search requests to reduce bot-like 503s

### DIFF
--- a/api/gateway/binderpos/storefront.go
+++ b/api/gateway/binderpos/storefront.go
@@ -3,10 +3,13 @@ package binderpos
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand/v2"
+	"net"
 	"net/http"
+	"net/http/cookiejar"
 	"net/url"
 	"os"
 	"strings"
@@ -20,6 +23,14 @@ import (
 const (
 	storefrontSuggestPath   = "/search/suggest.json"
 	binderposAttemptTimeout = 4 * time.Second
+	storefrontMaxRetries    = 2
+
+	storefrontRetryBaseDelay = 120 * time.Millisecond
+	storefrontRetryJitter    = 180 * time.Millisecond
+	storefrontRetryDelayCap  = 700 * time.Millisecond
+
+	storefrontDetailPauseBase   = 20 * time.Millisecond
+	storefrontDetailPauseJitter = 45 * time.Millisecond
 )
 
 type storefrontSuggestResponse struct {
@@ -46,6 +57,12 @@ type storefrontProductStock struct {
 	Title     string `json:"title"`
 	Available bool   `json:"available"`
 	Price     int    `json:"price"`
+}
+
+type storefrontRequestProfile struct {
+	userAgent      string
+	acceptLanguage string
+	referer        string
 }
 
 func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, searchURL, searchStr string) ([]gateway.Card, error) {
@@ -161,7 +178,11 @@ func annotateAttemptError(attempt int, strategy string, err error) error {
 }
 
 func searchByStorefrontAPIWithClient(ctx context.Context, client *http.Client, scrapVariant int, storeName, baseURL, searchStr string) ([]gateway.Card, error) {
-	products, err := fetchSuggestProducts(ctx, client, baseURL, searchStr)
+	requestProfile := newStorefrontRequestProfile(baseURL)
+	client = withStorefrontCookieJar(client)
+	_ = warmUpStorefrontSession(ctx, client, requestProfile, baseURL)
+
+	products, err := fetchSuggestProducts(ctx, client, requestProfile, baseURL, searchStr)
 	if err != nil {
 		return nil, err
 	}
@@ -171,13 +192,19 @@ func searchByStorefrontAPIWithClient(ctx context.Context, client *http.Client, s
 
 	cards := make([]gateway.Card, 0, len(products)*4)
 	seen := map[string]struct{}{}
-	for _, product := range products {
+	for idx, product := range products {
 		productURL := product.URL
 		if productURL == "" {
 			continue
 		}
 
-		detail, err := fetchProductDetail(ctx, client, baseURL, productURL)
+		if idx > 0 {
+			if err := pauseStorefrontDetailRequests(ctx); err != nil {
+				break
+			}
+		}
+
+		detail, err := fetchProductDetail(ctx, client, requestProfile, baseURL, productURL)
 		if err != nil {
 			continue
 		}
@@ -254,7 +281,112 @@ func newHTTPClientWithProxyURL(proxyURL string) (*http.Client, error) {
 	}, nil
 }
 
-func fetchSuggestProducts(ctx context.Context, client *http.Client, baseURL, searchStr string) ([]storefrontProduct, error) {
+func newStorefrontRequestProfile(baseURL string) storefrontRequestProfile {
+	acceptLanguageOptions := []string{
+		"en-SG,en;q=0.9,en-US;q=0.8",
+		"en-US,en;q=0.9",
+		"en-GB,en;q=0.9,en-US;q=0.8",
+	}
+
+	return storefrontRequestProfile{
+		userAgent:      gateway.RandomBrowserUserAgent(),
+		acceptLanguage: acceptLanguageOptions[rand.IntN(len(acceptLanguageOptions))],
+		referer:        normalizeStorefrontReferer(baseURL),
+	}
+}
+
+func withStorefrontCookieJar(client *http.Client) *http.Client {
+	if client == nil {
+		jar, _ := cookiejar.New(nil)
+		return &http.Client{
+			Timeout: binderposAttemptTimeout,
+			Jar:     jar,
+		}
+	}
+	if client.Jar != nil {
+		return client
+	}
+
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return client
+	}
+
+	cloned := *client
+	cloned.Jar = jar
+	return &cloned
+}
+
+func normalizeStorefrontReferer(baseURL string) string {
+	parsedBaseURL, err := url.Parse(baseURL)
+	if err != nil {
+		return strings.TrimSpace(baseURL)
+	}
+
+	parsedBaseURL.RawQuery = ""
+	parsedBaseURL.Fragment = ""
+	if parsedBaseURL.Path == "" {
+		parsedBaseURL.Path = "/"
+	}
+
+	return parsedBaseURL.String()
+}
+
+func resolveStorefrontProductPageURL(baseURL, productPath string) string {
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		return normalizeStorefrontReferer(baseURL)
+	}
+	pathURL, err := url.Parse(productPath)
+	if err != nil {
+		return normalizeStorefrontReferer(baseURL)
+	}
+
+	resolved := base.ResolveReference(pathURL)
+	resolved.RawQuery = ""
+	resolved.Fragment = ""
+	return resolved.String()
+}
+
+func pauseStorefrontDetailRequests(ctx context.Context) error {
+	wait := storefrontDetailPauseBase + time.Duration(rand.Int64N(int64(storefrontDetailPauseJitter)+1))
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func warmUpStorefrontSession(ctx context.Context, client *http.Client, profile storefrontRequestProfile, baseURL string) error {
+	homeURL := normalizeStorefrontReferer(baseURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, homeURL, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", profile.userAgent)
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8")
+	req.Header.Set("Accept-Language", profile.acceptLanguage)
+	req.Header.Set("Cache-Control", "no-cache")
+	req.Header.Set("Pragma", "no-cache")
+	if err := gateway.WaitForDomainRequestSlot(ctx, req.URL); err != nil {
+		return err
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(res.Body, 2048))
+
+	return nil
+}
+
+func fetchSuggestProducts(ctx context.Context, client *http.Client, profile storefrontRequestProfile, baseURL, searchStr string) ([]storefrontProduct, error) {
 	suggestURL, err := url.Parse(baseURL + storefrontSuggestPath)
 	if err != nil {
 		return nil, err
@@ -267,23 +399,20 @@ func fetchSuggestProducts(ctx context.Context, client *http.Client, baseURL, sea
 	query.Set("resources[options][unavailable_products]", "hide")
 	suggestURL.RawQuery = query.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, suggestURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("User-Agent", gateway.RandomBrowserUserAgent())
-	if err := gateway.WaitForDomainRequestSlot(ctx, req.URL); err != nil {
-		return nil, err
-	}
-
-	res, err := client.Do(req)
+	profile.referer = normalizeStorefrontReferer(baseURL)
+	res, err := doStorefrontGETWithRetry(ctx, client, suggestURL.String(), profile)
 	if err != nil {
 		return nil, err
 	}
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("storefront suggest request returned status %d", res.StatusCode)
+		body, _ := io.ReadAll(io.LimitReader(res.Body, 1024))
+		return nil, fmt.Errorf(
+			"storefront suggest request returned status %d body=%s",
+			res.StatusCode,
+			strings.TrimSpace(string(body)),
+		)
 	}
 
 	var payload storefrontSuggestResponse
@@ -294,22 +423,14 @@ func fetchSuggestProducts(ctx context.Context, client *http.Client, baseURL, sea
 	return payload.Resources.Results.Products, nil
 }
 
-func fetchProductDetail(ctx context.Context, client *http.Client, baseURL, productPath string) (*storefrontProductDetail, error) {
+func fetchProductDetail(ctx context.Context, client *http.Client, profile storefrontRequestProfile, baseURL, productPath string) (*storefrontProductDetail, error) {
 	productJSONURL, err := productPathToJSONURL(baseURL, productPath)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, productJSONURL, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("User-Agent", gateway.RandomBrowserUserAgent())
-	if err := gateway.WaitForDomainRequestSlot(ctx, req.URL); err != nil {
-		return nil, err
-	}
-
-	res, err := client.Do(req)
+	profile.referer = resolveStorefrontProductPageURL(baseURL, productPath)
+	res, err := doStorefrontGETWithRetry(ctx, client, productJSONURL, profile)
 	if err != nil {
 		return nil, err
 	}
@@ -326,6 +447,114 @@ func fetchProductDetail(ctx context.Context, client *http.Client, baseURL, produ
 	}
 
 	return &detail, nil
+}
+
+func doStorefrontGETWithRetry(ctx context.Context, client *http.Client, requestURL string, profile storefrontRequestProfile) (*http.Response, error) {
+	var lastErr error
+
+	for attempt := 0; attempt <= storefrontMaxRetries; attempt++ {
+		if attempt > 0 {
+			if err := waitStorefrontRetryDelay(ctx, attempt); err != nil {
+				return nil, err
+			}
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		applyStorefrontHeaders(req, profile)
+
+		if err := gateway.WaitForDomainRequestSlot(ctx, req.URL); err != nil {
+			return nil, err
+		}
+
+		res, err := client.Do(req)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			if attempt >= storefrontMaxRetries || !shouldRetryStorefrontTransportError(err) {
+				return nil, err
+			}
+			lastErr = err
+			continue
+		}
+
+		if shouldRetryStorefrontStatus(res.StatusCode) && attempt < storefrontMaxRetries {
+			io.Copy(io.Discard, res.Body)
+			res.Body.Close()
+			lastErr = fmt.Errorf("transient storefront status %d", res.StatusCode)
+			continue
+		}
+
+		return res, nil
+	}
+
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, fmt.Errorf("storefront request failed after retries")
+}
+
+func applyStorefrontHeaders(req *http.Request, profile storefrontRequestProfile) {
+	req.Header.Set("User-Agent", profile.userAgent)
+	req.Header.Set("Accept", "application/json, text/javascript, */*; q=0.01")
+	req.Header.Set("Accept-Language", profile.acceptLanguage)
+	req.Header.Set("Cache-Control", "no-cache")
+	req.Header.Set("Pragma", "no-cache")
+	req.Header.Set("X-Requested-With", "XMLHttpRequest")
+	if profile.referer != "" {
+		req.Header.Set("Referer", profile.referer)
+	}
+	if req.URL != nil {
+		req.Header.Set("Origin", req.URL.Scheme+"://"+req.URL.Host)
+	}
+}
+
+func shouldRetryStorefrontStatus(statusCode int) bool {
+	switch statusCode {
+	case http.StatusTooManyRequests, http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout, 520, 521, 522, 524:
+		return true
+	default:
+		return false
+	}
+}
+
+func shouldRetryStorefrontTransportError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	var networkErr net.Error
+	if errors.As(err, &networkErr) {
+		return true
+	}
+	return true
+}
+
+func waitStorefrontRetryDelay(ctx context.Context, attempt int) error {
+	if attempt <= 0 {
+		return nil
+	}
+
+	wait := storefrontRetryBaseDelay*time.Duration(attempt) + time.Duration(rand.Int64N(int64(storefrontRetryJitter)+1))
+	if wait > storefrontRetryDelayCap {
+		wait = storefrontRetryDelayCap
+	}
+
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func productPathToJSONURL(baseURL, productPath string) (string, error) {

--- a/api/gateway/binderpos/storefront_proxy_client_test.go
+++ b/api/gateway/binderpos/storefront_proxy_client_test.go
@@ -3,8 +3,11 @@ package binderpos
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
+	"sync/atomic"
 	"testing"
 
 	"mtg-price-checker-sg/gateway"
@@ -74,4 +77,92 @@ func TestRunWithAttemptTimeout(t *testing.T) {
 			t.Fatalf("expected %v, got %v", wantErr, err)
 		}
 	})
+}
+
+func TestDoStorefrontGETWithRetry_RetriesTransientStatusThenSucceeds(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		curr := attempts.Add(1)
+		if curr < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = io.WriteString(w, "temporary unavailable")
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	}))
+	defer server.Close()
+
+	client := &http.Client{Timeout: binderposAttemptTimeout}
+	profile := newStorefrontRequestProfile(server.URL)
+
+	resp, err := doStorefrontGETWithRetry(context.Background(), client, server.URL, profile)
+	if err != nil {
+		t.Fatalf("expected retry to eventually succeed, got error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200 after retries, got %d", resp.StatusCode)
+	}
+	if got := attempts.Load(); got != 3 {
+		t.Fatalf("expected 3 attempts, got %d", got)
+	}
+}
+
+func TestDoStorefrontGETWithRetry_NoRetryForBadRequest(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, "bad request")
+	}))
+	defer server.Close()
+
+	client := &http.Client{Timeout: binderposAttemptTimeout}
+	profile := newStorefrontRequestProfile(server.URL)
+
+	resp, err := doStorefrontGETWithRetry(context.Background(), client, server.URL, profile)
+	if err != nil {
+		t.Fatalf("expected non-retryable status to return response without transport error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", resp.StatusCode)
+	}
+	if got := attempts.Load(); got != 1 {
+		t.Fatalf("expected exactly one attempt for 400 status, got %d", got)
+	}
+}
+
+func TestApplyStorefrontHeaders_UsesBrowserLikeDefaults(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "https://example.com/search/suggest.json?q=test", nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	profile := storefrontRequestProfile{
+		userAgent:      "Mozilla/5.0 test-agent",
+		acceptLanguage: "en-SG,en;q=0.9",
+		referer:        "https://example.com/",
+	}
+
+	applyStorefrontHeaders(req, profile)
+
+	if req.Header.Get("User-Agent") != profile.userAgent {
+		t.Fatalf("unexpected User-Agent header: %s", req.Header.Get("User-Agent"))
+	}
+	if req.Header.Get("Accept-Language") != profile.acceptLanguage {
+		t.Fatalf("unexpected Accept-Language header: %s", req.Header.Get("Accept-Language"))
+	}
+	if req.Header.Get("Referer") != profile.referer {
+		t.Fatalf("unexpected Referer header: %s", req.Header.Get("Referer"))
+	}
+	if req.Header.Get("X-Requested-With") != "XMLHttpRequest" {
+		t.Fatalf("expected X-Requested-With header to mimic xhr requests")
+	}
+	if req.Header.Get("Origin") != "https://example.com" {
+		t.Fatalf("unexpected Origin header: %s", req.Header.Get("Origin"))
+	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- harden BinderPOS storefront API traffic to look more browser-like and less bot-like
- add transient retry behavior for Shopify/BinderPOS error statuses (including 503)
- add focused unit tests for retry behavior and request header shaping

## Changes
- introduced a per-search `storefrontRequestProfile` so suggest + detail requests reuse a consistent browser identity
  - consistent randomized browser User-Agent
  - realistic `Accept-Language`
  - per-request `Referer`/`Origin`
- added cookie persistence by cloning clients with a cookie jar when missing
- added a lightweight session warm-up request to the store root before suggest API calls
- added bounded jittered pauses between product detail requests to avoid bursty request signatures
- added `doStorefrontGETWithRetry` with retry-on-transient-status and transport-error handling
  - retries on 429/500/502/503/504 and common Cloudflare transient statuses
  - does not retry on non-transient statuses like 400
- preserved existing fallback chain behavior (API dedicated -> scrape dedicated -> API shared -> scrape direct)

## Validation
- `go test ./gateway/binderpos -run 'Test(NewHTTPClientWithProxyURL|RunWithAttemptTimeout|DoStorefrontGETWithRetry|ApplyStorefrontHeaders|SearchWithFallback)'`

## Notes
- full BinderPOS package tests include external integration-style cases that are network-dependent; targeted deterministic tests were used for code-path verification.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42b110f3-66a0-4c8f-8cbd-29cd93cc6f44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42b110f3-66a0-4c8f-8cbd-29cd93cc6f44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

