### PR TITLE
Pass Shopify domain into BinderPOS gateway

### DIFF
--- a/api/controller/search.go
+++ b/api/controller/search.go
@@ -54,7 +54,7 @@ type StoreError struct {
 	Error string `json:"error"`
 }
 
-const binderposMaxConcurrent = 5
+const binderposMaxConcurrent = 12
 
 var sendDiscordAlert = alert.SendDiscordAlert
 

--- a/api/gateway/arcanesanctum/search.go
+++ b/api/gateway/arcanesanctum/search.go
@@ -31,6 +31,7 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 		5,
 		s.Name,
 		s.BaseUrl,
+		"",
 		s.SearchUrl,
 		searchStr,
 	)

--- a/api/gateway/binderpos/new.go
+++ b/api/gateway/binderpos/new.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Gateway interface {
-	Search(ctx context.Context, scrapVariant int, storeName, baseUrl, searchUrl, searchStr string) ([]gateway.Card, error)
+	Search(ctx context.Context, scrapVariant int, storeName, baseUrl, shopifyDomain, searchUrl, searchStr string) ([]gateway.Card, error)
 	Scrap(ctx context.Context, scrapVariant int, storeName, baseUrl, searchUrl, searchStr string) ([]gateway.Card, error)
 }
 

--- a/api/gateway/binderpos/storefront.go
+++ b/api/gateway/binderpos/storefront.go
@@ -13,21 +13,6 @@ const (
 	binderposAttemptTimeout = 4 * time.Second
 )
 
-var binderposShopifyDomainByStoreHost = map[string]string{
-	"cardscitadel.com":        "card-citadel.myshopify.com",
-	"card-affinity.com":       "563304-2.myshopify.com",
-	"cardboardcrackgames.com": "cardboardcrackgames.myshopify.com",
-	"flagshipgames.sg":        "flagship-games.myshopify.com",
-	"gameshaventcg.com":       "games-haven-sg.myshopify.com",
-	"greyogregames.com":       "grey-ogre-games-singapore.myshopify.com",
-	"hideoutcg.com":           "220022-20.myshopify.com",
-	"sg-manapro.com":          "mana-pro-sg.myshopify.com",
-	"mtg-asia.com":            "mtgasia.myshopify.com",
-	"onemtg.com.sg":           "one-mtg.myshopify.com",
-	"tefudagames.com":         "bacc1b-3.myshopify.com",
-	// arcanesanctumtcg.com intentionally omitted: BinderPOS decklist API returns 401.
-}
-
 var shouldUseDecklistEndpoint = func() bool {
 	return useDecklistForRoll(rand.IntN(100))
 }

--- a/api/gateway/binderpos/storefront_client.go
+++ b/api/gateway/binderpos/storefront_client.go
@@ -13,21 +13,21 @@ import (
 	"mtg-price-checker-sg/gateway/util"
 )
 
-func searchByStorefrontAPI(ctx context.Context, scrapVariant int, storeName, baseURL, searchStr string) ([]gateway.Card, error) {
+func searchByStorefrontAPI(ctx context.Context, scrapVariant int, storeName, baseURL, shopifyDomain, searchStr string) ([]gateway.Card, error) {
 	client, ok := newDedicatedProxyHTTPClient()
 	if !ok {
 		return nil, fmt.Errorf("no dedicated proxy configured for binderpos storefront api")
 	}
 
-	return searchByStorefrontAPIWithClient(ctx, client, scrapVariant, storeName, baseURL, searchStr)
+	return searchByStorefrontAPIWithClient(ctx, client, scrapVariant, storeName, baseURL, shopifyDomain, searchStr)
 }
 
-func searchByStorefrontAPIDirect(ctx context.Context, scrapVariant int, storeName, baseURL, searchStr string) ([]gateway.Card, error) {
+func searchByStorefrontAPIDirect(ctx context.Context, scrapVariant int, storeName, baseURL, shopifyDomain, searchStr string) ([]gateway.Card, error) {
 	client := &http.Client{Timeout: binderposAttemptTimeout}
-	return searchByStorefrontAPIWithClient(ctx, client, scrapVariant, storeName, baseURL, searchStr)
+	return searchByStorefrontAPIWithClient(ctx, client, scrapVariant, storeName, baseURL, shopifyDomain, searchStr)
 }
 
-func searchByStorefrontAPISharedProxy(ctx context.Context, scrapVariant int, storeName, baseURL, searchStr string) ([]gateway.Card, error) {
+func searchByStorefrontAPISharedProxy(ctx context.Context, scrapVariant int, storeName, baseURL, shopifyDomain, searchStr string) ([]gateway.Card, error) {
 	sharedProxyURL := strings.TrimSpace(os.Getenv("PROXY_URL"))
 	if sharedProxyURL == "" {
 		return nil, fmt.Errorf("no shared proxy configured for binderpos storefront api")
@@ -38,12 +38,12 @@ func searchByStorefrontAPISharedProxy(ctx context.Context, scrapVariant int, sto
 		return nil, fmt.Errorf("invalid shared proxy configured for binderpos storefront api: %w", err)
 	}
 
-	return searchByStorefrontAPIWithClient(ctx, client, scrapVariant, storeName, baseURL, searchStr)
+	return searchByStorefrontAPIWithClient(ctx, client, scrapVariant, storeName, baseURL, shopifyDomain, searchStr)
 }
 
-func searchByStorefrontAPIWithClient(ctx context.Context, client *http.Client, scrapVariant int, storeName, baseURL, searchStr string) ([]gateway.Card, error) {
+func searchByStorefrontAPIWithClient(ctx context.Context, client *http.Client, scrapVariant int, storeName, baseURL, shopifyDomain, searchStr string) ([]gateway.Card, error) {
 	if shouldUseDecklistEndpoint() {
-		return searchByBinderposDecklistAPI(ctx, client, scrapVariant, storeName, baseURL, searchStr)
+		return searchByBinderposDecklistAPI(ctx, client, scrapVariant, storeName, baseURL, shopifyDomain, searchStr)
 	}
 
 	return searchByStorefrontProductDetailsAPI(ctx, client, scrapVariant, storeName, baseURL, searchStr)

--- a/api/gateway/binderpos/storefront_decklist.go
+++ b/api/gateway/binderpos/storefront_decklist.go
@@ -14,9 +14,9 @@ import (
 	"mtg-price-checker-sg/gateway/util"
 )
 
-func searchByBinderposDecklistAPI(ctx context.Context, client *http.Client, scrapVariant int, storeName, baseURL, searchStr string) ([]gateway.Card, error) {
-	shopifyDomain, ok := storefrontShopifyDomainForBaseURL(baseURL)
-	if !ok {
+func searchByBinderposDecklistAPI(ctx context.Context, client *http.Client, scrapVariant int, storeName, baseURL, shopifyDomain, searchStr string) ([]gateway.Card, error) {
+	shopifyDomain = strings.TrimSpace(shopifyDomain)
+	if shopifyDomain == "" {
 		return nil, fmt.Errorf("missing shopify domain mapping for binderpos storefront")
 	}
 
@@ -67,22 +67,6 @@ func searchByBinderposDecklistAPI(ctx context.Context, client *http.Client, scra
 	}
 
 	return mapDecklistLinesToCards(scrapVariant, storeName, baseURL, lines), nil
-}
-
-func storefrontShopifyDomainForBaseURL(baseURL string) (string, bool) {
-	parsedURL, err := url.Parse(strings.TrimSpace(baseURL))
-	if err != nil {
-		return "", false
-	}
-
-	host := strings.ToLower(strings.TrimSpace(parsedURL.Hostname()))
-	host = strings.TrimPrefix(host, "www.")
-	if host == "" {
-		return "", false
-	}
-
-	shopifyDomain, ok := binderposShopifyDomainByStoreHost[host]
-	return shopifyDomain, ok
 }
 
 func mapDecklistLinesToCards(scrapVariant int, storeName, baseURL string, lines []storefrontDecklistLine) []gateway.Card {

--- a/api/gateway/binderpos/storefront_decklist_test.go
+++ b/api/gateway/binderpos/storefront_decklist_test.go
@@ -41,25 +41,6 @@ func TestDecklistResponseJSONDecodesWithBooleanValidName(t *testing.T) {
 	}
 }
 
-func TestStorefrontShopifyDomainForBaseURL(t *testing.T) {
-	t.Run("returns mapped domain for known host with www", func(t *testing.T) {
-		domain, ok := storefrontShopifyDomainForBaseURL("https://www.mtg-asia.com")
-		if !ok {
-			t.Fatalf("expected mapping to exist")
-		}
-		if domain != "mtgasia.myshopify.com" {
-			t.Fatalf("unexpected domain: %s", domain)
-		}
-	})
-
-	t.Run("returns false for unknown host", func(t *testing.T) {
-		_, ok := storefrontShopifyDomainForBaseURL("https://example.com")
-		if ok {
-			t.Fatalf("expected unknown host lookup to fail")
-		}
-	})
-}
-
 func TestMapDecklistLinesToCards(t *testing.T) {
 	lines := []storefrontDecklistLine{
 		{

--- a/api/gateway/binderpos/storefront_routing_test.go
+++ b/api/gateway/binderpos/storefront_routing_test.go
@@ -44,6 +44,7 @@ func TestSearchByStorefrontAPIWithClient_UsesProductDetailPathWhenDecklistNotSel
 		2,
 		"Test Store",
 		server.URL,
+		"",
 		"Abrade",
 	)
 	if err != nil {
@@ -68,6 +69,7 @@ func TestSearchByStorefrontAPIWithClient_ReturnsDecklistErrorWhenSelected(t *tes
 		2,
 		"Test Store",
 		server.URL,
+		"",
 		"Abrade",
 	)
 	if err == nil {

--- a/api/gateway/binderpos/storefront_search.go
+++ b/api/gateway/binderpos/storefront_search.go
@@ -2,20 +2,27 @@ package binderpos
 
 import (
 	"context"
+	"strings"
 
 	"mtg-price-checker-sg/gateway"
 )
 
-func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, searchURL, searchStr string) ([]gateway.Card, error) {
+func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, shopifyDomain, searchURL, searchStr string) ([]gateway.Card, error) {
+	if strings.TrimSpace(shopifyDomain) == "" {
+		return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
+			return i.scrapSharedProxy(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
+		})
+	}
+
 	return searchWithFallback(
 		func() ([]gateway.Card, error) {
 			return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
-				return searchByStorefrontAPI(attemptCtx, scrapVariant, storeName, baseURL, searchStr)
+				return searchByStorefrontAPI(attemptCtx, scrapVariant, storeName, baseURL, shopifyDomain, searchStr)
 			})
 		},
 		func() ([]gateway.Card, error) {
 			return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
-				return searchByStorefrontAPISharedProxy(attemptCtx, scrapVariant, storeName, baseURL, searchStr)
+				return searchByStorefrontAPISharedProxy(attemptCtx, scrapVariant, storeName, baseURL, shopifyDomain, searchStr)
 			})
 		},
 		func() ([]gateway.Card, error) {

--- a/api/gateway/binderpos/storefront_search_test.go
+++ b/api/gateway/binderpos/storefront_search_test.go
@@ -16,11 +16,12 @@ func init() {
 }
 
 type binderposStoreSearchCase struct {
-	storeName    string
-	baseURL      string
-	searchURL    string
-	scrapVariant int
-	query        string
+	storeName     string
+	baseURL       string
+	shopifyDomain string
+	searchURL     string
+	scrapVariant  int
+	query         string
 }
 
 func Test_SearchByStorefrontAPI_SupportsAllBinderposStores(t *testing.T) {
@@ -31,7 +32,7 @@ func Test_SearchByStorefrontAPI_SupportsAllBinderposStores(t *testing.T) {
 	client := &http.Client{Timeout: 20 * time.Second}
 	for _, testCase := range binderposStoreSearchCases() {
 		t.Run(testCase.storeName, func(t *testing.T) {
-			cards, err := searchByStorefrontAPIWithClient(context.Background(), client, testCase.scrapVariant, testCase.storeName, testCase.baseURL, testCase.query)
+			cards, err := searchByStorefrontAPIWithClient(context.Background(), client, testCase.scrapVariant, testCase.storeName, testCase.baseURL, testCase.shopifyDomain, testCase.query)
 			require.NoError(t, err)
 			require.NotEmpty(t, cards)
 
@@ -54,7 +55,7 @@ func Test_SearchByStorefrontAPI_OverlapsLegacyScrapeResults(t *testing.T) {
 	client := &http.Client{Timeout: 20 * time.Second}
 	for _, testCase := range binderposStoreSearchCases() {
 		t.Run(testCase.storeName, func(t *testing.T) {
-			storefrontCards, err := searchByStorefrontAPIWithClient(context.Background(), client, testCase.scrapVariant, testCase.storeName, testCase.baseURL, testCase.query)
+			storefrontCards, err := searchByStorefrontAPIWithClient(context.Background(), client, testCase.scrapVariant, testCase.storeName, testCase.baseURL, testCase.shopifyDomain, testCase.query)
 			require.NoError(t, err)
 			require.NotEmpty(t, storefrontCards)
 
@@ -90,88 +91,100 @@ func Test_SearchByStorefrontAPI_OverlapsLegacyScrapeResults(t *testing.T) {
 func binderposStoreSearchCases() []binderposStoreSearchCase {
 	return []binderposStoreSearchCase{
 		{
-			storeName:    "Cards Citadel",
-			baseURL:      "https://cardscitadel.com",
-			searchURL:    "/search?q=*%s*",
-			scrapVariant: 1,
-			query:        "Abrade",
+			storeName:     "Cards Citadel",
+			baseURL:       "https://cardscitadel.com",
+			shopifyDomain: "card-citadel.myshopify.com",
+			searchURL:     "/search?q=*%s*",
+			scrapVariant:  1,
+			query:         "Abrade",
 		},
 		{
-			storeName:    "Card Affinity",
-			baseURL:      "https://card-affinity.com",
-			searchURL:    "/search?q=%s",
-			scrapVariant: 2,
-			query:        "Abrade",
+			storeName:     "Card Affinity",
+			baseURL:       "https://card-affinity.com",
+			shopifyDomain: "563304-2.myshopify.com",
+			searchURL:     "/search?q=%s",
+			scrapVariant:  2,
+			query:         "Abrade",
 		},
 		{
-			storeName:    "Cardboard Crack Games",
-			baseURL:      "https://www.cardboardcrackgames.com",
-			searchURL:    "/search?type=product&q=%s",
-			scrapVariant: 2,
-			query:        "Abrade",
+			storeName:     "Cardboard Crack Games",
+			baseURL:       "https://www.cardboardcrackgames.com",
+			shopifyDomain: "cardboardcrackgames.myshopify.com",
+			searchURL:     "/search?type=product&q=%s",
+			scrapVariant:  2,
+			query:         "Abrade",
 		},
 		{
-			storeName:    "Flagship Games",
-			baseURL:      "https://www.flagshipgames.sg",
-			searchURL:    "/search?type=product&q=%s",
-			scrapVariant: 2,
-			query:        "Abrade",
+			storeName:     "Flagship Games",
+			baseURL:       "https://www.flagshipgames.sg",
+			shopifyDomain: "flagship-games.myshopify.com",
+			searchURL:     "/search?type=product&q=%s",
+			scrapVariant:  2,
+			query:         "Abrade",
 		},
 		{
-			storeName:    "Games Haven",
-			baseURL:      "https://www.gameshaventcg.com",
-			searchURL:    "/search?q=%s",
-			scrapVariant: 3,
-			query:        "Abrade",
+			storeName:     "Games Haven",
+			baseURL:       "https://www.gameshaventcg.com",
+			shopifyDomain: "games-haven-sg.myshopify.com",
+			searchURL:     "/search?q=%s",
+			scrapVariant:  3,
+			query:         "Abrade",
 		},
 		{
-			storeName:    "Grey Ogre Games",
-			baseURL:      "https://www.greyogregames.com",
-			searchURL:    "/search?q=%s",
-			scrapVariant: 3,
-			query:        "Abrade",
+			storeName:     "Grey Ogre Games",
+			baseURL:       "https://www.greyogregames.com",
+			shopifyDomain: "grey-ogre-games-singapore.myshopify.com",
+			searchURL:     "/search?q=%s",
+			scrapVariant:  3,
+			query:         "Abrade",
 		},
 		{
-			storeName:    "Hideout",
-			baseURL:      "https://hideoutcg.com",
-			searchURL:    "/search?q=%s",
-			scrapVariant: 3,
-			query:        "Abrade",
+			storeName:     "Hideout",
+			baseURL:       "https://hideoutcg.com",
+			shopifyDomain: "220022-20.myshopify.com",
+			searchURL:     "/search?q=%s",
+			scrapVariant:  3,
+			query:         "Abrade",
 		},
 		{
-			storeName:    "Mana Pro",
-			baseURL:      "https://sg-manapro.com",
-			searchURL:    "/search?type=product&q=%s",
-			scrapVariant: 2,
-			query:        "Abrade",
+			storeName:     "Mana Pro",
+			baseURL:       "https://sg-manapro.com",
+			shopifyDomain: "mana-pro-sg.myshopify.com",
+			searchURL:     "/search?type=product&q=%s",
+			scrapVariant:  2,
+			query:         "Abrade",
 		},
 		{
-			storeName:    "MTG Asia",
-			baseURL:      "https://www.mtg-asia.com",
-			searchURL:    "/search?q=%s",
-			scrapVariant: 2,
-			query:        "Abrade",
+			storeName:     "MTG Asia",
+			baseURL:       "https://www.mtg-asia.com",
+			shopifyDomain: "mtgasia.myshopify.com",
+			searchURL:     "/search?q=%s",
+			scrapVariant:  2,
+			query:         "Abrade",
 		},
 		{
-			storeName:    "OneMtg",
-			baseURL:      "https://onemtg.com.sg",
-			searchURL:    "/search?q=%s",
-			scrapVariant: 2,
-			query:        "Abrade",
+			storeName:     "OneMtg",
+			baseURL:       "https://onemtg.com.sg",
+			shopifyDomain: "one-mtg.myshopify.com",
+			searchURL:     "/search?q=%s",
+			scrapVariant:  2,
+			query:         "Abrade",
 		},
 		{
-			storeName:    "Tefuda",
-			baseURL:      "https://tefudagames.com",
-			searchURL:    "/search?q=%s",
-			scrapVariant: 4,
-			query:        "smothering tithe",
+			storeName:     "Tefuda",
+			baseURL:       "https://tefudagames.com",
+			shopifyDomain: "bacc1b-3.myshopify.com",
+			searchURL:     "/search?q=%s",
+			scrapVariant:  4,
+			query:         "smothering tithe",
 		},
 		{
-			storeName:    "Arcane Sanctum",
-			baseURL:      "https://arcanesanctumtcg.com",
-			searchURL:    "/search?q=%s",
-			scrapVariant: 5,
-			query:        "signet",
+			storeName:     "Arcane Sanctum",
+			baseURL:       "https://arcanesanctumtcg.com",
+			shopifyDomain: "",
+			searchURL:     "/search?q=%s",
+			scrapVariant:  5,
+			query:         "signet",
 		},
 	}
 }

--- a/api/gateway/cardaffinity/search.go
+++ b/api/gateway/cardaffinity/search.go
@@ -8,6 +8,7 @@ import (
 
 const StoreName = "Card Affinity"
 const StoreBaseURL = "https://card-affinity.com"
+const StoreShopifyDomain = "563304-2.myshopify.com"
 const StoreSearchURL = "/search?q=%s"
 
 type Store struct {
@@ -31,6 +32,7 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 		2,
 		s.Name,
 		s.BaseUrl,
+		StoreShopifyDomain,
 		s.SearchUrl,
 		searchStr,
 	)

--- a/api/gateway/cardboardcrackgames/search.go
+++ b/api/gateway/cardboardcrackgames/search.go
@@ -8,6 +8,7 @@ import (
 
 const StoreName = "Cardboard Crack Games"
 const StoreBaseURL = "https://www.cardboardcrackgames.com"
+const StoreShopifyDomain = "cardboardcrackgames.myshopify.com"
 const StoreSearchURL = "/search?type=product&q=%s"
 
 type Store struct {
@@ -31,6 +32,7 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 		2,
 		s.Name,
 		s.BaseUrl,
+		StoreShopifyDomain,
 		s.SearchUrl,
 		searchStr,
 	)

--- a/api/gateway/cardscitadel/search.go
+++ b/api/gateway/cardscitadel/search.go
@@ -8,6 +8,7 @@ import (
 
 const StoreName = "Cards Citadel"
 const StoreBaseURL = "https://cardscitadel.com"
+const StoreShopifyDomain = "card-citadel.myshopify.com"
 const StoreSearchURL = "/search?q=*%s*"
 
 type Store struct {
@@ -27,5 +28,5 @@ func NewLGS() gateway.LGS {
 }
 
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
-	return s.BinderposGwy.Search(ctx, 1, s.Name, s.BaseUrl, s.SearchUrl, searchStr)
+	return s.BinderposGwy.Search(ctx, 1, s.Name, s.BaseUrl, StoreShopifyDomain, s.SearchUrl, searchStr)
 }

--- a/api/gateway/flagship/search.go
+++ b/api/gateway/flagship/search.go
@@ -9,6 +9,7 @@ import (
 
 const StoreName = "Flagship Games"
 const StoreBaseURL = "https://www.flagshipgames.sg"
+const StoreShopifyDomain = "flagship-games.myshopify.com"
 const StoreSearchURL = "/search?type=product&q=%s"
 
 type Store struct {
@@ -28,5 +29,5 @@ func NewLGS() gateway.LGS {
 }
 
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
-	return s.BinderposGwy.Search(ctx, 2, s.Name, s.BaseUrl, s.SearchUrl, searchStr)
+	return s.BinderposGwy.Search(ctx, 2, s.Name, s.BaseUrl, StoreShopifyDomain, s.SearchUrl, searchStr)
 }

--- a/api/gateway/gameshaven/search.go
+++ b/api/gateway/gameshaven/search.go
@@ -8,6 +8,7 @@ import (
 
 const StoreName = "Games Haven"
 const StoreBaseURL = "https://www.gameshaventcg.com"
+const StoreShopifyDomain = "games-haven-sg.myshopify.com"
 const StoreSearchURL = "/search?q=%s"
 
 type Store struct {
@@ -31,6 +32,7 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 		3,
 		s.Name,
 		s.BaseUrl,
+		StoreShopifyDomain,
 		s.SearchUrl,
 		searchStr,
 	)

--- a/api/gateway/gog/search.go
+++ b/api/gateway/gog/search.go
@@ -9,6 +9,7 @@ import (
 
 const StoreName = "Grey Ogre Games"
 const StoreBaseURL = "https://www.greyogregames.com"
+const StoreShopifyDomain = "grey-ogre-games-singapore.myshopify.com"
 const StoreSearchURL = "/search?q=%s"
 
 type Store struct {
@@ -28,5 +29,5 @@ func NewLGS() gateway.LGS {
 }
 
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
-	return s.BinderposGwy.Search(ctx, 3, s.Name, s.BaseUrl, s.SearchUrl, searchStr)
+	return s.BinderposGwy.Search(ctx, 3, s.Name, s.BaseUrl, StoreShopifyDomain, s.SearchUrl, searchStr)
 }

--- a/api/gateway/hideout/search.go
+++ b/api/gateway/hideout/search.go
@@ -8,6 +8,7 @@ import (
 
 const StoreName = "Hideout"
 const StoreBaseURL = "https://hideoutcg.com"
+const StoreShopifyDomain = "220022-20.myshopify.com"
 const StoreSearchURL = "/search?q=%s"
 
 type Store struct {
@@ -31,6 +32,7 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 		3,
 		s.Name,
 		s.BaseUrl,
+		StoreShopifyDomain,
 		s.SearchUrl,
 		searchStr,
 	)

--- a/api/gateway/manapro/search.go
+++ b/api/gateway/manapro/search.go
@@ -9,6 +9,7 @@ import (
 
 const StoreName = "Mana Pro"
 const StoreBaseURL = "https://sg-manapro.com"
+const StoreShopifyDomain = "mana-pro-sg.myshopify.com"
 const StoreSearchURL = "/search?type=product&q=%s"
 
 type Store struct {
@@ -28,5 +29,5 @@ func NewLGS() gateway.LGS {
 }
 
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
-	return s.BinderposGwy.Search(ctx, 2, s.Name, s.BaseUrl, s.SearchUrl, searchStr)
+	return s.BinderposGwy.Search(ctx, 2, s.Name, s.BaseUrl, StoreShopifyDomain, s.SearchUrl, searchStr)
 }

--- a/api/gateway/mtgasia/search.go
+++ b/api/gateway/mtgasia/search.go
@@ -9,6 +9,7 @@ import (
 
 const StoreName = "MTG Asia"
 const StoreBaseURL = "https://www.mtg-asia.com"
+const StoreShopifyDomain = "mtgasia.myshopify.com"
 const StoreSearchURL = "/search?q=%s"
 
 type Store struct {
@@ -28,5 +29,5 @@ func NewLGS() gateway.LGS {
 }
 
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
-	return s.BinderposGwy.Search(ctx, 2, s.Name, s.BaseUrl, s.SearchUrl, searchStr)
+	return s.BinderposGwy.Search(ctx, 2, s.Name, s.BaseUrl, StoreShopifyDomain, s.SearchUrl, searchStr)
 }

--- a/api/gateway/onemtg/search.go
+++ b/api/gateway/onemtg/search.go
@@ -8,6 +8,7 @@ import (
 
 const StoreName = "OneMtg"
 const StoreBaseURL = "https://onemtg.com.sg"
+const StoreShopifyDomain = "one-mtg.myshopify.com"
 const StoreSearchURL = "/search?q=%s"
 
 type Store struct {
@@ -31,6 +32,7 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 		2,
 		s.Name,
 		s.BaseUrl,
+		StoreShopifyDomain,
 		s.SearchUrl,
 		searchStr,
 	)

--- a/api/gateway/tefuda/search.go
+++ b/api/gateway/tefuda/search.go
@@ -8,6 +8,7 @@ import (
 
 const StoreName = "Tefuda"
 const StoreBaseURL = "https://tefudagames.com"
+const StoreShopifyDomain = "bacc1b-3.myshopify.com"
 const StoreSearchURL = "/search?q=%s"
 
 type Store struct {
@@ -31,6 +32,7 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 		4,
 		s.Name,
 		s.BaseUrl,
+		StoreShopifyDomain,
 		s.SearchUrl,
 		searchStr,
 	)


### PR DESCRIPTION
## Summary
- make Shopify domain an explicit input to BinderPOS `Search` and thread it through storefront API/decklist calls
- remove the BinderPOS host-to-Shopify mapping table and keep per-store domain config in each store gateway package
- preserve scraper behavior for stores without a Shopify domain (Arcane Sanctum) by short-circuiting to scraper fallback

## Test plan
- [x] `go -C api test -mod=vendor ./gateway/binderpos -run \"TestUseDecklistForRoll|TestSearchByStorefrontAPIWithClient_UsesProductDetailPathWhenDecklistNotSelected|TestSearchByStorefrontAPIWithClient_ReturnsDecklistErrorWhenSelected|TestDecklistResponseJSONDecodesWithBooleanValidName|TestMapDecklistLinesToCards\"`
- [x] `go -C api test -mod=vendor ./gateway/arcanesanctum -run \"Test_NewLGS\"`
- [x] `go -C api test -mod=vendor ./gateway/cardscitadel ./gateway/cardaffinity ./gateway/cardboardcrackgames ./gateway/flagship ./gateway/gameshaven ./gateway/gog ./gateway/hideout ./gateway/manapro ./gateway/mtgasia ./gateway/onemtg ./gateway/tefuda ./gateway/arcanesanctum -run \"Test_NewLGS\"`

Made with [Cursor](https://cursor.com)