### PR TITLE
Slow global per-domain HTTP pacing (~2x)

### DIFF
--- a/api/gateway/domain_rate_limiter.go
+++ b/api/gateway/domain_rate_limiter.go
@@ -9,9 +9,11 @@ import (
 	"time"
 )
 
+// Global per-host pacing for all Colly and storefront HTTP requests. Larger gaps reduce
+// burstiness to upstream CDNs/WAFs (fewer 403s) at the cost of slightly slower multi-page scrapes.
 const (
-	domainRequestMinInterval = 300 * time.Millisecond
-	domainRequestMaxJitter   = 600 * time.Millisecond
+	domainRequestMinInterval = 600 * time.Millisecond
+	domainRequestMaxJitter   = 1200 * time.Millisecond
 )
 
 var sharedDomainRequestLimiter = newDomainRequestLimiter(domainRequestMinInterval, domainRequestMaxJitter)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Doubles the global per-host pacing used by `waitForDomainRequestSlot` / `WaitForDomainRequestSlot` (Colly scrapes and BinderPOS storefront HTTP clients).

## Rationale

Wider spacing between consecutive requests to the **same** hostname lowers burstiness toward upstream CDNs and WAFs, which can reduce intermittent 403s. Trade-off: multi-step flows that hit one domain several times in sequence (e.g. suggest + product JSON, or paginated HTML) become proportionally slower.

## Constants

| | Before | After |
|--|--------|-------|
| Min interval | 300ms | 600ms |
| Max jitter | 600ms | 1200ms |

## Tests

- `make test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8b95bb9-2ff7-4f32-93a6-5fd7539894e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8b95bb9-2ff7-4f32-93a6-5fd7539894e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

