### PR TITLE
Theme toggle: translucent primary hover background

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -35,6 +35,11 @@ body {
   justify-content: center;
 }
 
+.btn.btn-outline-primary.theme-toggle-btn:hover,
+.btn.btn-outline-primary.theme-toggle-btn:focus-visible {
+  background-color: rgba(13, 110, 253, 0.25);
+}
+
 #lgsCheckboxes .form-check-input,
 #lgsCheckboxes .form-check-label {
   cursor: pointer;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The header dark/light theme button uses Bootstrap `btn-outline-primary`, which applies a solid primary blue fill on hover. This change overrides that hover (and `:focus-visible`) background to `rgba(13, 110, 253, 0.25)` so the tint stays translucent in both themes.

## Implementation

- Added a higher-specificity rule in `frontend/src/index.css` so it wins over Bootstrap’s `.btn-outline-primary:hover`.

## Testing

- `make test` (Go suite) passed.

## Screenshots

Small hover-only tweak on the theme toggle (top-right of header). Please verify hover and keyboard focus in light and dark mode in the browser; no layout changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2937bd6-0947-442f-af8b-9f77956bf95e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2937bd6-0947-442f-af8b-9f77956bf95e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

