### PR TITLE
feat(config): toggle leased vs random dedicated proxy

### DIFF
--- a/api/gateway/binderpos/storefront_client.go
+++ b/api/gateway/binderpos/storefront_client.go
@@ -10,6 +10,7 @@ import (
 
 	"mtg-price-checker-sg/gateway"
 	"mtg-price-checker-sg/gateway/util"
+	"mtg-price-checker-sg/pkg/config"
 )
 
 func searchByStorefrontAPI(ctx context.Context, scrapVariant int, storeName, baseURL, shopifyDomain, searchStr string) ([]gateway.Card, error) {
@@ -17,13 +18,24 @@ func searchByStorefrontAPI(ctx context.Context, scrapVariant int, storeName, bas
 	if len(proxyURLs) == 0 {
 		return nil, fmt.Errorf("no dedicated proxy configured for binderpos storefront api")
 	}
-	leasedURL, release, err := gateway.LeaseDedicatedProxyURL(ctx, proxyURLs)
-	if err != nil {
-		return nil, fmt.Errorf("dedicated proxy lease for binderpos storefront api: %w", err)
-	}
-	defer release()
 
-	client, err := newHTTPClientWithProxyURL(leasedURL)
+	var proxyURL string
+	if config.UseLeasedDedicatedProxy() {
+		leasedURL, release, err := gateway.LeaseDedicatedProxyURL(ctx, proxyURLs)
+		if err != nil {
+			return nil, fmt.Errorf("dedicated proxy lease for binderpos storefront api: %w", err)
+		}
+		defer release()
+		proxyURL = leasedURL
+	} else {
+		u, ok := gateway.RandomDedicatedProxyURL()
+		if !ok {
+			return nil, fmt.Errorf("no dedicated proxy configured for binderpos storefront api")
+		}
+		proxyURL = u
+	}
+
+	client, err := newHTTPClientWithProxyURL(proxyURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid dedicated proxy configured for binderpos storefront api: %w", err)
 	}

--- a/api/gateway/binderpos/storefront_client.go
+++ b/api/gateway/binderpos/storefront_client.go
@@ -20,7 +20,7 @@ func searchByStorefrontAPI(ctx context.Context, scrapVariant int, storeName, bas
 	}
 
 	var proxyURL string
-	if config.UseLeasedDedicatedProxy() {
+	if config.UseLeasedDedicatedProxy {
 		leasedURL, release, err := gateway.LeaseDedicatedProxyURL(ctx, proxyURLs)
 		if err != nil {
 			return nil, fmt.Errorf("dedicated proxy lease for binderpos storefront api: %w", err)

--- a/api/gateway/collector.go
+++ b/api/gateway/collector.go
@@ -178,7 +178,7 @@ func NewOptimizedCollectorForBinderpos(ctx context.Context) *colly.Collector {
 	c := colly.NewCollector(
 		colly.StdlibContext(ctx),
 	)
-	configureRequestOptimizations(c, config.UseLeasedDedicatedProxy())
+	configureRequestOptimizations(c, config.UseLeasedDedicatedProxy)
 	return c
 }
 
@@ -221,7 +221,7 @@ func applyCollectorDefaults(c *colly.Collector) {
 func leaseDedicatedProxyIfNeeded(enforceDedicatedProxyLease bool) (string, func()) {
 	var leasedDedicatedProxyURL string
 	releaseLeasedDedicatedProxy := func() {}
-	if enforceDedicatedProxyLease && config.UseProxy && config.UseLeasedDedicatedProxy() {
+	if enforceDedicatedProxyLease && config.UseProxy && config.UseLeasedDedicatedProxy {
 		if proxyURL, ok := dedicatedProxyLeases.acquire(util.GetDedicatedProxyURLs()); ok {
 			leasedDedicatedProxyURL = proxyURL
 			releaseLeasedDedicatedProxy = func() {

--- a/api/gateway/collector.go
+++ b/api/gateway/collector.go
@@ -178,7 +178,7 @@ func NewOptimizedCollectorForBinderpos(ctx context.Context) *colly.Collector {
 	c := colly.NewCollector(
 		colly.StdlibContext(ctx),
 	)
-	configureRequestOptimizations(c, true)
+	configureRequestOptimizations(c, config.UseLeasedDedicatedProxy())
 	return c
 }
 
@@ -221,7 +221,7 @@ func applyCollectorDefaults(c *colly.Collector) {
 func leaseDedicatedProxyIfNeeded(enforceDedicatedProxyLease bool) (string, func()) {
 	var leasedDedicatedProxyURL string
 	releaseLeasedDedicatedProxy := func() {}
-	if enforceDedicatedProxyLease && config.UseProxy {
+	if enforceDedicatedProxyLease && config.UseProxy && config.UseLeasedDedicatedProxy() {
 		if proxyURL, ok := dedicatedProxyLeases.acquire(util.GetDedicatedProxyURLs()); ok {
 			leasedDedicatedProxyURL = proxyURL
 			releaseLeasedDedicatedProxy = func() {
@@ -334,6 +334,11 @@ func VisitWithProxyInfo(c *colly.Collector, targetURL string) error {
 func clearProxy(c *colly.Collector) (string, string) {
 	c.SetProxyFunc(nil)
 	return "direct", ""
+}
+
+// RandomDedicatedProxyURL picks one configured dedicated proxy uniformly at random.
+func RandomDedicatedProxyURL() (string, bool) {
+	return randomDedicatedProxyURL("")
 }
 
 func randomDedicatedProxyURL(avoidProxyURL string) (string, bool) {

--- a/api/gateway/collector_test.go
+++ b/api/gateway/collector_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"mtg-price-checker-sg/gateway/util"
+	"mtg-price-checker-sg/pkg/config"
 
 	"github.com/gocolly/colly/v2"
 )
@@ -40,6 +41,34 @@ func TestInitialProxy(t *testing.T) {
 		if proxyURL != "http://user:pass@1.1.1.1:8080" {
 			t.Fatalf("unexpected dedicated proxy url: %q", proxyURL)
 		}
+	})
+}
+
+func TestLeaseDedicatedProxyIfNeededConfig(t *testing.T) {
+	t.Run("skips lease when disabled", func(t *testing.T) {
+		t.Setenv(config.UseLeasedDedicatedProxyEnv, "false")
+		for i := 1; i <= 7; i++ {
+			t.Setenv(fmt.Sprintf("DEDICATED_PROXY_%d", i), "")
+		}
+		t.Setenv("DEDICATED_PROXY_1", "10.0.0.1|1111|u|p")
+		u, release := leaseDedicatedProxyIfNeeded(true)
+		if u != "" {
+			t.Fatalf("expected no leased URL when %s=false, got %q", config.UseLeasedDedicatedProxyEnv, u)
+		}
+		release()
+	})
+
+	t.Run("acquires lease when enabled", func(t *testing.T) {
+		t.Setenv(config.UseLeasedDedicatedProxyEnv, "true")
+		for i := 1; i <= 7; i++ {
+			t.Setenv(fmt.Sprintf("DEDICATED_PROXY_%d", i), "")
+		}
+		t.Setenv("DEDICATED_PROXY_1", "10.0.0.1|1111|u|p")
+		u, release := leaseDedicatedProxyIfNeeded(true)
+		if u == "" {
+			t.Fatalf("expected leased URL when %s=true", config.UseLeasedDedicatedProxyEnv)
+		}
+		release()
 	})
 }
 

--- a/api/gateway/collector_test.go
+++ b/api/gateway/collector_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"mtg-price-checker-sg/gateway/util"
-	"mtg-price-checker-sg/pkg/config"
 
 	"github.com/gocolly/colly/v2"
 )
@@ -41,34 +40,6 @@ func TestInitialProxy(t *testing.T) {
 		if proxyURL != "http://user:pass@1.1.1.1:8080" {
 			t.Fatalf("unexpected dedicated proxy url: %q", proxyURL)
 		}
-	})
-}
-
-func TestLeaseDedicatedProxyIfNeededConfig(t *testing.T) {
-	t.Run("skips lease when disabled", func(t *testing.T) {
-		t.Setenv(config.UseLeasedDedicatedProxyEnv, "false")
-		for i := 1; i <= 7; i++ {
-			t.Setenv(fmt.Sprintf("DEDICATED_PROXY_%d", i), "")
-		}
-		t.Setenv("DEDICATED_PROXY_1", "10.0.0.1|1111|u|p")
-		u, release := leaseDedicatedProxyIfNeeded(true)
-		if u != "" {
-			t.Fatalf("expected no leased URL when %s=false, got %q", config.UseLeasedDedicatedProxyEnv, u)
-		}
-		release()
-	})
-
-	t.Run("acquires lease when enabled", func(t *testing.T) {
-		t.Setenv(config.UseLeasedDedicatedProxyEnv, "true")
-		for i := 1; i <= 7; i++ {
-			t.Setenv(fmt.Sprintf("DEDICATED_PROXY_%d", i), "")
-		}
-		t.Setenv("DEDICATED_PROXY_1", "10.0.0.1|1111|u|p")
-		u, release := leaseDedicatedProxyIfNeeded(true)
-		if u == "" {
-			t.Fatalf("expected leased URL when %s=true", config.UseLeasedDedicatedProxyEnv)
-		}
-		release()
 	})
 }
 

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -21,10 +21,11 @@ const (
 	// UseBinderposSharedProxyFallbackEnv is reserved for future BinderPOS proxy
 	// routing options. It no longer changes scraper behavior (lookups are single-attempt).
 	UseBinderposSharedProxyFallbackEnv = "USE_BINDERPOS_SHARED_PROXY_FALLBACK"
-	// UseLeasedDedicatedProxyEnv enables exclusive per-request leases from the dedicated proxy pool.
-	// When false (default), each request picks a random dedicated proxy instead of acquiring a lease.
-	UseLeasedDedicatedProxyEnv = "USE_LEASED_DEDICATED_PROXY"
 )
+
+// UseLeasedDedicatedProxy enables exclusive per-request leases from the dedicated proxy pool.
+// When false, each request picks a random dedicated proxy instead of acquiring a lease.
+const UseLeasedDedicatedProxy = false
 
 func UseBinderposStorefrontAPI() bool {
 	rawValue := strings.TrimSpace(os.Getenv(UseBinderposStorefrontAPIEnv))
@@ -42,22 +43,6 @@ func UseBinderposStorefrontAPI() bool {
 
 func UseBinderposSharedProxyFallback() bool {
 	rawValue := strings.TrimSpace(os.Getenv(UseBinderposSharedProxyFallbackEnv))
-	if rawValue == "" {
-		return false
-	}
-
-	enabled, err := strconv.ParseBool(rawValue)
-	if err != nil {
-		return false
-	}
-
-	return enabled
-}
-
-// UseLeasedDedicatedProxy returns whether dedicated proxy usage should acquire an exclusive lease
-// from the pool. Default is false (random selection among configured dedicated proxies).
-func UseLeasedDedicatedProxy() bool {
-	rawValue := strings.TrimSpace(os.Getenv(UseLeasedDedicatedProxyEnv))
 	if rawValue == "" {
 		return false
 	}

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -21,6 +21,9 @@ const (
 	// UseBinderposSharedProxyFallbackEnv is reserved for future BinderPOS proxy
 	// routing options. It no longer changes scraper behavior (lookups are single-attempt).
 	UseBinderposSharedProxyFallbackEnv = "USE_BINDERPOS_SHARED_PROXY_FALLBACK"
+	// UseLeasedDedicatedProxyEnv enables exclusive per-request leases from the dedicated proxy pool.
+	// When false (default), each request picks a random dedicated proxy instead of acquiring a lease.
+	UseLeasedDedicatedProxyEnv = "USE_LEASED_DEDICATED_PROXY"
 )
 
 func UseBinderposStorefrontAPI() bool {
@@ -39,6 +42,22 @@ func UseBinderposStorefrontAPI() bool {
 
 func UseBinderposSharedProxyFallback() bool {
 	rawValue := strings.TrimSpace(os.Getenv(UseBinderposSharedProxyFallbackEnv))
+	if rawValue == "" {
+		return false
+	}
+
+	enabled, err := strconv.ParseBool(rawValue)
+	if err != nil {
+		return false
+	}
+
+	return enabled
+}
+
+// UseLeasedDedicatedProxy returns whether dedicated proxy usage should acquire an exclusive lease
+// from the pool. Default is false (random selection among configured dedicated proxies).
+func UseLeasedDedicatedProxy() bool {
+	rawValue := strings.TrimSpace(os.Getenv(UseLeasedDedicatedProxyEnv))
 	if rawValue == "" {
 		return false
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `config.UseLeasedDedicatedProxy` as a **compile-time constant** set to **`false`**. Dedicated proxy usage always picks a **random** configured proxy (no exclusive lease). No environment variable.

When leasing is needed again, flip the constant to `true` (or reintroduce runtime configuration).

## Testing

- `make test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d97ed82-f5b1-46af-b1ec-0be8f64d5562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d97ed82-f5b1-46af-b1ec-0be8f64d5562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

