### PR TITLE
Fix results count text color in dark mode

### DIFF
--- a/frontend/src/components/SearchResults.jsx
+++ b/frontend/src/components/SearchResults.jsx
@@ -28,7 +28,7 @@ const SearchResults = ({
         ) : (
           <div
             id="resultCount"
-            className="mb-3 text-center bg-warning-subtle text-dark rounded py-2"
+            className="mb-3 text-center bg-warning-subtle text-warning-emphasis rounded py-2"
           >
             {results?.length || 0} result{results?.length !== 1 ? "s" : ""}{" "}
             found


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update the search results count banner text color to use a theme-aware Bootstrap emphasis class
- keep warning background while ensuring the text remains legible in dark mode

## Testing
- not run (visual styling change only)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f27771a-0acf-47f5-91e6-006826a6e6b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f27771a-0acf-47f5-91e6-006826a6e6b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

