### PR TITLE
Run deploy with silent make to avoid env-related command echo in CI

### DIFF
--- a/.github/workflows/deploy-on-merge.yml
+++ b/.github/workflows/deploy-on-merge.yml
@@ -48,4 +48,5 @@ jobs:
           aws-region: ap-southeast-1
 
       - name: Deploy
-        run: make deploy
+        # --silent: do not print each shell recipe (avoids echoing export lines and command noise in logs)
+        run: make --silent deploy


### PR DESCRIPTION
## Change
- Run the deploy job with `make --silent` (`make -s`) so Make does not echo each shell line for the `deploy` graph.

