### PR TITLE
Use shared-proxy scraper as BinderPOS attempt 4

### DIFF
--- a/api/controller/search_test.go
+++ b/api/controller/search_test.go
@@ -459,18 +459,18 @@ func TestFetchCardsConcurrently_CollatesDiscordErrors(t *testing.T) {
 
 func TestFormatDiscordErrorSummary(t *testing.T) {
 	got := formatDiscordErrorSummary("Uro, Titan of Nature's Wrath", []string{
-		"Error encountered searching [Tefuda] for [Uro, Titan of Nature's Wrath]: attempt 4 (scrap-direct): Service Unavailable (proxy_mode=dedicated proxy=DEDICATED_PROXY_5)",
-		"Error encountered searching [Arcane Sanctum] for [Uro, Titan of Nature's Wrath]: attempt 4 (scrap-direct): Service Unavailable (proxy_mode=dedicated proxy=DEDICATED_PROXY_2)",
+		"Error encountered searching [Tefuda] for [Uro, Titan of Nature's Wrath]: attempt 4 (scrap-shared): Service Unavailable (proxy_mode=shared proxy=PROXY_URL)",
+		"Error encountered searching [Arcane Sanctum] for [Uro, Titan of Nature's Wrath]: attempt 4 (scrap-shared): Service Unavailable (proxy_mode=shared proxy=PROXY_URL)",
 		"Recovered from panic in shop [ShopPanic]: panic value",
 	})
 
 	if !strings.Contains(got, "Encountered 3 error(s) while searching [Uro, Titan of Nature's Wrath]:") {
 		t.Fatalf("expected summary header, got: %s", got)
 	}
-	if !strings.Contains(got, "- [Arcane Sanctum] attempt 4 (scrap-direct): Service Unavailable (proxy_mode=dedicated proxy=DEDICATED_PROXY_2)") {
+	if !strings.Contains(got, "- [Arcane Sanctum] attempt 4 (scrap-shared): Service Unavailable (proxy_mode=shared proxy=PROXY_URL)") {
 		t.Fatalf("expected Arcane Sanctum concise line, got: %s", got)
 	}
-	if !strings.Contains(got, "- [Tefuda] attempt 4 (scrap-direct): Service Unavailable (proxy_mode=dedicated proxy=DEDICATED_PROXY_5)") {
+	if !strings.Contains(got, "- [Tefuda] attempt 4 (scrap-shared): Service Unavailable (proxy_mode=shared proxy=PROXY_URL)") {
 		t.Fatalf("expected Tefuda concise line, got: %s", got)
 	}
 	if !strings.Contains(got, "- Recovered from panic in shop [ShopPanic]: panic value") {

--- a/api/gateway/binderpos/scrap.go
+++ b/api/gateway/binderpos/scrap.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"mtg-price-checker-sg/gateway/util"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 
@@ -30,6 +31,20 @@ func (i impl) scrapDedicatedProxy(ctx context.Context, scrapVariant int, storeNa
 
 func (i impl) scrapDirect(ctx context.Context, scrapVariant int, storeName, baseUrl, searchUrl, searchStr string) ([]gateway.Card, error) {
 	return i.scrapWithCollectorFactory(ctx, scrapVariant, storeName, baseUrl, searchUrl, searchStr, newDirectNoRetryCollector)
+}
+
+func (i impl) scrapSharedProxy(ctx context.Context, scrapVariant int, storeName, baseUrl, searchUrl, searchStr string) ([]gateway.Card, error) {
+	sharedProxyURL := strings.TrimSpace(os.Getenv("PROXY_URL"))
+	if sharedProxyURL == "" {
+		return nil, fmt.Errorf("no shared proxy configured for binderpos scraper")
+	}
+	if _, err := newHTTPClientWithProxyURL(sharedProxyURL); err != nil {
+		return nil, fmt.Errorf("invalid shared proxy configured for binderpos scraper: %w", err)
+	}
+
+	return i.scrapWithCollectorFactory(ctx, scrapVariant, storeName, baseUrl, searchUrl, searchStr, func(factoryCtx context.Context) *colly.Collector {
+		return newSharedNoRetryCollector(factoryCtx, sharedProxyURL)
+	})
 }
 
 func (i impl) scrapWithCollectorFactory(
@@ -62,6 +77,21 @@ func newDedicatedNoRetryCollector(ctx context.Context) *colly.Collector {
 func newDirectNoRetryCollector(ctx context.Context) *colly.Collector {
 	c := gateway.NewOptimizedCollectorNoRetryDirect(ctx)
 	c.SetRequestTimeout(binderposAttemptTimeout)
+	return c
+}
+
+func newSharedNoRetryCollector(ctx context.Context, sharedProxyURL string) *colly.Collector {
+	c := gateway.NewOptimizedCollectorNoRetryDirect(ctx)
+	c.SetRequestTimeout(binderposAttemptTimeout)
+	// Proxy URL is validated in scrapSharedProxy before this collector is created.
+	_ = c.SetProxy(sharedProxyURL)
+	c.OnRequest(func(r *colly.Request) {
+		if r == nil || r.Ctx == nil {
+			return
+		}
+		r.Ctx.Put("last_proxy_mode", "shared")
+		r.Ctx.Put("last_proxy_url", sharedProxyURL)
+	})
 	return c
 }
 

--- a/api/gateway/binderpos/storefront.go
+++ b/api/gateway/binderpos/storefront.go
@@ -111,7 +111,7 @@ func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, 
 		},
 		func() ([]gateway.Card, error) {
 			return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
-				return i.scrapDirect(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
+				return i.scrapSharedProxy(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
 			})
 		},
 	)
@@ -155,7 +155,7 @@ func searchWithFallback(
 	searchAPIDedicatedFn func() ([]gateway.Card, error),
 	searchAPISharedFn func() ([]gateway.Card, error),
 	scrapDedicatedFn func() ([]gateway.Card, error),
-	scrapDirectFn func() ([]gateway.Card, error),
+	scrapSharedFn func() ([]gateway.Card, error),
 ) ([]gateway.Card, error) {
 	// Some stores legitimately return no matches for the query.
 	// If any attempt completes without an error, do not surface earlier failures.
@@ -188,21 +188,21 @@ func searchWithFallback(
 		return scrapedCards, nil
 	}
 
-	scrapedDirectCards, scrapDirectErr := scrapDirectFn()
-	scrapDirectErr = annotateAttemptError(4, "scrap-direct", scrapDirectErr)
-	if scrapDirectErr == nil {
+	scrapedSharedCards, scrapSharedErr := scrapSharedFn()
+	scrapSharedErr = annotateAttemptError(4, "scrap-shared", scrapSharedErr)
+	if scrapSharedErr == nil {
 		hasSuccessfulAttempt = true
 	}
-	if len(scrapedDirectCards) > 0 && scrapDirectErr == nil {
-		return scrapedDirectCards, nil
+	if len(scrapedSharedCards) > 0 && scrapSharedErr == nil {
+		return scrapedSharedCards, nil
 	}
 
 	if hasSuccessfulAttempt {
 		return []gateway.Card{}, nil
 	}
 
-	if scrapDirectErr != nil {
-		return scrapedDirectCards, scrapDirectErr
+	if scrapSharedErr != nil {
+		return scrapedSharedCards, scrapSharedErr
 	}
 	if scrapErr != nil {
 		return scrapedCards, scrapErr

--- a/api/gateway/binderpos/storefront_fallback_test.go
+++ b/api/gateway/binderpos/storefront_fallback_test.go
@@ -14,7 +14,7 @@ func TestSearchWithFallback(t *testing.T) {
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-dedicated"}}, nil },
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-shared"}}, nil },
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap"}}, nil },
-			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-direct"}}, nil },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-shared"}}, nil },
 		)
 		if err != nil {
 			t.Fatalf("expected nil error, got %v", err)
@@ -29,7 +29,7 @@ func TestSearchWithFallback(t *testing.T) {
 			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-shared"}}, nil },
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap"}}, nil },
-			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-direct"}}, nil },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-shared"}}, nil },
 		)
 		if err != nil {
 			t.Fatalf("expected nil error, got %v", err)
@@ -39,12 +39,12 @@ func TestSearchWithFallback(t *testing.T) {
 		}
 	})
 
-	t.Run("falls back to dedicated scraper before direct scraper", func(t *testing.T) {
+	t.Run("falls back to dedicated scraper before shared-proxy scraper", func(t *testing.T) {
 		cards, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
 			func() ([]gateway.Card, error) { return nil, errors.New("shared api failed") },
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap"}}, nil },
-			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-direct"}}, nil },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-shared"}}, nil },
 		)
 		if err != nil {
 			t.Fatalf("expected nil error, got %v", err)
@@ -54,36 +54,36 @@ func TestSearchWithFallback(t *testing.T) {
 		}
 	})
 
-	t.Run("falls back to direct scraper when dedicated api, shared api and dedicated scraper fail", func(t *testing.T) {
+	t.Run("falls back to shared-proxy scraper when dedicated api, shared api and dedicated scraper fail", func(t *testing.T) {
 		cards, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
 			func() ([]gateway.Card, error) { return nil, errors.New("shared api failed") },
 			func() ([]gateway.Card, error) { return nil, errors.New("scraper failed") },
-			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-direct"}}, nil },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-shared"}}, nil },
 		)
 		if err != nil {
 			t.Fatalf("expected nil error, got %v", err)
 		}
-		if len(cards) != 1 || cards[0].Name != "scrap-direct" {
-			t.Fatalf("expected direct scraper card, got %+v", cards)
+		if len(cards) != 1 || cards[0].Name != "scrap-shared" {
+			t.Fatalf("expected shared-proxy scraper card, got %+v", cards)
 		}
 	})
 
-	t.Run("returns final direct scraper error when all fail", func(t *testing.T) {
+	t.Run("returns final shared-proxy scraper error when all fail", func(t *testing.T) {
 		dedicatedErr := errors.New("dedicated api failed")
 		sharedErr := errors.New("shared api failed")
 		scrapErr := errors.New("scraper failed")
-		directErr := errors.New("direct scraper failed")
+		sharedScrapErr := errors.New("shared scraper failed")
 		_, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return nil, dedicatedErr },
 			func() ([]gateway.Card, error) { return nil, sharedErr },
 			func() ([]gateway.Card, error) { return nil, scrapErr },
-			func() ([]gateway.Card, error) { return nil, directErr },
+			func() ([]gateway.Card, error) { return nil, sharedScrapErr },
 		)
-		if !errors.Is(err, directErr) {
-			t.Fatalf("expected direct scraper error, got %v", err)
+		if !errors.Is(err, sharedScrapErr) {
+			t.Fatalf("expected shared-proxy scraper error, got %v", err)
 		}
-		expectedError := "attempt 4 (scrap-direct): direct scraper failed"
+		expectedError := "attempt 4 (scrap-shared): shared scraper failed"
 		if err == nil || err.Error() != expectedError {
 			t.Fatalf("expected final error %q, got %v", expectedError, err)
 		}
@@ -102,12 +102,12 @@ func TestSearchWithFallback(t *testing.T) {
 			fail("api-dedicated"),
 			fail("api-shared"),
 			fail("scrap-dedicated"),
-			fail("scrap-direct"),
+			fail("scrap-shared"),
 		)
 		if err == nil {
 			t.Fatalf("expected fallback chain to return the final error")
 		}
-		expected := []string{"api-dedicated", "api-shared", "scrap-dedicated", "scrap-direct"}
+		expected := []string{"api-dedicated", "api-shared", "scrap-dedicated", "scrap-shared"}
 		if len(sequence) != len(expected) {
 			t.Fatalf("expected %d attempts, got %d (%v)", len(expected), len(sequence), sequence)
 		}
@@ -123,7 +123,7 @@ func TestSearchWithFallback(t *testing.T) {
 			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
 			func() ([]gateway.Card, error) { return nil, errors.New("shared api failed") },
 			func() ([]gateway.Card, error) { return []gateway.Card{}, nil },
-			func() ([]gateway.Card, error) { return nil, errors.New("direct scraper failed") },
+			func() ([]gateway.Card, error) { return nil, errors.New("shared scraper failed") },
 		)
 		if err != nil {
 			t.Fatalf("expected nil error when any attempt succeeds with empty result, got %v", err)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- keep BinderPOS attempt 1 as dedicated-proxy storefront API (`api-dedicated`)
- keep attempt 2 as shared-proxy storefront API (`api-shared`)
- keep attempt 3 as dedicated-proxy scraper (`scrap-dedicated`)
- change attempt 4 from direct scraper to shared-proxy scraper (`scrap-shared`)
- add shared-proxy scraper implementation with explicit `PROXY_URL` presence/validity checks
- update fallback tests and controller error-summary expectations for the new attempt 4 label/proxy mode

## Testing
- `go test ./gateway/binderpos -run "TestSearchWithFallback|TestNewHTTPClientWithProxyURL|TestRunWithAttemptTimeout" -count=1`
- `go test ./controller -run TestFormatDiscordErrorSummary -count=1`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-422e93d1-0b60-42d1-b39d-555a71140c83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-422e93d1-0b60-42d1-b39d-555a71140c83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

