### PR TITLE
binderpos fallback tuning and non-interactive test target

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,3 +31,8 @@ Notes:
 ## UI deliverables
 
 - For any PR that includes UI changes, include screenshots of the updated UI at both desktop and mobile resolutions.
+
+## BinderPOS strategy memory (operational rule)
+
+- Canonical BinderPOS search/retry summary is tracked in `docs/skills/binderpos-search-strategy.md`.
+- If any BinderPOS search/fallback/retry behavior changes (including proxy routing or timeout behavior), update that summary file in the same PR.

--- a/Makefile
+++ b/Makefile
@@ -61,4 +61,4 @@ aws-login:
 	aws ecr get-login-password --region ap-southeast-1 | docker login --username AWS --password-stdin 206363131200.dkr.ecr.ap-southeast-1.amazonaws.com
 
 test:
-	cd api && go clean -testcache && go test -mod=vendor -failfast -timeout 5m ./... || (echo "\n\033[0;31mTESTS FAILED\033[0m. Continue deployment? [y/N] "; read ans; [ $${ans:-N} = y ])
+	cd api && go clean -testcache && go test -mod=vendor -failfast -timeout 5m ./...

--- a/api/gateway/binderpos/scrap.go
+++ b/api/gateway/binderpos/scrap.go
@@ -18,7 +18,7 @@ import (
 )
 
 func (i impl) Scrap(ctx context.Context, scrapVariant int, storeName, baseUrl, searchUrl, searchStr string) ([]gateway.Card, error) {
-	return i.scrapWithCollectorFactory(ctx, scrapVariant, storeName, baseUrl, searchUrl, searchStr, gateway.NewOptimizedCollectorForBinderpos)
+	return i.scrapWithCollectorFactory(ctx, scrapVariant, storeName, baseUrl, searchUrl, searchStr, newDedicatedNoRetryCollector)
 }
 
 func (i impl) scrapDedicatedProxy(ctx context.Context, scrapVariant int, storeName, baseUrl, searchUrl, searchStr string) ([]gateway.Card, error) {

--- a/api/gateway/binderpos/storefront.go
+++ b/api/gateway/binderpos/storefront.go
@@ -9,7 +9,9 @@ const (
 	storefrontSuggestPath   = "/search/suggest.json"
 	binderposDecklistAPIURL = "https://portal.binderpos.com/external/shopify/decklist"
 	binderposDecklistType   = "mtg"
-	binderposDecklistPct    = 70
+	// Keep the roll-based selector in place for production testing toggles.
+	// Current rollout is 100% decklist path.
+	binderposDecklistPct = 100
 	binderposAttemptTimeout = 2 * time.Second
 )
 

--- a/api/gateway/binderpos/storefront_fallback.go
+++ b/api/gateway/binderpos/storefront_fallback.go
@@ -9,8 +9,7 @@ import (
 func searchWithFallback(
 	searchAPIDedicatedFn func() ([]gateway.Card, error),
 	searchAPISharedFn func() ([]gateway.Card, error),
-	scrapSharedPrimaryFn func() ([]gateway.Card, error),
-	scrapSharedSecondaryFn func() ([]gateway.Card, error),
+	scrapSharedFn func() ([]gateway.Card, error),
 ) ([]gateway.Card, error) {
 	apiDedicatedCards, apiDedicatedErr := searchAPIDedicatedFn()
 	apiDedicatedErr = annotateAttemptError(1, "api-dedicated", apiDedicatedErr)
@@ -24,20 +23,10 @@ func searchWithFallback(
 		return apiSharedCards, nil
 	}
 
-	scrapedCards, scrapErr := scrapSharedPrimaryFn()
-	scrapErr = annotateAttemptError(3, "scrap-shared-primary", scrapErr)
+	scrapedCards, scrapErr := scrapSharedFn()
+	scrapErr = annotateAttemptError(3, "scrap-shared", scrapErr)
 	if scrapErr == nil {
 		return scrapedCards, nil
-	}
-
-	scrapedSharedCards, scrapSharedErr := scrapSharedSecondaryFn()
-	scrapSharedErr = annotateAttemptError(4, "scrap-shared-secondary", scrapSharedErr)
-	if scrapSharedErr == nil {
-		return scrapedSharedCards, nil
-	}
-
-	if scrapSharedErr != nil {
-		return scrapedSharedCards, scrapSharedErr
 	}
 	if scrapErr != nil {
 		return scrapedCards, scrapErr

--- a/api/gateway/binderpos/storefront_fallback.go
+++ b/api/gateway/binderpos/storefront_fallback.go
@@ -9,51 +9,31 @@ import (
 func searchWithFallback(
 	searchAPIDedicatedFn func() ([]gateway.Card, error),
 	searchAPISharedFn func() ([]gateway.Card, error),
-	scrapDedicatedFn func() ([]gateway.Card, error),
-	scrapSharedFn func() ([]gateway.Card, error),
+	scrapSharedPrimaryFn func() ([]gateway.Card, error),
+	scrapSharedSecondaryFn func() ([]gateway.Card, error),
 ) ([]gateway.Card, error) {
-	// Some stores legitimately return no matches for the query.
-	// If any attempt completes without an error, do not surface earlier failures.
-	hasSuccessfulAttempt := false
-
 	apiDedicatedCards, apiDedicatedErr := searchAPIDedicatedFn()
 	apiDedicatedErr = annotateAttemptError(1, "api-dedicated", apiDedicatedErr)
 	if apiDedicatedErr == nil {
-		hasSuccessfulAttempt = true
-	}
-	if len(apiDedicatedCards) > 0 && apiDedicatedErr == nil {
 		return apiDedicatedCards, nil
 	}
 
 	apiSharedCards, apiSharedErr := searchAPISharedFn()
 	apiSharedErr = annotateAttemptError(2, "api-shared", apiSharedErr)
 	if apiSharedErr == nil {
-		hasSuccessfulAttempt = true
-	}
-	if len(apiSharedCards) > 0 && apiSharedErr == nil {
 		return apiSharedCards, nil
 	}
 
-	scrapedCards, scrapErr := scrapDedicatedFn()
-	scrapErr = annotateAttemptError(3, "scrap-dedicated", scrapErr)
+	scrapedCards, scrapErr := scrapSharedPrimaryFn()
+	scrapErr = annotateAttemptError(3, "scrap-shared-primary", scrapErr)
 	if scrapErr == nil {
-		hasSuccessfulAttempt = true
-	}
-	if len(scrapedCards) > 0 && scrapErr == nil {
 		return scrapedCards, nil
 	}
 
-	scrapedSharedCards, scrapSharedErr := scrapSharedFn()
-	scrapSharedErr = annotateAttemptError(4, "scrap-shared", scrapSharedErr)
+	scrapedSharedCards, scrapSharedErr := scrapSharedSecondaryFn()
+	scrapSharedErr = annotateAttemptError(4, "scrap-shared-secondary", scrapSharedErr)
 	if scrapSharedErr == nil {
-		hasSuccessfulAttempt = true
-	}
-	if len(scrapedSharedCards) > 0 && scrapSharedErr == nil {
 		return scrapedSharedCards, nil
-	}
-
-	if hasSuccessfulAttempt {
-		return []gateway.Card{}, nil
 	}
 
 	if scrapSharedErr != nil {

--- a/api/gateway/binderpos/storefront_fallback_test.go
+++ b/api/gateway/binderpos/storefront_fallback_test.go
@@ -24,7 +24,7 @@ func TestSearchWithFallback(t *testing.T) {
 		}
 	})
 
-	t.Run("falls back to shared api before dedicated scraper", func(t *testing.T) {
+	t.Run("falls back to shared api before shared scraper attempts", func(t *testing.T) {
 		cards, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-shared"}}, nil },
@@ -39,7 +39,7 @@ func TestSearchWithFallback(t *testing.T) {
 		}
 	})
 
-	t.Run("falls back to dedicated scraper before shared-proxy scraper", func(t *testing.T) {
+	t.Run("falls back to primary shared-proxy scraper before secondary shared-proxy scraper", func(t *testing.T) {
 		cards, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
 			func() ([]gateway.Card, error) { return nil, errors.New("shared api failed") },
@@ -50,11 +50,11 @@ func TestSearchWithFallback(t *testing.T) {
 			t.Fatalf("expected nil error, got %v", err)
 		}
 		if len(cards) != 1 || cards[0].Name != "scrap" {
-			t.Fatalf("expected scraper card, got %+v", cards)
+			t.Fatalf("expected primary shared-proxy scraper card, got %+v", cards)
 		}
 	})
 
-	t.Run("falls back to shared-proxy scraper when dedicated api, shared api and dedicated scraper fail", func(t *testing.T) {
+	t.Run("falls back to secondary shared-proxy scraper when dedicated api, shared api and primary shared scraper fail", func(t *testing.T) {
 		cards, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
 			func() ([]gateway.Card, error) { return nil, errors.New("shared api failed") },
@@ -69,7 +69,7 @@ func TestSearchWithFallback(t *testing.T) {
 		}
 	})
 
-	t.Run("returns final shared-proxy scraper error when all fail", func(t *testing.T) {
+	t.Run("returns final secondary shared-proxy scraper error when all fail", func(t *testing.T) {
 		dedicatedErr := errors.New("dedicated api failed")
 		sharedErr := errors.New("shared api failed")
 		scrapErr := errors.New("scraper failed")
@@ -83,7 +83,7 @@ func TestSearchWithFallback(t *testing.T) {
 		if !errors.Is(err, sharedScrapErr) {
 			t.Fatalf("expected shared-proxy scraper error, got %v", err)
 		}
-		expectedError := "attempt 4 (scrap-shared): shared scraper failed"
+		expectedError := "attempt 4 (scrap-shared-secondary): shared scraper failed"
 		if err == nil || err.Error() != expectedError {
 			t.Fatalf("expected final error %q, got %v", expectedError, err)
 		}
@@ -101,13 +101,13 @@ func TestSearchWithFallback(t *testing.T) {
 		_, err := searchWithFallback(
 			fail("api-dedicated"),
 			fail("api-shared"),
-			fail("scrap-dedicated"),
-			fail("scrap-shared"),
+			fail("scrap-shared-primary"),
+			fail("scrap-shared-secondary"),
 		)
 		if err == nil {
 			t.Fatalf("expected fallback chain to return the final error")
 		}
-		expected := []string{"api-dedicated", "api-shared", "scrap-dedicated", "scrap-shared"}
+		expected := []string{"api-dedicated", "api-shared", "scrap-shared-primary", "scrap-shared-secondary"}
 		if len(sequence) != len(expected) {
 			t.Fatalf("expected %d attempts, got %d (%v)", len(expected), len(sequence), sequence)
 		}
@@ -118,18 +118,34 @@ func TestSearchWithFallback(t *testing.T) {
 		}
 	})
 
-	t.Run("returns no error when a fallback attempt succeeds with empty cards", func(t *testing.T) {
+	t.Run("does not fallback when an attempt returns no error with empty cards", func(t *testing.T) {
+		wasSharedAPICalled := false
+		wasPrimaryScraperCalled := false
+		wasSecondaryScraperCalled := false
+
 		cards, err := searchWithFallback(
-			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
-			func() ([]gateway.Card, error) { return nil, errors.New("shared api failed") },
 			func() ([]gateway.Card, error) { return []gateway.Card{}, nil },
-			func() ([]gateway.Card, error) { return nil, errors.New("shared scraper failed") },
+			func() ([]gateway.Card, error) {
+				wasSharedAPICalled = true
+				return []gateway.Card{{Name: "api-shared"}}, nil
+			},
+			func() ([]gateway.Card, error) {
+				wasPrimaryScraperCalled = true
+				return []gateway.Card{{Name: "scrap-primary"}}, nil
+			},
+			func() ([]gateway.Card, error) {
+				wasSecondaryScraperCalled = true
+				return []gateway.Card{{Name: "scrap-secondary"}}, nil
+			},
 		)
 		if err != nil {
-			t.Fatalf("expected nil error when any attempt succeeds with empty result, got %v", err)
+			t.Fatalf("expected nil error, got %v", err)
 		}
 		if len(cards) != 0 {
 			t.Fatalf("expected zero cards, got %+v", cards)
+		}
+		if wasSharedAPICalled || wasPrimaryScraperCalled || wasSecondaryScraperCalled {
+			t.Fatalf("expected no fallback attempts after first success, got sharedAPI=%t primaryScraper=%t secondaryScraper=%t", wasSharedAPICalled, wasPrimaryScraperCalled, wasSecondaryScraperCalled)
 		}
 	})
 }

--- a/api/gateway/binderpos/storefront_fallback_test.go
+++ b/api/gateway/binderpos/storefront_fallback_test.go
@@ -14,7 +14,6 @@ func TestSearchWithFallback(t *testing.T) {
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-dedicated"}}, nil },
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-shared"}}, nil },
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap"}}, nil },
-			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-shared"}}, nil },
 		)
 		if err != nil {
 			t.Fatalf("expected nil error, got %v", err)
@@ -29,7 +28,6 @@ func TestSearchWithFallback(t *testing.T) {
 			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-shared"}}, nil },
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap"}}, nil },
-			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-shared"}}, nil },
 		)
 		if err != nil {
 			t.Fatalf("expected nil error, got %v", err)
@@ -39,58 +37,40 @@ func TestSearchWithFallback(t *testing.T) {
 		}
 	})
 
-	t.Run("falls back to primary shared-proxy scraper before secondary shared-proxy scraper", func(t *testing.T) {
+	t.Run("falls back to shared-proxy scraper when both api attempts fail", func(t *testing.T) {
 		cards, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
 			func() ([]gateway.Card, error) { return nil, errors.New("shared api failed") },
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap"}}, nil },
-			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-shared"}}, nil },
 		)
 		if err != nil {
 			t.Fatalf("expected nil error, got %v", err)
 		}
 		if len(cards) != 1 || cards[0].Name != "scrap" {
-			t.Fatalf("expected primary shared-proxy scraper card, got %+v", cards)
-		}
-	})
-
-	t.Run("falls back to secondary shared-proxy scraper when dedicated api, shared api and primary shared scraper fail", func(t *testing.T) {
-		cards, err := searchWithFallback(
-			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
-			func() ([]gateway.Card, error) { return nil, errors.New("shared api failed") },
-			func() ([]gateway.Card, error) { return nil, errors.New("scraper failed") },
-			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-shared"}}, nil },
-		)
-		if err != nil {
-			t.Fatalf("expected nil error, got %v", err)
-		}
-		if len(cards) != 1 || cards[0].Name != "scrap-shared" {
 			t.Fatalf("expected shared-proxy scraper card, got %+v", cards)
 		}
 	})
 
-	t.Run("returns final secondary shared-proxy scraper error when all fail", func(t *testing.T) {
+	t.Run("returns final shared-proxy scraper error when all fail", func(t *testing.T) {
 		dedicatedErr := errors.New("dedicated api failed")
 		sharedErr := errors.New("shared api failed")
 		scrapErr := errors.New("scraper failed")
-		sharedScrapErr := errors.New("shared scraper failed")
 		_, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return nil, dedicatedErr },
 			func() ([]gateway.Card, error) { return nil, sharedErr },
 			func() ([]gateway.Card, error) { return nil, scrapErr },
-			func() ([]gateway.Card, error) { return nil, sharedScrapErr },
 		)
-		if !errors.Is(err, sharedScrapErr) {
+		if !errors.Is(err, scrapErr) {
 			t.Fatalf("expected shared-proxy scraper error, got %v", err)
 		}
-		expectedError := "attempt 4 (scrap-shared-secondary): shared scraper failed"
+		expectedError := "attempt 3 (scrap-shared): scraper failed"
 		if err == nil || err.Error() != expectedError {
 			t.Fatalf("expected final error %q, got %v", expectedError, err)
 		}
 	})
 
 	t.Run("runs attempts in the requested order", func(t *testing.T) {
-		sequence := make([]string, 0, 4)
+		sequence := make([]string, 0, 3)
 		fail := func(label string) func() ([]gateway.Card, error) {
 			return func() ([]gateway.Card, error) {
 				sequence = append(sequence, label)
@@ -101,13 +81,12 @@ func TestSearchWithFallback(t *testing.T) {
 		_, err := searchWithFallback(
 			fail("api-dedicated"),
 			fail("api-shared"),
-			fail("scrap-shared-primary"),
-			fail("scrap-shared-secondary"),
+			fail("scrap-shared"),
 		)
 		if err == nil {
 			t.Fatalf("expected fallback chain to return the final error")
 		}
-		expected := []string{"api-dedicated", "api-shared", "scrap-shared-primary", "scrap-shared-secondary"}
+		expected := []string{"api-dedicated", "api-shared", "scrap-shared"}
 		if len(sequence) != len(expected) {
 			t.Fatalf("expected %d attempts, got %d (%v)", len(expected), len(sequence), sequence)
 		}
@@ -120,8 +99,7 @@ func TestSearchWithFallback(t *testing.T) {
 
 	t.Run("does not fallback when an attempt returns no error with empty cards", func(t *testing.T) {
 		wasSharedAPICalled := false
-		wasPrimaryScraperCalled := false
-		wasSecondaryScraperCalled := false
+		wasSharedScraperCalled := false
 
 		cards, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return []gateway.Card{}, nil },
@@ -130,12 +108,8 @@ func TestSearchWithFallback(t *testing.T) {
 				return []gateway.Card{{Name: "api-shared"}}, nil
 			},
 			func() ([]gateway.Card, error) {
-				wasPrimaryScraperCalled = true
-				return []gateway.Card{{Name: "scrap-primary"}}, nil
-			},
-			func() ([]gateway.Card, error) {
-				wasSecondaryScraperCalled = true
-				return []gateway.Card{{Name: "scrap-secondary"}}, nil
+				wasSharedScraperCalled = true
+				return []gateway.Card{{Name: "scrap-shared"}}, nil
 			},
 		)
 		if err != nil {
@@ -144,8 +118,8 @@ func TestSearchWithFallback(t *testing.T) {
 		if len(cards) != 0 {
 			t.Fatalf("expected zero cards, got %+v", cards)
 		}
-		if wasSharedAPICalled || wasPrimaryScraperCalled || wasSecondaryScraperCalled {
-			t.Fatalf("expected no fallback attempts after first success, got sharedAPI=%t primaryScraper=%t secondaryScraper=%t", wasSharedAPICalled, wasPrimaryScraperCalled, wasSecondaryScraperCalled)
+		if wasSharedAPICalled || wasSharedScraperCalled {
+			t.Fatalf("expected no fallback attempts after first success, got sharedAPI=%t sharedScraper=%t", wasSharedAPICalled, wasSharedScraperCalled)
 		}
 	})
 }

--- a/api/gateway/binderpos/storefront_routing_test.go
+++ b/api/gateway/binderpos/storefront_routing_test.go
@@ -16,8 +16,8 @@ func TestUseDecklistForRoll(t *testing.T) {
 	}{
 		{name: "0 routes to decklist", roll: 0, want: true},
 		{name: "69 routes to decklist", roll: 69, want: true},
-		{name: "70 routes to product details fallback", roll: 70, want: false},
-		{name: "99 routes to product details fallback", roll: 99, want: false},
+		{name: "70 routes to decklist", roll: 70, want: true},
+		{name: "99 routes to decklist", roll: 99, want: true},
 	}
 
 	for _, test := range tests {

--- a/api/gateway/binderpos/storefront_search.go
+++ b/api/gateway/binderpos/storefront_search.go
@@ -23,11 +23,6 @@ func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, 
 				return i.scrapSharedProxy(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
 			})
 		},
-		func() ([]gateway.Card, error) {
-			return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
-				return i.scrapSharedProxy(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
-			})
-		},
 	)
 }
 

--- a/api/gateway/binderpos/storefront_search.go
+++ b/api/gateway/binderpos/storefront_search.go
@@ -20,7 +20,7 @@ func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, 
 		},
 		func() ([]gateway.Card, error) {
 			return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
-				return i.scrapDedicatedProxy(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
+				return i.scrapSharedProxy(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
 			})
 		},
 		func() ([]gateway.Card, error) {

--- a/docs/skills/binderpos-search-strategy.md
+++ b/docs/skills/binderpos-search-strategy.md
@@ -20,25 +20,24 @@ Entry point: `binderpos.impl.Search(...)`.
 Attempt order:
 1. `api-dedicated`: Storefront API with a dedicated proxy client.
 2. `api-shared`: Storefront API with shared proxy (`PROXY_URL`).
-3. `scrap-dedicated`: HTML scraping with dedicated proxy, no collector retries.
-4. `scrap-shared`: HTML scraping with shared proxy (`PROXY_URL`), no collector retries.
+3. `scrap-shared-primary`: HTML scraping with shared proxy (`PROXY_URL`), no collector retries.
+4. `scrap-shared-secondary`: HTML scraping with shared proxy (`PROXY_URL`), no collector retries.
 
 Per-attempt result handling:
-- If an attempt returns `err == nil` and `len(cards) > 0`, return immediately.
-- If an attempt returns `err == nil` and zero cards, continue to next attempt.
-- If at least one attempt ended with `err == nil` (even with zero cards), final result is `[]` with `nil` error.
+- If an attempt returns `err == nil` (including zero cards), return immediately.
+- Fallback to the next strategy only happens when the current attempt returns an error.
 - If all attempts fail, return the latest fallback error (priority: attempt 4 -> 3 -> 2 -> 1).
 - Errors are wrapped with attempt labels, e.g. `attempt 2 (api-shared): ...`.
 
 ## 2) Storefront API sub-strategy (inside attempts 1 and 2)
 
 `searchByStorefrontAPIWithClient(...)` does:
-- 70% path: BinderPOS decklist endpoint (`useDecklistForRoll(0..69)`).
-- 30% path: Shopify suggest + per-product details fallback (`useDecklistForRoll(70..99)`).
+- Current rollout is 100% decklist endpoint (`binderposDecklistPct = 100`), so `useDecklistForRoll(0..99)` routes to decklist.
+- Roll-based selector logic is intentionally preserved for runtime testing/rollback adjustments.
 
 Notes:
 - Decklist path depends on host-to-Shopify mapping in `binderposShopifyDomainByStoreHost`; unmapped hosts fail this path and rely on fallback attempts.
-- Product-details path tolerates individual product-detail fetch failures (skips failed products) and can still return partial success with `nil` error.
+- Product-details path code still exists but is currently not selected under the 100% decklist rollout.
 
 ## 3) Retry semantics (important distinction)
 

--- a/docs/skills/binderpos-search-strategy.md
+++ b/docs/skills/binderpos-search-strategy.md
@@ -15,18 +15,17 @@ Canonical source files:
 
 Entry point: `binderpos.impl.Search(...)`.
 
-`Search` runs a fixed 4-attempt fallback chain via `searchWithFallback`, and each attempt is wrapped by `runWithAttemptTimeout` with `binderposAttemptTimeout = 2s`.
+`Search` runs a fixed 3-attempt fallback chain via `searchWithFallback`, and each attempt is wrapped by `runWithAttemptTimeout` with `binderposAttemptTimeout = 2s`.
 
 Attempt order:
 1. `api-dedicated`: Storefront API with a dedicated proxy client.
 2. `api-shared`: Storefront API with shared proxy (`PROXY_URL`).
-3. `scrap-shared-primary`: HTML scraping with shared proxy (`PROXY_URL`), no collector retries.
-4. `scrap-shared-secondary`: HTML scraping with shared proxy (`PROXY_URL`), no collector retries.
+3. `scrap-shared`: HTML scraping with shared proxy (`PROXY_URL`), no collector retries.
 
 Per-attempt result handling:
 - If an attempt returns `err == nil` (including zero cards), return immediately.
 - Fallback to the next strategy only happens when the current attempt returns an error.
-- If all attempts fail, return the latest fallback error (priority: attempt 4 -> 3 -> 2 -> 1).
+- If all attempts fail, return the latest fallback error (priority: attempt 3 -> 2 -> 1).
 - Errors are wrapped with attempt labels, e.g. `attempt 2 (api-shared): ...`.
 
 ## 2) Storefront API sub-strategy (inside attempts 1 and 2)
@@ -42,9 +41,9 @@ Notes:
 ## 3) Retry semantics (important distinction)
 
 ### A) Retries for `Search`
-- `Search` itself has **fallback attempts** (4 sequential strategies), not per-request backoff retries.
+- `Search` itself has **fallback attempts** (3 sequential strategies), not per-request backoff retries.
 - No internal HTTP retry loop is used in attempts 1/2 beyond normal client behavior.
-- Attempts 3/4 explicitly use no-retry collectors (`NewOptimizedCollectorNoRetry*`), with 2s request timeout.
+- Attempt 3 explicitly uses a no-retry collector (`NewOptimizedCollectorNoRetry*`), with 2s request timeout.
 
 ### B) Retries for direct `Scrap` calls
 - `binderpos.impl.Scrap(...)` now uses the no-retry dedicated collector.

--- a/docs/skills/binderpos-search-strategy.md
+++ b/docs/skills/binderpos-search-strategy.md
@@ -1,0 +1,72 @@
+# BinderPOS Search Strategy and Retry Summary
+
+Last verified: 2026-04-23
+
+Canonical source files:
+- `api/gateway/binderpos/storefront_search.go`
+- `api/gateway/binderpos/storefront_fallback.go`
+- `api/gateway/binderpos/storefront_client.go`
+- `api/gateway/binderpos/storefront_decklist.go`
+- `api/gateway/binderpos/storefront_product_details.go`
+- `api/gateway/binderpos/scrap.go`
+- `api/gateway/collector.go`
+
+## 1) BinderPOS `Search` strategy (current behavior)
+
+Entry point: `binderpos.impl.Search(...)`.
+
+`Search` runs a fixed 4-attempt fallback chain via `searchWithFallback`, and each attempt is wrapped by `runWithAttemptTimeout` with `binderposAttemptTimeout = 2s`.
+
+Attempt order:
+1. `api-dedicated`: Storefront API with a dedicated proxy client.
+2. `api-shared`: Storefront API with shared proxy (`PROXY_URL`).
+3. `scrap-dedicated`: HTML scraping with dedicated proxy, no collector retries.
+4. `scrap-shared`: HTML scraping with shared proxy (`PROXY_URL`), no collector retries.
+
+Per-attempt result handling:
+- If an attempt returns `err == nil` and `len(cards) > 0`, return immediately.
+- If an attempt returns `err == nil` and zero cards, continue to next attempt.
+- If at least one attempt ended with `err == nil` (even with zero cards), final result is `[]` with `nil` error.
+- If all attempts fail, return the latest fallback error (priority: attempt 4 -> 3 -> 2 -> 1).
+- Errors are wrapped with attempt labels, e.g. `attempt 2 (api-shared): ...`.
+
+## 2) Storefront API sub-strategy (inside attempts 1 and 2)
+
+`searchByStorefrontAPIWithClient(...)` does:
+- 70% path: BinderPOS decklist endpoint (`useDecklistForRoll(0..69)`).
+- 30% path: Shopify suggest + per-product details fallback (`useDecklistForRoll(70..99)`).
+
+Notes:
+- Decklist path depends on host-to-Shopify mapping in `binderposShopifyDomainByStoreHost`; unmapped hosts fail this path and rely on fallback attempts.
+- Product-details path tolerates individual product-detail fetch failures (skips failed products) and can still return partial success with `nil` error.
+
+## 3) Retry semantics (important distinction)
+
+### A) Retries for `Search`
+- `Search` itself has **fallback attempts** (4 sequential strategies), not per-request backoff retries.
+- No internal HTTP retry loop is used in attempts 1/2 beyond normal client behavior.
+- Attempts 3/4 explicitly use no-retry collectors (`NewOptimizedCollectorNoRetry*`), with 2s request timeout.
+
+### B) Retries for direct `Scrap` calls
+- `binderpos.impl.Scrap(...)` (not `Search`) uses `NewOptimizedCollectorForBinderpos(...)`, which enables collector retries.
+- Current collector retry policy: `maxRetries = 2` (two retries after initial request).
+- Proxy progression for direct `Scrap` retries:
+  - Default: `dedicated -> dedicated -> direct`.
+  - Rollback mode (`USE_BINDERPOS_SHARED_PROXY_FALLBACK=true`): `dedicated -> shared(PROXY_URL) -> direct`.
+
+## 4) Proxy prerequisites and failure behavior
+
+- Dedicated proxy attempts require at least one configured dedicated proxy URL (`util.GetDedicatedProxyURLs()`); missing/invalid config fails that attempt immediately.
+- Shared proxy attempts require `PROXY_URL`; missing/invalid config fails that attempt immediately.
+- These config failures are treated as normal fallback errors and drive progression to the next attempt.
+
+## 5) Keep this summary up to date
+
+When changing BinderPOS search/retry logic, update this file in the same PR.
+
+Minimum trigger files:
+- `api/gateway/binderpos/storefront_search.go`
+- `api/gateway/binderpos/storefront_fallback.go`
+- `api/gateway/binderpos/storefront_client.go`
+- `api/gateway/binderpos/scrap.go`
+- `api/gateway/collector.go` (if BinderPOS retry/proxy flow is affected)

--- a/docs/skills/binderpos-search-strategy.md
+++ b/docs/skills/binderpos-search-strategy.md
@@ -47,11 +47,9 @@ Notes:
 - Attempts 3/4 explicitly use no-retry collectors (`NewOptimizedCollectorNoRetry*`), with 2s request timeout.
 
 ### B) Retries for direct `Scrap` calls
-- `binderpos.impl.Scrap(...)` (not `Search`) uses `NewOptimizedCollectorForBinderpos(...)`, which enables collector retries.
-- Current collector retry policy: `maxRetries = 2` (two retries after initial request).
-- Proxy progression for direct `Scrap` retries:
-  - Default: `dedicated -> dedicated -> direct`.
-  - Rollback mode (`USE_BINDERPOS_SHARED_PROXY_FALLBACK=true`): `dedicated -> shared(PROXY_URL) -> direct`.
+- `binderpos.impl.Scrap(...)` now uses the no-retry dedicated collector.
+- Each scrape request path is single-attempt (no collector retry loop).
+- If a scrape attempt returns an error, `Search` fallback logic is responsible for advancing to the next strategy.
 
 ## 4) Proxy prerequisites and failure behavior
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- force BinderPOS storefront decklist routing to 100% (`binderposDecklistPct = 100`) while preserving the roll-based selector logic
- update BinderPOS `Search` fallback behavior to advance only on errors (successful empty results now stop fallback)
- switch BinderPOS fallback attempt #3 to shared-proxy scrape and remove duplicate fallback attempt #4
- keep scrape paths single-attempt (no collector retries) and update BinderPOS strategy memory note accordingly
- remove interactive prompt from `make test` so failures exit immediately instead of asking `TESTS FAILED. Continue deployment? [y/N]`

## Validation
- `go test -mod=vendor ./gateway/binderpos/...`
- `make -n test`
- `go test -mod=vendor -failfast -timeout 5m ./gateway/... ./controller/...` *(fails at `gateway/arcanesanctum` in this environment due missing shared proxy configuration)*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f3aa94f6-c534-4225-8f76-d31544e455e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3aa94f6-c534-4225-8f76-d31544e455e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

