### PR TITLE
Use BinderPOS decklist endpoint to avoid per-product detail calls

### DIFF
--- a/api/gateway/binderpos/storefront.go
+++ b/api/gateway/binderpos/storefront.go
@@ -1,6 +1,7 @@
 package binderpos
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -19,8 +20,25 @@ import (
 
 const (
 	storefrontSuggestPath   = "/search/suggest.json"
+	binderposDecklistAPIURL = "https://portal.binderpos.com/external/shopify/decklist"
+	binderposDecklistType   = "mtg"
 	binderposAttemptTimeout = 4 * time.Second
 )
+
+var binderposShopifyDomainByStoreHost = map[string]string{
+	"cardscitadel.com":        "card-citadel.myshopify.com",
+	"card-affinity.com":       "563304-2.myshopify.com",
+	"cardboardcrackgames.com": "cardboardcrackgames.myshopify.com",
+	"flagshipgames.sg":        "flagship-games.myshopify.com",
+	"gameshaventcg.com":       "games-haven-sg.myshopify.com",
+	"greyogregames.com":       "grey-ogre-games-singapore.myshopify.com",
+	"hideoutcg.com":           "220022-20.myshopify.com",
+	"sg-manapro.com":          "mana-pro-sg.myshopify.com",
+	"mtg-asia.com":            "mtgasia.myshopify.com",
+	"onemtg.com.sg":           "one-mtg.myshopify.com",
+	"tefudagames.com":         "bacc1b-3.myshopify.com",
+	// arcanesanctumtcg.com intentionally omitted: BinderPOS decklist API returns 401.
+}
 
 type storefrontSuggestResponse struct {
 	Resources struct {
@@ -46,6 +64,32 @@ type storefrontProductStock struct {
 	Title     string `json:"title"`
 	Available bool   `json:"available"`
 	Price     int    `json:"price"`
+}
+
+type storefrontDecklistRequestItem struct {
+	Card     string `json:"card"`
+	Quantity int    `json:"quantity"`
+}
+
+type storefrontDecklistLine struct {
+	Products  []storefrontDecklistProduct `json:"products"`
+	ValidName string                      `json:"validName"`
+}
+
+type storefrontDecklistProduct struct {
+	Title    string                    `json:"title"`
+	Name     string                    `json:"name"`
+	Handle   string                    `json:"handle"`
+	SetName  string                    `json:"setName"`
+	Image    string                    `json:"img"`
+	Variants []storefrontDecklistStock `json:"variants"`
+}
+
+type storefrontDecklistStock struct {
+	ShopifyID int64   `json:"shopifyId"`
+	Title     string  `json:"title"`
+	Price     float64 `json:"price"`
+	Quantity  int     `json:"quantity"`
 }
 
 func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, searchURL, searchStr string) ([]gateway.Card, error) {
@@ -181,6 +225,11 @@ func annotateAttemptError(attempt int, strategy string, err error) error {
 }
 
 func searchByStorefrontAPIWithClient(ctx context.Context, client *http.Client, scrapVariant int, storeName, baseURL, searchStr string) ([]gateway.Card, error) {
+	decklistCards, err := searchByBinderposDecklistAPI(ctx, client, scrapVariant, storeName, baseURL, searchStr)
+	if err == nil {
+		return decklistCards, nil
+	}
+
 	products, err := fetchSuggestProducts(ctx, client, baseURL, searchStr)
 	if err != nil {
 		return nil, err
@@ -239,6 +288,146 @@ func searchByStorefrontAPIWithClient(ctx context.Context, client *http.Client, s
 	}
 
 	return cards, nil
+}
+
+func searchByBinderposDecklistAPI(ctx context.Context, client *http.Client, scrapVariant int, storeName, baseURL, searchStr string) ([]gateway.Card, error) {
+	shopifyDomain, ok := storefrontShopifyDomainForBaseURL(baseURL)
+	if !ok {
+		return nil, fmt.Errorf("missing shopify domain mapping for binderpos storefront")
+	}
+
+	decklistURL, err := url.Parse(binderposDecklistAPIURL)
+	if err != nil {
+		return nil, err
+	}
+	query := decklistURL.Query()
+	query.Set("storeUrl", shopifyDomain)
+	query.Set("type", binderposDecklistType)
+	decklistURL.RawQuery = query.Encode()
+
+	payload := []storefrontDecklistRequestItem{
+		{
+			Card:     strings.TrimSpace(searchStr),
+			Quantity: 1,
+		},
+	}
+	payloadBody, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, decklistURL.String(), bytes.NewReader(payloadBody))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", gateway.RandomBrowserUserAgent())
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	if err := gateway.WaitForDomainRequestSlot(ctx, req.URL); err != nil {
+		return nil, err
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(res.Body)
+		return nil, fmt.Errorf("binderpos decklist request failed status=%d body=%s", res.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var lines []storefrontDecklistLine
+	if err := json.NewDecoder(res.Body).Decode(&lines); err != nil {
+		return nil, err
+	}
+
+	return mapDecklistLinesToCards(scrapVariant, storeName, baseURL, lines), nil
+}
+
+func storefrontShopifyDomainForBaseURL(baseURL string) (string, bool) {
+	parsedURL, err := url.Parse(strings.TrimSpace(baseURL))
+	if err != nil {
+		return "", false
+	}
+
+	host := strings.ToLower(strings.TrimSpace(parsedURL.Hostname()))
+	host = strings.TrimPrefix(host, "www.")
+	if host == "" {
+		return "", false
+	}
+
+	shopifyDomain, ok := binderposShopifyDomainByStoreHost[host]
+	return shopifyDomain, ok
+}
+
+func mapDecklistLinesToCards(scrapVariant int, storeName, baseURL string, lines []storefrontDecklistLine) []gateway.Card {
+	cards := make([]gateway.Card, 0, len(lines)*4)
+	seen := map[string]struct{}{}
+
+	for _, line := range lines {
+		for _, product := range line.Products {
+			productTitle := strings.TrimSpace(product.Title)
+			if productTitle == "" {
+				productTitle = strings.TrimSpace(product.Name)
+			}
+			if productTitle == "" {
+				productTitle = strings.TrimSpace(line.ValidName)
+			}
+			if productTitle == "" {
+				continue
+			}
+
+			productPath := ""
+			if strings.TrimSpace(product.Handle) != "" {
+				productPath = "/products/" + strings.TrimSpace(product.Handle)
+			}
+
+			setName := strings.TrimSpace(product.SetName)
+			if setName == "" {
+				setName = extractSetName(productTitle)
+			}
+
+			image := buildCardImageURL(product.Image, productTitle)
+			for _, variant := range product.Variants {
+				if variant.Price <= 0 {
+					continue
+				}
+				if variant.ShopifyID <= 0 || productPath == "" {
+					continue
+				}
+
+				cardURL, err := buildProductURLWithVariant(baseURL, productPath, variant.ShopifyID)
+				if err != nil {
+					continue
+				}
+
+				quality := strings.TrimSpace(strings.ReplaceAll(variant.Title, "Foil", ""))
+				card := gateway.Card{
+					Name:    formatCardName(scrapVariant, productTitle, variant.Title),
+					Url:     cardURL,
+					Img:     image,
+					Price:   variant.Price,
+					InStock: variant.Quantity > 0,
+					IsFoil:  strings.Contains(strings.ToLower(variant.Title), "foil"),
+					Source:  storeName,
+					Quality: util.MapQuality(quality),
+				}
+				if scrapVariant == 3 && setName != "" {
+					card.ExtraInfo = []string{setName}
+				}
+
+				key := fmt.Sprintf("%s|%.2f|%t", card.Url, card.Price, card.InStock)
+				if _, exists := seen[key]; exists {
+					continue
+				}
+				seen[key] = struct{}{}
+				cards = append(cards, card)
+			}
+		}
+	}
+
+	return cards
 }
 
 func newDedicatedProxyHTTPClient() (*http.Client, bool) {

--- a/api/gateway/binderpos/storefront_decklist_test.go
+++ b/api/gateway/binderpos/storefront_decklist_test.go
@@ -1,0 +1,103 @@
+package binderpos
+
+import (
+	"testing"
+)
+
+func TestStorefrontShopifyDomainForBaseURL(t *testing.T) {
+	t.Run("returns mapped domain for known host with www", func(t *testing.T) {
+		domain, ok := storefrontShopifyDomainForBaseURL("https://www.mtg-asia.com")
+		if !ok {
+			t.Fatalf("expected mapping to exist")
+		}
+		if domain != "mtgasia.myshopify.com" {
+			t.Fatalf("unexpected domain: %s", domain)
+		}
+	})
+
+	t.Run("returns false for unknown host", func(t *testing.T) {
+		_, ok := storefrontShopifyDomainForBaseURL("https://example.com")
+		if ok {
+			t.Fatalf("expected unknown host lookup to fail")
+		}
+	})
+}
+
+func TestMapDecklistLinesToCards(t *testing.T) {
+	lines := []storefrontDecklistLine{
+		{
+			ValidName: "Abrade",
+			Products: []storefrontDecklistProduct{
+				{
+					Title:   "Abrade [Foundations]",
+					Handle:  "abrade-foundations",
+					SetName: "Foundations",
+					Image:   "https://images.example/abrade.png",
+					Variants: []storefrontDecklistStock{
+						{
+							ShopifyID: 111,
+							Title:     "Near Mint Foil",
+							Price:     0.85,
+							Quantity:  2,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("maps variant into card payload", func(t *testing.T) {
+		cards := mapDecklistLinesToCards(2, "MTG Asia", "https://www.mtg-asia.com", lines)
+		if len(cards) != 1 {
+			t.Fatalf("expected 1 card, got %d", len(cards))
+		}
+		card := cards[0]
+		if card.Name != "Abrade [Foundations] - Near Mint Foil" {
+			t.Fatalf("unexpected card name: %s", card.Name)
+		}
+		if card.Price != 0.85 {
+			t.Fatalf("unexpected card price: %f", card.Price)
+		}
+		if !card.InStock {
+			t.Fatalf("expected card to be in stock")
+		}
+		if !card.IsFoil {
+			t.Fatalf("expected foil card")
+		}
+	})
+
+	t.Run("uses set name in extra info for variant 3", func(t *testing.T) {
+		cards := mapDecklistLinesToCards(3, "Games Haven", "https://www.gameshaventcg.com", lines)
+		if len(cards) != 1 {
+			t.Fatalf("expected 1 card, got %d", len(cards))
+		}
+		if len(cards[0].ExtraInfo) != 1 || cards[0].ExtraInfo[0] != "Foundations" {
+			t.Fatalf("unexpected extra info: %+v", cards[0].ExtraInfo)
+		}
+	})
+
+	t.Run("skips variants with invalid URL data", func(t *testing.T) {
+		invalid := []storefrontDecklistLine{
+			{
+				Products: []storefrontDecklistProduct{
+					{
+						Title:  "Broken Product",
+						Handle: "",
+						Variants: []storefrontDecklistStock{
+							{
+								ShopifyID: 10,
+								Title:     "Near Mint",
+								Price:     1.23,
+								Quantity:  1,
+							},
+						},
+					},
+				},
+			},
+		}
+		cards := mapDecklistLinesToCards(2, "Store", "https://store.example", invalid)
+		if len(cards) != 0 {
+			t.Fatalf("expected no cards, got %+v", cards)
+		}
+	})
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a BinderPOS decklist API path (`/external/shopify/decklist`) as the primary storefront search strategy
- map BinderPOS store base domains to their authorized `*.myshopify.com` domains and issue a single POST search request per query
- convert decklist response products/variants directly into `gateway.Card` results while preserving existing naming, foil, quality, and variant-3 set metadata behavior
- keep the existing Shopify suggest + product detail flow as a fallback when decklist lookup is unavailable/fails
- add focused unit tests for Shopify domain mapping and decklist-to-card mapping

## Testing
- `go test ./gateway/binderpos`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-602c3e79-1f58-4c32-aa3f-9275978c4c2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-602c3e79-1f58-4c32-aa3f-9275978c4c2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

