### PR TITLE
Force Agora searches to run in direct mode

### DIFF
--- a/api/gateway/agora/search.go
+++ b/api/gateway/agora/search.go
@@ -50,7 +50,7 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 	searchURL := apiURL.String()
 	var cards []gateway.Card
 
-	c := gateway.NewOptimizedCollectorNoRetry(ctx)
+	c := gateway.NewOptimizedCollectorNoRetryDirect(ctx)
 
 	c.OnHTML("div#store_listingcontainer", func(e *colly.HTMLElement) {
 		e.ForEach("div.store-item", func(_ int, el *colly.HTMLElement) {

--- a/api/gateway/binderpos/scrap.go
+++ b/api/gateway/binderpos/scrap.go
@@ -60,9 +60,8 @@ func newDedicatedNoRetryCollector(ctx context.Context) *colly.Collector {
 }
 
 func newDirectNoRetryCollector(ctx context.Context) *colly.Collector {
-	c := gateway.NewOptimizedCollectorNoRetry(ctx)
+	c := gateway.NewOptimizedCollectorNoRetryDirect(ctx)
 	c.SetRequestTimeout(binderposAttemptTimeout)
-	c.SetProxyFunc(nil)
 	return c
 }
 

--- a/api/gateway/collector.go
+++ b/api/gateway/collector.go
@@ -119,6 +119,15 @@ func NewOptimizedCollectorNoRetry(ctx context.Context) *colly.Collector {
 	return c
 }
 
+func NewOptimizedCollectorNoRetryDirect(ctx context.Context) *colly.Collector {
+	c := colly.NewCollector(
+		colly.StdlibContext(ctx),
+	)
+	configureRequestOptimizations(c, false, false)
+	forceCollectorDirectProxy(c)
+	return c
+}
+
 func NewOptimizedCollectorForBinderpos(ctx context.Context) *colly.Collector {
 	c := colly.NewCollector(
 		colly.StdlibContext(ctx),
@@ -141,6 +150,17 @@ func ConfigureRequestOptimizations(c *colly.Collector) {
 
 func ConfigureRequestOptimizationsNoRetry(c *colly.Collector) {
 	configureRequestOptimizations(c, false, false)
+}
+
+func forceCollectorDirectProxy(c *colly.Collector) {
+	c.SetProxyFunc(nil)
+	c.OnRequest(func(r *colly.Request) {
+		if r == nil || r.Ctx == nil {
+			return
+		}
+		r.Ctx.Put("last_proxy_mode", "direct")
+		r.Ctx.Put("last_proxy_url", "")
+	})
 }
 
 // Core request optimization pipeline.

--- a/api/gateway/collector_test.go
+++ b/api/gateway/collector_test.go
@@ -376,6 +376,22 @@ func TestVisitWithProxyInfo(t *testing.T) {
 	}
 }
 
+func TestVisitWithProxyInfoDirectCollector(t *testing.T) {
+	t.Setenv("DEDICATED_PROXY_1", "4.4.4.4|8080|user|pass")
+
+	c := NewOptimizedCollectorNoRetryDirect(context.Background())
+	err := VisitWithProxyInfo(c, "http://127.0.0.1:1")
+	if err == nil {
+		t.Fatalf("expected visit error for unreachable endpoint")
+	}
+	if !strings.Contains(err.Error(), "proxy_mode=direct") {
+		t.Fatalf("expected direct proxy context in error, got %q", err)
+	}
+	if !strings.Contains(err.Error(), "proxy=none") {
+		t.Fatalf("expected no proxy label for direct collector, got %q", err)
+	}
+}
+
 func TestSeedProxyContextIfMissing(t *testing.T) {
 	t.Run("initializes mode and url when missing", func(t *testing.T) {
 		ctx := colly.NewContext()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `NewOptimizedCollectorNoRetryDirect` in `gateway/collector.go` to explicitly disable proxy usage and seed request context as direct mode
- switch Agora search scraper to use the new direct/no-retry collector so Agora requests no longer route through dedicated proxies
- update BinderPOS direct fallback collector to reuse the same direct collector helper
- add a collector regression test that verifies direct collector requests report `proxy_mode=direct` and `proxy=none`

## Testing
- `go test ./gateway -run 'TestVisitWithProxyInfoDirectCollector|TestVisitWithProxyInfo|TestApplyProxyForRetryAttempt|TestApplyProxyForRetryAttemptWithPinnedDedicated|TestSeedProxyContextIfMissing'`
- `go test ./gateway/agora`
- `go test ./gateway/binderpos`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80d1f8d6-1de8-4d77-b9f7-661eaf248327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80d1f8d6-1de8-4d77-b9f7-661eaf248327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

