### PR TITLE
Arcane Sanctum: dedicated proxy scraper first, then direct

### DIFF
--- a/api/controller/search_test.go
+++ b/api/controller/search_test.go
@@ -477,14 +477,14 @@ func TestFetchCardsConcurrently_CollatesDiscordErrors(t *testing.T) {
 func TestFormatDiscordErrorSummary(t *testing.T) {
 	got := formatDiscordErrorSummary("Uro, Titan of Nature's Wrath", []string{
 		"Error encountered searching [Tefuda] for [Uro, Titan of Nature's Wrath]: attempt 4 (scrap-shared): Service Unavailable (proxy_mode=shared proxy=PROXY_URL)",
-		"Error encountered searching [Arcane Sanctum] for [Uro, Titan of Nature's Wrath]: attempt 4 (scrap-shared): Service Unavailable (proxy_mode=shared proxy=PROXY_URL)",
+		"Error encountered searching [Arcane Sanctum] for [Uro, Titan of Nature's Wrath]: attempt 2 (scrap-direct): Service Unavailable (proxy_mode=direct proxy=none)",
 		"Recovered from panic in shop [ShopPanic]: panic value",
 	})
 
 	if !strings.Contains(got, "Encountered 3 error(s) while searching [Uro, Titan of Nature's Wrath]:") {
 		t.Fatalf("expected summary header, got: %s", got)
 	}
-	if !strings.Contains(got, "- [Arcane Sanctum] attempt 4 (scrap-shared): Service Unavailable (proxy_mode=shared proxy=PROXY_URL)") {
+	if !strings.Contains(got, "- [Arcane Sanctum] attempt 2 (scrap-direct): Service Unavailable (proxy_mode=direct proxy=none)") {
 		t.Fatalf("expected Arcane Sanctum concise line, got: %s", got)
 	}
 	if !strings.Contains(got, "- [Tefuda] attempt 4 (scrap-shared): Service Unavailable (proxy_mode=shared proxy=PROXY_URL)") {

--- a/api/gateway/arcanesanctum/search.go
+++ b/api/gateway/arcanesanctum/search.go
@@ -6,7 +6,7 @@ import (
 	"mtg-price-checker-sg/gateway/binderpos"
 )
 
-const StoreName = "Arcane Sanctum"
+const StoreName = binderpos.ArcaneSanctumStoreName
 const StoreBaseURL = "https://arcanesanctumtcg.com"
 const StoreSearchURL = "/search?q=%s"
 

--- a/api/gateway/binderpos/storefront_fallback.go
+++ b/api/gateway/binderpos/storefront_fallback.go
@@ -6,6 +6,26 @@ import (
 	"mtg-price-checker-sg/gateway"
 )
 
+// searchWithScrapDedicatedThenDirect tries a scrape using dedicated-proxy routing first (Scrap), then
+// a direct (no proxy) scrape on failure.
+func searchWithScrapDedicatedThenDirect(
+	scrapDedicatedFn func() ([]gateway.Card, error),
+	scrapDirectFn func() ([]gateway.Card, error),
+) ([]gateway.Card, error) {
+	cards, dedicatedErr := scrapDedicatedFn()
+	dedicatedErr = annotateAttemptError(1, "scrap-dedicated", dedicatedErr)
+	if dedicatedErr == nil {
+		return cards, nil
+	}
+
+	cards, directErr := scrapDirectFn()
+	directErr = annotateAttemptError(2, "scrap-direct", directErr)
+	if directErr == nil {
+		return cards, nil
+	}
+	return cards, directErr
+}
+
 func searchWithFallback(
 	searchAPIDedicatedFn func() ([]gateway.Card, error),
 	searchAPISharedFn func() ([]gateway.Card, error),

--- a/api/gateway/binderpos/storefront_fallback_test.go
+++ b/api/gateway/binderpos/storefront_fallback_test.go
@@ -111,3 +111,46 @@ func TestSearchWithFallback(t *testing.T) {
 		}
 	})
 }
+
+func TestSearchWithScrapDedicatedThenDirect(t *testing.T) {
+	t.Run("returns dedicated scraper results on first success", func(t *testing.T) {
+		cards, err := searchWithScrapDedicatedThenDirect(
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-dedicated"}}, nil },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-direct"}}, nil },
+		)
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if len(cards) != 1 || cards[0].Name != "scrap-dedicated" {
+			t.Fatalf("expected dedicated scraper card, got %+v", cards)
+		}
+	})
+
+	t.Run("falls back to direct when dedicated fails", func(t *testing.T) {
+		cards, err := searchWithScrapDedicatedThenDirect(
+			func() ([]gateway.Card, error) { return nil, errors.New("dedicated scrap failed") },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-direct"}}, nil },
+		)
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if len(cards) != 1 || cards[0].Name != "scrap-direct" {
+			t.Fatalf("expected direct scraper card, got %+v", cards)
+		}
+	})
+
+	t.Run("returns final direct error when both fail", func(t *testing.T) {
+		dedErr := errors.New("dedicated failed")
+		dirErr := errors.New("direct failed")
+		_, err := searchWithScrapDedicatedThenDirect(
+			func() ([]gateway.Card, error) { return nil, dedErr },
+			func() ([]gateway.Card, error) { return nil, dirErr },
+		)
+		if !errors.Is(err, dirErr) {
+			t.Fatalf("expected direct scraper error, got %v", err)
+		}
+		if err == nil || err.Error() != "attempt 2 (scrap-direct): direct failed" {
+			t.Fatalf("unexpected final error: %v", err)
+		}
+	})
+}

--- a/api/gateway/binderpos/storefront_search.go
+++ b/api/gateway/binderpos/storefront_search.go
@@ -7,8 +7,25 @@ import (
 	"mtg-price-checker-sg/gateway"
 )
 
+// ArcaneSanctumStoreName is the LGS name for Arcane Sanctum; used for store-specific search routing.
+const ArcaneSanctumStoreName = "Arcane Sanctum"
+
 func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, shopifyDomain, searchURL, searchStr string) ([]gateway.Card, error) {
 	if strings.TrimSpace(shopifyDomain) == "" {
+		if storeName == ArcaneSanctumStoreName {
+			return searchWithScrapDedicatedThenDirect(
+				func() ([]gateway.Card, error) {
+					return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
+						return i.Scrap(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
+					})
+				},
+				func() ([]gateway.Card, error) {
+					return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
+						return i.scrapDirect(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
+					})
+				},
+			)
+		}
 		return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
 			return i.scrapSharedProxy(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
 		})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Arcane Sanctum (BinderPOS, no Shopify domain) previously scraped only via the shared `PROXY_URL` path. It now tries a **dedicated-proxy** scrape first (same setup as `Scrap` / `NewOptimizedCollectorForBinderpos`—leased dedicated when `UseProxy` and pools are configured, otherwise a random dedicated from env, otherwise direct for that first attempt), and **falls back to a direct (no proxy) scraper** if the first attempt fails.

## Files

- `api/gateway/binderpos/storefront_search.go` — special-case `Arcane Sanctum` on the empty `shopifyDomain` path
- `api/gateway/binderpos/storefront_fallback.go` — `searchWithScrapDedicatedThenDirect` helper
- `api/gateway/binderpos/storefront_fallback_test.go` — unit tests
- `api/gateway/arcanesanctum/search.go` — `StoreName` uses `binderpos.ArcaneSanctumStoreName`
- `api/controller/search_test.go` — updated Discord summary fixture for the new error chain

## Testing

- `make test` (passes)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-223bc06d-fb31-4d64-bb46-e03b23ca216a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-223bc06d-fb31-4d64-bb46-e03b23ca216a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

