### PR TITLE
Rotate dedicated proxy on retry attempts

### DIFF
--- a/api/gateway/collector.go
+++ b/api/gateway/collector.go
@@ -381,9 +381,17 @@ func applyProxyForRetryAttemptWithPinnedDedicated(c *colly.Collector, retryAttem
 		return clearProxy(c)
 	}
 
-	// Keep pinned dedicated proxy only while retryAttempt <= dedicatedRetryThreshold (see constants).
-	// After that, prefer shared PROXY_URL fallback when available.
+	// Keep dedicated routing while retryAttempt <= dedicatedRetryThreshold (see constants).
+	// When pinned dedicated is present, keep it for attempt 0 and prefer rotating to a
+	// different dedicated proxy on retries.
+	// If no alternative dedicated proxy exists, fall back to pinned to preserve availability.
 	if pinnedDedicatedProxyURL != "" && isDedicatedRetryAttempt(retryAttempt, dedicatedRetryThreshold) {
+		if retryAttempt > 0 {
+			if proxyURL, ok := randomDedicatedProxyURL(pinnedDedicatedProxyURL); ok {
+				c.SetProxy(proxyURL)
+				return "dedicated", proxyURL
+			}
+		}
 		c.SetProxy(pinnedDedicatedProxyURL)
 		return "dedicated", pinnedDedicatedProxyURL
 	}

--- a/api/gateway/collector_test.go
+++ b/api/gateway/collector_test.go
@@ -164,17 +164,26 @@ func TestApplyProxyForRetryAttemptWithPinnedDedicated(t *testing.T) {
 	t.Setenv("PROXY_URL", "http://shared:8080")
 
 	pinned := "http://pinned:1234"
-	for attempt := 0; attempt <= 1; attempt++ {
-		mode, proxyURL := applyProxyForRetryAttemptWithPinnedDedicated(c, attempt, "", pinned, dedicatedProxyRetryThreshold, defaultMaxRetries)
-		if mode != "dedicated" {
-			t.Fatalf("expected dedicated mode for pinned proxy on attempt %d, got %q", attempt, mode)
-		}
-		if proxyURL != pinned {
-			t.Fatalf("expected pinned proxy url %q on attempt %d, got %q", pinned, attempt, proxyURL)
-		}
+	mode, proxyURL := applyProxyForRetryAttemptWithPinnedDedicated(c, 0, "", pinned, dedicatedProxyRetryThreshold, defaultMaxRetries)
+	if mode != "dedicated" {
+		t.Fatalf("expected dedicated mode for pinned proxy on attempt 0, got %q", mode)
+	}
+	if proxyURL != pinned {
+		t.Fatalf("expected pinned proxy url %q on attempt 0, got %q", pinned, proxyURL)
 	}
 
-	mode, proxyURL := applyProxyForRetryAttemptWithPinnedDedicated(c, 2, "", pinned, dedicatedProxyRetryThreshold, defaultMaxRetries)
+	mode, proxyURL = applyProxyForRetryAttemptWithPinnedDedicated(c, 1, "", pinned, dedicatedProxyRetryThreshold, defaultMaxRetries)
+	if mode != "dedicated" {
+		t.Fatalf("expected dedicated mode for pinned proxy on attempt 1, got %q", mode)
+	}
+	if proxyURL == pinned {
+		t.Fatalf("expected attempt 1 to rotate away from pinned proxy %q", pinned)
+	}
+	if proxyURL != "http://user:pass@9.9.9.9:9000" {
+		t.Fatalf("expected retry to use configured dedicated proxy, got %q", proxyURL)
+	}
+
+	mode, proxyURL = applyProxyForRetryAttemptWithPinnedDedicated(c, 2, "", pinned, dedicatedProxyRetryThreshold, defaultMaxRetries)
 	if mode != "direct" {
 		t.Fatalf("expected direct mode on final retry attempt 2, got %q", mode)
 	}
@@ -197,8 +206,14 @@ func TestApplyProxyForRetryAttemptWithPinnedDedicatedBinderpos(t *testing.T) {
 		}
 
 		mode, proxyURL = applyProxyForRetryAttemptWithPinnedDedicated(c, 1, "", pinned, binderposDedicatedRetryThreshold(), binderposMaxRetries)
-		if mode != "dedicated" || proxyURL != pinned {
+		if mode != "dedicated" {
 			t.Fatalf("expected dedicated on attempt 1, got mode=%q url=%q", mode, proxyURL)
+		}
+		if proxyURL == pinned {
+			t.Fatalf("expected attempt 1 to rotate away from pinned proxy %q", pinned)
+		}
+		if proxyURL != "http://user:pass@9.9.9.9:9000" {
+			t.Fatalf("expected dedicated retry proxy on attempt 1, got %q", proxyURL)
 		}
 
 		mode, proxyURL = applyProxyForRetryAttemptWithPinnedDedicated(c, 2, "", pinned, binderposDedicatedRetryThreshold(), binderposMaxRetries)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update dedicated retry selection so attempt `0` keeps the pinned dedicated proxy, but retry attempts rotate to a different dedicated proxy when available
- preserve availability by falling back to the pinned proxy if no alternate dedicated proxy URL exists
- adjust gateway retry tests (including binderpos default strategy) to assert retry attempt `1` no longer reuses the pinned dedicated proxy

## Testing
- `go test ./gateway -run TestApplyProxyForRetryAttemptWithPinnedDedicated -count=1`
- `go test ./gateway/...` *(fails in existing unrelated test: `gateway/tcgmarketplace Test_Search` JSON unmarshal error)*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3fe4609d-1a77-4b40-a213-bbea6ca7381a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3fe4609d-1a77-4b40-a213-bbea6ca7381a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

