### PR TITLE
binderpos: split first-attempt routing 50/50 to ease shared-host rate limiting

### DIFF
--- a/api/gateway/binderpos/storefront.go
+++ b/api/gateway/binderpos/storefront.go
@@ -1,7 +1,6 @@
 package binderpos
 
 import (
-	"math/rand/v2"
 	"time"
 )
 
@@ -9,7 +8,6 @@ const (
 	storefrontSuggestPath   = "/search/suggest.json"
 	binderposDecklistAPIURL = "https://portal.binderpos.com/external/shopify/decklist"
 	binderposDecklistType   = "mtg"
-	binderposDecklistPct    = 100
 	binderposAttemptTimeout = 10 * time.Second
 
 	// binderposDecklistMaxAttempts bounds how many times a single decklist call
@@ -26,8 +24,16 @@ const (
 	binderposDecklistRetryMaxDelay = 2500 * time.Millisecond
 )
 
+// shouldUseDecklistEndpoint decides whether one first-attempt storefront lookup
+// is routed through the shared BinderPOS decklist portal or the per-store
+// product-details path. It alternates deterministically (round-robin) so that,
+// across all selected stores in a single search, half of the first attempts hit
+// the shared portal host and half hit their own Shopify domains. Splitting the
+// load this way halves the concurrent burst on portal.binderpos.com, the host
+// most prone to 429/503 rate limiting because every BinderPOS store would
+// otherwise funnel into it at once.
 var shouldUseDecklistEndpoint = func() bool {
-	return useDecklistForRoll(rand.IntN(100))
+	return useDecklistForRoute(binderposDecklistRouteSeq.Add(1) - 1)
 }
 
 type storefrontSuggestResponse struct {

--- a/api/gateway/binderpos/storefront_client.go
+++ b/api/gateway/binderpos/storefront_client.go
@@ -16,6 +16,12 @@ import (
 // non-leased dedicated routing, so traffic round-robins across configured dedicated proxies.
 var binderposDedicatedProxySeq atomic.Uint32
 
+// binderposDecklistRouteSeq advances once per first-attempt storefront routing
+// decision so that decklist vs. product-details selection round-robins evenly
+// across the stores in a search instead of every store converging on the shared
+// portal host.
+var binderposDecklistRouteSeq atomic.Uint32
+
 // nextBinderposStorefrontProxyURL returns the next dedicated proxy URL in round-robin order.
 func nextBinderposStorefrontProxyURL(proxyURLs []string) string {
 	n := len(proxyURLs)
@@ -77,8 +83,11 @@ func searchByStorefrontAPIWithClient(ctx context.Context, client *http.Client, s
 	return searchByStorefrontProductDetailsAPI(ctx, client, scrapVariant, storeName, baseURL, searchStr)
 }
 
-func useDecklistForRoll(roll int) bool {
-	return roll < binderposDecklistPct
+// useDecklistForRoute returns true for even sequence numbers, yielding a 50/50
+// split between the shared decklist portal and the per-store product-details
+// path across consecutive routing decisions.
+func useDecklistForRoute(seq uint32) bool {
+	return seq%2 == 0
 }
 
 func newHTTPClientWithProxyURL(proxyURL string) (*http.Client, error) {

--- a/api/gateway/binderpos/storefront_routing_test.go
+++ b/api/gateway/binderpos/storefront_routing_test.go
@@ -8,25 +8,47 @@ import (
 	"testing"
 )
 
-func TestUseDecklistForRoll(t *testing.T) {
+func TestUseDecklistForRoute(t *testing.T) {
 	tests := []struct {
 		name string
-		roll int
+		seq  uint32
 		want bool
 	}{
-		{name: "0 routes to decklist", roll: 0, want: true},
-		{name: "50 routes to decklist", roll: 50, want: true},
-		{name: "99 routes to decklist", roll: 99, want: true},
-		{name: "100 routes to product details fallback", roll: 100, want: false},
+		{name: "even seq 0 routes to decklist", seq: 0, want: true},
+		{name: "odd seq 1 routes to product details", seq: 1, want: false},
+		{name: "even seq 2 routes to decklist", seq: 2, want: true},
+		{name: "odd seq 3 routes to product details", seq: 3, want: false},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := useDecklistForRoll(test.roll)
+			got := useDecklistForRoute(test.seq)
 			if got != test.want {
-				t.Fatalf("expected useDecklistForRoll(%d)=%t, got %t", test.roll, test.want, got)
+				t.Fatalf("expected useDecklistForRoute(%d)=%t, got %t", test.seq, test.want, got)
 			}
 		})
+	}
+}
+
+// TestShouldUseDecklistEndpoint_SplitsConsecutiveCallsEvenly verifies that the
+// round-robin selector hands half of the first attempts to the decklist portal
+// and half to the per-store product-details path, which is what reduces the
+// concurrent load on the shared portal host.
+func TestShouldUseDecklistEndpoint_SplitsConsecutiveCallsEvenly(t *testing.T) {
+	previousSeq := binderposDecklistRouteSeq.Load()
+	binderposDecklistRouteSeq.Store(0)
+	t.Cleanup(func() { binderposDecklistRouteSeq.Store(previousSeq) })
+
+	const calls = 10
+	decklistCount := 0
+	for i := 0; i < calls; i++ {
+		if shouldUseDecklistEndpoint() {
+			decklistCount++
+		}
+	}
+
+	if decklistCount != calls/2 {
+		t.Fatalf("expected %d of %d first attempts routed to decklist, got %d", calls/2, calls, decklistCount)
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Previously, on the first attempt for every selected BinderPOS store, `binderposDecklistPct = 100` forced **all** stores through the decklist API. That endpoint (`portal.binderpos.com`) is a single shared host that every BinderPOS-backed store funnels into, so a single search produced a concurrent burst against that one host — the prime trigger for 429/503 rate limiting.

This change splits the first attempt **50/50**:
- Half of the stores' first attempts go through the **decklist API** (shared `portal.binderpos.com`).
- The other half go through the **product-details path** (`/search/suggest.json` + `/products/*.js`), which hits each store's **own Shopify domain**, not the shared portal.

The split is deterministic via a round-robin atomic counter (`binderposDecklistRouteSeq`) rather than a random percentage, guaranteeing an even split across the stores in a search instead of relying on chance.

## Why this helps with rate limiting

The decklist portal is the bottleneck because all stores converge on it. There is already a dedicated concurrency gate (`binderposPortalMaxConcurrent`) and always-on pacing for that host precisely because it is shared. By routing only half of first attempts to the portal and sending the other half to per-store Shopify domains, the concurrent request volume against `portal.binderpos.com` is roughly halved while the rest is spread across many independent per-store hosts that are far less likely to throttle. This should meaningfully reduce 429/503 responses from the shared portal.

Note: the product-details path is already validated to work for all BinderPOS stores (see `Test_SearchByStorefrontAPI_SupportsAllBinderposStores`), and the fallback chain is unchanged, so any store whose chosen first path fails still falls back through the existing direct/dynamic/scrap attempts.

## Changes

- `storefront.go`: removed `binderposDecklistPct`; `shouldUseDecklistEndpoint` now alternates deterministically via `useDecklistForRoute(binderposDecklistRouteSeq.Add(1)-1)`.
- `storefront_client.go`: added `binderposDecklistRouteSeq` round-robin counter and `useDecklistForRoute` (even seq -> decklist, odd seq -> product details); removed the now-unused `useDecklistForRoll`.
- `storefront_routing_test.go`: replaced `TestUseDecklistForRoll` with `TestUseDecklistForRoute` and added `TestShouldUseDecklistEndpoint_SplitsConsecutiveCallsEvenly` verifying the even split.

## Testing

- `go build -mod=vendor ./gateway/binderpos/`
- `go vet -mod=vendor ./gateway/binderpos/`
- `go test -mod=vendor ./gateway/binderpos/` (non-live tests pass)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd439c87-a3bc-421d-aabc-61d8deda1ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd439c87-a3bc-421d-aabc-61d8deda1ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

