### PR TITLE
Add binderpos strategy integration test and harden network retries

### DIFF
--- a/api/gateway/binderpos/storefront_api_test.go
+++ b/api/gateway/binderpos/storefront_api_test.go
@@ -79,6 +79,32 @@ func Test_StorefrontSupportedGamesEndpoint_ExistsForGreyOgreAndMtgAsia(t *testin
 }
 
 func fetchShopifyShopDomain(ctx context.Context, client *http.Client, storeURL string) (string, error) {
+	// Storefronts occasionally return transient 5xx / rate limits; retry a few times for CI stability.
+	var lastErr error
+	for attempt := 1; attempt <= 3; attempt++ {
+		domain, err := fetchShopifyShopDomainOnce(ctx, client, storeURL)
+		if err == nil {
+			return domain, nil
+		}
+		lastErr = err
+		if attempt < 3 && shouldRetryShopifyFetchError(err) {
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+		return "", err
+	}
+	return "", lastErr
+}
+
+func shouldRetryShopifyFetchError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "status 50") || strings.Contains(s, "status 429") || strings.Contains(s, "i/o timeout")
+}
+
+func fetchShopifyShopDomainOnce(ctx context.Context, client *http.Client, storeURL string) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, storeURL, nil)
 	if err != nil {
 		return "", err

--- a/api/gateway/binderpos/storefront_product_details.go
+++ b/api/gateway/binderpos/storefront_product_details.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"mtg-price-checker-sg/gateway"
 	"mtg-price-checker-sg/gateway/util"
@@ -88,31 +89,49 @@ func fetchSuggestProducts(ctx context.Context, client *http.Client, baseURL, sea
 	query.Set("resources[options][unavailable_products]", "hide")
 	suggestURL.RawQuery = query.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, suggestURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("User-Agent", gateway.RandomBrowserUserAgent())
-	if err := gateway.WaitForDomainRequestSlot(ctx, req.URL); err != nil {
-		return nil, err
-	}
+	var payload storefrontSuggestResponse
+	fullURL := suggestURL.String()
+	for attempt := 1; attempt <= 3; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fullURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("User-Agent", gateway.RandomBrowserUserAgent())
+		if err := gateway.WaitForDomainRequestSlot(ctx, req.URL); err != nil {
+			return nil, err
+		}
 
-	res, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
+		res, err := client.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		if res.StatusCode == http.StatusOK {
+			if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+				res.Body.Close()
+				return nil, err
+			}
+			res.Body.Close()
+			return payload.Resources.Results.Products, nil
+		}
+		_, _ = io.Copy(io.Discard, res.Body)
+		res.Body.Close()
+		if attempt < 3 && isRetriableHTTPStatus(res.StatusCode) {
+			time.Sleep(400 * time.Duration(attempt) * time.Millisecond)
+			continue
+		}
 		return nil, fmt.Errorf("storefront suggest request returned status %d", res.StatusCode)
 	}
+	// 3 fixed iterations always return from inside the loop; keep for the compiler and linters.
+	return nil, fmt.Errorf("storefront suggest: exhausted transient retries")
+}
 
-	var payload storefrontSuggestResponse
-	if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
-		return nil, err
+func isRetriableHTTPStatus(status int) bool {
+	switch status {
+	case http.StatusTooManyRequests, http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
 	}
-
-	return payload.Resources.Results.Products, nil
 }
 
 func fetchProductDetail(ctx context.Context, client *http.Client, baseURL, productPath string) (*storefrontProductDetail, error) {

--- a/api/gateway/binderpos/strategies_smoke_test.go
+++ b/api/gateway/binderpos/strategies_smoke_test.go
@@ -1,0 +1,91 @@
+package binderpos
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/joho/godotenv"
+	"github.com/stretchr/testify/require"
+	"mtg-price-checker-sg/gateway"
+	"mtg-price-checker-sg/gateway/util"
+)
+
+// Test_EachSearchStrategyReturnsResults exercises the three real network paths
+// used by Search (dedicated API → shared API → shared-proxy scraper) without
+// fallback masking which layer produced cards.
+func Test_EachSearchStrategyReturnsResults(t *testing.T) {
+	_ = godotenv.Load("../../.env")
+
+	prev := shouldUseDecklistEndpoint
+	shouldUseDecklistEndpoint = func() bool { return false }
+	t.Cleanup(func() { shouldUseDecklistEndpoint = prev })
+
+	var tc *binderposStoreSearchCase
+	for i := range binderposStoreSearchCases() {
+		c := binderposStoreSearchCases()[i]
+		if c.storeName == "OneMtg" {
+			tc = &c
+			break
+		}
+	}
+	require.NotNil(t, tc, "expected OneMtg in binderposStoreSearchCases()")
+
+	if len(util.GetDedicatedProxyURLs()) == 0 {
+		t.Skip("DEDICATED_PROXY_* not configured; cannot test api-dedicated")
+	}
+	if strings.TrimSpace(os.Getenv("PROXY_URL")) == "" {
+		t.Skip("PROXY_URL not configured; cannot test api-shared or scrap-shared")
+	}
+
+	ctx := context.Background()
+	name := "OneMtg (smoke: dedicated storefront API over dedicated proxy)"
+	t.Run(name, func(t *testing.T) {
+		cards, err := searchByStorefrontAPI(ctx, tc.scrapVariant, tc.storeName, tc.baseURL, tc.query)
+		assertStrategyCards(t, cards, err, name)
+	})
+
+	name = "OneMtg (smoke: shared storefront API over PROXY_URL)"
+	t.Run(name, func(t *testing.T) {
+		cards, err := searchByStorefrontAPISharedProxy(ctx, tc.scrapVariant, tc.storeName, tc.baseURL, tc.query)
+		assertStrategyCards(t, cards, err, name)
+	})
+
+	name = "OneMtg (smoke: shared proxy scraper)"
+	t.Run(name, func(t *testing.T) {
+		impl, ok := New().(*impl)
+		require.True(t, ok, "New() should return *impl")
+		// colly uses binderposAttemptTimeout (2s), which is occasionally tight for full HTML
+		// through a shared proxy under parallel load; retry a few times on transport timeouts.
+		var cards []gateway.Card
+		var err error
+		for attempt := 1; attempt <= 3; attempt++ {
+			cards, err = impl.scrapSharedProxy(ctx, tc.scrapVariant, tc.storeName, tc.baseURL, tc.searchURL, tc.query)
+			if err == nil {
+				break
+			}
+			if attempt < 3 && (strings.Contains(err.Error(), "deadline exceeded") || strings.Contains(err.Error(), "timeout") || strings.Contains(err.Error(), "i/o timeout")) {
+				time.Sleep(2 * time.Second)
+				continue
+			}
+			break
+		}
+		assertStrategyCards(t, cards, err, name)
+	})
+}
+
+func assertStrategyCards(t *testing.T, cards []gateway.Card, err error, strategyName string) {
+	t.Helper()
+	require.NoError(t, err, strategyName)
+	require.NotEmpty(t, cards, strategyName)
+
+	for _, c := range cards {
+		require.NotEmpty(t, c.Name, strategyName)
+		require.NotEmpty(t, c.Url, strategyName)
+		require.NotEmpty(t, c.Img, strategyName)
+		require.NotEmpty(t, c.Source, strategyName)
+		require.Greater(t, c.Price, float64(0), strategyName)
+	}
+}

--- a/api/gateway/collector_test.go
+++ b/api/gateway/collector_test.go
@@ -160,6 +160,10 @@ func TestApplyProxyForRetryAttempt(t *testing.T) {
 
 func TestApplyProxyForRetryAttemptWithPinnedDedicated(t *testing.T) {
 	c := colly.NewCollector()
+	t.Setenv("DEDICATED_PROXY_2", "")
+	t.Setenv("DEDICATED_PROXY_3", "")
+	t.Setenv("DEDICATED_PROXY_4", "")
+	t.Setenv("DEDICATED_PROXY_5", "")
 	t.Setenv("DEDICATED_PROXY_1", "9.9.9.9|9000|user|pass")
 	t.Setenv("PROXY_URL", "http://shared:8080")
 
@@ -195,6 +199,10 @@ func TestApplyProxyForRetryAttemptWithPinnedDedicated(t *testing.T) {
 func TestApplyProxyForRetryAttemptWithPinnedDedicatedBinderpos(t *testing.T) {
 	t.Run("default strategy uses dedicated then direct", func(t *testing.T) {
 		c := colly.NewCollector()
+		t.Setenv("DEDICATED_PROXY_2", "")
+		t.Setenv("DEDICATED_PROXY_3", "")
+		t.Setenv("DEDICATED_PROXY_4", "")
+		t.Setenv("DEDICATED_PROXY_5", "")
 		t.Setenv("DEDICATED_PROXY_1", "9.9.9.9|9000|user|pass")
 		t.Setenv("PROXY_URL", "http://shared:8080")
 		t.Setenv("USE_BINDERPOS_SHARED_PROXY_FALLBACK", "false")
@@ -227,6 +235,10 @@ func TestApplyProxyForRetryAttemptWithPinnedDedicatedBinderpos(t *testing.T) {
 
 	t.Run("rollback strategy uses shared fallback", func(t *testing.T) {
 		c := colly.NewCollector()
+		t.Setenv("DEDICATED_PROXY_2", "")
+		t.Setenv("DEDICATED_PROXY_3", "")
+		t.Setenv("DEDICATED_PROXY_4", "")
+		t.Setenv("DEDICATED_PROXY_5", "")
 		t.Setenv("DEDICATED_PROXY_1", "9.9.9.9|9000|user|pass")
 		t.Setenv("PROXY_URL", "http://shared:8080")
 		t.Setenv("USE_BINDERPOS_SHARED_PROXY_FALLBACK", "true")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This work verifies the three **Binderpos `Search` strategies** in isolation and reduces flaky network-dependent tests.

## What changed

- **`Test_EachSearchStrategyReturnsResults`** in `api/gateway/binderpos/strategies_smoke_test.go` calls, for OneMtg with decklist disabled:
  - **api-dedicated** — `searchByStorefrontAPI` (dedicated proxy)
  - **api-shared** — `searchByStorefrontAPISharedProxy` (`PROXY_URL`)
  - **scrap-shared** — `scrapSharedProxy` (with a few retries on 2s timeout under parallel load)
- **Shopify `fetchShopifyShopDomain` test helper** — retries on transient 5xx / 429 for the supported-games HTML fetch.
- **`fetchSuggestProducts`** — retries 429/5xx on the storefront suggest request (affects all Binderpos product-detail search, not just tests).
- **`collector_test.go`** — unsets `DEDICATED_PROXY_2`–`5` where tests pin `DEDICATED_PROXY_1`, so a real dev/CI `DEDICATED_PROXY_2+` in the environment cannot make `randomDedicatedProxyURL` return an unexpected host.

## Verification

- `make test`
- `cd api && go test -mod=vendor -failfast -timeout 5m ./gateway/... ./controller/...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c514a17e-9894-4819-9aea-0240216f78d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c514a17e-9894-4819-9aea-0240216f78d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

