### PR TITLE
Minor FE: primary theme toggle, pointer cursor on store checkboxes

### DIFF
--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -7,7 +7,7 @@ const Header = ({ theme, onToggleTheme }) => {
         <div className="position-absolute top-0 end-0">
           <button
             type="button"
-            className="btn btn-sm btn-outline-secondary theme-toggle-btn"
+            className="btn btn-sm btn-outline-primary theme-toggle-btn"
             onClick={onToggleTheme}
             aria-label={`Switch to ${isDarkMode ? "light" : "dark"} mode`}
             title={`Switch to ${isDarkMode ? "light" : "dark"} mode`}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -35,6 +35,11 @@ body {
   justify-content: center;
 }
 
+#lgsCheckboxes .form-check-input,
+#lgsCheckboxes .form-check-label {
+  cursor: pointer;
+}
+
 .map-item iframe {
   float: left;
   min-height: 450px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change aligns the light/dark mode control with Bootstrap's primary palette so hover/focus match the main Search button (`#0d6efd`), and adds `cursor: pointer` on the store checkboxes and labels in `#lgsCheckboxes`.

## Notes

- The header button uses `btn-outline-primary` instead of custom hover CSS, so colors stay in sync with Bootstrap and the search CTA.
- The pointer cursor is applied to both the checkbox and its label for a consistent affordance on the full row.

## Test plan

- `make test`
- `cd frontend && npm run build` and `npm run lint` (no new issues; pre-existing gtag warning in `index.html`)

## Screenshots (desktop and mobile)

Theme toggle with hover (desktop and mobile; primary blue on hover).

![Desktop: theme button hover](https://cursor.com/artifacts/c/art-85ddacb7-d977-46ea-aaec-45d2c63254b2)
![Mobile: theme button hover](https://cursor.com/artifacts/c/art-4dcf7327-ea86-44ab-ab37-4e94cca27e1d)

Store label hover (pointer cursor; desktop and mobile). Cursor is a UI affordance; screenshots show the relevant header/store area in context.

![Desktop: store row hover](https://cursor.com/artifacts/c/art-21189549-c5a9-4eb7-bed0-0185ac3d6733)
![Mobile: store row hover](https://cursor.com/artifacts/c/art-e590a48e-1fe7-4110-a36a-ab652c138261)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ed740bf-8721-45a3-b8ee-c647a02b401d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ed740bf-8721-45a3-b8ee-c647a02b401d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

