### PR TITLE
Set binderposDecklistPct to 100% and update routing tests

### DIFF
--- a/api/gateway/binderpos/storefront.go
+++ b/api/gateway/binderpos/storefront.go
@@ -9,7 +9,7 @@ const (
 	storefrontSuggestPath   = "/search/suggest.json"
 	binderposDecklistAPIURL = "https://portal.binderpos.com/external/shopify/decklist"
 	binderposDecklistType   = "mtg"
-	binderposDecklistPct    = 70
+	binderposDecklistPct    = 100
 	binderposAttemptTimeout = 4 * time.Second
 )
 

--- a/api/gateway/binderpos/storefront_routing_test.go
+++ b/api/gateway/binderpos/storefront_routing_test.go
@@ -15,9 +15,9 @@ func TestUseDecklistForRoll(t *testing.T) {
 		want bool
 	}{
 		{name: "0 routes to decklist", roll: 0, want: true},
-		{name: "69 routes to decklist", roll: 69, want: true},
-		{name: "70 routes to product details fallback", roll: 70, want: false},
-		{name: "99 routes to product details fallback", roll: 99, want: false},
+		{name: "50 routes to decklist", roll: 50, want: true},
+		{name: "99 routes to decklist", roll: 99, want: true},
+		{name: "100 routes to product details fallback", roll: 100, want: false},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Set `binderposDecklistPct` to `100` in `api/gateway/binderpos/storefront.go` so every `rand.IntN(100)` roll (0–99) selects the decklist path via `useDecklistForRoll`.
- Updated `TestUseDecklistForRoll` in `storefront_routing_test.go` to assert decklist for representative rolls 0, 50, and 99, and product-details behavior for `roll: 100` (outside the live random range, documents the `roll < 100` boundary).

## Testing
- `make test` (all packages passed, including `gateway/binderpos`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0e0d748-bbd9-4de7-a16c-79b44f4a782f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0e0d748-bbd9-4de7-a16c-79b44f4a782f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

