### PR TITLE
Temporarily disable Arcane Sanctum and Tefuda (frontend + API)

### DIFF
--- a/api/controller/search.go
+++ b/api/controller/search.go
@@ -23,7 +23,7 @@ import (
 	"mtg-price-checker-sg/gateway/mtgasia"
 	"mtg-price-checker-sg/gateway/onemtg"
 	"mtg-price-checker-sg/gateway/tcgmarketplace"
-	"mtg-price-checker-sg/gateway/tefuda"
+	// "mtg-price-checker-sg/gateway/tefuda"
 	"mtg-price-checker-sg/pkg/alert"
 	"mtg-price-checker-sg/pkg/config"
 	"sort"
@@ -81,7 +81,7 @@ var shopRegistry = []shopSpec{
 	{name: moxandlotus.StoreName, newLGS: moxandlotus.NewLGS},
 	{name: mtgasia.StoreName, newLGS: mtgasia.NewLGS, isBinderpos: true},
 	{name: onemtg.StoreName, newLGS: onemtg.NewLGS, isBinderpos: true},
-	{name: tefuda.StoreName, newLGS: tefuda.NewLGS, isBinderpos: true},
+	// {name: tefuda.StoreName, newLGS: tefuda.NewLGS, isBinderpos: true},
 	{name: tcgmarketplace.StoreName, newLGS: tcgmarketplace.NewLGS},
 	// {name: unsleeved.StoreName, newLGS: unsleeved.NewLGS},
 }

--- a/api/controller/search.go
+++ b/api/controller/search.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"mtg-price-checker-sg/gateway"
 	"mtg-price-checker-sg/gateway/agora"
-	"mtg-price-checker-sg/gateway/arcanesanctum"
+	// "mtg-price-checker-sg/gateway/arcanesanctum"
 	"mtg-price-checker-sg/gateway/cardaffinity"
 	"mtg-price-checker-sg/gateway/cardboardcrackgames"
 	"mtg-price-checker-sg/gateway/cardsandcollection"
@@ -66,7 +66,7 @@ type shopSpec struct {
 
 var shopRegistry = []shopSpec{
 	{name: agora.StoreName, newLGS: agora.NewLGS},
-	{name: arcanesanctum.StoreName, newLGS: arcanesanctum.NewLGS, isBinderpos: true},
+	// {name: arcanesanctum.StoreName, newLGS: arcanesanctum.NewLGS, isBinderpos: true},
 	{name: cardaffinity.StoreName, newLGS: cardaffinity.NewLGS, isBinderpos: true},
 	{name: cardboardcrackgames.StoreName, newLGS: cardboardcrackgames.NewLGS, isBinderpos: true},
 	{name: cardscitadel.StoreName, newLGS: cardscitadel.NewLGS, isBinderpos: true},

--- a/api/controller/search_test.go
+++ b/api/controller/search_test.go
@@ -10,7 +10,7 @@ import (
 	"mtg-price-checker-sg/gateway/gameshaven"
 	"mtg-price-checker-sg/gateway/gog"
 	"mtg-price-checker-sg/gateway/hideout"
-	"mtg-price-checker-sg/gateway/tefuda"
+	"mtg-price-checker-sg/gateway/mtgasia"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -19,7 +19,7 @@ import (
 )
 
 func TestInitAndMapShops_FiltersByRequestedLGS(t *testing.T) {
-	shops := initAndMapShops([]string{agora.StoreName, tefuda.StoreName})
+	shops := initAndMapShops([]string{agora.StoreName, hideout.StoreName})
 
 	if len(shops) != 2 {
 		t.Fatalf("expected 2 shops after filtering, got %d", len(shops))
@@ -27,8 +27,8 @@ func TestInitAndMapShops_FiltersByRequestedLGS(t *testing.T) {
 	if _, ok := shops[agora.StoreName]; !ok {
 		t.Fatalf("expected %q to be included", agora.StoreName)
 	}
-	if _, ok := shops[tefuda.StoreName]; !ok {
-		t.Fatalf("expected %q to be included", tefuda.StoreName)
+	if _, ok := shops[hideout.StoreName]; !ok {
+		t.Fatalf("expected %q to be included", hideout.StoreName)
 	}
 	if _, ok := shops[cardaffinity.StoreName]; ok {
 		t.Fatalf("did not expect %q to be included", cardaffinity.StoreName)
@@ -347,7 +347,7 @@ func TestSearchShops_IncludesStoreErrors(t *testing.T) {
 func TestIsBinderposStore(t *testing.T) {
 	tests := map[string]bool{
 		cardscitadel.StoreName: true,
-		tefuda.StoreName:       true,
+		hideout.StoreName:      true,
 		agora.StoreName:        false,
 		"Unknown Shop":         false,
 	}
@@ -370,7 +370,7 @@ func TestFetchCardsConcurrently_BinderposGate(t *testing.T) {
 		cardaffinity.StoreName,
 		hideout.StoreName,
 		gameshaven.StoreName,
-		tefuda.StoreName,
+		mtgasia.StoreName,
 		gog.StoreName,
 	}
 	shops := make(map[string]gateway.LGS, len(binderposShops)+1)

--- a/api/gateway/arcanesanctum/search_test.go
+++ b/api/gateway/arcanesanctum/search_test.go
@@ -13,6 +13,7 @@ func init() {
 }
 
 func Test_Search(t *testing.T) {
+	t.Skip("Arcane Sanctum is temporarily disabled in controller; re-enable this test when the store is wired back in")
 	s := NewLGS()
 	result, err := s.Search(context.Background(), "signet")
 	require.NoError(t, err)

--- a/api/gateway/tefuda/search_test.go
+++ b/api/gateway/tefuda/search_test.go
@@ -13,6 +13,7 @@ func init() {
 }
 
 func Test_Search(t *testing.T) {
+	t.Skip("Tefuda is temporarily disabled in controller; re-enable this test when the store is wired back in")
 	s := NewLGS()
 	result, err := s.Search(context.Background(), "smothering tithe")
 	require.NoError(t, err)

--- a/api/handler/search.go
+++ b/api/handler/search.go
@@ -49,7 +49,7 @@ func Search(ctx context.Context, request events.APIGatewayProxyRequest) (events.
 
 	if os.Getenv("ENV") != config.EnvProd && os.Getenv("ENV") != config.EnvStaging {
 		searchString = "Opt"
-		lgsString, _ = url.QueryUnescape("Flagship%20Games%2CGames%20Haven%2CGrey%20Ogre%20Games%2CHideout%2CMana%20Pro%2CMox%20%26%20Lotus%2COneMtg%2CSanctuary%20Gaming%2CTefuda")
+		lgsString, _ = url.QueryUnescape("Flagship%20Games%2CGames%20Haven%2CGrey%20Ogre%20Games%2CHideout%2CMana%20Pro%2CMox%20%26%20Lotus%2COneMtg%2CSanctuary%20Gaming")
 	}
 
 	if searchString == "" || len(searchString) < 3 {

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -19,7 +19,7 @@ export const LGS_OPTIONS = [
   "Mox & Lotus",
   "MTG Asia",
   "OneMtg",
-  "Tefuda",
+  // "Tefuda",
   "The TCG Marketplace",
 ];
 
@@ -137,14 +137,14 @@ export const LGS_MAP = [
       "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3988.7866900551694!2d103.85910407451628!3d1.3029641617257042!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x31da19180d91f3a1%3A0x75c807bf93d430a4!2sOne%20MTG!5e0!3m2!1sen!2ssg!4v1702821425238!5m2!1sen!2ssg",
     website: "https://onemtg.com.sg/",
   },
-  {
-    id: "tefuda-map",
-    name: "Tefuda",
-    address: "B1-02 Macpherson Mall, Singapore 368125",
-    iframe:
-      "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3988.740634996764!2d103.8765490749657!3d1.3317319986556433!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x31da178ea031acdb%3A0xac7ea94397d6a870!2sTefuda!5e0!3m2!1sen!2ssg!4v1743179304416!5m2!1sen!2ssg",
-    website: "https://tefudagames.com/",
-  },
+  // {
+  //   id: "tefuda-map",
+  //   name: "Tefuda",
+  //   address: "B1-02 Macpherson Mall, Singapore 368125",
+  //   iframe:
+  //     "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3988.740634996764!2d103.8765490749657!3d1.3317319986556433!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x31da178ea031acdb%3A0xac7ea94397d6a870!2sTefuda!5e0!3m2!1sen!2ssg!4v1743179304416!5m2!1sen!2ssg",
+  //   website: "https://tefudagames.com/",
+  // },
   {
     id: "unsleeved-map",
     name: "Unsleeved",

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -5,7 +5,7 @@ export const PAGE_TITLE =
 export const LGS_OPTIONS = [
   "5 Mana",
   "Agora Hobby",
-  "Arcane Sanctum",
+  // "Arcane Sanctum",
   "Card Affinity",
   "Cardboard Crack Games",
   "Cards Citadel",
@@ -40,14 +40,14 @@ export const LGS_MAP = [
       "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3988.778050505021!2d103.85967687451628!3d1.3084089617085968!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x31da19c9f7d7f74d%3A0xeaa1a66df7d4bcd6!2sAgora%20Hobby!5e0!3m2!1sen!2ssg!4v1702820213937!5m2!1sen!2ssg",
     website: "https://agorahobby.com/",
   },
-  {
-    id: "arcane-sanctum-map",
-    name: "Arcane Sanctum",
-    address: "809 French Rd, #02-36 Kitchener Complex, Singapore 200809",
-    iframe:
-      "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3988.778059032544!2d103.8596768749415!3d1.3084035986791807!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x31da197e8c761a49%3A0x8c56b7150064528b!2sArcane%20Sanctum!5e0!3m2!1sen!2ssg!4v1768317836907!5m2!1sen!2ssg",
-    website: "https://arcanesanctumtcg.com/",
-  },
+  // {
+  //   id: "arcane-sanctum-map",
+  //   name: "Arcane Sanctum",
+  //   address: "809 French Rd, #02-36 Kitchener Complex, Singapore 200809",
+  //   iframe:
+  //     "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3988.778059032544!2d103.8596768749415!3d1.3084035986791807!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x31da197e8c761a49%3A0x8c56b7150064528b!2sArcane%20Sanctum!5e0!3m2!1sen!2ssg!4v1768317836907!5m2!1sen!2ssg",
+  //   website: "https://arcanesanctumtcg.com/",
+  // },
   {
     id: "cardboard-crack-games-map",
     name: "Cardboard Crack Games",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Arcane Sanctum and Tefuda are temporarily removed from the storefront search path and from the frontend LGS lists, matching the existing pattern used for other disabled stores (for example, unsleeved in `shopRegistry`).

## Changes

- **Frontend** (`frontend/src/constants.js`): Commented out the `LGS_OPTIONS` entries and the corresponding `LGS_MAP` objects for Arcane Sanctum and Tefuda so those stores no longer appear in the selector or map section.
- **API** (`api/controller/search.go`): Commented out the `arcanesanctum` and `tefuda` imports and `shopRegistry` entries so searches never instantiate those gateways.
- **Handler** (`api/handler/search.go`): Removed Tefuda from the non-prod default `lgs` query string used by local `go run` so it matches the disabled registry.
- **Tests**: `TestInitAndMapShops_FiltersByRequestedLGS` now uses Agora + Hideout (still asserts Card Affinity is excluded). Binderpos gate and `isBinderpos` tests use other Binderpos stores. `gateway/arcanesanctum` and `gateway/tefuda` live integration tests are skipped while those stores are disabled so `make test` completes without requiring flaky upstream access.

## Verification

- `make test` (full Go suite) passes.
- `npm run build` in `frontend/` succeeds.

## Re-enable later

1. Uncomment the frontend blocks in `constants.js`.
2. Uncomment the imports and `shopRegistry` lines in `api/controller/search.go`.
3. Restore Tefuda in `api/handler/search.go` local default LGS if desired.
4. Restore prior `search_test.go` expectations or keep the Agora + Hideout variant (both are valid).
5. Remove the `t.Skip` calls in `api/gateway/arcanesanctum/search_test.go` and `api/gateway/tefuda/search_test.go`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26a151b5-4654-41c7-aa39-502382a1a815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26a151b5-4654-41c7-aa39-502382a1a815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

