### PR TITLE
Suppress binderpos fallback errors after empty successful attempt

### DIFF
--- a/api/gateway/binderpos/storefront.go
+++ b/api/gateway/binderpos/storefront.go
@@ -113,28 +113,48 @@ func searchWithFallback(
 	searchAPISharedFn func() ([]gateway.Card, error),
 	scrapDirectFn func() ([]gateway.Card, error),
 ) ([]gateway.Card, error) {
+	// Some stores legitimately return no matches for the query.
+	// If any attempt completes without an error, do not surface earlier failures.
+	hasSuccessfulAttempt := false
+
 	apiDedicatedCards, apiDedicatedErr := searchAPIDedicatedFn()
 	apiDedicatedErr = annotateAttemptError(1, "api-dedicated", apiDedicatedErr)
+	if apiDedicatedErr == nil {
+		hasSuccessfulAttempt = true
+	}
 	if len(apiDedicatedCards) > 0 && apiDedicatedErr == nil {
 		return apiDedicatedCards, nil
 	}
 
 	scrapedCards, scrapErr := scrapDedicatedFn()
 	scrapErr = annotateAttemptError(2, "scrap-dedicated", scrapErr)
+	if scrapErr == nil {
+		hasSuccessfulAttempt = true
+	}
 	if len(scrapedCards) > 0 && scrapErr == nil {
 		return scrapedCards, nil
 	}
 
 	apiSharedCards, apiSharedErr := searchAPISharedFn()
 	apiSharedErr = annotateAttemptError(3, "api-shared", apiSharedErr)
+	if apiSharedErr == nil {
+		hasSuccessfulAttempt = true
+	}
 	if len(apiSharedCards) > 0 && apiSharedErr == nil {
 		return apiSharedCards, nil
 	}
 
 	scrapedDirectCards, scrapDirectErr := scrapDirectFn()
 	scrapDirectErr = annotateAttemptError(4, "scrap-direct", scrapDirectErr)
+	if scrapDirectErr == nil {
+		hasSuccessfulAttempt = true
+	}
 	if len(scrapedDirectCards) > 0 && scrapDirectErr == nil {
 		return scrapedDirectCards, nil
+	}
+
+	if hasSuccessfulAttempt {
+		return []gateway.Card{}, nil
 	}
 
 	if scrapDirectErr != nil {

--- a/api/gateway/binderpos/storefront_fallback_test.go
+++ b/api/gateway/binderpos/storefront_fallback_test.go
@@ -117,4 +117,19 @@ func TestSearchWithFallback(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("returns no error when a fallback attempt succeeds with empty cards", func(t *testing.T) {
+		cards, err := searchWithFallback(
+			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
+			func() ([]gateway.Card, error) { return []gateway.Card{}, nil },
+			func() ([]gateway.Card, error) { return nil, errors.New("shared api failed") },
+			func() ([]gateway.Card, error) { return nil, errors.New("direct scraper failed") },
+		)
+		if err != nil {
+			t.Fatalf("expected nil error when any attempt succeeds with empty result, got %v", err)
+		}
+		if len(cards) != 0 {
+			t.Fatalf("expected zero cards, got %+v", cards)
+		}
+	})
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update BinderPOS `searchWithFallback` to treat any successful attempt (including empty card results) as a successful overall search
- prevent earlier attempt errors from being surfaced when a later fallback returns zero cards without error
- add a regression test to verify empty successful fallback attempts return `[]` and `nil` error

## Testing
- `go test ./gateway/binderpos -run TestSearchWithFallback`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab4b4d5d-5513-470e-bda6-9dfec6ab50c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab4b4d5d-5513-470e-bda6-9dfec6ab50c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

