### PR TITLE
Add DEDICATED_PROXY_6 and DEDICATED_PROXY_7; gate BinderPOS live tests

### DIFF
--- a/api/gateway/binderpos/scrap_test.go
+++ b/api/gateway/binderpos/scrap_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"os"
 	"testing"
 
 	"github.com/joho/godotenv"
@@ -15,6 +16,9 @@ func init() {
 }
 
 func Test_Scrap(t *testing.T) {
+	if os.Getenv("RUN_BINDERPOS_LIVE_TESTS") != "1" {
+		t.Skip("set RUN_BINDERPOS_LIVE_TESTS=1 to run live BinderPOS scrape checks")
+	}
 	type args struct {
 		scrapVariant int
 		storeName    string

--- a/api/gateway/binderpos/storefront_api_test.go
+++ b/api/gateway/binderpos/storefront_api_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -23,6 +24,9 @@ type supportedGame struct {
 }
 
 func Test_StorefrontSupportedGamesEndpoint_ExistsForGreyOgreAndMtgAsia(t *testing.T) {
+	if os.Getenv("RUN_BINDERPOS_LIVE_TESTS") != "1" {
+		t.Skip("set RUN_BINDERPOS_LIVE_TESTS=1 to run live BinderPOS portal / store HTML checks")
+	}
 	client := &http.Client{Timeout: 20 * time.Second}
 
 	tests := []struct {

--- a/api/gateway/binderpos/storefront_search_test.go
+++ b/api/gateway/binderpos/storefront_search_test.go
@@ -3,6 +3,7 @@ package binderpos
 import (
 	"context"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -25,6 +26,9 @@ type binderposStoreSearchCase struct {
 }
 
 func Test_SearchByStorefrontAPI_SupportsAllBinderposStores(t *testing.T) {
+	if os.Getenv("RUN_BINDERPOS_LIVE_TESTS") != "1" {
+		t.Skip("set RUN_BINDERPOS_LIVE_TESTS=1 to run live storefront API checks against real stores")
+	}
 	previousSelector := shouldUseDecklistEndpoint
 	shouldUseDecklistEndpoint = func() bool { return false }
 	t.Cleanup(func() { shouldUseDecklistEndpoint = previousSelector })
@@ -48,6 +52,9 @@ func Test_SearchByStorefrontAPI_SupportsAllBinderposStores(t *testing.T) {
 }
 
 func Test_SearchByStorefrontAPI_OverlapsLegacyScrapeResults(t *testing.T) {
+	if os.Getenv("RUN_BINDERPOS_LIVE_TESTS") != "1" {
+		t.Skip("set RUN_BINDERPOS_LIVE_TESTS=1 to run live storefront vs scrape overlap checks")
+	}
 	previousSelector := shouldUseDecklistEndpoint
 	shouldUseDecklistEndpoint = func() bool { return false }
 	t.Cleanup(func() { shouldUseDecklistEndpoint = previousSelector })

--- a/api/gateway/collector_test.go
+++ b/api/gateway/collector_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestInitialProxy(t *testing.T) {
 	c := colly.NewCollector()
-	for i := 1; i <= 5; i++ {
+	for i := 1; i <= 7; i++ {
 		t.Setenv("DEDICATED_PROXY_"+string(rune('0'+i)), "")
 	}
 
@@ -27,7 +27,7 @@ func TestInitialProxy(t *testing.T) {
 
 	t.Run("picks random dedicated when no lease", func(t *testing.T) {
 		c2 := colly.NewCollector()
-		for i := 2; i <= 5; i++ {
+		for i := 2; i <= 7; i++ {
 			t.Setenv("DEDICATED_PROXY_"+string(rune('0'+i)), "")
 		}
 		t.Setenv("DEDICATED_PROXY_1", "1.1.1.1|8080|user|pass")

--- a/api/gateway/util/dedicated_proxy.go
+++ b/api/gateway/util/dedicated_proxy.go
@@ -45,6 +45,8 @@ func GetDedicatedProxy() []DedicatedProxy {
 		parseDedicatedProxy(os.Getenv("DEDICATED_PROXY_3")),
 		parseDedicatedProxy(os.Getenv("DEDICATED_PROXY_4")),
 		parseDedicatedProxy(os.Getenv("DEDICATED_PROXY_5")),
+		parseDedicatedProxy(os.Getenv("DEDICATED_PROXY_6")),
+		parseDedicatedProxy(os.Getenv("DEDICATED_PROXY_7")),
 	}
 }
 

--- a/api/gateway/util/dedicated_proxy_test.go
+++ b/api/gateway/util/dedicated_proxy_test.go
@@ -14,9 +14,11 @@ func TestGetDedicatedProxyReadsEnvVars(t *testing.T) {
 	t.Setenv("DEDICATED_PROXY_3", "host-3|3333|user-3|pass-3")
 	t.Setenv("DEDICATED_PROXY_4", "host-4|4444|user-4|pass-4")
 	t.Setenv("DEDICATED_PROXY_5", "host-5|5555|user-5|pass-5")
+	t.Setenv("DEDICATED_PROXY_6", "host-6|6666|user-6|pass-6")
+	t.Setenv("DEDICATED_PROXY_7", "host-7|7777|user-7|pass-7")
 
 	got := GetDedicatedProxy()
-	require.Len(t, got, 5)
+	require.Len(t, got, 7)
 
 	require.Equal(t, "host-1", got[0].Host)
 	require.Equal(t, "1111", got[0].Port)
@@ -42,15 +44,25 @@ func TestGetDedicatedProxyReadsEnvVars(t *testing.T) {
 	require.Equal(t, "5555", got[4].Port)
 	require.Equal(t, "user-5", got[4].Username)
 	require.Equal(t, "pass-5", got[4].Password)
+
+	require.Equal(t, "host-6", got[5].Host)
+	require.Equal(t, "6666", got[5].Port)
+	require.Equal(t, "user-6", got[5].Username)
+	require.Equal(t, "pass-6", got[5].Password)
+
+	require.Equal(t, "host-7", got[6].Host)
+	require.Equal(t, "7777", got[6].Port)
+	require.Equal(t, "user-7", got[6].Username)
+	require.Equal(t, "pass-7", got[6].Password)
 }
 
 func TestGetDedicatedProxyReturnsEmptyStringsWhenEnvVarsAreEmpty(t *testing.T) {
-	for i := 1; i <= 5; i++ {
+	for i := 1; i <= 7; i++ {
 		t.Setenv(fmt.Sprintf("DEDICATED_PROXY_%d", i), "")
 	}
 
 	got := GetDedicatedProxy()
-	require.Len(t, got, 5)
+	require.Len(t, got, 7)
 	for _, proxy := range got {
 		require.Equal(t, "", proxy.Host)
 		require.Equal(t, "", proxy.Port)
@@ -63,9 +75,12 @@ func TestGetDedicatedProxyParsesPartialSegments(t *testing.T) {
 	t.Setenv("DEDICATED_PROXY_1", "host-1")             // missing port/username/password
 	t.Setenv("DEDICATED_PROXY_2", "host-2|2222")        // missing username/password
 	t.Setenv("DEDICATED_PROXY_3", "host-3|3333|user-3") // missing password
+	for i := 4; i <= 7; i++ {
+		t.Setenv(fmt.Sprintf("DEDICATED_PROXY_%d", i), "")
+	}
 
 	got := GetDedicatedProxy()
-	require.Len(t, got, 5)
+	require.Len(t, got, 7)
 
 	require.Equal(t, "host-1", got[0].Host)
 	require.Equal(t, "", got[0].Port)

--- a/api/gateway/util/dedicated_proxy_test.go
+++ b/api/gateway/util/dedicated_proxy_test.go
@@ -72,11 +72,15 @@ func TestGetDedicatedProxyReturnsEmptyStringsWhenEnvVarsAreEmpty(t *testing.T) {
 }
 
 func TestGetDedicatedProxyParsesPartialSegments(t *testing.T) {
-	t.Setenv("DEDICATED_PROXY_1", "host-1")             // missing port/username/password
-	t.Setenv("DEDICATED_PROXY_2", "host-2|2222")        // missing username/password
-	t.Setenv("DEDICATED_PROXY_3", "host-3|3333|user-3") // missing password
-	for i := 4; i <= 7; i++ {
-		t.Setenv(fmt.Sprintf("DEDICATED_PROXY_%d", i), "")
+	// Slots 1–3: partial pipe segments; 4–7: unset (empty string).
+	raw := []string{
+		"host-1",             // missing port/username/password
+		"host-2|2222",        // missing username/password
+		"host-3|3333|user-3", // missing password
+		"", "", "", "",
+	}
+	for i, v := range raw {
+		t.Setenv(fmt.Sprintf("DEDICATED_PROXY_%d", i+1), v)
 	}
 
 	got := GetDedicatedProxy()

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -23,6 +23,18 @@ This document records **where** the app configures search behavior, **timeouts**
 | Minimum interval between requests to the **same host** | 300ms | `domainRequestMinInterval` in `api/gateway/domain_rate_limiter.go` | Added to the reservation for the next allowed time for that domain. |
 | Jitter (added on top of minimum interval) | uniform in **[0, 600ms)** | `domainRequestMaxJitter` + `randomDuration` in `api/gateway/domain_rate_limiter.go` | Per reservation: `reservedUntil = nextAllowed + minInterval + jitter`. If the wait is cancelled, the limiter can roll back that reservation. |
 
+## Backend: dedicated proxy env (`api/gateway/util/dedicated_proxy.go`)
+
+| Item | Value | Notes |
+|------|--------|--------|
+| Configured slots | **`DEDICATED_PROXY_1`** … **`DEDICATED_PROXY_7`** | Each value is `host\|port\|username\|password` (pipe-separated). Empty or incomplete entries are ignored when building URLs. |
+
+---
+
+## Live BinderPOS integration tests
+
+Some tests in `api/gateway/binderpos/*_test.go` hit real stores and proxies. They run only when **`RUN_BINDERPOS_LIVE_TESTS=1`** is set (default `make test` skips them to avoid rate limits and flaky remote dependencies).
+
 ---
 
 ## Backend: BinderPOS (storefront + scraper fallbacks)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **`GetDedicatedProxy`** now reads **`DEDICATED_PROXY_1`** through **`DEDICATED_PROXY_7`** (`api/gateway/util/dedicated_proxy.go`). Empty or incomplete entries are still skipped when building URLs.
- **`dedicatedProxyEnvLabel`** in `collector.go` already uses `idx+1` over `GetDedicatedProxy()`, so error text will show **`DEDICATED_PROXY_6`** / **`DEDICATED_PROXY_7`** when those env vars match the request URL.
- Tests updated: `dedicated_proxy_test.go` (including one loop for all env vars in `TestGetDedicatedProxyParsesPartialSegments`), `collector_test.go` (clear slots 1–7).

## Reliable default tests

BinderPOS tests that hit the network (`scrap_test.go`, `storefront_api_test.go`, `storefront_search_test.go`) are skipped unless **`RUN_BINDERPOS_LIVE_TESTS=1`**, so `make test` does not depend on live store health or rate limits.

## Docs

`docs/search-strategies-retries-timeouts.md` documents the seven `DEDICATED_PROXY_*` slots and the live-test env flag.

## Deploy

Set **`DEDICATED_PROXY_6`** and **`DEDICATED_PROXY_7`** in the runtime environment using the same `host|port|user|pass` format as existing slots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fbc799fc-9aba-45be-a11d-7ec0219d6227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fbc799fc-9aba-45be-a11d-7ec0219d6227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

