### PR TITLE
Default theme to light mode on first visit

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -64,12 +64,10 @@ export default function App() {
         return savedTheme;
       }
     } catch {
-      // Ignore storage access issues and fall back to system preference.
+      // Ignore storage access issues and keep light mode as the default.
     }
 
-    return window.matchMedia?.("(prefers-color-scheme: dark)").matches
-      ? "dark"
-      : "light";
+    return "light";
   });
 
   useEffect(() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- change theme initialization fallback to always start in light mode when there is no saved preference
- keep persistent theme behavior unchanged by still honoring saved `localStorage` values (`light` or `dark`)

## Validation
- `npm run lint` ✅ (passes with one pre-existing warning in `index.html` for Google Analytics inline snippet using `arguments`)
- `npm run build` ✅
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1974e520-bf3c-441e-892f-5a073f721bca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1974e520-bf3c-441e-892f-5a073f721bca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

