### PR TITLE
Reduce BinderPOS per-attempt timeout to 2 seconds

### DIFF
--- a/api/gateway/binderpos/storefront.go
+++ b/api/gateway/binderpos/storefront.go
@@ -23,7 +23,7 @@ const (
 	binderposDecklistAPIURL = "https://portal.binderpos.com/external/shopify/decklist"
 	binderposDecklistType   = "mtg"
 	binderposDecklistPct    = 70
-	binderposAttemptTimeout = 4 * time.Second
+	binderposAttemptTimeout = 2 * time.Second
 )
 
 var binderposShopifyDomainByStoreHost = map[string]string{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- change BinderPOS `binderposAttemptTimeout` from `4 * time.Second` to `2 * time.Second`
- this applies to per-attempt API/search and scraper fallback paths that use the shared BinderPOS timeout constant

## Testing
- `go test -mod=vendor ./gateway/binderpos -run 'TestUseDecklistForRoll|TestSearchByStorefrontAPIWithClient_UsesProductDetailPathWhenDecklistNotSelected|TestSearchByStorefrontAPIWithClient_ReturnsDecklistErrorWhenSelected|TestStorefrontShopifyDomainForBaseURL|TestMapDecklistLinesToCards|TestSearchWithFallback|TestNewHTTPClientWithProxyURL|TestRunWithAttemptTimeout'`
- `go test -mod=vendor ./controller`

## Notes
- Full BinderPOS integration tests are network-dependent and can be flaky in CI/local environments.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-333e9998-6178-4c41-8ff9-c63e24ed753c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-333e9998-6178-4c41-8ff9-c63e24ed753c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

