### PR TITLE
Increase BinderPOS max concurrency to 12

### DIFF
--- a/api/controller/search.go
+++ b/api/controller/search.go
@@ -56,7 +56,7 @@ type StoreError struct {
 	Error string `json:"error"`
 }
 
-const binderposMaxConcurrent = 10
+const binderposMaxConcurrent = 12
 
 var sendDiscordAlert = alert.SendDiscordAlert
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- increase `binderposMaxConcurrent` from `10` to `12`
- keep BinderPOS store detection and concurrency gating logic unchanged
- make this a temporary hardcoded limit change (no dynamic derivation)

## Testing
- `go test ./controller`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8477fbd-1b54-4b15-851d-a1b795e3cf6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8477fbd-1b54-4b15-851d-a1b795e3cf6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

