### PR TITLE
Update Cards Citadel address to North Bridge Road

### DIFF
--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -59,9 +59,9 @@ export const LGS_MAP = [
   {
     id: "cards-citadel-map",
     name: "Cards Citadel",
-    address: "464 Crawford Ln, #02-01, Singapore 190464",
+    address: "Blk 10 North Bridge Road, #02-5117, Singapore 190010",
     iframe:
-      "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3988.783678524258!2d103.85966947451631!3d1.3048646617197366!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x31da190c9e183751%3A0xa2119a95d1e683f2!2sCards%20Citadel!5e0!3m2!1sen!2ssg!4v1702820792196!5m2!1sen!2ssg",
+      "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3988.783678524258!2d103.863559!3d1.305557!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x31da190c9e183751%3A0xa2119a95d1e683f2!2sCards%20Citadel!5e0!3m2!1sen!2ssg!4v1782086400000!5m2!1sen!2ssg",
     website: "https://cardscitadel.com/",
   },
   {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cards Citadel has relocated from Crawford Lane to **Blk 10 North Bridge Road, #02-5117, Singapore 190010**. This updates the LGS map entry to match the current Google Maps listing.

## Changes

- Updated `address` in `frontend/src/constants.js` for Cards Citadel
- Updated the Google Maps embed iframe coordinates to the new North Bridge Road location (resolved from [Google Maps](https://maps.app.goo.gl/7PHtXqqmkkjoeD6B6))

## Testing

- Verified the new embed URL returns HTTP 200
- `make test` — unrelated live scraper failures in `cardboardcrackgames` and `cardscentral` (pre-existing, not caused by this change)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5dc0ecb-e001-4018-9d11-feaa420dd35b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5dc0ecb-e001-4018-9d11-feaa420dd35b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

