### PR TITLE
BinderPOS: three-step search (drop dedicated scraper fallback)

### DIFF
--- a/api/gateway/binderpos/scrap.go
+++ b/api/gateway/binderpos/scrap.go
@@ -21,14 +21,6 @@ func (i impl) Scrap(ctx context.Context, scrapVariant int, storeName, baseUrl, s
 	return i.scrapWithCollectorFactory(ctx, scrapVariant, storeName, baseUrl, searchUrl, searchStr, gateway.NewOptimizedCollectorForBinderpos)
 }
 
-func (i impl) scrapDedicatedProxy(ctx context.Context, scrapVariant int, storeName, baseUrl, searchUrl, searchStr string) ([]gateway.Card, error) {
-	if !dedicatedProxyConfigured() {
-		return nil, fmt.Errorf("no dedicated proxy configured for binderpos scraper")
-	}
-
-	return i.scrapWithCollectorFactory(ctx, scrapVariant, storeName, baseUrl, searchUrl, searchStr, newDedicatedNoRetryCollector)
-}
-
 func (i impl) scrapDirect(ctx context.Context, scrapVariant int, storeName, baseUrl, searchUrl, searchStr string) ([]gateway.Card, error) {
 	return i.scrapWithCollectorFactory(ctx, scrapVariant, storeName, baseUrl, searchUrl, searchStr, newDirectNoRetryCollector)
 }
@@ -68,12 +60,6 @@ func (i impl) scrapWithCollectorFactory(
 	return []gateway.Card{}, fmt.Errorf("invalid scrap variant: %d", scrapVariant)
 }
 
-func newDedicatedNoRetryCollector(ctx context.Context) *colly.Collector {
-	c := gateway.NewOptimizedCollectorNoRetry(ctx)
-	c.SetRequestTimeout(binderposAttemptTimeout)
-	return c
-}
-
 func newDirectNoRetryCollector(ctx context.Context) *colly.Collector {
 	c := gateway.NewOptimizedCollectorNoRetryDirect(ctx)
 	c.SetRequestTimeout(binderposAttemptTimeout)
@@ -93,10 +79,6 @@ func newSharedNoRetryCollector(ctx context.Context, sharedProxyURL string) *coll
 		r.Ctx.Put("last_proxy_url", sharedProxyURL)
 	})
 	return c
-}
-
-func dedicatedProxyConfigured() bool {
-	return len(util.GetDedicatedProxyURLs()) > 0
 }
 
 // buildSafeSearchURL safely constructs the URL using url.URL and url.Values to isolate user string input.

--- a/api/gateway/binderpos/storefront.go
+++ b/api/gateway/binderpos/storefront.go
@@ -64,8 +64,8 @@ type storefrontDecklistRequestItem struct {
 }
 
 type storefrontDecklistLine struct {
-	Products  []storefrontDecklistProduct `json:"products"`
-	ValidName string                      `json:"validName"`
+	// The API can send a boolean validName; binding it would break decode, so it is not mapped.
+	Products []storefrontDecklistProduct `json:"products"`
 }
 
 type storefrontDecklistProduct struct {

--- a/api/gateway/binderpos/storefront_decklist.go
+++ b/api/gateway/binderpos/storefront_decklist.go
@@ -96,9 +96,6 @@ func mapDecklistLinesToCards(scrapVariant int, storeName, baseURL string, lines 
 				productTitle = strings.TrimSpace(product.Name)
 			}
 			if productTitle == "" {
-				productTitle = strings.TrimSpace(line.ValidName)
-			}
-			if productTitle == "" {
 				continue
 			}
 
@@ -153,4 +150,3 @@ func mapDecklistLinesToCards(scrapVariant int, storeName, baseURL string, lines 
 
 	return cards
 }
-

--- a/api/gateway/binderpos/storefront_decklist_test.go
+++ b/api/gateway/binderpos/storefront_decklist_test.go
@@ -1,8 +1,45 @@
 package binderpos
 
 import (
+	"encoding/json"
 	"testing"
 )
+
+func TestDecklistResponseJSONDecodesWithBooleanValidName(t *testing.T) {
+	// Real API can include "validName": false (bool); older struct used string and broke unmarshal.
+	const sample = `[
+	  {
+		"requested": 1,
+		"found": 1,
+		"searchName": "Abrade",
+		"productDetails": null,
+		"products": [
+		  {
+			"title": "Abrade [LCI]",
+			"name": "Abrade",
+			"handle": "abrade-lci",
+			"setName": "The Lost Caverns of Ixalan",
+			"img": "https://images.binderpos.com/x.png",
+			"variants": [
+			  { "shopifyId": 123, "title": "Near Mint", "price": 0.4, "quantity": 1 }
+			]
+		  }
+		],
+		"validName": false
+	  }
+	]`
+	var lines []storefrontDecklistLine
+	if err := json.Unmarshal([]byte(sample), &lines); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(lines) != 1 || len(lines[0].Products) != 1 {
+		t.Fatalf("unexpected structure: %+v", lines)
+	}
+	cards := mapDecklistLinesToCards(2, "Test", "https://www.mtg-asia.com", lines)
+	if len(cards) != 1 {
+		t.Fatalf("expected 1 card from mapped response, got %d", len(cards))
+	}
+}
 
 func TestStorefrontShopifyDomainForBaseURL(t *testing.T) {
 	t.Run("returns mapped domain for known host with www", func(t *testing.T) {
@@ -26,7 +63,6 @@ func TestStorefrontShopifyDomainForBaseURL(t *testing.T) {
 func TestMapDecklistLinesToCards(t *testing.T) {
 	lines := []storefrontDecklistLine{
 		{
-			ValidName: "Abrade",
 			Products: []storefrontDecklistProduct{
 				{
 					Title:   "Abrade [Foundations]",
@@ -98,6 +134,25 @@ func TestMapDecklistLinesToCards(t *testing.T) {
 		cards := mapDecklistLinesToCards(2, "Store", "https://store.example", invalid)
 		if len(cards) != 0 {
 			t.Fatalf("expected no cards, got %+v", cards)
+		}
+	})
+
+	t.Run("skips product when title and name are empty", func(t *testing.T) {
+		skipName := []storefrontDecklistLine{
+			{
+				Products: []storefrontDecklistProduct{
+					{
+						Handle:  "some-handle",
+						SetName: "A Set",
+						Variants: []storefrontDecklistStock{
+							{ShopifyID: 1, Title: "Near Mint", Price: 1, Quantity: 1},
+						},
+					},
+				},
+			},
+		}
+		if n := len(mapDecklistLinesToCards(2, "Store", "https://store.example", skipName)); n != 0 {
+			t.Fatalf("expected 0 cards when product has no title/name, got %d", n)
 		}
 	})
 }

--- a/api/gateway/binderpos/storefront_fallback.go
+++ b/api/gateway/binderpos/storefront_fallback.go
@@ -9,7 +9,6 @@ import (
 func searchWithFallback(
 	searchAPIDedicatedFn func() ([]gateway.Card, error),
 	searchAPISharedFn func() ([]gateway.Card, error),
-	scrapDedicatedFn func() ([]gateway.Card, error),
 	scrapSharedFn func() ([]gateway.Card, error),
 ) ([]gateway.Card, error) {
 	// Some stores legitimately return no matches for the query.
@@ -34,17 +33,8 @@ func searchWithFallback(
 		return apiSharedCards, nil
 	}
 
-	scrapedCards, scrapErr := scrapDedicatedFn()
-	scrapErr = annotateAttemptError(3, "scrap-dedicated", scrapErr)
-	if scrapErr == nil {
-		hasSuccessfulAttempt = true
-	}
-	if len(scrapedCards) > 0 && scrapErr == nil {
-		return scrapedCards, nil
-	}
-
 	scrapedSharedCards, scrapSharedErr := scrapSharedFn()
-	scrapSharedErr = annotateAttemptError(4, "scrap-shared", scrapSharedErr)
+	scrapSharedErr = annotateAttemptError(3, "scrap-shared", scrapSharedErr)
 	if scrapSharedErr == nil {
 		hasSuccessfulAttempt = true
 	}
@@ -58,9 +48,6 @@ func searchWithFallback(
 
 	if scrapSharedErr != nil {
 		return scrapedSharedCards, scrapSharedErr
-	}
-	if scrapErr != nil {
-		return scrapedCards, scrapErr
 	}
 	if apiSharedErr != nil {
 		return apiSharedCards, apiSharedErr

--- a/api/gateway/binderpos/storefront_fallback_test.go
+++ b/api/gateway/binderpos/storefront_fallback_test.go
@@ -13,7 +13,6 @@ func TestSearchWithFallback(t *testing.T) {
 		cards, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-dedicated"}}, nil },
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-shared"}}, nil },
-			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap"}}, nil },
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-shared"}}, nil },
 		)
 		if err != nil {
@@ -24,11 +23,10 @@ func TestSearchWithFallback(t *testing.T) {
 		}
 	})
 
-	t.Run("falls back to shared api before dedicated scraper", func(t *testing.T) {
+	t.Run("falls back to shared api before shared scraper", func(t *testing.T) {
 		cards, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-shared"}}, nil },
-			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap"}}, nil },
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-shared"}}, nil },
 		)
 		if err != nil {
@@ -39,26 +37,10 @@ func TestSearchWithFallback(t *testing.T) {
 		}
 	})
 
-	t.Run("falls back to dedicated scraper before shared-proxy scraper", func(t *testing.T) {
+	t.Run("falls back to shared-proxy scraper when both api attempts fail", func(t *testing.T) {
 		cards, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
 			func() ([]gateway.Card, error) { return nil, errors.New("shared api failed") },
-			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap"}}, nil },
-			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-shared"}}, nil },
-		)
-		if err != nil {
-			t.Fatalf("expected nil error, got %v", err)
-		}
-		if len(cards) != 1 || cards[0].Name != "scrap" {
-			t.Fatalf("expected scraper card, got %+v", cards)
-		}
-	})
-
-	t.Run("falls back to shared-proxy scraper when dedicated api, shared api and dedicated scraper fail", func(t *testing.T) {
-		cards, err := searchWithFallback(
-			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
-			func() ([]gateway.Card, error) { return nil, errors.New("shared api failed") },
-			func() ([]gateway.Card, error) { return nil, errors.New("scraper failed") },
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-shared"}}, nil },
 		)
 		if err != nil {
@@ -72,25 +54,23 @@ func TestSearchWithFallback(t *testing.T) {
 	t.Run("returns final shared-proxy scraper error when all fail", func(t *testing.T) {
 		dedicatedErr := errors.New("dedicated api failed")
 		sharedErr := errors.New("shared api failed")
-		scrapErr := errors.New("scraper failed")
 		sharedScrapErr := errors.New("shared scraper failed")
 		_, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return nil, dedicatedErr },
 			func() ([]gateway.Card, error) { return nil, sharedErr },
-			func() ([]gateway.Card, error) { return nil, scrapErr },
 			func() ([]gateway.Card, error) { return nil, sharedScrapErr },
 		)
 		if !errors.Is(err, sharedScrapErr) {
 			t.Fatalf("expected shared-proxy scraper error, got %v", err)
 		}
-		expectedError := "attempt 4 (scrap-shared): shared scraper failed"
+		expectedError := "attempt 3 (scrap-shared): shared scraper failed"
 		if err == nil || err.Error() != expectedError {
 			t.Fatalf("expected final error %q, got %v", expectedError, err)
 		}
 	})
 
 	t.Run("runs attempts in the requested order", func(t *testing.T) {
-		sequence := make([]string, 0, 4)
+		sequence := make([]string, 0, 3)
 		fail := func(label string) func() ([]gateway.Card, error) {
 			return func() ([]gateway.Card, error) {
 				sequence = append(sequence, label)
@@ -101,13 +81,12 @@ func TestSearchWithFallback(t *testing.T) {
 		_, err := searchWithFallback(
 			fail("api-dedicated"),
 			fail("api-shared"),
-			fail("scrap-dedicated"),
 			fail("scrap-shared"),
 		)
 		if err == nil {
 			t.Fatalf("expected fallback chain to return the final error")
 		}
-		expected := []string{"api-dedicated", "api-shared", "scrap-dedicated", "scrap-shared"}
+		expected := []string{"api-dedicated", "api-shared", "scrap-shared"}
 		if len(sequence) != len(expected) {
 			t.Fatalf("expected %d attempts, got %d (%v)", len(expected), len(sequence), sequence)
 		}
@@ -123,7 +102,6 @@ func TestSearchWithFallback(t *testing.T) {
 			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
 			func() ([]gateway.Card, error) { return nil, errors.New("shared api failed") },
 			func() ([]gateway.Card, error) { return []gateway.Card{}, nil },
-			func() ([]gateway.Card, error) { return nil, errors.New("shared scraper failed") },
 		)
 		if err != nil {
 			t.Fatalf("expected nil error when any attempt succeeds with empty result, got %v", err)

--- a/api/gateway/binderpos/storefront_search.go
+++ b/api/gateway/binderpos/storefront_search.go
@@ -20,11 +20,6 @@ func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, 
 		},
 		func() ([]gateway.Card, error) {
 			return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
-				return i.scrapDedicatedProxy(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
-			})
-		},
-		func() ([]gateway.Card, error) {
-			return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
 				return i.scrapSharedProxy(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
 			})
 		},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
This PR has two changes:

### 1. BinderPOS search (3 steps)
- **1** Dedicated proxy storefront API  
- **2** Shared proxy (`PROXY_URL`) storefront API  
- **3** HTML scrape on shared proxy only  

The dedicated-proxy scraper step was removed and dead helper code in `scrap.go` was deleted.

### 2. Decklist response decoding
The BinderPOS decklist API can return `"validName": false` (boolean). The struct previously used `string` for `validName`, which **broke** `json.Unmarshal` for the whole body.

- Do not decode `validName` from the line object.
- Product display name comes only from each product’s **title** or **name**; if both are empty, **skip** that product (no line-level fallback).
- Added tests for unmarshal with boolean `validName` and for skipping empty name/title.

## Suggested review
- `api/gateway/binderpos/storefront_decklist.go` and `storefront.go` for decode + mapping
- `api/gateway/binderpos/storefront_search.go` / `storefront_fallback.go` for the 3-step chain

## Tests
- `go test -mod=vendor -timeout 2m ./api/gateway/binderpos/...` (unit tests; decklist unmarshal + mapping)
- For full `make test`, set `PROXY_URL` (and dedicated proxies) when CI can reach live stores.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82a31277-2085-4b8a-a418-646072c28292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82a31277-2085-4b8a-a418-646072c28292"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

