### PR TITLE
build: update Go to 1.26.3 and refresh distroless base

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ Notes:
 
 ### Go version requirement
 
-The project requires Go 1.26.2 (per `api/go.mod`). The update script installs it to `/usr/local/go`. You must have `/usr/local/go/bin` in your PATH:
+The project requires Go 1.26.3 (per `api/go.mod`). The update script installs it to `/usr/local/go`. You must have `/usr/local/go/bin` in your PATH:
 
 ```bash
 export PATH="/usr/local/go/bin:$PATH"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2-alpine AS build
+FROM golang:1.26.3-alpine AS build
 WORKDIR /mtg-price-checker
 # Copy dependencies list
 COPY api ./api
@@ -8,7 +8,7 @@ RUN go mod download -x
 RUN env GOOS=linux GOARCH=amd64 go build -tags lambda.norpc -ldflags="-s -w" -o main cmd/main.go
 
 # Copy artifacts to a clean image
-FROM gcr.io/distroless/static-debian13 AS final
+FROM gcr.io/distroless/static-debian13@sha256:47b2d72ff90843eb8a768b5c2f89b40741843b639d065b9b937b07cd59b479c6 AS final
 #FROM public.ecr.aws/lambda/provided:al2023
 COPY --from=build /mtg-price-checker/api/main /main
 ENTRYPOINT [ "/main" ]

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module mtg-price-checker-sg
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/PuerkitoBio/goquery v1.11.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update the Go toolchain version pin from 1.26.2 to 1.26.3
- update the Docker builder image to `golang:1.26.3-alpine`
- pin the distroless runtime image to the current `static-debian13` digest `sha256:47b2d72ff90843eb8a768b5c2f89b40741843b639d065b9b937b07cd59b479c6`
- align the workspace instructions in `AGENTS.md` with the new Go version

## Testing
- `make test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-053256cb-1b1d-4a8b-9a14-7a961ca48a5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-053256cb-1b1d-4a8b-9a14-7a961ca48a5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

