### PR TITLE
Increase binderpos search max concurrency to 10

### DIFF
--- a/api/controller/search.go
+++ b/api/controller/search.go
@@ -51,7 +51,7 @@ type Card struct {
 	ExtraInfo string  `json:"extraInfo"`
 }
 
-const binderposMaxConcurrent = 5
+const binderposMaxConcurrent = 10
 
 var sendDiscordAlert = alert.SendDiscordAlert
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- increase the binderpos search concurrency gate from `5` to `10`
- keep existing binderpos gating behavior unchanged, only raise the capacity

## Testing
- pre-test revision pushed; targeted tests will be run next and this PR will be updated if needed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b84fd159-206c-47df-bccf-f1be1304a604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b84fd159-206c-47df-bccf-f1be1304a604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

