### PR TITLE
Move BinderPOS dynamic proxy fallbacks last

### DIFF
--- a/api/gateway/binderpos/storefront_fallback.go
+++ b/api/gateway/binderpos/storefront_fallback.go
@@ -11,33 +11,35 @@ type fallbackAttempt struct {
 	fn       func() ([]gateway.Card, error)
 }
 
-// searchWithScrapDedicatedThenDynamicThenDirect tries a scrape using dedicated-proxy routing first,
-// then dynamic proxy routing, then a direct (no proxy) scrape on failure.
-func searchWithScrapDedicatedThenDynamicThenDirect(
+// searchWithScrapDedicatedThenDirectThenDynamic tries a scrape using dedicated-proxy routing first,
+// then a direct (no proxy) scrape, and only uses the dynamic proxy as the last fallback.
+func searchWithScrapDedicatedThenDirectThenDynamic(
 	scrapDedicatedFn func() ([]gateway.Card, error),
-	scrapDynamicFn func() ([]gateway.Card, error),
 	scrapDirectFn func() ([]gateway.Card, error),
+	scrapDynamicFn func() ([]gateway.Card, error),
 ) ([]gateway.Card, error) {
 	return runFallbackAttempts(
 		fallbackAttempt{strategy: "scrap-dedicated", fn: scrapDedicatedFn},
-		fallbackAttempt{strategy: "scrap-dynamic", fn: scrapDynamicFn},
 		fallbackAttempt{strategy: "scrap-direct", fn: scrapDirectFn},
+		fallbackAttempt{strategy: "scrap-dynamic", fn: scrapDynamicFn},
 	)
 }
 
 func searchWithFallback(
 	searchAPIDedicatedFn func() ([]gateway.Card, error),
-	searchAPIDynamicFn func() ([]gateway.Card, error),
+	searchAPIDirectFn func() ([]gateway.Card, error),
 	scrapDedicatedFn func() ([]gateway.Card, error),
-	scrapDynamicFn func() ([]gateway.Card, error),
 	scrapDirectFn func() ([]gateway.Card, error),
+	searchAPIDynamicFn func() ([]gateway.Card, error),
+	scrapDynamicFn func() ([]gateway.Card, error),
 ) ([]gateway.Card, error) {
 	return runFallbackAttempts(
 		fallbackAttempt{strategy: "api-dedicated", fn: searchAPIDedicatedFn},
-		fallbackAttempt{strategy: "api-dynamic", fn: searchAPIDynamicFn},
+		fallbackAttempt{strategy: "api-direct", fn: searchAPIDirectFn},
 		fallbackAttempt{strategy: "scrap-dedicated", fn: scrapDedicatedFn},
-		fallbackAttempt{strategy: "scrap-dynamic", fn: scrapDynamicFn},
 		fallbackAttempt{strategy: "scrap-direct", fn: scrapDirectFn},
+		fallbackAttempt{strategy: "api-dynamic", fn: searchAPIDynamicFn},
+		fallbackAttempt{strategy: "scrap-dynamic", fn: scrapDynamicFn},
 	)
 }
 

--- a/api/gateway/binderpos/storefront_fallback_test.go
+++ b/api/gateway/binderpos/storefront_fallback_test.go
@@ -12,10 +12,11 @@ func TestSearchWithFallback(t *testing.T) {
 	t.Run("returns dedicated api results first", func(t *testing.T) {
 		cards, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-dedicated"}}, nil },
-			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-dynamic"}}, nil },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-direct"}}, nil },
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-dedicated"}}, nil },
-			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-dynamic"}}, nil },
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-direct"}}, nil },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-dynamic"}}, nil },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-dynamic"}}, nil },
 		)
 		if err != nil {
 			t.Fatalf("expected nil error, got %v", err)
@@ -25,29 +26,43 @@ func TestSearchWithFallback(t *testing.T) {
 		}
 	})
 
-	t.Run("falls back to dynamic api when dedicated api fails", func(t *testing.T) {
+	t.Run("falls back to direct api before any dynamic attempt", func(t *testing.T) {
 		cards, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
-			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-dynamic"}}, nil },
-			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-dedicated"}}, nil },
-			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-dynamic"}}, nil },
-			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-direct"}}, nil },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-direct"}}, nil },
+			func() ([]gateway.Card, error) {
+				t.Fatal("scrap dedicated should not run after direct api success")
+				return nil, nil
+			},
+			func() ([]gateway.Card, error) {
+				t.Fatal("scrap direct should not run after direct api success")
+				return nil, nil
+			},
+			func() ([]gateway.Card, error) {
+				t.Fatal("dynamic api should not run after direct api success")
+				return nil, nil
+			},
+			func() ([]gateway.Card, error) {
+				t.Fatal("dynamic scrape should not run after direct api success")
+				return nil, nil
+			},
 		)
 		if err != nil {
 			t.Fatalf("expected nil error, got %v", err)
 		}
-		if len(cards) != 1 || cards[0].Name != "api-dynamic" {
-			t.Fatalf("expected dynamic api card, got %+v", cards)
+		if len(cards) != 1 || cards[0].Name != "api-direct" {
+			t.Fatalf("expected direct api card, got %+v", cards)
 		}
 	})
 
 	t.Run("falls back to dedicated scraper when api attempts fail", func(t *testing.T) {
 		cards, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
-			func() ([]gateway.Card, error) { return nil, errors.New("dynamic api failed") },
+			func() ([]gateway.Card, error) { return nil, errors.New("direct api failed") },
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-dedicated"}}, nil },
-			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-dynamic"}}, nil },
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-direct"}}, nil },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-dynamic"}}, nil },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-dynamic"}}, nil },
 		)
 		if err != nil {
 			t.Fatalf("expected nil error, got %v", err)
@@ -57,29 +72,20 @@ func TestSearchWithFallback(t *testing.T) {
 		}
 	})
 
-	t.Run("falls back to dynamic scraper when proxy api and dedicated scrape fail", func(t *testing.T) {
+	t.Run("falls back to direct scraper before any dynamic attempt", func(t *testing.T) {
 		cards, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
-			func() ([]gateway.Card, error) { return nil, errors.New("dynamic api failed") },
+			func() ([]gateway.Card, error) { return nil, errors.New("direct api failed") },
 			func() ([]gateway.Card, error) { return nil, errors.New("dedicated scraper failed") },
-			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-dynamic"}}, nil },
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-direct"}}, nil },
-		)
-		if err != nil {
-			t.Fatalf("expected nil error, got %v", err)
-		}
-		if len(cards) != 1 || cards[0].Name != "scrap-dynamic" {
-			t.Fatalf("expected dynamic scraper card, got %+v", cards)
-		}
-	})
-
-	t.Run("falls back to direct scraper when all proxy attempts fail", func(t *testing.T) {
-		cards, err := searchWithFallback(
-			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
-			func() ([]gateway.Card, error) { return nil, errors.New("dynamic api failed") },
-			func() ([]gateway.Card, error) { return nil, errors.New("dedicated scraper failed") },
-			func() ([]gateway.Card, error) { return nil, errors.New("dynamic scraper failed") },
-			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-direct"}}, nil },
+			func() ([]gateway.Card, error) {
+				t.Fatal("dynamic api should not run after direct scrape success")
+				return nil, nil
+			},
+			func() ([]gateway.Card, error) {
+				t.Fatal("dynamic scrape should not run after direct scrape success")
+				return nil, nil
+			},
 		)
 		if err != nil {
 			t.Fatalf("expected nil error, got %v", err)
@@ -89,30 +95,66 @@ func TestSearchWithFallback(t *testing.T) {
 		}
 	})
 
-	t.Run("returns final direct scraper error when all fail", func(t *testing.T) {
+	t.Run("falls back to dynamic api only after cheaper attempts fail", func(t *testing.T) {
+		cards, err := searchWithFallback(
+			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
+			func() ([]gateway.Card, error) { return nil, errors.New("direct api failed") },
+			func() ([]gateway.Card, error) { return nil, errors.New("dedicated scraper failed") },
+			func() ([]gateway.Card, error) { return nil, errors.New("direct scraper failed") },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "api-dynamic"}}, nil },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-dynamic"}}, nil },
+		)
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if len(cards) != 1 || cards[0].Name != "api-dynamic" {
+			t.Fatalf("expected dynamic api card, got %+v", cards)
+		}
+	})
+
+	t.Run("falls back to dynamic scraper when every other attempt fails", func(t *testing.T) {
+		cards, err := searchWithFallback(
+			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
+			func() ([]gateway.Card, error) { return nil, errors.New("direct api failed") },
+			func() ([]gateway.Card, error) { return nil, errors.New("dedicated scraper failed") },
+			func() ([]gateway.Card, error) { return nil, errors.New("direct scraper failed") },
+			func() ([]gateway.Card, error) { return nil, errors.New("dynamic api failed") },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-dynamic"}}, nil },
+		)
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if len(cards) != 1 || cards[0].Name != "scrap-dynamic" {
+			t.Fatalf("expected dynamic scraper card, got %+v", cards)
+		}
+	})
+
+	t.Run("returns final dynamic scraper error when all fail", func(t *testing.T) {
 		apiDedicatedErr := errors.New("dedicated api failed")
-		apiDynamicErr := errors.New("dynamic api failed")
+		apiDirectErr := errors.New("direct api failed")
 		scrapDedicatedErr := errors.New("dedicated scraper failed")
-		scrapDynamicErr := errors.New("dynamic scraper failed")
 		directScrapErr := errors.New("direct scraper failed")
+		apiDynamicErr := errors.New("dynamic api failed")
+		scrapDynamicErr := errors.New("dynamic scraper failed")
 		_, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return nil, apiDedicatedErr },
-			func() ([]gateway.Card, error) { return nil, apiDynamicErr },
+			func() ([]gateway.Card, error) { return nil, apiDirectErr },
 			func() ([]gateway.Card, error) { return nil, scrapDedicatedErr },
-			func() ([]gateway.Card, error) { return nil, scrapDynamicErr },
 			func() ([]gateway.Card, error) { return nil, directScrapErr },
+			func() ([]gateway.Card, error) { return nil, apiDynamicErr },
+			func() ([]gateway.Card, error) { return nil, scrapDynamicErr },
 		)
-		if !errors.Is(err, directScrapErr) {
-			t.Fatalf("expected direct scraper error, got %v", err)
+		if !errors.Is(err, scrapDynamicErr) {
+			t.Fatalf("expected dynamic scraper error, got %v", err)
 		}
-		expectedError := "attempt 5 (scrap-direct): direct scraper failed"
+		expectedError := "attempt 6 (scrap-dynamic): dynamic scraper failed"
 		if err == nil || err.Error() != expectedError {
 			t.Fatalf("expected final error %q, got %v", expectedError, err)
 		}
 	})
 
 	t.Run("runs attempts in the requested order", func(t *testing.T) {
-		sequence := make([]string, 0, 5)
+		sequence := make([]string, 0, 6)
 		fail := func(label string) func() ([]gateway.Card, error) {
 			return func() ([]gateway.Card, error) {
 				sequence = append(sequence, label)
@@ -122,15 +164,16 @@ func TestSearchWithFallback(t *testing.T) {
 
 		_, err := searchWithFallback(
 			fail("api-dedicated"),
-			fail("api-dynamic"),
+			fail("api-direct"),
 			fail("scrap-dedicated"),
-			fail("scrap-dynamic"),
 			fail("scrap-direct"),
+			fail("api-dynamic"),
+			fail("scrap-dynamic"),
 		)
 		if err == nil {
 			t.Fatalf("expected fallback chain to return the final error")
 		}
-		expected := []string{"api-dedicated", "api-dynamic", "scrap-dedicated", "scrap-dynamic", "scrap-direct"}
+		expected := []string{"api-dedicated", "api-direct", "scrap-dedicated", "scrap-direct", "api-dynamic", "scrap-dynamic"}
 		if len(sequence) != len(expected) {
 			t.Fatalf("expected %d attempts, got %d (%v)", len(expected), len(sequence), sequence)
 		}
@@ -144,9 +187,10 @@ func TestSearchWithFallback(t *testing.T) {
 	t.Run("returns no error when a fallback attempt succeeds with empty cards", func(t *testing.T) {
 		cards, err := searchWithFallback(
 			func() ([]gateway.Card, error) { return nil, errors.New("dedicated api failed") },
-			func() ([]gateway.Card, error) { return nil, errors.New("dynamic api failed") },
+			func() ([]gateway.Card, error) { return nil, errors.New("direct api failed") },
 			func() ([]gateway.Card, error) { return nil, errors.New("dedicated scraper failed") },
-			func() ([]gateway.Card, error) { return nil, errors.New("dynamic scraper failed") },
+			func() ([]gateway.Card, error) { return nil, errors.New("direct scraper failed") },
+			func() ([]gateway.Card, error) { return nil, errors.New("dynamic api failed") },
 			func() ([]gateway.Card, error) { return []gateway.Card{}, nil },
 		)
 		if err != nil {
@@ -158,12 +202,12 @@ func TestSearchWithFallback(t *testing.T) {
 	})
 }
 
-func TestSearchWithScrapDedicatedThenDynamicThenDirect(t *testing.T) {
+func TestSearchWithScrapDedicatedThenDirectThenDynamic(t *testing.T) {
 	t.Run("returns dedicated scraper results on first success", func(t *testing.T) {
-		cards, err := searchWithScrapDedicatedThenDynamicThenDirect(
+		cards, err := searchWithScrapDedicatedThenDirectThenDynamic(
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-dedicated"}}, nil },
-			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-dynamic"}}, nil },
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-direct"}}, nil },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-dynamic"}}, nil },
 		)
 		if err != nil {
 			t.Fatalf("expected nil error, got %v", err)
@@ -173,25 +217,14 @@ func TestSearchWithScrapDedicatedThenDynamicThenDirect(t *testing.T) {
 		}
 	})
 
-	t.Run("falls back to dynamic when dedicated fails", func(t *testing.T) {
-		cards, err := searchWithScrapDedicatedThenDynamicThenDirect(
+	t.Run("falls back to direct when dedicated fails", func(t *testing.T) {
+		cards, err := searchWithScrapDedicatedThenDirectThenDynamic(
 			func() ([]gateway.Card, error) { return nil, errors.New("dedicated scrap failed") },
-			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-dynamic"}}, nil },
 			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-direct"}}, nil },
-		)
-		if err != nil {
-			t.Fatalf("expected nil error, got %v", err)
-		}
-		if len(cards) != 1 || cards[0].Name != "scrap-dynamic" {
-			t.Fatalf("expected dynamic scraper card, got %+v", cards)
-		}
-	})
-
-	t.Run("falls back to direct when dedicated and dynamic fail", func(t *testing.T) {
-		cards, err := searchWithScrapDedicatedThenDynamicThenDirect(
-			func() ([]gateway.Card, error) { return nil, errors.New("dedicated scrap failed") },
-			func() ([]gateway.Card, error) { return nil, errors.New("dynamic scrap failed") },
-			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-direct"}}, nil },
+			func() ([]gateway.Card, error) {
+				t.Fatal("dynamic scrape should not run after direct success")
+				return nil, nil
+			},
 		)
 		if err != nil {
 			t.Fatalf("expected nil error, got %v", err)
@@ -201,19 +234,61 @@ func TestSearchWithScrapDedicatedThenDynamicThenDirect(t *testing.T) {
 		}
 	})
 
-	t.Run("returns final direct error when both fail", func(t *testing.T) {
-		dedErr := errors.New("dedicated failed")
-		dynErr := errors.New("dynamic failed")
-		dirErr := errors.New("direct failed")
-		_, err := searchWithScrapDedicatedThenDynamicThenDirect(
-			func() ([]gateway.Card, error) { return nil, dedErr },
-			func() ([]gateway.Card, error) { return nil, dynErr },
-			func() ([]gateway.Card, error) { return nil, dirErr },
+	t.Run("falls back to dynamic when dedicated and direct fail", func(t *testing.T) {
+		cards, err := searchWithScrapDedicatedThenDirectThenDynamic(
+			func() ([]gateway.Card, error) { return nil, errors.New("dedicated scrap failed") },
+			func() ([]gateway.Card, error) { return nil, errors.New("direct scrap failed") },
+			func() ([]gateway.Card, error) { return []gateway.Card{{Name: "scrap-dynamic"}}, nil },
 		)
-		if !errors.Is(err, dirErr) {
-			t.Fatalf("expected direct scraper error, got %v", err)
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
 		}
-		if err == nil || err.Error() != "attempt 3 (scrap-direct): direct failed" {
+		if len(cards) != 1 || cards[0].Name != "scrap-dynamic" {
+			t.Fatalf("expected dynamic scraper card, got %+v", cards)
+		}
+	})
+
+	t.Run("runs attempts in the requested order", func(t *testing.T) {
+		sequence := make([]string, 0, 3)
+		fail := func(label string) func() ([]gateway.Card, error) {
+			return func() ([]gateway.Card, error) {
+				sequence = append(sequence, label)
+				return nil, fmt.Errorf("%s failed", label)
+			}
+		}
+
+		_, err := searchWithScrapDedicatedThenDirectThenDynamic(
+			fail("scrap-dedicated"),
+			fail("scrap-direct"),
+			fail("scrap-dynamic"),
+		)
+		if err == nil {
+			t.Fatalf("expected fallback chain to return the final error")
+		}
+		expected := []string{"scrap-dedicated", "scrap-direct", "scrap-dynamic"}
+		if len(sequence) != len(expected) {
+			t.Fatalf("expected %d attempts, got %d (%v)", len(expected), len(sequence), sequence)
+		}
+		for i := range expected {
+			if sequence[i] != expected[i] {
+				t.Fatalf("attempt %d: expected %q, got %q", i+1, expected[i], sequence[i])
+			}
+		}
+	})
+
+	t.Run("returns final dynamic error when all fail", func(t *testing.T) {
+		dedErr := errors.New("dedicated failed")
+		dirErr := errors.New("direct failed")
+		dynErr := errors.New("dynamic failed")
+		_, err := searchWithScrapDedicatedThenDirectThenDynamic(
+			func() ([]gateway.Card, error) { return nil, dedErr },
+			func() ([]gateway.Card, error) { return nil, dirErr },
+			func() ([]gateway.Card, error) { return nil, dynErr },
+		)
+		if !errors.Is(err, dynErr) {
+			t.Fatalf("expected dynamic scraper error, got %v", err)
+		}
+		if err == nil || err.Error() != "attempt 3 (scrap-dynamic): dynamic failed" {
 			t.Fatalf("unexpected final error: %v", err)
 		}
 	})

--- a/api/gateway/binderpos/storefront_search.go
+++ b/api/gateway/binderpos/storefront_search.go
@@ -12,7 +12,7 @@ const ArcaneSanctumStoreName = "Arcane Sanctum"
 
 func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, shopifyDomain, searchURL, searchStr string) ([]gateway.Card, error) {
 	if strings.TrimSpace(shopifyDomain) == "" {
-		return searchWithScrapDedicatedThenDynamicThenDirect(
+		return searchWithScrapDedicatedThenDirectThenDynamic(
 			func() ([]gateway.Card, error) {
 				return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
 					return i.Scrap(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
@@ -20,12 +20,12 @@ func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, 
 			},
 			func() ([]gateway.Card, error) {
 				return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
-					return i.scrapDynamic(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
+					return i.scrapDirect(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
 				})
 			},
 			func() ([]gateway.Card, error) {
 				return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
-					return i.scrapDirect(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
+					return i.scrapDynamic(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
 				})
 			},
 		)
@@ -39,7 +39,7 @@ func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, 
 		},
 		func() ([]gateway.Card, error) {
 			return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
-				return searchByStorefrontAPIDynamic(attemptCtx, scrapVariant, storeName, baseURL, shopifyDomain, searchStr)
+				return searchByStorefrontAPIDirect(attemptCtx, scrapVariant, storeName, baseURL, shopifyDomain, searchStr)
 			})
 		},
 		func() ([]gateway.Card, error) {
@@ -49,12 +49,17 @@ func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, 
 		},
 		func() ([]gateway.Card, error) {
 			return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
-				return i.scrapDynamic(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
+				return i.scrapDirect(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
 			})
 		},
 		func() ([]gateway.Card, error) {
 			return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
-				return i.scrapDirect(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
+				return searchByStorefrontAPIDynamic(attemptCtx, scrapVariant, storeName, baseURL, shopifyDomain, searchStr)
+			})
+		},
+		func() ([]gateway.Card, error) {
+			return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
+				return i.scrapDynamic(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
 			})
 		},
 	)

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -18,8 +18,9 @@ const (
 	// UseBinderposStorefrontAPIEnv toggles BinderPOS storefront API search mode.
 	// Default is enabled; set to "false" to force legacy scraping.
 	UseBinderposStorefrontAPIEnv = "USE_BINDERPOS_STOREFRONT_API"
-	// DynamicProxyEnv contains an authenticated proxy URL used as a fallback after
-	// dedicated proxy routing and before direct/no-proxy requests.
+	// DynamicProxyEnv contains an authenticated proxy URL used for explicit
+	// dynamic-proxy fallback attempts, which BinderPOS now reserves for the
+	// final fallback after dedicated and direct/no-proxy attempts.
 	DynamicProxyEnv = "DYNAMIC_PROXY"
 	// UseBinderposSharedProxyFallbackEnv is reserved for future BinderPOS proxy
 	// routing options. It no longer changes scraper behavior (lookups are single-attempt).

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -28,7 +28,7 @@ This document records **where** the app configures search behavior, **timeouts**
 | Item | Value | Notes |
 |------|--------|--------|
 | Configured slots | **`DEDICATED_PROXY_1`** … **`DEDICATED_PROXY_7`** | Each value is `host\|port\|username\|password` (pipe-separated). Empty or incomplete entries are ignored when building URLs. |
-| Dynamic fallback proxy | **`DYNAMIC_PROXY`** | Uses the same `host\|port\|username\|password` format as `DEDICATED_PROXY_*` (full proxy URLs are also accepted). It is used after dedicated proxy routing and before direct/no-proxy fallbacks. |
+| Dynamic fallback proxy | **`DYNAMIC_PROXY`** | Uses the same `host\|port\|username\|password` format as `DEDICATED_PROXY_*` (full proxy URLs are also accepted). BinderPOS reserves it for the final fallback after dedicated and direct/no-proxy attempts. |
 
 ---
 
@@ -44,13 +44,13 @@ Some tests in `api/gateway/binderpos/*_test.go` hit real stores and proxies. The
 
 | Scenario | Order of strategies (each step is one attempt) | Per-step attempt timeout / HTTP client |
 |----------|--------------------------------------------------|----------------------------------------|
-| `shopifyDomain` **non-empty** (normal) | 1) **api-dedicated** → 2) **api-dynamic** → 3) **scrap-dedicated** → 4) **scrap-dynamic** → 5) **scrap-direct** | **10s** per step: `binderposAttemptTimeout` in `api/gateway/binderpos/storefront.go`; `runWithAttemptTimeout` in `storefront_search.go`. HTTP clients in `storefront_client.go` use the same `binderposAttemptTimeout`. |
-| `shopifyDomain` **empty** | **scrap-dedicated** → **scrap-dynamic** → **scrap-direct** (three `runWithAttemptTimeout` steps in `searchWithScrapDedicatedThenDynamicThenDirect`) | **10s** per step (same constant). No API attempts. |
+| `shopifyDomain` **non-empty** (normal) | 1) **api-dedicated** → 2) **api-direct** → 3) **scrap-dedicated** → 4) **scrap-direct** → 5) **api-dynamic** → 6) **scrap-dynamic** | **10s** per step: `binderposAttemptTimeout` in `api/gateway/binderpos/storefront.go`; `runWithAttemptTimeout` in `storefront_search.go`. HTTP clients in `storefront_client.go` use the same `binderposAttemptTimeout`. |
+| `shopifyDomain` **empty** | **scrap-dedicated** → **scrap-direct** → **scrap-dynamic** (three `runWithAttemptTimeout` steps in `searchWithScrapDedicatedThenDirectThenDynamic`) | **10s** per step (same constant). No API attempts. |
 
 | Item | Value | Source | Notes |
 |------|--------|--------|--------|
 | **api-dedicated** proxy selection (storefront HTTP client) | Round-robin | `nextBinderposStorefrontProxyURL` + `binderposDedicatedProxySeq` in `api/gateway/binderpos/storefront_client.go` | When `UseLeasedDedicatedProxy` is **false** (default in `api/pkg/config/config.go`), each storefront API call cycles **proxy₁ → … → proxyₙ** then repeats, using all URLs from `GetDedicatedProxyURLs()`. When `UseLeasedDedicatedProxy` is **true**, selection is unchanged: `LeaseDedicatedProxyURL` from the dedicated pool. |
-| **api-dynamic** proxy selection (storefront HTTP client) | Fixed env URL | `searchByStorefrontAPIDynamic` in `api/gateway/binderpos/storefront_client.go` | Uses `DYNAMIC_PROXY` as the authenticated proxy URL for the dynamic fallback attempt. |
+| **api-dynamic** proxy selection (storefront HTTP client) | Fixed env URL | `searchByStorefrontAPIDynamic` in `api/gateway/binderpos/storefront_client.go` | Uses `DYNAMIC_PROXY` as the authenticated proxy URL for the final BinderPOS API fallback attempt. |
 | Colly for BinderPOS scrapes | 10s | `SetRequestTimeout(binderposAttemptTimeout)` in `api/gateway/binderpos/scrap.go` | Tighter than generic `PerSiteTimeout` (20s) for binderpos scrape collectors. |
 | “Retries” | N/A (sequential fallbacks) | `searchWithFallback` | Stops on first **success**; returns last error if all attempts fail. This is **not** exponential backoff retry of a single request. |
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- reorder BinderPOS storefront and scraper fallback chains so direct attempts run before dynamic proxy attempts
- use the existing direct storefront API client in the fallback sequence instead of going to dynamic proxy immediately
- update fallback tests and strategy documentation to match the new ordering

## Testing
- `cd api && go test -mod=vendor -failfast -timeout 5m ./gateway/... ./controller/...`
- `make test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-78baf599-b426-4659-a5d6-c41b62770779"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78baf599-b426-4659-a5d6-c41b62770779"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

