### PR TITLE
BinderPOS: retire shared proxy; api → scrap-dedicated → scrap-direct

### DIFF
--- a/api/controller/search_test.go
+++ b/api/controller/search_test.go
@@ -476,7 +476,7 @@ func TestFetchCardsConcurrently_CollatesDiscordErrors(t *testing.T) {
 
 func TestFormatDiscordErrorSummary(t *testing.T) {
 	got := formatDiscordErrorSummary("Uro, Titan of Nature's Wrath", []string{
-		"Error encountered searching [Tefuda] for [Uro, Titan of Nature's Wrath]: attempt 4 (scrap-shared): Service Unavailable (proxy_mode=shared proxy=PROXY_URL)",
+		"Error encountered searching [Tefuda] for [Uro, Titan of Nature's Wrath]: attempt 3 (scrap-direct): Service Unavailable (proxy_mode=direct proxy=none)",
 		"Error encountered searching [Arcane Sanctum] for [Uro, Titan of Nature's Wrath]: attempt 2 (scrap-direct): Service Unavailable (proxy_mode=direct proxy=none)",
 		"Recovered from panic in shop [ShopPanic]: panic value",
 	})
@@ -487,7 +487,7 @@ func TestFormatDiscordErrorSummary(t *testing.T) {
 	if !strings.Contains(got, "- [Arcane Sanctum] attempt 2 (scrap-direct): Service Unavailable (proxy_mode=direct proxy=none)") {
 		t.Fatalf("expected Arcane Sanctum concise line, got: %s", got)
 	}
-	if !strings.Contains(got, "- [Tefuda] attempt 4 (scrap-shared): Service Unavailable (proxy_mode=shared proxy=PROXY_URL)") {
+	if !strings.Contains(got, "- [Tefuda] attempt 3 (scrap-direct): Service Unavailable (proxy_mode=direct proxy=none)") {
 		t.Fatalf("expected Tefuda concise line, got: %s", got)
 	}
 	if !strings.Contains(got, "- Recovered from panic in shop [ShopPanic]: panic value") {

--- a/api/gateway/binderpos/scrap.go
+++ b/api/gateway/binderpos/scrap.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"mtg-price-checker-sg/gateway/util"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 
@@ -23,20 +22,6 @@ func (i impl) Scrap(ctx context.Context, scrapVariant int, storeName, baseUrl, s
 
 func (i impl) scrapDirect(ctx context.Context, scrapVariant int, storeName, baseUrl, searchUrl, searchStr string) ([]gateway.Card, error) {
 	return i.scrapWithCollectorFactory(ctx, scrapVariant, storeName, baseUrl, searchUrl, searchStr, newDirectNoRetryCollector)
-}
-
-func (i impl) scrapSharedProxy(ctx context.Context, scrapVariant int, storeName, baseUrl, searchUrl, searchStr string) ([]gateway.Card, error) {
-	sharedProxyURL := strings.TrimSpace(os.Getenv("PROXY_URL"))
-	if sharedProxyURL == "" {
-		return nil, fmt.Errorf("no shared proxy configured for binderpos scraper")
-	}
-	if _, err := newHTTPClientWithProxyURL(sharedProxyURL); err != nil {
-		return nil, fmt.Errorf("invalid shared proxy configured for binderpos scraper: %w", err)
-	}
-
-	return i.scrapWithCollectorFactory(ctx, scrapVariant, storeName, baseUrl, searchUrl, searchStr, func(factoryCtx context.Context) *colly.Collector {
-		return newSharedNoRetryCollector(factoryCtx, sharedProxyURL)
-	})
 }
 
 func (i impl) scrapWithCollectorFactory(
@@ -63,21 +48,6 @@ func (i impl) scrapWithCollectorFactory(
 func newDirectNoRetryCollector(ctx context.Context) *colly.Collector {
 	c := gateway.NewOptimizedCollectorNoRetryDirect(ctx)
 	c.SetRequestTimeout(binderposAttemptTimeout)
-	return c
-}
-
-func newSharedNoRetryCollector(ctx context.Context, sharedProxyURL string) *colly.Collector {
-	c := gateway.NewOptimizedCollectorNoRetryDirect(ctx)
-	c.SetRequestTimeout(binderposAttemptTimeout)
-	// Proxy URL is validated in scrapSharedProxy before this collector is created.
-	_ = c.SetProxy(sharedProxyURL)
-	c.OnRequest(func(r *colly.Request) {
-		if r == nil || r.Ctx == nil {
-			return
-		}
-		r.Ctx.Put("last_proxy_mode", "shared")
-		r.Ctx.Put("last_proxy_url", sharedProxyURL)
-	})
 	return c
 }
 

--- a/api/gateway/binderpos/storefront_client.go
+++ b/api/gateway/binderpos/storefront_client.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"os"
-	"strings"
 	"sync/atomic"
 
 	"mtg-price-checker-sg/gateway"
@@ -64,20 +62,6 @@ func searchByStorefrontAPI(ctx context.Context, scrapVariant int, storeName, bas
 
 func searchByStorefrontAPIDirect(ctx context.Context, scrapVariant int, storeName, baseURL, shopifyDomain, searchStr string) ([]gateway.Card, error) {
 	client := &http.Client{Timeout: binderposAttemptTimeout}
-	return searchByStorefrontAPIWithClient(ctx, client, scrapVariant, storeName, baseURL, shopifyDomain, searchStr)
-}
-
-func searchByStorefrontAPISharedProxy(ctx context.Context, scrapVariant int, storeName, baseURL, shopifyDomain, searchStr string) ([]gateway.Card, error) {
-	sharedProxyURL := strings.TrimSpace(os.Getenv("PROXY_URL"))
-	if sharedProxyURL == "" {
-		return nil, fmt.Errorf("no shared proxy configured for binderpos storefront api")
-	}
-
-	client, err := newHTTPClientWithProxyURL(sharedProxyURL)
-	if err != nil {
-		return nil, fmt.Errorf("invalid shared proxy configured for binderpos storefront api: %w", err)
-	}
-
 	return searchByStorefrontAPIWithClient(ctx, client, scrapVariant, storeName, baseURL, shopifyDomain, searchStr)
 }
 

--- a/api/gateway/binderpos/storefront_fallback.go
+++ b/api/gateway/binderpos/storefront_fallback.go
@@ -28,8 +28,8 @@ func searchWithScrapDedicatedThenDirect(
 
 func searchWithFallback(
 	searchAPIDedicatedFn func() ([]gateway.Card, error),
-	searchAPISharedFn func() ([]gateway.Card, error),
-	scrapSharedFn func() ([]gateway.Card, error),
+	scrapDedicatedFn func() ([]gateway.Card, error),
+	scrapDirectFn func() ([]gateway.Card, error),
 ) ([]gateway.Card, error) {
 	apiDedicatedCards, apiDedicatedErr := searchAPIDedicatedFn()
 	apiDedicatedErr = annotateAttemptError(1, "api-dedicated", apiDedicatedErr)
@@ -37,20 +37,20 @@ func searchWithFallback(
 		return apiDedicatedCards, nil
 	}
 
-	apiSharedCards, apiSharedErr := searchAPISharedFn()
-	apiSharedErr = annotateAttemptError(2, "api-shared", apiSharedErr)
-	if apiSharedErr == nil {
-		return apiSharedCards, nil
+	scrapDedicatedCards, scrapDedicatedErr := scrapDedicatedFn()
+	scrapDedicatedErr = annotateAttemptError(2, "scrap-dedicated", scrapDedicatedErr)
+	if scrapDedicatedErr == nil {
+		return scrapDedicatedCards, nil
 	}
 
-	scrapedSharedCards, scrapSharedErr := scrapSharedFn()
-	scrapSharedErr = annotateAttemptError(3, "scrap-shared", scrapSharedErr)
-	if scrapSharedErr == nil {
-		return scrapedSharedCards, nil
+	scrapDirectCards, scrapDirectErr := scrapDirectFn()
+	scrapDirectErr = annotateAttemptError(3, "scrap-direct", scrapDirectErr)
+	if scrapDirectErr == nil {
+		return scrapDirectCards, nil
 	}
 
 	// Reaching here means all three attempts errored.
-	return scrapedSharedCards, scrapSharedErr
+	return scrapDirectCards, scrapDirectErr
 }
 
 func annotateAttemptError(attempt int, strategy string, err error) error {

--- a/api/gateway/binderpos/storefront_fallback_test.go
+++ b/api/gateway/binderpos/storefront_fallback_test.go
@@ -12,8 +12,8 @@ func TestSearchWithFallback(t *testing.T) {
 	t.Run("returns dedicated api results first", func(t *testing.T) {
 		cards, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-dedicated"}}, nil },
-			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-shared"}}, nil },
-			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-shared"}}, nil },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-dedicated"}}, nil },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-direct"}}, nil },
 		)
 		if err != nil {
 			t.Fatalf("expected nil error, got %v", err)
@@ -23,47 +23,47 @@ func TestSearchWithFallback(t *testing.T) {
 		}
 	})
 
-	t.Run("falls back to shared api before shared scraper", func(t *testing.T) {
+	t.Run("falls back to scrap-dedicated when api fails", func(t *testing.T) {
 		cards, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
-			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-shared"}}, nil },
-			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-shared"}}, nil },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-dedicated"}}, nil },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-direct"}}, nil },
 		)
 		if err != nil {
 			t.Fatalf("expected nil error, got %v", err)
 		}
-		if len(cards) != 1 || cards[0].Name != "api-shared" {
-			t.Fatalf("expected shared api card, got %+v", cards)
+		if len(cards) != 1 || cards[0].Name != "scrap-dedicated" {
+			t.Fatalf("expected scrap-dedicated card, got %+v", cards)
 		}
 	})
 
-	t.Run("falls back to shared-proxy scraper when both api attempts fail", func(t *testing.T) {
+	t.Run("falls back to scrap-direct when api and scrap-dedicated fail", func(t *testing.T) {
 		cards, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
-			func() ([]gateway.Card, error) { return nil, errors.New("shared api failed") },
-			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-shared"}}, nil },
+			func() ([]gateway.Card, error) { return nil, errors.New("dedicated scrap failed") },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-direct"}}, nil },
 		)
 		if err != nil {
 			t.Fatalf("expected nil error, got %v", err)
 		}
-		if len(cards) != 1 || cards[0].Name != "scrap-shared" {
-			t.Fatalf("expected shared-proxy scraper card, got %+v", cards)
+		if len(cards) != 1 || cards[0].Name != "scrap-direct" {
+			t.Fatalf("expected direct scraper card, got %+v", cards)
 		}
 	})
 
-	t.Run("returns final shared-proxy scraper error when all fail", func(t *testing.T) {
+	t.Run("returns final scrap-direct error when all fail", func(t *testing.T) {
 		dedicatedErr := errors.New("dedicated api failed")
-		sharedErr := errors.New("shared api failed")
-		sharedScrapErr := errors.New("shared scraper failed")
+		scrapDedErr := errors.New("dedicated scrap failed")
+		directErr := errors.New("direct scrap failed")
 		_, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return nil, dedicatedErr },
-			func() ([]gateway.Card, error) { return nil, sharedErr },
-			func() ([]gateway.Card, error) { return nil, sharedScrapErr },
+			func() ([]gateway.Card, error) { return nil, scrapDedErr },
+			func() ([]gateway.Card, error) { return nil, directErr },
 		)
-		if !errors.Is(err, sharedScrapErr) {
-			t.Fatalf("expected shared-proxy scraper error, got %v", err)
+		if !errors.Is(err, directErr) {
+			t.Fatalf("expected direct scraper error, got %v", err)
 		}
-		expectedError := "attempt 3 (scrap-shared): shared scraper failed"
+		expectedError := "attempt 3 (scrap-direct): direct scrap failed"
 		if err == nil || err.Error() != expectedError {
 			t.Fatalf("expected final error %q, got %v", expectedError, err)
 		}
@@ -80,13 +80,13 @@ func TestSearchWithFallback(t *testing.T) {
 
 		_, err := searchWithFallback(
 			fail("api-dedicated"),
-			fail("api-shared"),
-			fail("scrap-shared"),
+			fail("scrap-dedicated"),
+			fail("scrap-direct"),
 		)
 		if err == nil {
 			t.Fatalf("expected fallback chain to return the final error")
 		}
-		expected := []string{"api-dedicated", "api-shared", "scrap-shared"}
+		expected := []string{"api-dedicated", "scrap-dedicated", "scrap-direct"}
 		if len(sequence) != len(expected) {
 			t.Fatalf("expected %d attempts, got %d (%v)", len(expected), len(sequence), sequence)
 		}
@@ -100,7 +100,7 @@ func TestSearchWithFallback(t *testing.T) {
 	t.Run("returns no error when a fallback attempt succeeds with empty cards", func(t *testing.T) {
 		cards, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
-			func() ([]gateway.Card, error) { return nil, errors.New("shared api failed") },
+			func() ([]gateway.Card, error) { return nil, errors.New("dedicated scrap failed") },
 			func() ([]gateway.Card, error) { return []gateway.Card{}, nil },
 		)
 		if err != nil {

--- a/api/gateway/binderpos/storefront_search.go
+++ b/api/gateway/binderpos/storefront_search.go
@@ -7,28 +7,23 @@ import (
 	"mtg-price-checker-sg/gateway"
 )
 
-// ArcaneSanctumStoreName is the LGS name for Arcane Sanctum; used for store-specific search routing.
+// ArcaneSanctumStoreName is the LGS name for Arcane Sanctum; other packages reference it for store identity.
 const ArcaneSanctumStoreName = "Arcane Sanctum"
 
 func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, shopifyDomain, searchURL, searchStr string) ([]gateway.Card, error) {
 	if strings.TrimSpace(shopifyDomain) == "" {
-		if storeName == ArcaneSanctumStoreName {
-			return searchWithScrapDedicatedThenDirect(
-				func() ([]gateway.Card, error) {
-					return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
-						return i.Scrap(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
-					})
-				},
-				func() ([]gateway.Card, error) {
-					return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
-						return i.scrapDirect(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
-					})
-				},
-			)
-		}
-		return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
-			return i.scrapSharedProxy(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
-		})
+		return searchWithScrapDedicatedThenDirect(
+			func() ([]gateway.Card, error) {
+				return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
+					return i.Scrap(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
+				})
+			},
+			func() ([]gateway.Card, error) {
+				return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
+					return i.scrapDirect(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
+				})
+			},
+		)
 	}
 
 	return searchWithFallback(
@@ -39,12 +34,12 @@ func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, 
 		},
 		func() ([]gateway.Card, error) {
 			return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
-				return searchByStorefrontAPISharedProxy(attemptCtx, scrapVariant, storeName, baseURL, shopifyDomain, searchStr)
+				return i.Scrap(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
 			})
 		},
 		func() ([]gateway.Card, error) {
 			return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
-				return i.scrapSharedProxy(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
+				return i.scrapDirect(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
 			})
 		},
 	)

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -23,6 +23,16 @@ This document records **where** the app configures search behavior, **timeouts**
 | Minimum interval between requests to the **same host** | 300ms | `domainRequestMinInterval` in `api/gateway/domain_rate_limiter.go` | Added to the reservation for the next allowed time for that domain. |
 | Jitter (added on top of minimum interval) | uniform in **[0, 600ms)** | `domainRequestMaxJitter` + `randomDuration` in `api/gateway/domain_rate_limiter.go` | Per reservation: `reservedUntil = nextAllowed + minInterval + jitter`. If the wait is cancelled, the limiter can roll back that reservation. |
 
+---
+
+## Backend: BinderPOS api-dedicated proxy selection (`storefront_client.go`)
+
+| Item | Value | Source | Notes |
+|------|--------|--------|--------|
+| Lease vs round-robin for storefront HTTP client | `config.UseLeasedDedicatedProxy` in `api/pkg/config/config.go` | `searchByStorefrontAPI` | When **true**, `gateway.LeaseDedicatedProxyURL` holds one dedicated URL for the whole storefront attempt. When **false**, `nextBinderposStorefrontProxyURL` round-robins **proxy₁ → … → proxyₙ → direct (no HTTP proxy)** per call. Colly scrapes still use the collector lease path when `NewOptimizedCollectorForBinderpos` applies. |
+
+---
+
 ## Backend: dedicated proxy env (`api/gateway/util/dedicated_proxy.go`)
 
 | Item | Value | Notes |
@@ -43,14 +53,14 @@ Some tests in `api/gateway/binderpos/*_test.go` hit real stores and proxies. The
 
 | Scenario | Order of strategies (each step is one attempt) | Per-step attempt timeout / HTTP client |
 |----------|--------------------------------------------------|----------------------------------------|
-| `shopifyDomain` **non-empty** (normal) | 1) **api-dedicated** → 2) **api-shared** → 3) **scrap-shared** (shared-proxy scrape) | **10s** per step: `binderposAttemptTimeout` in `api/gateway/binderpos/storefront.go`; `runWithAttemptTimeout` in `storefront_search.go`. HTTP clients in `storefront_client.go` use the same `binderposAttemptTimeout`. |
-| `shopifyDomain` **empty** | Scrape only (**scrap-shared** path, single `runWithAttemptTimeout`) | **10s** (same constant). No API attempts. |
+| `shopifyDomain` **non-empty** (normal) | 1) **api-dedicated** → 2) **scrap-dedicated** → 3) **scrap-direct** | **10s** per step: `binderposAttemptTimeout` in `api/gateway/binderpos/storefront.go`; `runWithAttemptTimeout` in `storefront_search.go`. HTTP clients in `storefront_client.go` use the same `binderposAttemptTimeout`. |
+| `shopifyDomain` **empty** | **scrap-dedicated** → **scrap-direct** (`searchWithScrapDedicatedThenDirect`) | **10s** per step (same constant). No API attempts. |
 
 | Item | Value | Source | Notes |
 |------|--------|--------|--------|
 | **api-dedicated** proxy selection (storefront HTTP client) | Round-robin | `nextBinderposStorefrontProxyURL` + `binderposDedicatedProxySeq` in `api/gateway/binderpos/storefront_client.go` | When `UseLeasedDedicatedProxy` is **false** (default in `api/pkg/config/config.go`), each storefront API call cycles **proxy₁ → … → proxyₙ → direct (no HTTP proxy)** then repeats, using all URLs from `GetDedicatedProxyURLs()`. When `UseLeasedDedicatedProxy` is **true**, selection is unchanged: `LeaseDedicatedProxyURL` from the dedicated pool only (no direct slot in that path). |
 | Colly for BinderPOS scrapes | 10s | `SetRequestTimeout(binderposAttemptTimeout)` in `api/gateway/binderpos/scrap.go` | Tighter than generic `PerSiteTimeout` (20s) for binderpos scrape collectors. |
-| “Retries” | N/A (sequential fallbacks) | `searchWithFallback` | Stops on first **success**; returns last error if all three fail. This is **not** exponential backoff retry of a single request. |
+| “Retries” | N/A (sequential fallbacks) | `searchWithFallback` | Stops on first **success**; returns last error if api-dedicated, scrap-dedicated, and scrap-direct all fail. This is **not** exponential backoff retry of a single request. |
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

BinderPOS search no longer uses **`PROXY_URL`** / shared-proxy paths.

### When `shopifyDomain` is set
1. **api-dedicated** — Shopify Storefront API via dedicated routing in `searchByStorefrontAPI`.
2. **scrap-dedicated** — HTML scrape via `Scrap()` (BinderPOS colly + dedicated proxy lease).
3. **scrap-direct** — HTML scrape with no proxy (`scrapDirect`).

### When `shopifyDomain` is empty
**scrap-dedicated** → **scrap-direct** for all stores.

### Rebased onto current `master` (includes #99)
- **`searchByStorefrontAPI`**: when `UseLeasedDedicatedProxy` is **true**, `LeaseDedicatedProxyURL`; when **false**, **`nextBinderposStorefrontProxyURL`** round-robins across configured dedicated URLs plus a **direct** HTTP client slot (no `PROXY_URL`). Shared API helper removed.
- **Docs**: `search-strategies-retries-timeouts.md` updated for strategy order and the round-robin + lease summary (no stale `RandomDedicatedProxyURL` wording).

### Removed
- `searchByStorefrontAPISharedProxy`
- `scrapSharedProxy` / shared colly usage for BinderPOS search

### Tests
BinderPOS live tests remain behind **`RUN_BINDERPOS_LIVE_TESTS=1`**.

`make test` passes on this branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fbc799fc-9aba-45be-a11d-7ec0219d6227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fbc799fc-9aba-45be-a11d-7ec0219d6227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

