### PR TITLE
Lower shared domain request pacing to 200ms

### DIFF
--- a/api/gateway/binderpos/storefront_proxy_client_test.go
+++ b/api/gateway/binderpos/storefront_proxy_client_test.go
@@ -154,7 +154,7 @@ func TestRunWithAttemptTimeout(t *testing.T) {
 		if err != nil {
 			t.Fatalf("expected nil error, got %v", err)
 		}
-		if elapsed := time.Since(start); elapsed < 250*time.Millisecond {
+		if elapsed := time.Since(start); elapsed < 150*time.Millisecond {
 			t.Fatalf("expected fallback attempts to keep pacing, got elapsed=%s", elapsed)
 		}
 	})

--- a/api/gateway/domain_rate_limiter.go
+++ b/api/gateway/domain_rate_limiter.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-const domainRequestMinInterval = 300 * time.Millisecond
+const domainRequestMinInterval = 200 * time.Millisecond
 
 type domainRequestPacingDisabledKey struct{}
 

--- a/api/gateway/domain_rate_limiter_test.go
+++ b/api/gateway/domain_rate_limiter_test.go
@@ -106,30 +106,30 @@ func TestDomainRequestLimiterWaitBypassesDisabledPacing(t *testing.T) {
 }
 
 func TestDomainRequestLimiterReserveDelayFirstRequestImmediate(t *testing.T) {
-	limiter := newDomainRequestLimiter(300 * time.Millisecond)
+	limiter := newDomainRequestLimiter(200 * time.Millisecond)
 	now := time.Unix(100, 0)
 
 	delay, reservedUntil := limiter.reserveDelay("portal.binderpos.com", now)
 	if delay != 0 {
 		t.Fatalf("expected first request delay to be 0, got %s", delay)
 	}
-	if want := now.Add(300 * time.Millisecond); !reservedUntil.Equal(want) {
+	if want := now.Add(200 * time.Millisecond); !reservedUntil.Equal(want) {
 		t.Fatalf("expected first reservation until %s, got %s", want, reservedUntil)
 	}
 }
 
 func TestDomainRequestLimiterReserveDelayUsesFixedMinimumInterval(t *testing.T) {
-	limiter := newDomainRequestLimiter(300 * time.Millisecond)
+	limiter := newDomainRequestLimiter(200 * time.Millisecond)
 	now := time.Unix(100, 0)
 
 	_, firstReservedUntil := limiter.reserveDelay("portal.binderpos.com", now)
-	secondNow := now.Add(150 * time.Millisecond)
+	secondNow := now.Add(100 * time.Millisecond)
 	delay, secondReservedUntil := limiter.reserveDelay("portal.binderpos.com", secondNow)
 
-	if want := 150 * time.Millisecond; delay != want {
+	if want := 100 * time.Millisecond; delay != want {
 		t.Fatalf("expected second request delay %s, got %s", want, delay)
 	}
-	if want := firstReservedUntil.Add(300 * time.Millisecond); !secondReservedUntil.Equal(want) {
+	if want := firstReservedUntil.Add(200 * time.Millisecond); !secondReservedUntil.Equal(want) {
 		t.Fatalf("expected second reservation until %s, got %s", want, secondReservedUntil)
 	}
 }

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -20,7 +20,7 @@ This document records **where** the app configures search behavior, **timeouts**
 
 | Item | Value | Source | Notes |
 |------|--------|--------|--------|
-| Minimum interval between requests to the **same host** | 300ms | `domainRequestMinInterval` in `api/gateway/domain_rate_limiter.go` | Per reservation: `reservedUntil = nextAllowed + minInterval`. The first request for a host is immediate; later requests wait until the prior reservation expires. If the wait is cancelled, the limiter can roll back that reservation. |
+| Minimum interval between requests to the **same host** | 200ms | `domainRequestMinInterval` in `api/gateway/domain_rate_limiter.go` | Per reservation: `reservedUntil = nextAllowed + minInterval`. The first request for a host is immediate; later requests wait until the prior reservation expires. If the wait is cancelled, the limiter can roll back that reservation. |
 
 ## Backend: dedicated proxy env (`api/gateway/util/dedicated_proxy.go`)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- lower the shared per-domain request pacing interval from 300ms to 200ms
- update limiter and BinderPOS fallback timing tests to match the new fixed interval
- refresh the request-pacing documentation to reflect the new value

## Testing
- `cd api && go test -mod=vendor -failfast -timeout 5m ./gateway/... ./controller/...`
- `make test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21ad5d31-8f86-4398-969a-86bf5e9a52b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21ad5d31-8f86-4398-969a-86bf5e9a52b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

