### PR TITLE
Support pipe-format dynamic proxy config

### DIFF
--- a/api/gateway/collector.go
+++ b/api/gateway/collector.go
@@ -375,7 +375,11 @@ func clearProxy(c *colly.Collector) (string, string) {
 }
 
 func DynamicProxyURL() string {
-	return strings.TrimSpace(os.Getenv(config.DynamicProxyEnv))
+	proxyURL, ok := util.BuildProxyURL(os.Getenv(config.DynamicProxyEnv))
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(proxyURL)
 }
 
 // RandomDedicatedProxyURL picks one configured dedicated proxy uniformly at random.

--- a/api/gateway/collector_test.go
+++ b/api/gateway/collector_test.go
@@ -45,7 +45,7 @@ func TestInitialProxy(t *testing.T) {
 
 	t.Run("falls back to dynamic when no dedicated proxy is configured", func(t *testing.T) {
 		c2 := colly.NewCollector()
-		t.Setenv("DYNAMIC_PROXY", "http://dynamic-user:dynamic-pass@dynamic-proxy:9000")
+		t.Setenv("DYNAMIC_PROXY", "dynamic-proxy|9000|dynamic-user|dynamic-pass")
 
 		mode, proxyURL := applyInitialProxy(c2, "")
 		if mode != "dynamic" {
@@ -188,7 +188,7 @@ func TestFormatProxyContext(t *testing.T) {
 	})
 
 	t.Run("uses dynamic proxy env label", func(t *testing.T) {
-		t.Setenv("DYNAMIC_PROXY", "http://dynamic-proxy:8080")
+		t.Setenv("DYNAMIC_PROXY", "dynamic-proxy|8080||")
 		got := formatProxyContext("dynamic", "http://dynamic-proxy:8080")
 		if got != "proxy_mode=dynamic proxy=DYNAMIC_PROXY" {
 			t.Fatalf("unexpected proxy context: %q", got)
@@ -219,7 +219,7 @@ func TestResolveProxyLabel(t *testing.T) {
 	})
 
 	t.Run("matches dynamic env key by URL", func(t *testing.T) {
-		t.Setenv("DYNAMIC_PROXY", "http://dynamic:4444")
+		t.Setenv("DYNAMIC_PROXY", "dynamic|4444||")
 		if got := resolveProxyLabel("dynamic", "http://dynamic:4444"); got != "DYNAMIC_PROXY" {
 			t.Fatalf("expected DYNAMIC_PROXY, got %q", got)
 		}

--- a/api/gateway/util/dedicated_proxy.go
+++ b/api/gateway/util/dedicated_proxy.go
@@ -62,6 +62,19 @@ func BuildDedicatedProxyURL(proxy DedicatedProxy) (string, bool) {
 	return fmt.Sprintf("http://%s:%s", proxy.Host, proxy.Port), true
 }
 
+// BuildProxyURL supports either a fully-formed proxy URL or the pipe-separated
+// host|port|username|password format used by DEDICATED_PROXY_* env vars.
+func BuildProxyURL(raw string) (string, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", false
+	}
+	if strings.Contains(raw, "://") {
+		return raw, true
+	}
+	return BuildDedicatedProxyURL(parseDedicatedProxy(raw))
+}
+
 func GetDedicatedProxyURLs() []string {
 	proxies := GetDedicatedProxy()
 	proxyURLs := make([]string, 0, len(proxies))

--- a/api/gateway/util/dedicated_proxy_test.go
+++ b/api/gateway/util/dedicated_proxy_test.go
@@ -101,3 +101,23 @@ func TestGetDedicatedProxyParsesPartialSegments(t *testing.T) {
 	require.Equal(t, "user-3", got[2].Username)
 	require.Equal(t, "", got[2].Password)
 }
+
+func TestBuildProxyURL(t *testing.T) {
+	t.Run("builds url from pipe separated proxy config", func(t *testing.T) {
+		got, ok := BuildProxyURL("dc.com|10000|user-spsykhacft-country-sg|F+password")
+		require.True(t, ok)
+		require.Equal(t, "http://user-spsykhacft-country-sg:F+password@dc.com:10000", got)
+	})
+
+	t.Run("preserves fully formed proxy url", func(t *testing.T) {
+		got, ok := BuildProxyURL("http://user:pass@proxy.example:8080")
+		require.True(t, ok)
+		require.Equal(t, "http://user:pass@proxy.example:8080", got)
+	})
+
+	t.Run("rejects incomplete proxy config", func(t *testing.T) {
+		got, ok := BuildProxyURL("dc.com")
+		require.False(t, ok)
+		require.Equal(t, "", got)
+	})
+}

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -28,7 +28,7 @@ This document records **where** the app configures search behavior, **timeouts**
 | Item | Value | Notes |
 |------|--------|--------|
 | Configured slots | **`DEDICATED_PROXY_1`** … **`DEDICATED_PROXY_7`** | Each value is `host\|port\|username\|password` (pipe-separated). Empty or incomplete entries are ignored when building URLs. |
-| Dynamic fallback proxy | **`DYNAMIC_PROXY`** | Authenticated proxy URL used after dedicated proxy routing and before direct/no-proxy fallbacks. |
+| Dynamic fallback proxy | **`DYNAMIC_PROXY`** | Uses the same `host\|port\|username\|password` format as `DEDICATED_PROXY_*` (full proxy URLs are also accepted). It is used after dedicated proxy routing and before direct/no-proxy fallbacks. |
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- support `DYNAMIC_PROXY` in the same `host|port|username|password` format as `DEDICATED_PROXY_*`
- keep accepting fully formed proxy URLs for `DYNAMIC_PROXY`
- add focused parsing and proxy-label tests plus docs for the supported format

## Testing
- `cd api && go test -mod=vendor ./gateway/util ./gateway ./gateway/binderpos` ✅
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abb6e4d4-82e2-4abf-a29b-42bec951514a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abb6e4d4-82e2-4abf-a29b-42bec951514a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

