### PR TITLE
BinderPOS storefront API: round-robin dedicated proxies with direct slot

### DIFF
--- a/api/gateway/binderpos/storefront_client.go
+++ b/api/gateway/binderpos/storefront_client.go
@@ -7,11 +7,29 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync/atomic"
 
 	"mtg-price-checker-sg/gateway"
 	"mtg-price-checker-sg/gateway/util"
 	"mtg-price-checker-sg/pkg/config"
 )
+
+// binderposDedicatedProxySeq advances for each BinderPOS storefront API call that uses
+// non-leased dedicated routing, so traffic round-robins across each configured proxy
+// plus one direct (no proxy) slot.
+var binderposDedicatedProxySeq atomic.Uint32
+
+// nextBinderposStorefrontProxyURL returns the next proxy URL in round-robin order among
+// proxyURLs and a final direct slot (direct==true means use no HTTP proxy).
+func nextBinderposStorefrontProxyURL(proxyURLs []string) (proxyURL string, direct bool) {
+	n := len(proxyURLs) + 1
+	v := binderposDedicatedProxySeq.Add(1) - 1
+	slot := int(v % uint32(n))
+	if slot == len(proxyURLs) {
+		return "", true
+	}
+	return proxyURLs[slot], false
+}
 
 func searchByStorefrontAPI(ctx context.Context, scrapVariant int, storeName, baseURL, shopifyDomain, searchStr string) ([]gateway.Card, error) {
 	proxyURLs := util.GetDedicatedProxyURLs()
@@ -28,9 +46,10 @@ func searchByStorefrontAPI(ctx context.Context, scrapVariant int, storeName, bas
 		defer release()
 		proxyURL = leasedURL
 	} else {
-		u, ok := gateway.RandomDedicatedProxyURL()
-		if !ok {
-			return nil, fmt.Errorf("no dedicated proxy configured for binderpos storefront api")
+		u, useDirect := nextBinderposStorefrontProxyURL(proxyURLs)
+		if useDirect {
+			client := &http.Client{Timeout: binderposAttemptTimeout}
+			return searchByStorefrontAPIWithClient(ctx, client, scrapVariant, storeName, baseURL, shopifyDomain, searchStr)
 		}
 		proxyURL = u
 	}

--- a/api/gateway/binderpos/storefront_proxy_client_test.go
+++ b/api/gateway/binderpos/storefront_proxy_client_test.go
@@ -10,6 +10,40 @@ import (
 	"mtg-price-checker-sg/gateway"
 )
 
+func TestNextBinderposStorefrontProxyURLRoundRobin(t *testing.T) {
+	binderposDedicatedProxySeq.Store(0)
+
+	urls := []string{"http://a:1", "http://b:2"}
+	want := []struct {
+		url    string
+		direct bool
+	}{
+		{url: "http://a:1", direct: false},
+		{url: "http://b:2", direct: false},
+		{url: "", direct: true},
+		{url: "http://a:1", direct: false},
+	}
+	for i, w := range want {
+		gotURL, gotDirect := nextBinderposStorefrontProxyURL(urls)
+		if gotURL != w.url || gotDirect != w.direct {
+			t.Fatalf("step %d: got (%q, %v), want (%q, %v)", i, gotURL, gotDirect, w.url, w.direct)
+		}
+	}
+}
+
+func TestNextBinderposStorefrontProxyURLSingleProxyIncludesDirect(t *testing.T) {
+	binderposDedicatedProxySeq.Store(0)
+	urls := []string{"http://only:8080"}
+	u0, d0 := nextBinderposStorefrontProxyURL(urls)
+	if d0 || u0 != "http://only:8080" {
+		t.Fatalf("first slot: got (%q, %v)", u0, d0)
+	}
+	u1, d1 := nextBinderposStorefrontProxyURL(urls)
+	if !d1 || u1 != "" {
+		t.Fatalf("second slot (direct): got (%q, %v)", u1, d1)
+	}
+}
+
 func TestNewHTTPClientWithProxyURL(t *testing.T) {
 	t.Run("returns error for invalid proxy URL", func(t *testing.T) {
 		_, err := newHTTPClientWithProxyURL("://invalid-proxy")

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -48,6 +48,7 @@ Some tests in `api/gateway/binderpos/*_test.go` hit real stores and proxies. The
 
 | Item | Value | Source | Notes |
 |------|--------|--------|--------|
+| **api-dedicated** proxy selection (storefront HTTP client) | Round-robin | `nextBinderposStorefrontProxyURL` + `binderposDedicatedProxySeq` in `api/gateway/binderpos/storefront_client.go` | When `UseLeasedDedicatedProxy` is **false** (default in `api/pkg/config/config.go`), each storefront API call cycles **proxy₁ → … → proxyₙ → direct (no HTTP proxy)** then repeats, using all URLs from `GetDedicatedProxyURLs()`. When `UseLeasedDedicatedProxy` is **true**, selection is unchanged: `LeaseDedicatedProxyURL` from the dedicated pool only (no direct slot in that path). |
 | Colly for BinderPOS scrapes | 10s | `SetRequestTimeout(binderposAttemptTimeout)` in `api/gateway/binderpos/scrap.go` | Tighter than generic `PerSiteTimeout` (20s) for binderpos scrape collectors. |
 | “Retries” | N/A (sequential fallbacks) | `searchWithFallback` | Stops on first **success**; returns last error if all three fail. This is **not** exponential backoff retry of a single request. |
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

BinderPOS storefront API calls that use the dedicated proxy pool (when `UseLeasedDedicatedProxy` is false) previously picked a **random** dedicated proxy on each request. They now **round-robin** across every configured `DEDICATED_PROXY_*` URL and include **one direct (no HTTP proxy) slot** per full cycle.

## Behavior

- With N valid dedicated proxy URLs, each request advances a global counter and uses slot `counter mod (N+1)`: slots `0..N-1` use the corresponding proxy URL; slot N uses a plain `http.Client` with no proxy (same as `searchByStorefrontAPIDirect`).
- Leased mode (`UseLeasedDedicatedProxy` true) is unchanged: still acquires a lease from the pool only.

## Tests

- `make test`
- Unit tests for `nextBinderposStorefrontProxyURL` in `storefront_proxy_client_test.go`

## Documentation

- `docs/search-strategies-retries-timeouts.md` BinderPOS section updated to describe round-robin + direct slot and leased vs non-leased behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-00413f2f-d07e-4321-b42d-0afe2f0edb18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-00413f2f-d07e-4321-b42d-0afe2f0edb18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

