### PR TITLE
Revert storefront anti-bot header fingerprinting for BinderPOS

### DIFF
--- a/api/gateway/binderpos/storefront.go
+++ b/api/gateway/binderpos/storefront.go
@@ -12,6 +12,7 @@ import (
 	"net/http/cookiejar"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -31,7 +32,12 @@ const (
 
 	storefrontDetailPauseBase   = 20 * time.Millisecond
 	storefrontDetailPauseJitter = 45 * time.Millisecond
+
+	storefrontErrorBodyReadLimit = 1024
+	storefrontErrorBodyMaxLen    = 220
 )
+
+var storefrontHTMLTitlePattern = regexp.MustCompile(`(?is)<title[^>]*>(.*?)</title>`)
 
 type storefrontSuggestResponse struct {
 	Resources struct {
@@ -407,12 +413,7 @@ func fetchSuggestProducts(ctx context.Context, client *http.Client, profile stor
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(res.Body, 1024))
-		return nil, fmt.Errorf(
-			"storefront suggest request returned status %d body=%s",
-			res.StatusCode,
-			strings.TrimSpace(string(body)),
-		)
+		return nil, storefrontStatusError(res, "storefront suggest request")
 	}
 
 	var payload storefrontSuggestResponse
@@ -437,8 +438,7 @@ func fetchProductDetail(ctx context.Context, client *http.Client, profile storef
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(res.Body)
-		return nil, fmt.Errorf("product detail request failed status=%d body=%s", res.StatusCode, strings.TrimSpace(string(body)))
+		return nil, storefrontStatusError(res, "product detail request")
 	}
 
 	var detail storefrontProductDetail
@@ -481,7 +481,7 @@ func doStorefrontGETWithRetry(ctx context.Context, client *http.Client, requestU
 			continue
 		}
 
-		if shouldRetryStorefrontStatus(res.StatusCode) && attempt < storefrontMaxRetries {
+		if shouldRetryStorefrontResponse(res) && attempt < storefrontMaxRetries {
 			io.Copy(io.Discard, res.Body)
 			res.Body.Close()
 			lastErr = fmt.Errorf("transient storefront status %d", res.StatusCode)
@@ -497,18 +497,32 @@ func doStorefrontGETWithRetry(ctx context.Context, client *http.Client, requestU
 	return nil, fmt.Errorf("storefront request failed after retries")
 }
 
+func shouldRetryStorefrontResponse(res *http.Response) bool {
+	if res == nil {
+		return false
+	}
+	if !shouldRetryStorefrontStatus(res.StatusCode) {
+		return false
+	}
+
+	// HTML 429s from bot-protection pages are not solved by immediate retries.
+	if res.StatusCode == http.StatusTooManyRequests {
+		if looksLikeHTMLResponse("", res.Header.Get("Content-Type")) {
+			return false
+		}
+	}
+
+	return true
+}
+
 func applyStorefrontHeaders(req *http.Request, profile storefrontRequestProfile) {
 	req.Header.Set("User-Agent", profile.userAgent)
 	req.Header.Set("Accept", "application/json, text/javascript, */*; q=0.01")
-	req.Header.Set("Accept-Language", profile.acceptLanguage)
-	req.Header.Set("Cache-Control", "no-cache")
-	req.Header.Set("Pragma", "no-cache")
-	req.Header.Set("X-Requested-With", "XMLHttpRequest")
+	if profile.acceptLanguage != "" {
+		req.Header.Set("Accept-Language", profile.acceptLanguage)
+	}
 	if profile.referer != "" {
 		req.Header.Set("Referer", profile.referer)
-	}
-	if req.URL != nil {
-		req.Header.Set("Origin", req.URL.Scheme+"://"+req.URL.Host)
 	}
 }
 
@@ -555,6 +569,63 @@ func waitStorefrontRetryDelay(ctx context.Context, attempt int) error {
 	case <-timer.C:
 		return nil
 	}
+}
+
+func storefrontStatusError(res *http.Response, requestName string) error {
+	body, _ := io.ReadAll(io.LimitReader(res.Body, storefrontErrorBodyReadLimit))
+	bodySummary := summarizeStorefrontErrorBody(body, res.Header.Get("Content-Type"))
+	retryAfter := strings.TrimSpace(res.Header.Get("Retry-After"))
+	if retryAfter != "" {
+		return fmt.Errorf("%s returned status %d retry_after=%s body=%s", requestName, res.StatusCode, retryAfter, bodySummary)
+	}
+
+	return fmt.Errorf("%s returned status %d body=%s", requestName, res.StatusCode, bodySummary)
+}
+
+func summarizeStorefrontErrorBody(body []byte, contentType string) string {
+	trimmed := strings.TrimSpace(string(body))
+	if trimmed == "" {
+		return "<empty>"
+	}
+
+	collapsed := strings.Join(strings.Fields(trimmed), " ")
+	if looksLikeHTMLResponse(collapsed, contentType) {
+		if title := extractHTMLTitle(collapsed); title != "" {
+			return fmt.Sprintf("<html response title=%q>", truncateString(title, storefrontErrorBodyMaxLen))
+		}
+		return "<html response>"
+	}
+
+	return truncateString(collapsed, storefrontErrorBodyMaxLen)
+}
+
+func looksLikeHTMLResponse(body, contentType string) bool {
+	lowerContentType := strings.ToLower(contentType)
+	if strings.Contains(lowerContentType, "text/html") || strings.Contains(lowerContentType, "application/xhtml+xml") {
+		return true
+	}
+
+	lowerBody := strings.ToLower(body)
+	return strings.Contains(lowerBody, "<!doctype html") || strings.Contains(lowerBody, "<html")
+}
+
+func extractHTMLTitle(body string) string {
+	matches := storefrontHTMLTitlePattern.FindStringSubmatch(body)
+	if len(matches) < 2 {
+		return ""
+	}
+
+	return strings.Join(strings.Fields(strings.TrimSpace(matches[1])), " ")
+}
+
+func truncateString(value string, maxLen int) string {
+	if maxLen <= 0 || len(value) <= maxLen {
+		return value
+	}
+	if maxLen <= 3 {
+		return value[:maxLen]
+	}
+	return value[:maxLen-3] + "..."
 }
 
 func productPathToJSONURL(baseURL, productPath string) (string, error) {

--- a/api/gateway/binderpos/storefront_proxy_client_test.go
+++ b/api/gateway/binderpos/storefront_proxy_client_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -137,6 +138,33 @@ func TestDoStorefrontGETWithRetry_NoRetryForBadRequest(t *testing.T) {
 	}
 }
 
+func TestDoStorefrontGETWithRetry_DoesNotRetryCloudflareHTMLChallenge429(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, `<!DOCTYPE html><html><head><title>Verifying your connection...</title></head><body>challenge</body></html>`)
+	}))
+	defer server.Close()
+
+	client := &http.Client{Timeout: binderposAttemptTimeout}
+	profile := newStorefrontRequestProfile(server.URL)
+
+	resp, err := doStorefrontGETWithRetry(context.Background(), client, server.URL, profile)
+	if err != nil {
+		t.Fatalf("expected status response without transport error, got %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("expected status 429, got %d", resp.StatusCode)
+	}
+	if got := attempts.Load(); got != 1 {
+		t.Fatalf("expected exactly one attempt for html challenge 429, got %d", got)
+	}
+}
+
 func TestApplyStorefrontHeaders_UsesBrowserLikeDefaults(t *testing.T) {
 	req, err := http.NewRequest(http.MethodGet, "https://example.com/search/suggest.json?q=test", nil)
 	if err != nil {
@@ -159,10 +187,37 @@ func TestApplyStorefrontHeaders_UsesBrowserLikeDefaults(t *testing.T) {
 	if req.Header.Get("Referer") != profile.referer {
 		t.Fatalf("unexpected Referer header: %s", req.Header.Get("Referer"))
 	}
-	if req.Header.Get("X-Requested-With") != "XMLHttpRequest" {
-		t.Fatalf("expected X-Requested-With header to mimic xhr requests")
+	if req.Header.Get("X-Requested-With") != "" {
+		t.Fatalf("did not expect X-Requested-With header, got %s", req.Header.Get("X-Requested-With"))
 	}
-	if req.Header.Get("Origin") != "https://example.com" {
-		t.Fatalf("unexpected Origin header: %s", req.Header.Get("Origin"))
+	if req.Header.Get("Origin") != "" {
+		t.Fatalf("did not expect Origin header, got %s", req.Header.Get("Origin"))
+	}
+}
+
+func TestSummarizeStorefrontErrorBody_HandlesHTMLChallengePages(t *testing.T) {
+	body := []byte(`<!DOCTYPE html>
+<html lang="en">
+<head>
+<title>Verifying your connection...</title>
+</head>
+<body>challenge</body>
+</html>`)
+
+	got := summarizeStorefrontErrorBody(body, "text/html; charset=utf-8")
+	want := `<html response title="Verifying your connection...">`
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestSummarizeStorefrontErrorBody_TruncatesPlaintext(t *testing.T) {
+	veryLong := strings.Repeat("x", storefrontErrorBodyMaxLen+20)
+	got := summarizeStorefrontErrorBody([]byte(veryLong), "text/plain")
+	if len(got) != storefrontErrorBodyMaxLen {
+		t.Fatalf("expected truncated length %d, got %d", storefrontErrorBodyMaxLen, len(got))
+	}
+	if !strings.HasSuffix(got, "...") {
+		t.Fatalf("expected truncated summary to end with ellipsis, got %q", got)
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove synthetic request headers from BinderPOS storefront API requests (`X-Requested-With`, forced `Origin`, and explicit cache-control headers)
- keep browser-like essentials only (`User-Agent`, `Accept`, optional `Accept-Language`, and `Referer`) to reduce bot-protection challenges
- sanitize non-200 storefront response bodies so Discord/log errors no longer include raw HTML challenge pages
- include `Retry-After` in error summaries when present
- avoid retrying HTML 429 challenge responses so fallback strategies run sooner instead of repeating blocked calls

## Testing
- `go test ./gateway/binderpos -run 'Test(DoStorefrontGETWithRetry|SummarizeStorefrontErrorBody|ApplyStorefrontHeaders)'`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-57dbee43-e872-4148-b6ba-de26380b5490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57dbee43-e872-4148-b6ba-de26380b5490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

