### PR TITLE
Add browser-like HTTP headers for Colly and BinderPOS storefront requests

### DIFF
--- a/api/gateway/binderpos/storefront_decklist.go
+++ b/api/gateway/binderpos/storefront_decklist.go
@@ -44,6 +44,8 @@ func searchByBinderposDecklistAPI(ctx context.Context, client *http.Client, scra
 	if err != nil {
 		return nil, err
 	}
+	storeBase, _ := url.Parse(baseURL)
+	gateway.ApplyBrowserLikeJSONFetchHeaders(&req.Header, storeBase)
 	req.Header.Set("User-Agent", gateway.RandomBrowserUserAgent())
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	if err := gateway.WaitForDomainRequestSlot(ctx, req.URL); err != nil {

--- a/api/gateway/binderpos/storefront_product_details.go
+++ b/api/gateway/binderpos/storefront_product_details.go
@@ -92,6 +92,8 @@ func fetchSuggestProducts(ctx context.Context, client *http.Client, baseURL, sea
 	if err != nil {
 		return nil, err
 	}
+	storeBase, _ := url.Parse(baseURL)
+	gateway.ApplyBrowserLikeJSONFetchHeaders(&req.Header, storeBase)
 	req.Header.Set("User-Agent", gateway.RandomBrowserUserAgent())
 	if err := gateway.WaitForDomainRequestSlot(ctx, req.URL); err != nil {
 		return nil, err
@@ -125,6 +127,8 @@ func fetchProductDetail(ctx context.Context, client *http.Client, baseURL, produ
 	if err != nil {
 		return nil, err
 	}
+	storeBase, _ := url.Parse(baseURL)
+	gateway.ApplyBrowserLikeJSONFetchHeaders(&req.Header, storeBase)
 	req.Header.Set("User-Agent", gateway.RandomBrowserUserAgent())
 	if err := gateway.WaitForDomainRequestSlot(ctx, req.URL); err != nil {
 		return nil, err

--- a/api/gateway/browser_headers.go
+++ b/api/gateway/browser_headers.go
@@ -1,0 +1,47 @@
+package gateway
+
+import (
+	"net/http"
+	"net/url"
+)
+
+const (
+	browserLikeAcceptHTML     = "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8"
+	browserLikeAcceptJSON     = "application/json, text/javascript, */*;q=0.01"
+	browserLikeAcceptLanguage = "en-US,en;q=0.9"
+)
+
+// navigationReferer returns scheme://host/ for use as Referer when emulating same-origin navigation.
+func navigationReferer(target *url.URL) string {
+	if target == nil || target.Scheme == "" || target.Host == "" {
+		return ""
+	}
+	return target.Scheme + "://" + target.Host + "/"
+}
+
+// ApplyBrowserLikeHTMLHeaders sets headers typical of a top-level browser document request.
+func ApplyBrowserLikeHTMLHeaders(h *http.Header, pageURL *url.URL) {
+	if h == nil {
+		return
+	}
+	if ref := navigationReferer(pageURL); ref != "" {
+		h.Set("Referer", ref)
+	}
+	h.Set("Accept", browserLikeAcceptHTML)
+	h.Set("Accept-Language", browserLikeAcceptLanguage)
+	h.Set("Upgrade-Insecure-Requests", "1")
+}
+
+// ApplyBrowserLikeJSONFetchHeaders sets headers typical of in-page JSON/XHR requests to a store domain.
+// storeBase is the public shop URL (e.g. https://example.com); it may be nil to omit Referer only.
+func ApplyBrowserLikeJSONFetchHeaders(h *http.Header, storeBase *url.URL) {
+	if h == nil {
+		return
+	}
+	if ref := navigationReferer(storeBase); ref != "" {
+		h.Set("Referer", ref)
+	}
+	h.Set("Accept", browserLikeAcceptJSON)
+	h.Set("Accept-Language", browserLikeAcceptLanguage)
+	h.Set("Accept-Encoding", "gzip")
+}

--- a/api/gateway/browser_headers_test.go
+++ b/api/gateway/browser_headers_test.go
@@ -1,0 +1,64 @@
+package gateway
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestApplyBrowserLikeHTMLHeaders(t *testing.T) {
+	u, err := url.Parse("https://shop.example/path?q=1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := make(http.Header)
+	ApplyBrowserLikeHTMLHeaders(&h, u)
+
+	if got := h.Get("Referer"); got != "https://shop.example/" {
+		t.Fatalf("Referer: got %q", got)
+	}
+	if got := h.Get("Accept"); got != browserLikeAcceptHTML {
+		t.Fatalf("Accept: got %q", got)
+	}
+	if got := h.Get("Accept-Language"); got != browserLikeAcceptLanguage {
+		t.Fatalf("Accept-Language: got %q", got)
+	}
+	if got := h.Get("Upgrade-Insecure-Requests"); got != "1" {
+		t.Fatalf("Upgrade-Insecure-Requests: got %q", got)
+	}
+}
+
+func TestApplyBrowserLikeHTMLHeaders_nilHeader(t *testing.T) {
+	u, _ := url.Parse("https://a.test/")
+	ApplyBrowserLikeHTMLHeaders(nil, u) // must not panic
+}
+
+func TestApplyBrowserLikeJSONFetchHeaders(t *testing.T) {
+	base, err := url.Parse("https://store.example")
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := make(http.Header)
+	ApplyBrowserLikeJSONFetchHeaders(&h, base)
+
+	if got := h.Get("Referer"); got != "https://store.example/" {
+		t.Fatalf("Referer: got %q", got)
+	}
+	if got := h.Get("Accept"); got != browserLikeAcceptJSON {
+		t.Fatalf("Accept: got %q", got)
+	}
+	if got := h.Get("Accept-Encoding"); got != "gzip" {
+		t.Fatalf("Accept-Encoding: got %q", got)
+	}
+}
+
+func TestApplyBrowserLikeJSONFetchHeaders_nilStoreOmitsReferer(t *testing.T) {
+	h := make(http.Header)
+	ApplyBrowserLikeJSONFetchHeaders(&h, nil)
+	if h.Get("Referer") != "" {
+		t.Fatalf("expected empty Referer, got %q", h.Get("Referer"))
+	}
+	if h.Get("Accept-Language") == "" {
+		t.Fatal("expected Accept-Language")
+	}
+}

--- a/api/gateway/collector.go
+++ b/api/gateway/collector.go
@@ -304,9 +304,12 @@ func registerRequestHandler(c *colly.Collector, leasedDedicatedProxyURL string) 
 			r.Abort()
 			return
 		}
-		// Keep gzip only. Go's default client does not transparently decode brotli ("br").
-		r.Headers.Set("Accept-Encoding", "gzip")
-		r.Headers.Set("User-Agent", RandomBrowserUserAgent())
+		if r.Headers != nil {
+			ApplyBrowserLikeHTMLHeaders(r.Headers, r.URL)
+			// Keep gzip only. Go's default client does not transparently decode brotli ("br").
+			r.Headers.Set("Accept-Encoding", "gzip")
+			r.Headers.Set("User-Agent", RandomBrowserUserAgent())
+		}
 		seedProxyContextIfMissing(r.Ctx, initialProxyMode, initialProxyURL)
 	})
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements richer browser-style headers for store-facing HTTP traffic, as discussed for reducing shallow bot/WAF friction without changing proxy configuration.

## Changes

- **Colly (HTML scraping):** Each request now sends `Accept` (HTML document profile), `Accept-Language`, `Upgrade-Insecure-Requests`, and a same-origin `Referer` (`scheme://host/`), then the existing `Accept-Encoding: gzip` and randomized `User-Agent`.
- **BinderPOS storefront JSON:** Suggest, product JSON GETs, and decklist POST now use `ApplyBrowserLikeJSONFetchHeaders` with a fetch-style `Accept`, `Accept-Language`, `Accept-Encoding: gzip`, and `Referer` derived from the store `baseURL`.

## Tests

- `make test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8b95bb9-2ff7-4f32-93a6-5fd7539894e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8b95bb9-2ff7-4f32-93a6-5fd7539894e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

