### PR TITLE
docs: add Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,3 +31,39 @@ Notes:
 ## UI deliverables
 
 - For any PR that includes UI changes, include screenshots of the updated UI at both desktop and mobile resolutions.
+
+## Cursor Cloud specific instructions
+
+### Services overview
+
+| Service | Location | Run command | Port |
+|---------|----------|-------------|------|
+| Go backend (Lambda handler) | `api/` | `cd api && go run -mod=vendor ./cmd/main.go` | N/A (one-shot, prints JSON) |
+| Frontend dev server (Vite) | `frontend/` | `cd frontend && npm run dev` | 5173 |
+
+### Go version requirement
+
+The project requires Go 1.26.2 (per `api/go.mod`). The update script installs it to `/usr/local/go`. You must have `/usr/local/go/bin` in your PATH:
+
+```bash
+export PATH="/usr/local/go/bin:$PATH"
+```
+
+### Running tests
+
+- Full test suite: `make test` (from repo root)
+- Gateway/controller focused: `cd api && go test -mod=vendor -failfast -timeout 5m ./gateway/... ./controller/...`
+- Frontend lint: `cd frontend && npm run lint`
+
+### Known test behaviour
+
+- The `gateway/arcanesanctum` test hits a live website that blocks direct requests without a proxy. It will fail with "Forbidden (proxy_mode=direct proxy=none)" unless `PROXY_URL` or `DEDICATED_PROXY_*` env vars are set. This is expected in environments without proxy credentials.
+- Many gateway tests hit live upstream store websites, so transient network failures or rate-limiting can cause sporadic failures.
+
+### Frontend API connection
+
+The frontend SPA points to `staging-api.gishathfetch.com` when running on localhost (see `frontend/src/constants.js`). CORS headers on the staging API only allow recognized origins; to test the full search flow through the browser, either use the computerUse agent to navigate (it works via fetch from the page) or add a Vite proxy configuration temporarily (revert before committing).
+
+### Backend local mode
+
+When `ENV` is unset (local mode), `go run ./cmd/main.go` executes a hardcoded test search for "Opt" across a subset of stores and prints the JSON result to stdout. No server is started; the process exits after printing.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with development environment guidance for Cloud Agent VMs.

### What's included

- Services overview table (Go backend + Vite frontend dev server)
- Go 1.26.2 version requirement and PATH setup notes
- Test running commands and known test behaviours (e.g. `arcanesanctum` proxy requirement)
- Frontend API connection notes (CORS with staging API)
- Backend local mode explanation (hardcoded "Opt" search when `ENV` is unset)

### Environment verification

The following was verified during setup:

- Go 1.26.2 installed and backend compiles/runs successfully
- `make test` passes (22/23 packages; 1 expected failure due to upstream store blocking without proxy)
- Frontend `npm install` + `npm run dev` starts Vite on port 5173
- Frontend lint (`npm run lint`) runs (pre-existing lint issues only)
- Backend local search returns structured JSON with card results from 8+ stores

![Frontend search results for Lightning Bolt](https://cursor.com/artifacts/c/art-b73392b4-5126-497a-b523-cdc13dc3fb21)
![More search results scrolled down](https://cursor.com/artifacts/c/art-ddde9a50-b4d2-4d84-95fd-2a40a5fa68a5)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5894ee8a-9bd2-4bc1-958b-c45c098a4fdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5894ee8a-9bd2-4bc1-958b-c45c098a4fdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

