### PR TITLE
Lease dedicated proxy for BinderPOS storefront API

### DIFF
--- a/api/gateway/binderpos/storefront_client.go
+++ b/api/gateway/binderpos/storefront_client.go
@@ -3,7 +3,6 @@ package binderpos
 import (
 	"context"
 	"fmt"
-	"math/rand/v2"
 	"net/http"
 	"net/url"
 	"os"
@@ -14,9 +13,19 @@ import (
 )
 
 func searchByStorefrontAPI(ctx context.Context, scrapVariant int, storeName, baseURL, shopifyDomain, searchStr string) ([]gateway.Card, error) {
-	client, ok := newDedicatedProxyHTTPClient()
-	if !ok {
+	proxyURLs := util.GetDedicatedProxyURLs()
+	if len(proxyURLs) == 0 {
 		return nil, fmt.Errorf("no dedicated proxy configured for binderpos storefront api")
+	}
+	leasedURL, release, err := gateway.LeaseDedicatedProxyURL(ctx, proxyURLs)
+	if err != nil {
+		return nil, fmt.Errorf("dedicated proxy lease for binderpos storefront api: %w", err)
+	}
+	defer release()
+
+	client, err := newHTTPClientWithProxyURL(leasedURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid dedicated proxy configured for binderpos storefront api: %w", err)
 	}
 
 	return searchByStorefrontAPIWithClient(ctx, client, scrapVariant, storeName, baseURL, shopifyDomain, searchStr)
@@ -51,25 +60,6 @@ func searchByStorefrontAPIWithClient(ctx context.Context, client *http.Client, s
 
 func useDecklistForRoll(roll int) bool {
 	return roll < binderposDecklistPct
-}
-
-func newDedicatedProxyHTTPClient() (*http.Client, bool) {
-	proxyURLs := util.GetDedicatedProxyURLs()
-	if len(proxyURLs) == 0 {
-		return nil, false
-	}
-
-	proxyURL := strings.TrimSpace(proxyURLs[rand.IntN(len(proxyURLs))])
-	if proxyURL == "" {
-		return nil, false
-	}
-
-	client, err := newHTTPClientWithProxyURL(proxyURL)
-	if err != nil {
-		return nil, false
-	}
-
-	return client, true
 }
 
 func newHTTPClientWithProxyURL(proxyURL string) (*http.Client, error) {

--- a/api/gateway/collector.go
+++ b/api/gateway/collector.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"math/rand/v2"
@@ -55,17 +56,64 @@ func (p *dedicatedProxyLeasePool) acquire(proxyURLs []string) (string, bool) {
 	defer p.mu.Unlock()
 
 	for {
-		for _, idx := range rand.Perm(len(proxyURLs)) {
-			proxyURL := proxyURLs[idx]
-			if proxyURL == "" {
-				continue
-			}
-			if !p.inUse[proxyURL] {
-				p.inUse[proxyURL] = true
-				return proxyURL, true
-			}
+		if proxyURL, ok := p.tryAcquireLocked(proxyURLs); ok {
+			return proxyURL, true
 		}
 		p.cond.Wait()
+	}
+}
+
+// tryAcquireLocked picks a free dedicated proxy in random order among proxyURLs.
+// Caller must hold p.mu.
+func (p *dedicatedProxyLeasePool) tryAcquireLocked(proxyURLs []string) (string, bool) {
+	for _, idx := range rand.Perm(len(proxyURLs)) {
+		proxyURL := proxyURLs[idx]
+		if proxyURL == "" {
+			continue
+		}
+		if !p.inUse[proxyURL] {
+			p.inUse[proxyURL] = true
+			return proxyURL, true
+		}
+	}
+	return "", false
+}
+
+// acquireCtx is like acquire but returns when ctx is cancelled or timed out if no slot is available.
+func (p *dedicatedProxyLeasePool) acquireCtx(ctx context.Context, proxyURLs []string) (string, error) {
+	if len(proxyURLs) == 0 {
+		return "", errors.New("no dedicated proxy URLs")
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	stop := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			p.mu.Lock()
+			p.cond.Broadcast()
+			p.mu.Unlock()
+		case <-stop:
+		}
+	}()
+	defer close(stop)
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	for {
+		if proxyURL, ok := p.tryAcquireLocked(proxyURLs); ok {
+			return proxyURL, nil
+		}
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
+		p.cond.Wait()
+		if err := ctx.Err(); err != nil {
+			return "", err
+		}
 	}
 }
 
@@ -81,6 +129,23 @@ func (p *dedicatedProxyLeasePool) release(proxyURL string) {
 		delete(p.inUse, proxyURL)
 		p.cond.Signal()
 	}
+}
+
+// LeaseDedicatedProxyURL acquires one free dedicated proxy URL from proxyURLs, trying URLs in a
+// random order until one is available. The caller must invoke release exactly once when finished.
+// If ctx is cancelled or times out before a slot is available, err is non-nil and release is a no-op.
+func LeaseDedicatedProxyURL(ctx context.Context, proxyURLs []string) (leasedURL string, release func(), err error) {
+	if len(proxyURLs) == 0 {
+		return "", func() {}, errors.New("no dedicated proxy URLs")
+	}
+	leasedURL, err = dedicatedProxyLeases.acquireCtx(ctx, proxyURLs)
+	if err != nil {
+		return "", func() {}, err
+	}
+	u := leasedURL
+	return leasedURL, func() {
+		dedicatedProxyLeases.release(u)
+	}, nil
 }
 
 // Collector constructors and top-level configuration.

--- a/api/gateway/collector_test.go
+++ b/api/gateway/collector_test.go
@@ -2,6 +2,8 @@ package gateway
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -87,6 +89,47 @@ func TestDedicatedProxyLeasePoolAcquireRelease(t *testing.T) {
 
 	pool.release(second)
 	pool.release(first)
+}
+
+func TestLeaseDedicatedProxyURLGlobalPool(t *testing.T) {
+	for i := 1; i <= 7; i++ {
+		t.Setenv(fmt.Sprintf("DEDICATED_PROXY_%d", i), "")
+	}
+	t.Setenv("DEDICATED_PROXY_1", "10.0.0.1|1111|lease-a|secret-a")
+
+	urls := util.GetDedicatedProxyURLs()
+	if len(urls) != 1 {
+		t.Fatalf("expected 1 dedicated proxy URL, got %d (%v)", len(urls), urls)
+	}
+
+	u, release, err := LeaseDedicatedProxyURL(context.Background(), urls)
+	if err != nil {
+		t.Fatalf("first lease: %v", err)
+	}
+	if u != urls[0] {
+		t.Fatalf("expected leased url %q, got %q", urls[0], u)
+	}
+
+	ctxWait, cancelWait := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancelWait()
+	_, _, errBlocked := LeaseDedicatedProxyURL(ctxWait, urls)
+	if errBlocked == nil {
+		t.Fatalf("expected second lease to fail while first is held")
+	}
+	if !errors.Is(errBlocked, context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded, got %v", errBlocked)
+	}
+
+	release()
+
+	u2, release2, err2 := LeaseDedicatedProxyURL(context.Background(), urls)
+	if err2 != nil {
+		t.Fatalf("after release: %v", err2)
+	}
+	if u2 != urls[0] {
+		t.Fatalf("expected same url after release, got %q", u2)
+	}
+	release2()
 }
 
 func TestDedicatedProxyURLHelpers(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

BinderPOS **api-dedicated** (storefront HTTP client) now uses the same **dedicated proxy lease pool** as `NewOptimizedCollectorForBinderpos`: a free `DEDICATED_PROXY_*` URL is chosen in **random order**, held for the full storefront attempt, then released. This avoids overloading the same dedicated exit when many BinderPOS stores run concurrently and aligns storefront with scrape leasing semantics.

## Implementation

- Refactored `dedicatedProxyLeasePool` with `tryAcquireLocked` and added `acquireCtx` so waits respect `context` cancellation/deadline (used by `runWithAttemptTimeout`).
- New `gateway.LeaseDedicatedProxyURL(ctx, proxyURLs)` returns `(leasedURL, release, err)`.
- `searchByStorefrontAPI` acquires via the global pool, builds `http.Client` for the leased URL, `defer release()`.
- Goroutine on context done broadcasts the condition variable so blocked acquirers wake without leaking.

## Tests

- `make test` and `go test ./gateway/... ./controller/...` pass.
- Added `TestLeaseDedicatedProxyURLGlobalPool` for single-proxy contention against the real pool.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b9ccd18-cab4-4b73-81e8-da37dda52a12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b9ccd18-cab4-4b73-81e8-da37dda52a12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

