### PR TITLE
Harden search error reporting reliability

### DIFF
--- a/api/controller/search.go
+++ b/api/controller/search.go
@@ -153,7 +153,9 @@ func fetchCardsConcurrently(ctx context.Context, searchString string, shops map[
 
 	wg.Wait()
 	if len(discordErrorMessages) > 0 {
-		go sendDiscordAlert(formatDiscordErrorSummary(searchString, discordErrorMessages))
+		// Send synchronously so alerts are not dropped when the Lambda invocation
+		// finishes before a detached goroutine gets scheduled.
+		sendDiscordAlert(formatDiscordErrorSummary(searchString, discordErrorMessages))
 	}
 	if len(siteErrors) > 0 {
 		log.Printf("Shops with errors for [%s]: %d", searchString, len(siteErrors))

--- a/api/gateway/binderpos/storefront.go
+++ b/api/gateway/binderpos/storefront.go
@@ -190,6 +190,9 @@ func searchByStorefrontAPIWithClient(ctx context.Context, client *http.Client, s
 	}
 
 	cards := make([]gateway.Card, 0, len(products)*4)
+	detailAttempts := 0
+	detailFailures := 0
+	var lastDetailErr error
 	seen := map[string]struct{}{}
 	for _, product := range products {
 		productURL := product.URL
@@ -197,8 +200,11 @@ func searchByStorefrontAPIWithClient(ctx context.Context, client *http.Client, s
 			continue
 		}
 
+		detailAttempts++
 		detail, err := fetchProductDetail(ctx, client, baseURL, productURL)
 		if err != nil {
+			detailFailures++
+			lastDetailErr = err
 			continue
 		}
 
@@ -236,6 +242,10 @@ func searchByStorefrontAPIWithClient(ctx context.Context, client *http.Client, s
 			seen[key] = struct{}{}
 			cards = append(cards, card)
 		}
+	}
+
+	if detailAttempts > 0 && detailFailures == detailAttempts {
+		return nil, fmt.Errorf("storefront detail request failed for all %d candidate products: %w", detailAttempts, lastDetailErr)
 	}
 
 	return cards, nil

--- a/api/gateway/binderpos/storefront_proxy_client_test.go
+++ b/api/gateway/binderpos/storefront_proxy_client_test.go
@@ -2,9 +2,13 @@ package binderpos
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 
 	"mtg-price-checker-sg/gateway"
@@ -72,6 +76,75 @@ func TestRunWithAttemptTimeout(t *testing.T) {
 		})
 		if !errors.Is(err, wantErr) {
 			t.Fatalf("expected %v, got %v", wantErr, err)
+		}
+	})
+}
+
+func TestSearchByStorefrontAPIWithClient_DetailRequestFailures(t *testing.T) {
+	t.Run("returns error when all detail requests fail", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case storefrontSuggestPath:
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(storefrontSuggestResponse{
+					Resources: struct {
+						Results struct {
+							Products []storefrontProduct `json:"products"`
+						} `json:"results"`
+					}{
+						Results: struct {
+							Products []storefrontProduct `json:"products"`
+						}{
+							Products: []storefrontProduct{
+								{Title: "Card A", URL: "/products/card-a", Image: "//img/a.jpg"},
+								{Title: "Card B", URL: "/products/card-b", Image: "//img/b.jpg"},
+							},
+						},
+					},
+				})
+			case "/products/card-a.js", "/products/card-b.js":
+				http.Error(w, "upstream unavailable", http.StatusServiceUnavailable)
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer server.Close()
+
+		cards, err := searchByStorefrontAPIWithClient(context.Background(), server.Client(), 2, "Test Store", server.URL, "Abrade")
+		if err == nil {
+			t.Fatal("expected error when all product detail requests fail")
+		}
+		if len(cards) != 0 {
+			t.Fatalf("expected no cards when all product detail requests fail, got %+v", cards)
+		}
+		if !strings.Contains(err.Error(), "storefront detail request failed for all 2 candidate products") {
+			t.Fatalf("expected aggregated detail failure error, got %v", err)
+		}
+	})
+
+	t.Run("returns cards when at least one detail request succeeds", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case storefrontSuggestPath:
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprint(w, `{"resources":{"results":{"products":[{"title":"Card A","url":"/products/card-a","image":"//img/a.jpg"},{"title":"Card B","url":"/products/card-b","image":"//img/b.jpg"}]}}}`)
+			case "/products/card-a.js":
+				http.Error(w, "upstream unavailable", http.StatusServiceUnavailable)
+			case "/products/card-b.js":
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = fmt.Fprint(w, `{"title":"Card B","variants":[{"id":12345,"title":"NM","available":true,"price":250}]}`)
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer server.Close()
+
+		cards, err := searchByStorefrontAPIWithClient(context.Background(), server.Client(), 2, "Test Store", server.URL, "Abrade")
+		if err != nil {
+			t.Fatalf("expected nil error when at least one detail request succeeds, got %v", err)
+		}
+		if len(cards) != 1 {
+			t.Fatalf("expected one card from successful detail response, got %+v", cards)
 		}
 	})
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- send collated Discord search error alerts synchronously after all shop goroutines finish, so alerts are not lost when the Lambda invocation ends
- improve BinderPOS storefront error surfacing by returning an explicit error when every candidate product detail request fails
- add BinderPOS unit tests to cover all-detail-fail and partial-detail-success scenarios

## Testing
- `go test ./controller ./gateway/binderpos ./handler`
- `go test ./...` *(currently has an existing failure in `gateway/tcgmarketplace` integration test due to upstream response shape: `json: cannot unmarshal string into ... data.data`)*

## Why this helps
These changes reduce silent failure modes in search observability: errors are now more likely to be reported and bubbled up instead of appearing as unexplained empty results.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77d0048a-9c7b-453d-8786-9519f26485b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77d0048a-9c7b-453d-8786-9519f26485b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

