### PR TITLE
Apply BinderPOS pacing only to fallback attempts

### DIFF
--- a/api/gateway/binderpos/storefront_proxy_client_test.go
+++ b/api/gateway/binderpos/storefront_proxy_client_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+	"time"
 
 	"mtg-price-checker-sg/gateway"
 )
@@ -86,7 +87,7 @@ func TestNewHTTPClientWithProxyURL(t *testing.T) {
 
 func TestRunWithAttemptTimeout(t *testing.T) {
 	t.Run("returns callback result when callback succeeds", func(t *testing.T) {
-		got, err := runWithAttemptTimeout(context.Background(), func(attemptCtx context.Context) ([]gateway.Card, error) {
+		got, err := runWithAttemptTimeout(context.Background(), false, func(attemptCtx context.Context) ([]gateway.Card, error) {
 			if _, hasDeadline := attemptCtx.Deadline(); !hasDeadline {
 				t.Fatalf("expected attempt context to have deadline")
 			}
@@ -102,11 +103,59 @@ func TestRunWithAttemptTimeout(t *testing.T) {
 
 	t.Run("propagates callback error", func(t *testing.T) {
 		wantErr := errors.New("boom")
-		_, err := runWithAttemptTimeout(context.Background(), func(_ context.Context) ([]gateway.Card, error) {
+		_, err := runWithAttemptTimeout(context.Background(), true, func(_ context.Context) ([]gateway.Card, error) {
 			return nil, wantErr
 		})
 		if !errors.Is(err, wantErr) {
 			t.Fatalf("expected %v, got %v", wantErr, err)
+		}
+	})
+
+	t.Run("skips shared request pacing for first attempts", func(t *testing.T) {
+		targetURL, err := url.Parse("https://initial-attempt.example.com/items")
+		if err != nil {
+			t.Fatalf("failed to parse target URL: %v", err)
+		}
+
+		start := time.Now()
+		_, err = runWithAttemptTimeout(context.Background(), false, func(attemptCtx context.Context) ([]gateway.Card, error) {
+			if err := gateway.WaitForDomainRequestSlot(attemptCtx, targetURL); err != nil {
+				return nil, err
+			}
+			if err := gateway.WaitForDomainRequestSlot(attemptCtx, targetURL); err != nil {
+				return nil, err
+			}
+			return nil, nil
+		})
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if elapsed := time.Since(start); elapsed >= 120*time.Millisecond {
+			t.Fatalf("expected first attempts to skip pacing, got elapsed=%s", elapsed)
+		}
+	})
+
+	t.Run("keeps shared request pacing for fallbacks", func(t *testing.T) {
+		targetURL, err := url.Parse("https://fallback-attempt.example.com/items")
+		if err != nil {
+			t.Fatalf("failed to parse target URL: %v", err)
+		}
+
+		start := time.Now()
+		_, err = runWithAttemptTimeout(context.Background(), true, func(attemptCtx context.Context) ([]gateway.Card, error) {
+			if err := gateway.WaitForDomainRequestSlot(attemptCtx, targetURL); err != nil {
+				return nil, err
+			}
+			if err := gateway.WaitForDomainRequestSlot(attemptCtx, targetURL); err != nil {
+				return nil, err
+			}
+			return nil, nil
+		})
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if elapsed := time.Since(start); elapsed < 250*time.Millisecond {
+			t.Fatalf("expected fallback attempts to keep pacing, got elapsed=%s", elapsed)
 		}
 	})
 }

--- a/api/gateway/binderpos/storefront_search.go
+++ b/api/gateway/binderpos/storefront_search.go
@@ -14,17 +14,17 @@ func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, 
 	if strings.TrimSpace(shopifyDomain) == "" {
 		return searchWithScrapDedicatedThenDirectThenDynamic(
 			func() ([]gateway.Card, error) {
-				return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
+				return runWithAttemptTimeout(ctx, false, func(attemptCtx context.Context) ([]gateway.Card, error) {
 					return i.Scrap(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
 				})
 			},
 			func() ([]gateway.Card, error) {
-				return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
+				return runWithAttemptTimeout(ctx, true, func(attemptCtx context.Context) ([]gateway.Card, error) {
 					return i.scrapDirect(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
 				})
 			},
 			func() ([]gateway.Card, error) {
-				return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
+				return runWithAttemptTimeout(ctx, true, func(attemptCtx context.Context) ([]gateway.Card, error) {
 					return i.scrapDynamic(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
 				})
 			},
@@ -33,39 +33,43 @@ func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, 
 
 	return searchWithFallback(
 		func() ([]gateway.Card, error) {
-			return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
+			return runWithAttemptTimeout(ctx, false, func(attemptCtx context.Context) ([]gateway.Card, error) {
 				return searchByStorefrontAPI(attemptCtx, scrapVariant, storeName, baseURL, shopifyDomain, searchStr)
 			})
 		},
 		func() ([]gateway.Card, error) {
-			return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
+			return runWithAttemptTimeout(ctx, true, func(attemptCtx context.Context) ([]gateway.Card, error) {
 				return searchByStorefrontAPIDirect(attemptCtx, scrapVariant, storeName, baseURL, shopifyDomain, searchStr)
 			})
 		},
 		func() ([]gateway.Card, error) {
-			return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
+			return runWithAttemptTimeout(ctx, true, func(attemptCtx context.Context) ([]gateway.Card, error) {
 				return i.Scrap(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
 			})
 		},
 		func() ([]gateway.Card, error) {
-			return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
+			return runWithAttemptTimeout(ctx, true, func(attemptCtx context.Context) ([]gateway.Card, error) {
 				return i.scrapDirect(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
 			})
 		},
 		func() ([]gateway.Card, error) {
-			return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
+			return runWithAttemptTimeout(ctx, true, func(attemptCtx context.Context) ([]gateway.Card, error) {
 				return searchByStorefrontAPIDynamic(attemptCtx, scrapVariant, storeName, baseURL, shopifyDomain, searchStr)
 			})
 		},
 		func() ([]gateway.Card, error) {
-			return runWithAttemptTimeout(ctx, func(attemptCtx context.Context) ([]gateway.Card, error) {
+			return runWithAttemptTimeout(ctx, true, func(attemptCtx context.Context) ([]gateway.Card, error) {
 				return i.scrapDynamic(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
 			})
 		},
 	)
 }
 
-func runWithAttemptTimeout(ctx context.Context, fn func(context.Context) ([]gateway.Card, error)) ([]gateway.Card, error) {
+func runWithAttemptTimeout(ctx context.Context, applyRequestPacing bool, fn func(context.Context) ([]gateway.Card, error)) ([]gateway.Card, error) {
+	if !applyRequestPacing {
+		// Let the first BinderPOS attempt start immediately; fallbacks still share pacing.
+		ctx = gateway.WithDomainRequestPacingDisabled(ctx)
+	}
 	attemptCtx, cancel := context.WithTimeout(ctx, binderposAttemptTimeout)
 	defer cancel()
 	return fn(attemptCtx)

--- a/api/gateway/domain_rate_limiter.go
+++ b/api/gateway/domain_rate_limiter.go
@@ -10,9 +10,12 @@ import (
 
 const domainRequestMinInterval = 300 * time.Millisecond
 
-var sharedDomainRequestLimiter = newDomainRequestLimiter(domainRequestMinInterval)
-
 type domainRequestPacingDisabledKey struct{}
+
+var (
+	sharedDomainRequestLimiter    = newDomainRequestLimiter(domainRequestMinInterval)
+	disableDomainRequestPacingKey = domainRequestPacingDisabledKey{}
+)
 
 type domainRequestLimiter struct {
 	mu          sync.Mutex
@@ -47,7 +50,7 @@ func WithDomainRequestPacingDisabled(ctx context.Context) context.Context {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	return context.WithValue(ctx, domainRequestPacingDisabledKey{}, true)
+	return context.WithValue(ctx, disableDomainRequestPacingKey, true)
 }
 
 func (l *domainRequestLimiter) wait(ctx context.Context, targetURL *url.URL) error {
@@ -115,6 +118,6 @@ func domainRequestPacingDisabled(ctx context.Context) bool {
 		return false
 	}
 
-	disabled, _ := ctx.Value(domainRequestPacingDisabledKey{}).(bool)
+	disabled, _ := ctx.Value(disableDomainRequestPacingKey).(bool)
 	return disabled
 }

--- a/api/gateway/domain_rate_limiter.go
+++ b/api/gateway/domain_rate_limiter.go
@@ -12,6 +12,8 @@ const domainRequestMinInterval = 300 * time.Millisecond
 
 var sharedDomainRequestLimiter = newDomainRequestLimiter(domainRequestMinInterval)
 
+type domainRequestPacingDisabledKey struct{}
+
 type domainRequestLimiter struct {
 	mu          sync.Mutex
 	nextAllowed map[string]time.Time
@@ -39,12 +41,24 @@ func WaitForDomainRequestSlot(ctx context.Context, targetURL *url.URL) error {
 	return waitForDomainRequestSlot(ctx, targetURL)
 }
 
+// WithDomainRequestPacingDisabled bypasses shared per-domain pacing for work that
+// should not pay the inter-request delay, such as a BinderPOS store's first attempt.
+func WithDomainRequestPacingDisabled(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, domainRequestPacingDisabledKey{}, true)
+}
+
 func (l *domainRequestLimiter) wait(ctx context.Context, targetURL *url.URL) error {
 	if l == nil || targetURL == nil {
 		return nil
 	}
 	if ctx == nil {
 		ctx = context.Background()
+	}
+	if domainRequestPacingDisabled(ctx) {
+		return nil
 	}
 
 	domain := canonicalDomain(targetURL)
@@ -94,4 +108,13 @@ func (l *domainRequestLimiter) rollbackReservation(domain string, reservedUntil 
 
 func canonicalDomain(targetURL *url.URL) string {
 	return strings.ToLower(strings.TrimSpace(targetURL.Hostname()))
+}
+
+func domainRequestPacingDisabled(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+
+	disabled, _ := ctx.Value(domainRequestPacingDisabledKey{}).(bool)
+	return disabled
 }

--- a/api/gateway/domain_rate_limiter_test.go
+++ b/api/gateway/domain_rate_limiter_test.go
@@ -81,6 +81,30 @@ func TestDomainRequestLimiterRollbackOnCancellation(t *testing.T) {
 	}
 }
 
+func TestDomainRequestLimiterWaitBypassesDisabledPacing(t *testing.T) {
+	limiter := newDomainRequestLimiter(80 * time.Millisecond)
+	targetURL, err := url.Parse("https://example.com/items")
+	if err != nil {
+		t.Fatalf("failed to parse URL: %v", err)
+	}
+
+	disabledCtx := WithDomainRequestPacingDisabled(context.Background())
+	start := time.Now()
+	if err := limiter.wait(disabledCtx, targetURL); err != nil {
+		t.Fatalf("first disabled wait returned error: %v", err)
+	}
+	if err := limiter.wait(disabledCtx, targetURL); err != nil {
+		t.Fatalf("second disabled wait returned error: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed >= 40*time.Millisecond {
+		t.Fatalf("expected disabled pacing waits to return immediately, got elapsed=%s", elapsed)
+	}
+
+	if _, exists := limiter.nextAllowed["example.com"]; exists {
+		t.Fatalf("expected disabled pacing waits to avoid reserving a domain slot")
+	}
+}
+
 func TestDomainRequestLimiterReserveDelayFirstRequestImmediate(t *testing.T) {
 	limiter := newDomainRequestLimiter(300 * time.Millisecond)
 	now := time.Unix(100, 0)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- skip shared domain pacing for the first BinderPOS attempt so initial store searches start immediately
- keep the existing delay for later BinderPOS fallback/retry attempts
- clean up the pacing context key to use a package-level variable for readability
- add focused tests for the pacing bypass and BinderPOS attempt behavior

## Testing
- `cd api && go test -mod=vendor -failfast -timeout 5m ./gateway/... ./controller/...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b08f6cc7-b581-4bf5-a200-8352923fe31b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b08f6cc7-b581-4bf5-a200-8352923fe31b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

