### PR TITLE
Add Cards Central (cardscentral.com); retire Cardboard Crack Games

### DIFF
--- a/api/controller/search.go
+++ b/api/controller/search.go
@@ -9,8 +9,12 @@ import (
 	"mtg-price-checker-sg/gateway/agora"
 	// "mtg-price-checker-sg/gateway/arcanesanctum"
 	"mtg-price-checker-sg/gateway/cardaffinity"
-	"mtg-price-checker-sg/gateway/cardboardcrackgames"
+	// Cardboard Crack Games retired its standalone Shopify storefront and
+	// redirected to the Cards Central platform; its singles are searchable
+	// via the cardscentral gateway below.
+	// "mtg-price-checker-sg/gateway/cardboardcrackgames"
 	"mtg-price-checker-sg/gateway/cardsandcollection"
+	"mtg-price-checker-sg/gateway/cardscentral"
 	"mtg-price-checker-sg/gateway/cardscitadel"
 	"mtg-price-checker-sg/gateway/duellerpoint"
 	"mtg-price-checker-sg/gateway/fivemana"
@@ -68,7 +72,8 @@ var shopRegistry = []shopSpec{
 	{name: agora.StoreName, newLGS: agora.NewLGS},
 	// {name: arcanesanctum.StoreName, newLGS: arcanesanctum.NewLGS, isBinderpos: true},
 	{name: cardaffinity.StoreName, newLGS: cardaffinity.NewLGS, isBinderpos: true},
-	{name: cardboardcrackgames.StoreName, newLGS: cardboardcrackgames.NewLGS, isBinderpos: true},
+	// {name: cardboardcrackgames.StoreName, newLGS: cardboardcrackgames.NewLGS, isBinderpos: true}, // retired → cardscentral
+	{name: cardscentral.StoreName, newLGS: cardscentral.NewLGS},
 	{name: cardscitadel.StoreName, newLGS: cardscitadel.NewLGS, isBinderpos: true},
 	{name: cardsandcollection.StoreName, newLGS: cardsandcollection.NewLGS},
 	{name: duellerpoint.StoreName, newLGS: duellerpoint.NewLGS},

--- a/api/gateway/cardscentral/search.go
+++ b/api/gateway/cardscentral/search.go
@@ -1,0 +1,122 @@
+package cardscentral
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"mtg-price-checker-sg/gateway"
+	"mtg-price-checker-sg/pkg/config"
+)
+
+// Cards Central runs its own platform (cardscentral.com), not BinderPOS or
+// Shopify, so it can't be crawled like the other storefronts. It exposes a
+// purpose-built JSON feed for aggregators instead: one row per in-stock raw
+// single, MTG-filtered, cheapest-first. See
+// https://cardscentral.com/api/lgs/search?q=<card name>
+const StoreName = "Cards Central"
+const StoreBaseURL = "https://cardscentral.com"
+const StoreSearchAPI = "/api/lgs/search"
+
+// item mirrors one element of the /api/lgs/search response array.
+type item struct {
+	Name      string  `json:"name"`
+	Set       string  `json:"set"`
+	Url       string  `json:"url"`
+	Img       string  `json:"img"`
+	Price     float64 `json:"price"`
+	Currency  string  `json:"currency"`
+	InStock   bool    `json:"inStock"`
+	Finish    string  `json:"finish"`
+	IsFoil    bool    `json:"isFoil"`
+	Condition string  `json:"condition"`
+}
+
+type Store struct {
+	Name      string
+	BaseUrl   string
+	SearchAPI string
+}
+
+func NewLGS() gateway.LGS {
+	return Store{
+		Name:      StoreName,
+		BaseUrl:   StoreBaseURL,
+		SearchAPI: StoreSearchAPI,
+	}
+}
+
+func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
+	var cards []gateway.Card
+
+	apiURL := &url.URL{
+		Scheme:   "https",
+		Host:     strings.TrimPrefix(strings.TrimPrefix(s.BaseUrl, "https://"), "http://"),
+		Path:     s.SearchAPI,
+		RawQuery: url.Values{"q": {searchStr}}.Encode(),
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL.String(), nil)
+	if err != nil {
+		return cards, err
+	}
+	req.Header.Set("Accept", "application/json")
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return cards, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return cards, err
+	}
+
+	var items []item
+	if err = json.Unmarshal(body, &items); err != nil {
+		return cards, err
+	}
+
+	for _, it := range items {
+		if !it.InStock || it.Price <= 0 {
+			continue
+		}
+
+		// Stamp the aggregator's utm_source on the product link.
+		productURL := it.Url
+		if u, perr := url.Parse(it.Url); perr == nil {
+			q := u.Query()
+			q.Set("utm_source", config.UtmSource)
+			u.RawQuery = q.Encode()
+			productURL = u.String()
+		}
+
+		// ExtraInfo carries the set (foil rides IsFoil; condition rides Quality).
+		// Matches how the other custom stores annotate a row.
+		extra := []string{}
+		if it.Set != "" {
+			extra = append(extra, fmt.Sprintf("[%s]", it.Set))
+		}
+
+		cards = append(cards, gateway.Card{
+			Name:      strings.TrimSpace(it.Name),
+			Url:       strings.TrimSpace(productURL),
+			Img:       it.Img,
+			Price:     it.Price,
+			InStock:   true,
+			IsFoil:    it.IsFoil,
+			Source:    s.Name,
+			Quality:   it.Condition,
+			ExtraInfo: extra,
+		})
+	}
+
+	return cards, nil
+}

--- a/api/gateway/cardscentral/search_test.go
+++ b/api/gateway/cardscentral/search_test.go
@@ -1,0 +1,25 @@
+package cardscentral
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Search(t *testing.T) {
+	s := NewLGS()
+	result, err := s.Search(context.Background(), "lightning bolt")
+	require.NoError(t, err)
+
+	for _, card := range result {
+		if card.InStock {
+			require.NotEmpty(t, card.Name)
+			require.Equal(t, StoreName, card.Source)
+			require.Contains(t, card.Url, StoreBaseURL+"/card/")
+			require.NotEmpty(t, card.Img)
+			require.Greater(t, card.Price, float64(0))
+			require.NotEmpty(t, card.Quality)
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds **Cards Central** as a searchable store, and retires **Cardboard Crack Games**.

### Cards Central — new custom store
Cards Central (https://cardscentral.com) runs its own platform, not BinderPOS/Shopify, so it can't be crawled like the other storefronts. It exposes a purpose-built JSON feed for aggregators instead:

`GET https://cardscentral.com/api/lgs/search?q=<card name>` → flat array, one row per in-stock raw single (MTG-filtered, cheapest-first):
```json
[{ "name":"Lightning Bolt", "set":"Double Masters 2022", "url":"https://cardscentral.com/card/...",
   "img":"https://...", "price":2.80, "currency":"SGD", "inStock":true,
   "finish":"foil", "isFoil":true, "condition":"NM" }]
```
New `gateway/cardscentral` package hits that endpoint and maps each row to `gateway.Card` (set → ExtraInfo, condition → Quality, foil → IsFoil), registered as a non-binderpos custom store. The endpoint is **live**, so the gateway test passes against real data.

### Cardboard Crack Games — retired
CCG shut its standalone Shopify storefront and redirected to the Cards Central platform; its singles are now searchable through the cardscentral gateway. Its registry entry is commented out (package kept, matching the `arcanesanctum`/`tefuda` convention).

**Heads up:** `gateway/cardboardcrackgames` still has a live-site test. Once the redirect to cardscentral.com is fully live, that test will fail (the old storefront no longer serves products). Happy to delete the package + test in this PR instead if you'd prefer a clean removal — left it commented to match how the other disabled stores are handled.

## Test
`cd api && go test -mod=vendor ./gateway/cardscentral/... ./controller/...`