### PR TITLE
Retry BinderPOS decklist 503/429 with backoff and Retry-After

### DIFF
--- a/api/gateway/binderpos/storefront.go
+++ b/api/gateway/binderpos/storefront.go
@@ -11,6 +11,19 @@ const (
 	binderposDecklistType   = "mtg"
 	binderposDecklistPct    = 100
 	binderposAttemptTimeout = 10 * time.Second
+
+	// binderposDecklistMaxAttempts bounds how many times a single decklist call
+	// is sent (initial try plus retries) when the shared portal host responds
+	// with a transient rate-limit/5xx status or a network error. Retries stay
+	// within the per-attempt timeout budget and back off between sends so a
+	// struggling upstream is not hammered.
+	binderposDecklistMaxAttempts = 3
+	// binderposDecklistRetryBaseDelay is the first backoff step; subsequent
+	// retries grow it exponentially with equal jitter.
+	binderposDecklistRetryBaseDelay = 300 * time.Millisecond
+	// binderposDecklistRetryMaxDelay caps a single backoff/Retry-After wait so a
+	// large or hostile Retry-After value cannot stall the attempt.
+	binderposDecklistRetryMaxDelay = 2500 * time.Millisecond
 )
 
 var shouldUseDecklistEndpoint = func() bool {

--- a/api/gateway/binderpos/storefront_decklist.go
+++ b/api/gateway/binderpos/storefront_decklist.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -40,14 +39,19 @@ func searchByBinderposDecklistAPI(ctx context.Context, client *http.Client, scra
 		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, decklistURL.String(), bytes.NewReader(payloadBody))
-	if err != nil {
-		return nil, err
-	}
 	storeBase, _ := url.Parse(baseURL)
-	gateway.ApplyBrowserLikeJSONFetchHeaders(&req.Header, storeBase)
-	req.Header.Set("User-Agent", gateway.RandomBrowserUserAgent())
-	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	// Rebuilt per send so each retry carries a fresh User-Agent and a
+	// re-readable body, which also helps evade naive fingerprint throttling.
+	newRequest := func() (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, decklistURL.String(), bytes.NewReader(payloadBody))
+		if err != nil {
+			return nil, err
+		}
+		gateway.ApplyBrowserLikeJSONFetchHeaders(&req.Header, storeBase)
+		req.Header.Set("User-Agent", gateway.RandomBrowserUserAgent())
+		req.Header.Set("Content-Type", "application/json; charset=utf-8")
+		return req, nil
+	}
 
 	releasePortalSlot, err := acquireBinderposPortalSlot(ctx)
 	if err != nil {
@@ -55,20 +59,11 @@ func searchByBinderposDecklistAPI(ctx context.Context, client *http.Client, scra
 	}
 	defer releasePortalSlot()
 
-	if err := gateway.WaitForDomainRequestSlot(ctx, req.URL); err != nil {
-		return nil, err
-	}
-
-	res, err := client.Do(req)
+	res, err := doDecklistRequestWithRetry(ctx, client, newRequest)
 	if err != nil {
 		return nil, err
 	}
 	defer res.Body.Close()
-
-	if res.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(res.Body)
-		return nil, fmt.Errorf("binderpos decklist request failed status=%d body=%s", res.StatusCode, strings.TrimSpace(string(body)))
-	}
 
 	var lines []storefrontDecklistLine
 	if err := json.NewDecoder(res.Body).Decode(&lines); err != nil {

--- a/api/gateway/binderpos/storefront_decklist_retry.go
+++ b/api/gateway/binderpos/storefront_decklist_retry.go
@@ -1,0 +1,169 @@
+package binderpos
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"mtg-price-checker-sg/gateway"
+)
+
+// retriableDecklistStatuses are upstream responses that signal a transient
+// load or rate-limit condition on the shared portal host. They are retried with
+// backoff (honoring Retry-After) instead of immediately failing over to a
+// heavier, more expensive strategy, which reduces the user-visible 503 rate
+// without changing card data.
+var retriableDecklistStatuses = map[int]struct{}{
+	http.StatusTooManyRequests:     {}, // 429
+	http.StatusInternalServerError: {}, // 500
+	http.StatusBadGateway:          {}, // 502
+	http.StatusServiceUnavailable:  {}, // 503
+	http.StatusGatewayTimeout:      {}, // 504
+}
+
+func isRetriableDecklistStatus(status int) bool {
+	_, ok := retriableDecklistStatuses[status]
+	return ok
+}
+
+// doDecklistRequestWithRetry sends the decklist request, retrying transient
+// rate-limit/5xx responses and network errors with jittered exponential backoff
+// bounded by ctx. newRequest rebuilds the request for every send so each retry
+// carries a fresh User-Agent (set by the caller) and a re-readable body. On the
+// dynamic-proxy attempt every retry egresses from a fresh rotating IP, which is
+// the most effective mitigation for per-IP throttling on the shared portal host.
+//
+// On success it returns the response with its body still open for the caller to
+// decode. On failure it returns the last observed error and no response.
+func doDecklistRequestWithRetry(ctx context.Context, client *http.Client, newRequest func() (*http.Request, error)) (*http.Response, error) {
+	var lastErr error
+
+	for attempt := 0; attempt < binderposDecklistMaxAttempts; attempt++ {
+		req, err := newRequest()
+		if err != nil {
+			return nil, err
+		}
+		if err := gateway.WaitForDomainRequestSlot(ctx, req.URL); err != nil {
+			return nil, err
+		}
+
+		res, err := client.Do(req)
+		if err != nil {
+			lastErr = err
+			if isLastDecklistAttempt(attempt) || !waitBeforeDecklistRetry(ctx, decklistBackoffDelay(attempt)) {
+				return nil, lastErr
+			}
+			continue
+		}
+
+		if res.StatusCode == http.StatusOK {
+			return res, nil
+		}
+
+		body, _ := io.ReadAll(res.Body)
+		res.Body.Close()
+		lastErr = fmt.Errorf("binderpos decklist request failed status=%d body=%s", res.StatusCode, strings.TrimSpace(string(body)))
+
+		if !isRetriableDecklistStatus(res.StatusCode) || isLastDecklistAttempt(attempt) {
+			return nil, lastErr
+		}
+
+		delay := parseRetryAfter(res.Header.Get("Retry-After"))
+		if delay <= 0 {
+			delay = decklistBackoffDelay(attempt)
+		}
+		if !waitBeforeDecklistRetry(ctx, delay) {
+			return nil, lastErr
+		}
+	}
+
+	return nil, lastErr
+}
+
+func isLastDecklistAttempt(attempt int) bool {
+	return attempt >= binderposDecklistMaxAttempts-1
+}
+
+// decklistBackoffDelay returns an equal-jitter exponential backoff for the given
+// zero-based attempt, capped at binderposDecklistRetryMaxDelay. Equal jitter
+// keeps a guaranteed minimum spacing while still desynchronizing concurrent
+// callers that all retry against the same host.
+func decklistBackoffDelay(attempt int) time.Duration {
+	if attempt < 0 {
+		attempt = 0
+	}
+
+	base := binderposDecklistRetryBaseDelay << attempt
+	if base <= 0 || base > binderposDecklistRetryMaxDelay {
+		base = binderposDecklistRetryMaxDelay
+	}
+
+	half := base / 2
+	if half <= 0 {
+		return base
+	}
+	return half + time.Duration(rand.Int64N(int64(half)+1))
+}
+
+// waitBeforeDecklistRetry sleeps for delay unless ctx is cancelled or the
+// remaining ctx budget cannot accommodate it. It returns true only when the
+// wait completed and a retry should proceed.
+func waitBeforeDecklistRetry(ctx context.Context, delay time.Duration) bool {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if delay <= 0 {
+		return ctx.Err() == nil
+	}
+	if deadline, ok := ctx.Deadline(); ok && time.Until(deadline) <= delay {
+		return false
+	}
+
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// parseRetryAfter parses a Retry-After header expressed either as a number of
+// seconds or an HTTP date. It returns 0 when the header is absent or
+// unparseable, and caps the wait so a huge value cannot stall the attempt.
+func parseRetryAfter(value string) time.Duration {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+
+	if seconds, err := strconv.Atoi(value); err == nil {
+		if seconds <= 0 {
+			return 0
+		}
+		return capRetryAfter(time.Duration(seconds) * time.Second)
+	}
+
+	if when, err := http.ParseTime(value); err == nil {
+		delay := time.Until(when)
+		if delay <= 0 {
+			return 0
+		}
+		return capRetryAfter(delay)
+	}
+
+	return 0
+}
+
+func capRetryAfter(delay time.Duration) time.Duration {
+	if delay > binderposDecklistRetryMaxDelay {
+		return binderposDecklistRetryMaxDelay
+	}
+	return delay
+}

--- a/api/gateway/binderpos/storefront_decklist_retry_test.go
+++ b/api/gateway/binderpos/storefront_decklist_retry_test.go
@@ -1,0 +1,211 @@
+package binderpos
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func newDecklistTestRequest(t *testing.T, urlStr string) func() (*http.Request, error) {
+	t.Helper()
+	return func() (*http.Request, error) {
+		return http.NewRequest(http.MethodPost, urlStr, bytes.NewReader([]byte(`[{"card":"Abrade","quantity":1}]`)))
+	}
+}
+
+func TestIsRetriableDecklistStatus(t *testing.T) {
+	retriable := []int{
+		http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout,
+	}
+	for _, status := range retriable {
+		if !isRetriableDecklistStatus(status) {
+			t.Fatalf("expected status %d to be retriable", status)
+		}
+	}
+
+	notRetriable := []int{
+		http.StatusOK,
+		http.StatusBadRequest,
+		http.StatusUnauthorized,
+		http.StatusForbidden,
+		http.StatusNotFound,
+	}
+	for _, status := range notRetriable {
+		if isRetriableDecklistStatus(status) {
+			t.Fatalf("expected status %d to not be retriable", status)
+		}
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	t.Run("empty returns zero", func(t *testing.T) {
+		if d := parseRetryAfter(""); d != 0 {
+			t.Fatalf("expected 0, got %s", d)
+		}
+	})
+
+	t.Run("parses seconds", func(t *testing.T) {
+		if d := parseRetryAfter("2"); d != 2*time.Second {
+			t.Fatalf("expected 2s, got %s", d)
+		}
+	})
+
+	t.Run("non-positive seconds returns zero", func(t *testing.T) {
+		if d := parseRetryAfter("0"); d != 0 {
+			t.Fatalf("expected 0, got %s", d)
+		}
+	})
+
+	t.Run("caps large seconds at max", func(t *testing.T) {
+		if d := parseRetryAfter("3600"); d != binderposDecklistRetryMaxDelay {
+			t.Fatalf("expected cap %s, got %s", binderposDecklistRetryMaxDelay, d)
+		}
+	})
+
+	t.Run("parses http date in the future", func(t *testing.T) {
+		when := time.Now().Add(1 * time.Second).UTC().Format(http.TimeFormat)
+		d := parseRetryAfter(when)
+		if d <= 0 || d > binderposDecklistRetryMaxDelay {
+			t.Fatalf("expected positive capped delay, got %s", d)
+		}
+	})
+
+	t.Run("past http date returns zero", func(t *testing.T) {
+		when := time.Now().Add(-1 * time.Hour).UTC().Format(http.TimeFormat)
+		if d := parseRetryAfter(when); d != 0 {
+			t.Fatalf("expected 0 for past date, got %s", d)
+		}
+	})
+
+	t.Run("garbage returns zero", func(t *testing.T) {
+		if d := parseRetryAfter("soon"); d != 0 {
+			t.Fatalf("expected 0 for unparseable value, got %s", d)
+		}
+	})
+}
+
+func TestDecklistBackoffDelayIsBoundedAndGrows(t *testing.T) {
+	for attempt := 0; attempt < 6; attempt++ {
+		d := decklistBackoffDelay(attempt)
+		if d <= 0 {
+			t.Fatalf("attempt %d: expected positive delay, got %s", attempt, d)
+		}
+		if d > binderposDecklistRetryMaxDelay {
+			t.Fatalf("attempt %d: expected delay <= %s, got %s", attempt, binderposDecklistRetryMaxDelay, d)
+		}
+	}
+
+	// Equal jitter guarantees a minimum that grows with the attempt until capped.
+	if min0 := binderposDecklistRetryBaseDelay / 2; decklistBackoffDelay(0) < min0 {
+		t.Fatalf("attempt 0 below equal-jitter floor %s", min0)
+	}
+}
+
+func TestDoDecklistRequestWithRetry_SucceedsAfterTransient503(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if calls.Add(1) <= 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), binderposAttemptTimeout)
+	defer cancel()
+
+	res, err := doDecklistRequestWithRetry(ctx, server.Client(), newDecklistTestRequest(t, server.URL))
+	if err != nil {
+		t.Fatalf("expected success after retries, got %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", res.StatusCode)
+	}
+	if got := calls.Load(); got != 3 {
+		t.Fatalf("expected 3 calls (2 failures + success), got %d", got)
+	}
+}
+
+func TestDoDecklistRequestWithRetry_ExhaustsRetriesOnPersistent503(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("rate limited"))
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), binderposAttemptTimeout)
+	defer cancel()
+
+	res, err := doDecklistRequestWithRetry(ctx, server.Client(), newDecklistTestRequest(t, server.URL))
+	if err == nil {
+		if res != nil {
+			res.Body.Close()
+		}
+		t.Fatal("expected error after exhausting retries")
+	}
+	if !strings.Contains(err.Error(), "status=503") {
+		t.Fatalf("expected status=503 in error, got %v", err)
+	}
+	if got := calls.Load(); got != int32(binderposDecklistMaxAttempts) {
+		t.Fatalf("expected %d calls, got %d", binderposDecklistMaxAttempts, got)
+	}
+}
+
+func TestDoDecklistRequestWithRetry_DoesNotRetryNonRetriableStatus(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), binderposAttemptTimeout)
+	defer cancel()
+
+	_, err := doDecklistRequestWithRetry(ctx, server.Client(), newDecklistTestRequest(t, server.URL))
+	if err == nil {
+		t.Fatal("expected error for 404 response")
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 call for non-retriable status, got %d", got)
+	}
+}
+
+func TestDoDecklistRequestWithRetry_StopsWhenContextCancelled(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	// Budget smaller than the first backoff so the retry wait is refused.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	_, err := doDecklistRequestWithRetry(ctx, server.Client(), newDecklistTestRequest(t, server.URL))
+	if err == nil {
+		t.Fatal("expected error when context budget is exhausted")
+	}
+	// A budget smaller than the first backoff must prevent the retry loop from
+	// running the full attempt count. The exact count (0 or 1) depends on shared
+	// per-host pacing, so only assert it stopped well short of exhaustion.
+	if got := calls.Load(); got >= int32(binderposDecklistMaxAttempts) {
+		t.Fatalf("expected fewer than %d calls on tight budget, got %d", binderposDecklistMaxAttempts, got)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

BinderPOS searches frequently hit `503` (and `429`) rate limiting. All ~10 BinderPOS-backed stores funnel their primary lookup into a single shared host, `portal.binderpos.com` (the `/external/shopify/decklist` API). Previously this request had **no HTTP-level retry or backoff**: a transient `503` immediately failed the attempt and fell through to heavier, more expensive strategies (direct → scrape → dynamic), and nothing honored the upstream `Retry-After` header.

Rotating IPs via dynamic proxies alone doesn't fix this because (a) the primary attempt uses the small dedicated proxy pool, and (b) the server also applies short-lived global/transient throttling that a brief, well-behaved backoff lets clear.

## What this changes

Adds a focused retry layer to the decklist request that is the canonical mitigation for upstream rate limiting, while keeping search results real-time:

- **Bounded retry (3 sends max)** on transient statuses (`429`, `500`, `502`, `503`, `504`) and network errors, all within the existing 10s per-attempt timeout budget.
- **Honors `Retry-After`** (both seconds and HTTP-date forms), capped so a hostile/huge value can't stall the attempt.
- **Equal-jitter exponential backoff** between sends, which desynchronizes concurrent callers retrying against the same host (avoids thundering-herd re-bursts).
- **Fresh `User-Agent` per send** (request is rebuilt each retry), which also helps against naive fingerprint-based throttling. On the dynamic-proxy fallback attempt, each retry naturally egresses from a fresh rotating IP.
- Respects the request context: it won't sleep past the deadline and stops promptly on cancellation.

The existing protections (portal concurrency gate of 4, 200ms per-domain pacing on `portal.binderpos.com`, and the cost-conscious dedicated → direct → scrape → dynamic fallback ordering) are unchanged. The portal slot is held across retries so a struggling upstream naturally sees less concurrent load.

## Why not other approaches

The fallback chain intentionally reserves dynamic (rotating-IP) proxies for last due to cost, so the ordering was left as-is. This change is deliberately small and isolated to the decklist path, in line with the repo's "favor small, testable changes" guidance, and it does not alter any card data (security/correctness/data-integrity unaffected).

## Files

- `api/gateway/binderpos/storefront.go` — retry tuning constants.
- `api/gateway/binderpos/storefront_decklist_retry.go` — new retry helper (`doDecklistRequestWithRetry`, `parseRetryAfter`, backoff, retriable-status set).
- `api/gateway/binderpos/storefront_decklist.go` — wire the request through the retry helper via a per-send request factory.
- `api/gateway/binderpos/storefront_decklist_retry_test.go` — unit tests.

## Testing

- `go test ./gateway/binderpos/... ./controller/...` — pass.
- New tests cover: retriable status classification, `Retry-After` parsing (seconds/date/garbage/cap), bounded+growing backoff, success-after-transient-503, retry exhaustion on persistent 503, no-retry on non-retriable status, and early stop on a tight context budget.
- Full `./gateway/...` suite: the only failures are `cardboardcrackgames` (retired store) and `cardscentral` (live quality-mapping data drift) which also fail on `master` and are unrelated to this change.

## Further mitigation ideas (not in this PR)

If 503s persist, consider: short-TTL in-memory caching or in-flight request coalescing (singleflight) keyed by store+query to collapse duplicate concurrent lookups; preferring the rotating-IP dynamic proxy earlier in the chain specifically for the shared portal host; or jittering the per-domain pacing interval.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9664b91-557c-430d-b019-5207bd7e1263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9664b91-557c-430d-b019-5207bd7e1263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

