### PR TITLE
Propagate BinderPOS product detail 4xx/5xx errors

### DIFF
--- a/api/gateway/binderpos/storefront.go
+++ b/api/gateway/binderpos/storefront.go
@@ -3,6 +3,7 @@ package binderpos
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand/v2"
@@ -46,6 +47,19 @@ type storefrontProductStock struct {
 	Title     string `json:"title"`
 	Available bool   `json:"available"`
 	Price     int    `json:"price"`
+}
+
+type httpStatusError struct {
+	operation string
+	status    int
+	body      string
+}
+
+func (e *httpStatusError) Error() string {
+	if strings.TrimSpace(e.body) == "" {
+		return fmt.Sprintf("%s request failed status=%d", e.operation, e.status)
+	}
+	return fmt.Sprintf("%s request failed status=%d body=%s", e.operation, e.status, e.body)
 }
 
 func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, searchURL, searchStr string) ([]gateway.Card, error) {
@@ -199,6 +213,9 @@ func searchByStorefrontAPIWithClient(ctx context.Context, client *http.Client, s
 
 		detail, err := fetchProductDetail(ctx, client, baseURL, productURL)
 		if err != nil {
+			if isClientOrServerStatusError(err) {
+				return nil, err
+			}
 			continue
 		}
 
@@ -335,17 +352,33 @@ func fetchProductDetail(ctx context.Context, client *http.Client, baseURL, produ
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusOK {
+	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices {
 		body, _ := io.ReadAll(res.Body)
-		return nil, fmt.Errorf("product detail request failed status=%d body=%s", res.StatusCode, strings.TrimSpace(string(body)))
+		return nil, &httpStatusError{
+			operation: "product detail",
+			status:    res.StatusCode,
+			body:      strings.TrimSpace(string(body)),
+		}
 	}
 
 	var detail storefrontProductDetail
 	if err := json.NewDecoder(res.Body).Decode(&detail); err != nil {
+		if errors.Is(err, io.EOF) {
+			return &detail, nil
+		}
 		return nil, err
 	}
 
 	return &detail, nil
+}
+
+func isClientOrServerStatusError(err error) bool {
+	var statusErr *httpStatusError
+	if !errors.As(err, &statusErr) {
+		return false
+	}
+
+	return statusErr.status >= http.StatusBadRequest && statusErr.status <= 599
 }
 
 func productPathToJSONURL(baseURL, productPath string) (string, error) {

--- a/api/gateway/binderpos/storefront_proxy_client_test.go
+++ b/api/gateway/binderpos/storefront_proxy_client_test.go
@@ -3,8 +3,11 @@ package binderpos
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net/http/httptest"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 
 	"mtg-price-checker-sg/gateway"
@@ -74,4 +77,78 @@ func TestRunWithAttemptTimeout(t *testing.T) {
 			t.Fatalf("expected %v, got %v", wantErr, err)
 		}
 	})
+}
+
+func TestFetchProductDetail_AcceptsAny2xxStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/products/test-card.js" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	detail, err := fetchProductDetail(context.Background(), server.Client(), server.URL, "/products/test-card")
+	if err != nil {
+		t.Fatalf("expected nil error for 2xx response, got %v", err)
+	}
+	if detail == nil {
+		t.Fatalf("expected detail struct for 2xx response")
+	}
+}
+
+func TestFetchProductDetail_ReturnsErrorFor4xxAnd5xx(t *testing.T) {
+	tests := []int{http.StatusNotFound, http.StatusServiceUnavailable}
+
+	for _, status := range tests {
+		t.Run(fmt.Sprintf("status-%d", status), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/products/test-card.js" {
+					t.Fatalf("unexpected path: %s", r.URL.Path)
+				}
+				w.WriteHeader(status)
+				_, _ = w.Write([]byte("detail endpoint failed"))
+			}))
+			t.Cleanup(server.Close)
+
+			_, err := fetchProductDetail(context.Background(), server.Client(), server.URL, "/products/test-card")
+			if err == nil {
+				t.Fatalf("expected error for %d response", status)
+			}
+			var statusErr *httpStatusError
+			if !errors.As(err, &statusErr) {
+				t.Fatalf("expected httpStatusError, got %T (%v)", err, err)
+			}
+			if statusErr.status != status {
+				t.Fatalf("expected status %d, got %d", status, statusErr.status)
+			}
+		})
+	}
+}
+
+func TestSearchByStorefrontAPIWithClient_PropagatesDetail4xx5xxErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/search/suggest.json":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"resources":{"results":{"products":[{"title":"Test Card","url":"/products/test-card","image":"//example.com/image.png"}]}}}`))
+		case "/products/test-card.js":
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte("temporarily unavailable"))
+		default:
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	cards, err := searchByStorefrontAPIWithClient(context.Background(), server.Client(), 2, "Test Shop", server.URL, "test card")
+	if err == nil {
+		t.Fatalf("expected detail 5xx error to be propagated")
+	}
+	if len(cards) != 0 {
+		t.Fatalf("expected no cards when detail endpoint fails, got %+v", cards)
+	}
+	if !strings.Contains(err.Error(), "status=503") {
+		t.Fatalf("expected status code in error, got %v", err)
+	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- treat BinderPOS product-detail responses as successful for any HTTP 2xx status
- propagate product-detail 4xx/5xx status failures from `searchByStorefrontAPIWithClient` instead of silently continuing
- add focused unit tests covering:
  - 2xx detail responses returning nil error
  - 4xx/5xx detail responses returning a typed status error
  - storefront search surfacing detail 5xx failures

## Testing
- `go test ./gateway/binderpos -run "TestFetchProductDetail_|TestSearchByStorefrontAPIWithClient_PropagatesDetail4xx5xxErrors|TestNewHTTPClientWithProxyURL|TestRunWithAttemptTimeout"`
- `go test ./gateway/binderpos`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a693a513-7048-4b2f-9c59-2f9c17ee88ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a693a513-7048-4b2f-9c59-2f9c17ee88ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

