### PR TITLE
Add persistent dark mode toggle

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useCallback, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useState } from "react";
 import "./index.css";
 
 import Footer from "./components/Footer";
@@ -16,6 +16,8 @@ import { BASE_URL, LGS_MAP, LGS_OPTIONS, MIN_SEARCH_LENGTH } from "./constants";
 // --- Hooks ---
 import useCart from "./hooks/useCart";
 import useSearch from "./hooks/useSearch";
+
+const THEME_STORAGE_KEY = "gishathfetch-theme";
 
 export default function App() {
   const {
@@ -51,6 +53,37 @@ export default function App() {
   } = useSearch();
 
   const [modalType, setModalType] = useState(null);
+  const [theme, setTheme] = useState(() => {
+    if (typeof window === "undefined") {
+      return "light";
+    }
+
+    try {
+      const savedTheme = localStorage.getItem(THEME_STORAGE_KEY);
+      if (savedTheme === "light" || savedTheme === "dark") {
+        return savedTheme;
+      }
+    } catch {
+      // Ignore storage access issues and fall back to system preference.
+    }
+
+    return window.matchMedia?.("(prefers-color-scheme: dark)").matches
+      ? "dark"
+      : "light";
+  });
+
+  useEffect(() => {
+    document.documentElement.setAttribute("data-bs-theme", theme);
+    try {
+      localStorage.setItem(THEME_STORAGE_KEY, theme);
+    } catch {
+      // Ignore storage access issues and keep in-memory theme state only.
+    }
+  }, [theme]);
+
+  const handleThemeToggle = useCallback(() => {
+    setTheme((currentTheme) => (currentTheme === "dark" ? "light" : "dark"));
+  }, []);
 
   // --- Handlers ---
   const handleCardSearch = useCallback(
@@ -86,7 +119,7 @@ export default function App() {
   // --- Main Render ---
   return (
     <div id="top" className="container-xl my-3 px-3 pb-3">
-      <Header />
+      <Header theme={theme} onToggleTheme={handleThemeToggle} />
 
       <SearchForm
         searchQuery={searchQuery}

--- a/frontend/src/components/AdComponent.jsx
+++ b/frontend/src/components/AdComponent.jsx
@@ -51,7 +51,11 @@ const AdComponent = ({ variant = "leaderboard" }) => {
       if (cancelled) return;
       if (hasFilledAd()) setCollapsed(false);
     });
-    observer.observe(insEl, { childList: true, subtree: true, attributes: true });
+    observer.observe(insEl, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+    });
 
     return () => {
       cancelled = true;

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,5 +1,3 @@
-import { Moon, Sun } from "react-feather";
-
 const Header = ({ theme, onToggleTheme }) => {
   const isDarkMode = theme === "dark";
 
@@ -9,13 +7,15 @@ const Header = ({ theme, onToggleTheme }) => {
         <div className="position-absolute top-0 end-0">
           <button
             type="button"
-            className="btn btn-sm btn-outline-secondary d-inline-flex align-items-center gap-2"
+            className="btn btn-sm btn-outline-secondary theme-toggle-btn"
             onClick={onToggleTheme}
             aria-label={`Switch to ${isDarkMode ? "light" : "dark"} mode`}
             title={`Switch to ${isDarkMode ? "light" : "dark"} mode`}
+            aria-pressed={isDarkMode}
           >
-            {isDarkMode ? <Sun size={14} /> : <Moon size={14} />}
-            <span>{isDarkMode ? "Light" : "Dark"} mode</span>
+            <span className="theme-toggle-icon" aria-hidden="true">
+              💡
+            </span>
           </button>
         </div>
         <div>

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,7 +1,23 @@
-const Header = () => {
+import { Moon, Sun } from "react-feather";
+
+const Header = ({ theme, onToggleTheme }) => {
+  const isDarkMode = theme === "dark";
+
   return (
     <div className="mb-3 text-center">
-      <div className="d-flex flex-row align-items-center justify-content-center mb-1">
+      <div className="d-flex flex-row align-items-center justify-content-center mb-1 position-relative">
+        <div className="position-absolute top-0 end-0">
+          <button
+            type="button"
+            className="btn btn-sm btn-outline-secondary d-inline-flex align-items-center gap-2"
+            onClick={onToggleTheme}
+            aria-label={`Switch to ${isDarkMode ? "light" : "dark"} mode`}
+            title={`Switch to ${isDarkMode ? "light" : "dark"} mode`}
+          >
+            {isDarkMode ? <Sun size={14} /> : <Moon size={14} />}
+            <span>{isDarkMode ? "Light" : "Dark"} mode</span>
+          </button>
+        </div>
         <div>
           <a href="/">
             <img

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -14,6 +14,12 @@
 
 body {
   font-family: "Barlow", serif;
+  background-color: var(--bs-body-bg);
+  color: var(--bs-body-color);
+}
+
+#root {
+  min-height: 100vh;
 }
 
 #logo {
@@ -69,7 +75,7 @@ body {
 }
 
 #suggestions {
-  border: 1px solid #dee2e6;
+  border: 1px solid var(--bs-border-color);
   border-radius: 5px;
   display: none;
   margin-top: 5px;
@@ -77,7 +83,7 @@ body {
   overflow-y: scroll;
   position: absolute;
   z-index: 2;
-  background: #fff;
+  background: var(--bs-body-bg);
   width: 100%;
 }
 
@@ -87,11 +93,11 @@ body {
 }
 
 #suggestions div:nth-child(even) {
-  background-color: #fbfbfb;
+  background-color: color-mix(in srgb, var(--bs-body-bg) 92%, var(--bs-body-color) 8%);
 }
 
 #suggestions div:not(:last-child) {
-  border-bottom: 1px solid #f3f3f3;
+  border-bottom: 1px solid var(--bs-border-color-translucent);
 }
 
 #suggestions div.suggestion-item:hover,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -93,7 +93,11 @@ body {
 }
 
 #suggestions div:nth-child(even) {
-  background-color: color-mix(in srgb, var(--bs-body-bg) 92%, var(--bs-body-color) 8%);
+  background-color: color-mix(
+    in srgb,
+    var(--bs-body-bg) 92%,
+    var(--bs-body-color) 8%
+  );
 }
 
 #suggestions div:not(:last-child) {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -26,6 +26,15 @@ body {
   width: 120px;
 }
 
+.theme-toggle-btn {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .map-item iframe {
   float: left;
   min-height: 450px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add app-level theme state with persistent storage using `localStorage`
- apply the selected theme through Bootstrap 5's `data-bs-theme` attribute on the document root
- add a top-right lightbulb icon toggle for dark/light mode with accessible labels
- update key page and autocomplete styles to use Bootstrap theme variables so dark mode renders correctly
- apply Biome-required formatting updates in `AdComponent.jsx` and `index.css`

## Validation
- `npm run lint` ✅ (passes with one pre-existing warning in `index.html` for Google Analytics inline snippet using `arguments`)
- `npm run build` ✅

## UI Screenshot (desktop)
[Dark mode lightbulb toggle in header - desktop](https://cursor.com/agents/bc-1974e520-bf3c-441e-892f-5a073f721bca/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdark-mode-toggle-dark.png)

## UI Screenshot (mobile)
[Dark mode lightbulb toggle in header - mobile](https://cursor.com/agents/bc-1974e520-bf3c-441e-892f-5a073f721bca/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdark-mode-toggle-mobile.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1974e520-bf3c-441e-892f-5a073f721bca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1974e520-bf3c-441e-892f-5a073f721bca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

