### PR TITLE
Switch BinderPOS retry fallback to shared-proxy scraper

### DIFF
--- a/api/gateway/binderpos/scrap.go
+++ b/api/gateway/binderpos/scrap.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"mtg-price-checker-sg/gateway/util"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 
@@ -30,6 +31,29 @@ func (i impl) scrapDedicatedProxy(ctx context.Context, scrapVariant int, storeNa
 
 func (i impl) scrapDirect(ctx context.Context, scrapVariant int, storeName, baseUrl, searchUrl, searchStr string) ([]gateway.Card, error) {
 	return i.scrapWithCollectorFactory(ctx, scrapVariant, storeName, baseUrl, searchUrl, searchStr, newDirectNoRetryCollector)
+}
+
+func (i impl) scrapSharedProxy(ctx context.Context, scrapVariant int, storeName, baseUrl, searchUrl, searchStr string) ([]gateway.Card, error) {
+	sharedProxyURL := strings.TrimSpace(os.Getenv("PROXY_URL"))
+	if sharedProxyURL == "" {
+		return nil, fmt.Errorf("no shared proxy configured for binderpos scraper")
+	}
+
+	if _, err := newHTTPClientWithProxyURL(sharedProxyURL); err != nil {
+		return nil, fmt.Errorf("invalid shared proxy configured for binderpos scraper: %w", err)
+	}
+
+	return i.scrapWithCollectorFactory(
+		ctx,
+		scrapVariant,
+		storeName,
+		baseUrl,
+		searchUrl,
+		searchStr,
+		func(ctx context.Context) *colly.Collector {
+			return newSharedNoRetryCollector(ctx, sharedProxyURL)
+		},
+	)
 }
 
 func (i impl) scrapWithCollectorFactory(
@@ -62,6 +86,20 @@ func newDedicatedNoRetryCollector(ctx context.Context) *colly.Collector {
 func newDirectNoRetryCollector(ctx context.Context) *colly.Collector {
 	c := gateway.NewOptimizedCollectorNoRetryDirect(ctx)
 	c.SetRequestTimeout(binderposAttemptTimeout)
+	return c
+}
+
+func newSharedNoRetryCollector(ctx context.Context, sharedProxyURL string) *colly.Collector {
+	c := gateway.NewOptimizedCollectorNoRetry(ctx)
+	c.SetRequestTimeout(binderposAttemptTimeout)
+	_ = c.SetProxy(sharedProxyURL)
+	c.OnRequest(func(r *colly.Request) {
+		if r == nil || r.Ctx == nil {
+			return
+		}
+		r.Ctx.Put("last_proxy_mode", "shared")
+		r.Ctx.Put("last_proxy_url", sharedProxyURL)
+	})
 	return c
 }
 

--- a/api/gateway/binderpos/scrap_shared_proxy_test.go
+++ b/api/gateway/binderpos/scrap_shared_proxy_test.go
@@ -1,0 +1,49 @@
+package binderpos
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestScrapSharedProxy(t *testing.T) {
+	i := impl{}
+
+	t.Run("returns error when shared proxy is missing", func(t *testing.T) {
+		t.Setenv("PROXY_URL", "")
+
+		_, err := i.scrapSharedProxy(
+			context.Background(),
+			2,
+			"Test Store",
+			"https://example.com",
+			"/search?q=%s",
+			"abrade",
+		)
+		if err == nil {
+			t.Fatalf("expected missing shared proxy to return an error")
+		}
+		if !strings.Contains(err.Error(), "no shared proxy configured for binderpos scraper") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("returns error when shared proxy is invalid", func(t *testing.T) {
+		t.Setenv("PROXY_URL", "://bad-proxy")
+
+		_, err := i.scrapSharedProxy(
+			context.Background(),
+			2,
+			"Test Store",
+			"https://example.com",
+			"/search?q=%s",
+			"abrade",
+		)
+		if err == nil {
+			t.Fatalf("expected invalid shared proxy to return an error")
+		}
+		if !strings.Contains(err.Error(), "invalid shared proxy configured for binderpos scraper") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}

--- a/api/gateway/binderpos/storefront.go
+++ b/api/gateway/binderpos/storefront.go
@@ -8,7 +8,6 @@ import (
 	"math/rand/v2"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 
@@ -62,7 +61,7 @@ func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, 
 		},
 		func() ([]gateway.Card, error) {
 			return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
-				return searchByStorefrontAPISharedProxy(attemptCtx, scrapVariant, storeName, baseURL, searchStr)
+				return i.scrapSharedProxy(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
 			})
 		},
 		func() ([]gateway.Card, error) {
@@ -93,24 +92,10 @@ func searchByStorefrontAPIDirect(ctx context.Context, scrapVariant int, storeNam
 	return searchByStorefrontAPIWithClient(ctx, client, scrapVariant, storeName, baseURL, searchStr)
 }
 
-func searchByStorefrontAPISharedProxy(ctx context.Context, scrapVariant int, storeName, baseURL, searchStr string) ([]gateway.Card, error) {
-	sharedProxyURL := strings.TrimSpace(os.Getenv("PROXY_URL"))
-	if sharedProxyURL == "" {
-		return nil, fmt.Errorf("no shared proxy configured for binderpos storefront api")
-	}
-
-	client, err := newHTTPClientWithProxyURL(sharedProxyURL)
-	if err != nil {
-		return nil, fmt.Errorf("invalid shared proxy configured for binderpos storefront api: %w", err)
-	}
-
-	return searchByStorefrontAPIWithClient(ctx, client, scrapVariant, storeName, baseURL, searchStr)
-}
-
 func searchWithFallback(
 	searchAPIDedicatedFn func() ([]gateway.Card, error),
 	scrapDedicatedFn func() ([]gateway.Card, error),
-	searchAPISharedFn func() ([]gateway.Card, error),
+	scrapSharedFn func() ([]gateway.Card, error),
 	scrapDirectFn func() ([]gateway.Card, error),
 ) ([]gateway.Card, error) {
 	// Some stores legitimately return no matches for the query.
@@ -135,13 +120,13 @@ func searchWithFallback(
 		return scrapedCards, nil
 	}
 
-	apiSharedCards, apiSharedErr := searchAPISharedFn()
-	apiSharedErr = annotateAttemptError(3, "api-shared", apiSharedErr)
-	if apiSharedErr == nil {
+	scrapSharedCards, scrapSharedErr := scrapSharedFn()
+	scrapSharedErr = annotateAttemptError(3, "scrap-shared", scrapSharedErr)
+	if scrapSharedErr == nil {
 		hasSuccessfulAttempt = true
 	}
-	if len(apiSharedCards) > 0 && apiSharedErr == nil {
-		return apiSharedCards, nil
+	if len(scrapSharedCards) > 0 && scrapSharedErr == nil {
+		return scrapSharedCards, nil
 	}
 
 	scrapedDirectCards, scrapDirectErr := scrapDirectFn()
@@ -160,8 +145,8 @@ func searchWithFallback(
 	if scrapDirectErr != nil {
 		return scrapedDirectCards, scrapDirectErr
 	}
-	if apiSharedErr != nil {
-		return apiSharedCards, apiSharedErr
+	if scrapSharedErr != nil {
+		return scrapSharedCards, scrapSharedErr
 	}
 	if scrapErr != nil {
 		return scrapedCards, scrapErr

--- a/api/gateway/binderpos/storefront_fallback_test.go
+++ b/api/gateway/binderpos/storefront_fallback_test.go
@@ -13,7 +13,7 @@ func TestSearchWithFallback(t *testing.T) {
 		cards, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-dedicated"}}, nil },
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap"}}, nil },
-			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-shared"}}, nil },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-shared"}}, nil },
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-direct"}}, nil },
 		)
 		if err != nil {
@@ -28,7 +28,7 @@ func TestSearchWithFallback(t *testing.T) {
 		cards, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap"}}, nil },
-			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-shared"}}, nil },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-shared"}}, nil },
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-direct"}}, nil },
 		)
 		if err != nil {
@@ -39,26 +39,26 @@ func TestSearchWithFallback(t *testing.T) {
 		}
 	})
 
-	t.Run("falls back to shared api before direct api", func(t *testing.T) {
+	t.Run("falls back to shared scraper before direct scraper", func(t *testing.T) {
 		cards, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
 			func() ([]gateway.Card, error) { return nil, errors.New("scraper failed") },
-			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-shared"}}, nil },
-			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-direct"}}, nil },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-shared"}}, nil },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-direct"}}, nil },
 		)
 		if err != nil {
 			t.Fatalf("expected nil error, got %v", err)
 		}
-		if len(cards) != 1 || cards[0].Name != "api-shared" {
-			t.Fatalf("expected shared api card, got %+v", cards)
+		if len(cards) != 1 || cards[0].Name != "scrap-shared" {
+			t.Fatalf("expected shared scraper card, got %+v", cards)
 		}
 	})
 
-	t.Run("falls back to direct scraper when dedicated api, scraper and shared api fail", func(t *testing.T) {
+	t.Run("falls back to direct scraper when dedicated api, dedicated scraper and shared scraper fail", func(t *testing.T) {
 		cards, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
 			func() ([]gateway.Card, error) { return nil, errors.New("scraper failed") },
-			func() ([]gateway.Card, error) { return nil, errors.New("shared api failed") },
+			func() ([]gateway.Card, error) { return nil, errors.New("shared scraper failed") },
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-direct"}}, nil },
 		)
 		if err != nil {
@@ -72,7 +72,7 @@ func TestSearchWithFallback(t *testing.T) {
 	t.Run("returns final direct scraper error when all fail", func(t *testing.T) {
 		dedicatedErr := errors.New("dedicated api failed")
 		scrapErr := errors.New("scraper failed")
-		sharedErr := errors.New("shared api failed")
+		sharedErr := errors.New("shared scraper failed")
 		directErr := errors.New("direct scraper failed")
 		_, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return nil, dedicatedErr },
@@ -101,13 +101,13 @@ func TestSearchWithFallback(t *testing.T) {
 		_, err := searchWithFallback(
 			fail("api-dedicated"),
 			fail("scrap-dedicated"),
-			fail("api-shared"),
+			fail("scrap-shared"),
 			fail("scrap-direct"),
 		)
 		if err == nil {
 			t.Fatalf("expected fallback chain to return the final error")
 		}
-		expected := []string{"api-dedicated", "scrap-dedicated", "api-shared", "scrap-direct"}
+		expected := []string{"api-dedicated", "scrap-dedicated", "scrap-shared", "scrap-direct"}
 		if len(sequence) != len(expected) {
 			t.Fatalf("expected %d attempts, got %d (%v)", len(expected), len(sequence), sequence)
 		}
@@ -122,7 +122,7 @@ func TestSearchWithFallback(t *testing.T) {
 		cards, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
 			func() ([]gateway.Card, error) { return []gateway.Card{}, nil },
-			func() ([]gateway.Card, error) { return nil, errors.New("shared api failed") },
+			func() ([]gateway.Card, error) { return nil, errors.New("shared scraper failed") },
 			func() ([]gateway.Card, error) { return nil, errors.New("direct scraper failed") },
 		)
 		if err != nil {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- changed BinderPOS search fallback attempt 3 from Storefront API over `PROXY_URL` to scraper over `PROXY_URL`
- added `scrapSharedProxy` and `newSharedNoRetryCollector` to run scrape requests through shared proxy with explicit shared proxy context labeling
- updated fallback strategy labels/tests from `api-shared` to `scrap-shared`
- added unit tests for missing/invalid `PROXY_URL` handling in the shared scraper path

## Testing
- `go test ./gateway/binderpos -run 'TestSearchWithFallback|TestScrapSharedProxy|TestNewHTTPClientWithProxyURL|TestRunWithAttemptTimeout'`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b9894e5-ede3-48df-ada4-27c5c92a1ea5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b9894e5-ede3-48df-ada4-27c5c92a1ea5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

