### PR TITLE
Remove domain request jitter

### DIFF
--- a/api/gateway/domain_rate_limiter.go
+++ b/api/gateway/domain_rate_limiter.go
@@ -2,39 +2,30 @@ package gateway
 
 import (
 	"context"
-	"math/rand/v2"
 	"net/url"
 	"strings"
 	"sync"
 	"time"
 )
 
-const (
-	domainRequestMinInterval = 300 * time.Millisecond
-	domainRequestMaxJitter   = 600 * time.Millisecond
-)
+const domainRequestMinInterval = 300 * time.Millisecond
 
-var sharedDomainRequestLimiter = newDomainRequestLimiter(domainRequestMinInterval, domainRequestMaxJitter)
+var sharedDomainRequestLimiter = newDomainRequestLimiter(domainRequestMinInterval)
 
 type domainRequestLimiter struct {
 	mu          sync.Mutex
 	nextAllowed map[string]time.Time
 	minInterval time.Duration
-	maxJitter   time.Duration
 }
 
-func newDomainRequestLimiter(minInterval, maxJitter time.Duration) *domainRequestLimiter {
+func newDomainRequestLimiter(minInterval time.Duration) *domainRequestLimiter {
 	if minInterval < 0 {
 		minInterval = 0
-	}
-	if maxJitter < 0 {
-		maxJitter = 0
 	}
 
 	return &domainRequestLimiter{
 		nextAllowed: make(map[string]time.Time),
 		minInterval: minInterval,
-		maxJitter:   maxJitter,
 	}
 }
 
@@ -87,8 +78,7 @@ func (l *domainRequestLimiter) reserveDelay(domain string, now time.Time) (time.
 		nextAllowed = now
 	}
 
-	jitter := randomDuration(l.maxJitter)
-	reservedUntil := nextAllowed.Add(l.minInterval + jitter)
+	reservedUntil := nextAllowed.Add(l.minInterval)
 	l.nextAllowed[domain] = reservedUntil
 	return nextAllowed.Sub(now), reservedUntil
 }
@@ -104,12 +94,4 @@ func (l *domainRequestLimiter) rollbackReservation(domain string, reservedUntil 
 
 func canonicalDomain(targetURL *url.URL) string {
 	return strings.ToLower(strings.TrimSpace(targetURL.Hostname()))
-}
-
-func randomDuration(max time.Duration) time.Duration {
-	if max <= 0 {
-		return 0
-	}
-
-	return time.Duration(rand.Int64N(int64(max)))
 }

--- a/api/gateway/domain_rate_limiter_test.go
+++ b/api/gateway/domain_rate_limiter_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestDomainRequestLimiterWaitSameDomain(t *testing.T) {
-	limiter := newDomainRequestLimiter(40*time.Millisecond, 0)
+	limiter := newDomainRequestLimiter(40 * time.Millisecond)
 	targetURL, err := url.Parse("https://example.com/products")
 	if err != nil {
 		t.Fatalf("failed to parse URL: %v", err)
@@ -29,7 +29,7 @@ func TestDomainRequestLimiterWaitSameDomain(t *testing.T) {
 }
 
 func TestDomainRequestLimiterWaitDifferentDomains(t *testing.T) {
-	limiter := newDomainRequestLimiter(50*time.Millisecond, 0)
+	limiter := newDomainRequestLimiter(50 * time.Millisecond)
 	firstURL, err := url.Parse("https://example.com/a")
 	if err != nil {
 		t.Fatalf("failed to parse first URL: %v", err)
@@ -54,7 +54,7 @@ func TestDomainRequestLimiterWaitDifferentDomains(t *testing.T) {
 }
 
 func TestDomainRequestLimiterRollbackOnCancellation(t *testing.T) {
-	limiter := newDomainRequestLimiter(150*time.Millisecond, 0)
+	limiter := newDomainRequestLimiter(150 * time.Millisecond)
 	targetURL, err := url.Parse("https://example.com/items")
 	if err != nil {
 		t.Fatalf("failed to parse URL: %v", err)
@@ -78,5 +78,34 @@ func TestDomainRequestLimiterRollbackOnCancellation(t *testing.T) {
 
 	if elapsed >= 60*time.Millisecond {
 		t.Fatalf("expected rollback to clear pending reservation, got elapsed=%s", elapsed)
+	}
+}
+
+func TestDomainRequestLimiterReserveDelayFirstRequestImmediate(t *testing.T) {
+	limiter := newDomainRequestLimiter(300 * time.Millisecond)
+	now := time.Unix(100, 0)
+
+	delay, reservedUntil := limiter.reserveDelay("portal.binderpos.com", now)
+	if delay != 0 {
+		t.Fatalf("expected first request delay to be 0, got %s", delay)
+	}
+	if want := now.Add(300 * time.Millisecond); !reservedUntil.Equal(want) {
+		t.Fatalf("expected first reservation until %s, got %s", want, reservedUntil)
+	}
+}
+
+func TestDomainRequestLimiterReserveDelayUsesFixedMinimumInterval(t *testing.T) {
+	limiter := newDomainRequestLimiter(300 * time.Millisecond)
+	now := time.Unix(100, 0)
+
+	_, firstReservedUntil := limiter.reserveDelay("portal.binderpos.com", now)
+	secondNow := now.Add(150 * time.Millisecond)
+	delay, secondReservedUntil := limiter.reserveDelay("portal.binderpos.com", secondNow)
+
+	if want := 150 * time.Millisecond; delay != want {
+		t.Fatalf("expected second request delay %s, got %s", want, delay)
+	}
+	if want := firstReservedUntil.Add(300 * time.Millisecond); !secondReservedUntil.Equal(want) {
+		t.Fatalf("expected second reservation until %s, got %s", want, secondReservedUntil)
 	}
 }

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -1,6 +1,6 @@
 # Search strategies, retries, and timing
 
-This document records **where** the app configures search behavior, **timeouts**, **fallback/attempt ordering**, **concurrency limits**, and **jittered pacing**. It is meant for code agents and maintainers: when you change a constant, update this file in the same PR.
+This document records **where** the app configures search behavior, **timeouts**, **fallback/attempt ordering**, **concurrency limits**, and **request pacing**. It is meant for code agents and maintainers: when you change a constant, update this file in the same PR.
 
 ---
 
@@ -20,8 +20,7 @@ This document records **where** the app configures search behavior, **timeouts**
 
 | Item | Value | Source | Notes |
 |------|--------|--------|--------|
-| Minimum interval between requests to the **same host** | 300ms | `domainRequestMinInterval` in `api/gateway/domain_rate_limiter.go` | Added to the reservation for the next allowed time for that domain. |
-| Jitter (added on top of minimum interval) | uniform in **[0, 600ms)** | `domainRequestMaxJitter` + `randomDuration` in `api/gateway/domain_rate_limiter.go` | Per reservation: `reservedUntil = nextAllowed + minInterval + jitter`. If the wait is cancelled, the limiter can roll back that reservation. |
+| Minimum interval between requests to the **same host** | 300ms | `domainRequestMinInterval` in `api/gateway/domain_rate_limiter.go` | Per reservation: `reservedUntil = nextAllowed + minInterval`. The first request for a host is immediate; later requests wait until the prior reservation expires. If the wait is cancelled, the limiter can roll back that reservation. |
 
 ## Backend: dedicated proxy env (`api/gateway/util/dedicated_proxy.go`)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove random per-domain request jitter from the shared request limiter
- keep the fixed 300ms minimum interval between requests to the same host
- add focused limiter tests covering first-request behavior and fixed spacing
- update the search-strategy docs to reflect fixed request pacing

## Testing
- `cd api && go test -mod=vendor -failfast -timeout 5m ./gateway/... ./controller/...` *(fails in unrelated live upstream test: `gateway/agora` timeout against `https://agorahobby.com/...`)*
- `make test` *(fails for the same unrelated `gateway/agora` live-site timeout)*
- `cd api && go test -mod=vendor ./gateway -run DomainRequestLimiter`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-78f5cabc-4796-4397-b10e-1b107a54dc3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78f5cabc-4796-4397-b10e-1b107a54dc3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

