### PR TITLE
Sanitize AWS Lambda CLI deploy output; quiet go mod in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /mtg-price-checker
 # Copy dependencies list
 COPY api ./api
 WORKDIR /mtg-price-checker/api
-RUN go mod download -x
+RUN go mod download
 # Build
 RUN env GOOS=linux GOARCH=amd64 go build -tags lambda.norpc -ldflags="-s -w" -o main cmd/main.go
 

--- a/Makefile
+++ b/Makefile
@@ -34,28 +34,33 @@ frontend-update-staging: frontend-build
 	export AWS_PAGER="" && aws cloudfront create-invalidation --distribution-id E33AK6HADX83U0 --paths "/*"
 
 lambda-create:
+	# --query: avoid full JSON (includes Environment.Variables) in CI logs
 	export AWS_PAGER="" && aws lambda create-function \
       --function-name mtg-price-scrapper \
       --package-type Image \
       --code ImageUri=206363131200.dkr.ecr.ap-southeast-1.amazonaws.com/mtg-price-scrapper:latest \
-      --role arn:aws:iam::206363131200:role/lambda-mtg
+      --role arn:aws:iam::206363131200:role/lambda-mtg \
+      --output text --query 'FunctionName'
 
 lambda-create-staging:
 	export AWS_PAGER="" && aws lambda create-function \
       --function-name mtg-price-scrapper-staging \
       --package-type Image \
       --code ImageUri=206363131200.dkr.ecr.ap-southeast-1.amazonaws.com/mtg-price-scrapper:staging \
-      --role arn:aws:iam::206363131200:role/lambda-mtg
+      --role arn:aws:iam::206363131200:role/lambda-mtg \
+      --output text --query 'FunctionName'
 
 lambda-update:
 	export AWS_PAGER="" && aws lambda update-function-code \
       --function-name mtg-price-scrapper \
-      --image-uri 206363131200.dkr.ecr.ap-southeast-1.amazonaws.com/mtg-price-scrapper:latest
+      --image-uri 206363131200.dkr.ecr.ap-southeast-1.amazonaws.com/mtg-price-scrapper:latest \
+      --output text --query 'FunctionName'
 
 lambda-update-staging:
 	export AWS_PAGER="" && aws lambda update-function-code \
       --function-name mtg-price-scrapper-staging \
-      --image-uri 206363131200.dkr.ecr.ap-southeast-1.amazonaws.com/mtg-price-scrapper:staging
+      --image-uri 206363131200.dkr.ecr.ap-southeast-1.amazonaws.com/mtg-price-scrapper:staging \
+      --output text --query 'FunctionName'
 
 aws-login:
 	aws ecr get-login-password --region ap-southeast-1 | docker login --username AWS --password-stdin 206363131200.dkr.ecr.ap-southeast-1.amazonaws.com


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
After a successful ECR `docker push` (the digest line), the deploy runs `aws lambda update-function-code`. The AWS CLI default JSON for that call includes the full function configuration, including the `Environment` object. This change limits `create-function` and `update-function-code` output to the function name so deploy logs stay minimal.

The Docker build no longer uses `go mod download -x` so module resolution does not emit verbose command traces in the build output.

## Testing
- `make test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8aa7c67a-f815-4c98-86d3-10417928e97a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8aa7c67a-f815-4c98-86d3-10417928e97a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

