### PR TITLE
Restore previous light-mode suggestion striping

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -102,6 +102,10 @@ body {
 }
 
 #suggestions div:nth-child(even) {
+  background-color: #fbfbfb;
+}
+
+[data-bs-theme="dark"] #suggestions div:nth-child(even) {
   background-color: color-mix(
     in srgb,
     var(--bs-body-bg) 92%,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- confirm suggestion row striping itself is not newly introduced, but its tone was updated in the recent dark-mode commit
- restore the previous lighter alternating row color for light mode (`#fbfbfb`)
- keep dark mode using theme-aware alternating row color for readability

## Testing
- `npm --prefix frontend run lint` (passes with one pre-existing warning in `index.html` about `arguments` in GA snippet)
- `npm --prefix frontend run build`

## Screenshots (dropdown visible)
### Light mode — Desktop
![Light mode desktop with open suggestions](https://cursor.com/artifacts/c/art-3617ce9f-0607-45a7-ba2b-3b1b96b306f5)

### Light mode — Mobile
![Light mode mobile with open suggestions](https://cursor.com/artifacts/c/art-238882cd-3766-4264-b3ef-6233e376551d)

### Dark mode — Desktop
![Dark mode desktop with open suggestions](https://cursor.com/artifacts/c/art-0626f8f3-335e-49f8-9e37-631f28149f83)

### Dark mode — Mobile
![Dark mode mobile with open suggestions](https://cursor.com/artifacts/c/art-bd3be012-285c-40b6-a232-9526aa2fa10e)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9a3a7b5-c788-451f-9bba-f456410bbade"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9a3a7b5-c788-451f-9bba-f456410bbade"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

