### PR TITLE
binderpos: stop decklist fallback within same API attempt

### DIFF
--- a/api/gateway/binderpos/storefront.go
+++ b/api/gateway/binderpos/storefront.go
@@ -231,10 +231,7 @@ func annotateAttemptError(attempt int, strategy string, err error) error {
 
 func searchByStorefrontAPIWithClient(ctx context.Context, client *http.Client, scrapVariant int, storeName, baseURL, searchStr string) ([]gateway.Card, error) {
 	if shouldUseDecklistEndpoint() {
-		decklistCards, err := searchByBinderposDecklistAPI(ctx, client, scrapVariant, storeName, baseURL, searchStr)
-		if err == nil {
-			return decklistCards, nil
-		}
+		return searchByBinderposDecklistAPI(ctx, client, scrapVariant, storeName, baseURL, searchStr)
 	}
 
 	return searchByStorefrontProductDetailsAPI(ctx, client, scrapVariant, storeName, baseURL, searchStr)

--- a/api/gateway/binderpos/storefront_routing_test.go
+++ b/api/gateway/binderpos/storefront_routing_test.go
@@ -54,7 +54,7 @@ func TestSearchByStorefrontAPIWithClient_UsesProductDetailPathWhenDecklistNotSel
 	}
 }
 
-func TestSearchByStorefrontAPIWithClient_FallsBackAfterDecklistError(t *testing.T) {
+func TestSearchByStorefrontAPIWithClient_ReturnsDecklistErrorWhenSelected(t *testing.T) {
 	server := newStorefrontProductDetailFixtureServer()
 	defer server.Close()
 
@@ -70,11 +70,11 @@ func TestSearchByStorefrontAPIWithClient_FallsBackAfterDecklistError(t *testing.
 		server.URL,
 		"Abrade",
 	)
-	if err != nil {
-		t.Fatalf("expected nil error after decklist failure fallback, got %v", err)
+	if err == nil {
+		t.Fatalf("expected decklist request error, got nil")
 	}
-	if len(cards) != 1 {
-		t.Fatalf("expected 1 fallback card, got %d", len(cards))
+	if len(cards) != 0 {
+		t.Fatalf("expected 0 cards when decklist request fails, got %d", len(cards))
 	}
 }
 

--- a/api/gateway/binderpos/storefront_search_test.go
+++ b/api/gateway/binderpos/storefront_search_test.go
@@ -24,6 +24,10 @@ type binderposStoreSearchCase struct {
 }
 
 func Test_SearchByStorefrontAPI_SupportsAllBinderposStores(t *testing.T) {
+	previousSelector := shouldUseDecklistEndpoint
+	shouldUseDecklistEndpoint = func() bool { return false }
+	t.Cleanup(func() { shouldUseDecklistEndpoint = previousSelector })
+
 	client := &http.Client{Timeout: 20 * time.Second}
 	for _, testCase := range binderposStoreSearchCases() {
 		t.Run(testCase.storeName, func(t *testing.T) {
@@ -43,6 +47,10 @@ func Test_SearchByStorefrontAPI_SupportsAllBinderposStores(t *testing.T) {
 }
 
 func Test_SearchByStorefrontAPI_OverlapsLegacyScrapeResults(t *testing.T) {
+	previousSelector := shouldUseDecklistEndpoint
+	shouldUseDecklistEndpoint = func() bool { return false }
+	t.Cleanup(func() { shouldUseDecklistEndpoint = previousSelector })
+
 	client := &http.Client{Timeout: 20 * time.Second}
 	for _, testCase := range binderposStoreSearchCases() {
 		t.Run(testCase.storeName, func(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- changed `searchByStorefrontAPIWithClient` so when the decklist route is selected it now returns decklist results/errors directly
- removed same-attempt fallback from decklist to product-details so errors can bubble up to the outer strategy chain and proceed to the next attempt/proxy
- updated routing tests to assert decklist errors are returned when decklist is selected
- stabilized storefront integration tests by forcing decklist selection off in those tests so they continue validating product-details behavior deterministically

## Testing
- `go test ./gateway/binderpos -run 'TestSearchByStorefrontAPIWithClient|TestSearchWithFallback'`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8bcf5291-6874-4c7b-8ad7-9ca91387a355"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8bcf5291-6874-4c7b-8ad7-9ca91387a355"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

