### PR TITLE
Route BinderPOS storefront search via 70/30 decklist split

### DIFF
--- a/api/gateway/binderpos/storefront.go
+++ b/api/gateway/binderpos/storefront.go
@@ -22,6 +22,7 @@ const (
 	storefrontSuggestPath   = "/search/suggest.json"
 	binderposDecklistAPIURL = "https://portal.binderpos.com/external/shopify/decklist"
 	binderposDecklistType   = "mtg"
+	binderposDecklistPct    = 70
 	binderposAttemptTimeout = 4 * time.Second
 )
 
@@ -38,6 +39,10 @@ var binderposShopifyDomainByStoreHost = map[string]string{
 	"onemtg.com.sg":           "one-mtg.myshopify.com",
 	"tefudagames.com":         "bacc1b-3.myshopify.com",
 	// arcanesanctumtcg.com intentionally omitted: BinderPOS decklist API returns 401.
+}
+
+var shouldUseDecklistEndpoint = func() bool {
+	return useDecklistForRoll(rand.IntN(100))
 }
 
 type storefrontSuggestResponse struct {
@@ -225,11 +230,21 @@ func annotateAttemptError(attempt int, strategy string, err error) error {
 }
 
 func searchByStorefrontAPIWithClient(ctx context.Context, client *http.Client, scrapVariant int, storeName, baseURL, searchStr string) ([]gateway.Card, error) {
-	decklistCards, err := searchByBinderposDecklistAPI(ctx, client, scrapVariant, storeName, baseURL, searchStr)
-	if err == nil {
-		return decklistCards, nil
+	if shouldUseDecklistEndpoint() {
+		decklistCards, err := searchByBinderposDecklistAPI(ctx, client, scrapVariant, storeName, baseURL, searchStr)
+		if err == nil {
+			return decklistCards, nil
+		}
 	}
 
+	return searchByStorefrontProductDetailsAPI(ctx, client, scrapVariant, storeName, baseURL, searchStr)
+}
+
+func useDecklistForRoll(roll int) bool {
+	return roll < binderposDecklistPct
+}
+
+func searchByStorefrontProductDetailsAPI(ctx context.Context, client *http.Client, scrapVariant int, storeName, baseURL, searchStr string) ([]gateway.Card, error) {
 	products, err := fetchSuggestProducts(ctx, client, baseURL, searchStr)
 	if err != nil {
 		return nil, err

--- a/api/gateway/binderpos/storefront_routing_test.go
+++ b/api/gateway/binderpos/storefront_routing_test.go
@@ -1,0 +1,116 @@
+package binderpos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestUseDecklistForRoll(t *testing.T) {
+	tests := []struct {
+		name string
+		roll int
+		want bool
+	}{
+		{name: "0 routes to decklist", roll: 0, want: true},
+		{name: "69 routes to decklist", roll: 69, want: true},
+		{name: "70 routes to product details fallback", roll: 70, want: false},
+		{name: "99 routes to product details fallback", roll: 99, want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := useDecklistForRoll(test.roll)
+			if got != test.want {
+				t.Fatalf("expected useDecklistForRoll(%d)=%t, got %t", test.roll, test.want, got)
+			}
+		})
+	}
+}
+
+func TestSearchByStorefrontAPIWithClient_UsesProductDetailPathWhenDecklistNotSelected(t *testing.T) {
+	server := newStorefrontProductDetailFixtureServer()
+	defer server.Close()
+
+	previousSelector := shouldUseDecklistEndpoint
+	shouldUseDecklistEndpoint = func() bool { return false }
+	t.Cleanup(func() { shouldUseDecklistEndpoint = previousSelector })
+
+	cards, err := searchByStorefrontAPIWithClient(
+		context.Background(),
+		server.Client(),
+		2,
+		"Test Store",
+		server.URL,
+		"Abrade",
+	)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if len(cards) != 1 {
+		t.Fatalf("expected 1 card from product details path, got %d", len(cards))
+	}
+}
+
+func TestSearchByStorefrontAPIWithClient_FallsBackAfterDecklistError(t *testing.T) {
+	server := newStorefrontProductDetailFixtureServer()
+	defer server.Close()
+
+	previousSelector := shouldUseDecklistEndpoint
+	shouldUseDecklistEndpoint = func() bool { return true }
+	t.Cleanup(func() { shouldUseDecklistEndpoint = previousSelector })
+
+	cards, err := searchByStorefrontAPIWithClient(
+		context.Background(),
+		server.Client(),
+		2,
+		"Test Store",
+		server.URL,
+		"Abrade",
+	)
+	if err != nil {
+		t.Fatalf("expected nil error after decklist failure fallback, got %v", err)
+	}
+	if len(cards) != 1 {
+		t.Fatalf("expected 1 fallback card, got %d", len(cards))
+	}
+}
+
+func newStorefrontProductDetailFixtureServer() *httptest.Server {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case storefrontSuggestPath:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"resources": map[string]any{
+					"results": map[string]any{
+						"products": []map[string]any{
+							{
+								"title": "Abrade [Foundations]",
+								"url":   "/products/abrade",
+								"image": "https://images.example/abrade.png",
+							},
+						},
+					},
+				},
+			})
+		case "/products/abrade.js":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"title": "Abrade [Foundations]",
+				"variants": []map[string]any{
+					{
+						"id":        int64(12345),
+						"title":     "Near Mint",
+						"available": true,
+						"price":     199,
+					},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	return httptest.NewServer(handler)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a decklist traffic split selector so BinderPOS storefront search uses the decklist endpoint 70% of the time
- route the remaining 30% directly through suggest + product details requests to spread load across endpoints
- keep existing safety behavior: when decklist is selected but fails, automatically fall back to the product details flow
- factor the product details implementation into a dedicated helper for clearer routing behavior

## Testing
- `go test ./gateway/binderpos -run 'Test(SearchWithFallback|RunWithAttemptTimeout|StorefrontShopifyDomainForBaseURL|MapDecklistLinesToCards|UseDecklistForRoll|SearchByStorefrontAPIWithClient_UsesProductDetailPathWhenDecklistNotSelected|SearchByStorefrontAPIWithClient_FallsBackAfterDecklistError)$'`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de5d057f-f26d-4130-8766-74753efbdea6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de5d057f-f26d-4130-8766-74753efbdea6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

