### PR TITLE
feat(gateway): add Fyendal Hobby store gateway

### DIFF
--- a/api/controller/search.go
+++ b/api/controller/search.go
@@ -19,6 +19,7 @@ import (
 	"mtg-price-checker-sg/gateway/duellerpoint"
 	"mtg-price-checker-sg/gateway/fivemana"
 	"mtg-price-checker-sg/gateway/flagship"
+	"mtg-price-checker-sg/gateway/fyendalhobby"
 	"mtg-price-checker-sg/gateway/gameshaven"
 	"mtg-price-checker-sg/gateway/gog"
 	"mtg-price-checker-sg/gateway/hideout"
@@ -79,6 +80,7 @@ var shopRegistry = []shopSpec{
 	{name: duellerpoint.StoreName, newLGS: duellerpoint.NewLGS},
 	{name: fivemana.StoreName, newLGS: fivemana.NewLGS},
 	{name: flagship.StoreName, newLGS: flagship.NewLGS, isBinderpos: true},
+	{name: fyendalhobby.StoreName, newLGS: fyendalhobby.NewLGS},
 	{name: gameshaven.StoreName, newLGS: gameshaven.NewLGS, isBinderpos: true},
 	{name: gog.StoreName, newLGS: gog.NewLGS, isBinderpos: true},
 	{name: hideout.StoreName, newLGS: hideout.NewLGS, isBinderpos: true},

--- a/api/gateway/fyendalhobby/search.go
+++ b/api/gateway/fyendalhobby/search.go
@@ -1,0 +1,247 @@
+package fyendalhobby
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"mtg-price-checker-sg/gateway"
+	"mtg-price-checker-sg/gateway/util"
+	"mtg-price-checker-sg/pkg/config"
+)
+
+const StoreName = "Fyendal Hobby"
+const StoreBaseURL = "https://fyendalhobby.com"
+const StoreSearchPath = "/search/suggest.json"
+
+// predictiveSearchLimit is the maximum number of products Shopify's predictive
+// search endpoint will return per request (the platform caps this at 10).
+const predictiveSearchLimit = "10"
+
+// foilTitlePrefix is the prefix Fyendal Hobby uses on foil single listings, e.g.
+// "[Foil] Cauldron of Essence". The non-foil counterpart has no prefix.
+const foilTitlePrefix = "[foil]"
+
+type Store struct {
+	Name       string
+	BaseUrl    string
+	SearchPath string
+}
+
+func NewLGS() gateway.LGS {
+	return Store{
+		Name:       StoreName,
+		BaseUrl:    StoreBaseURL,
+		SearchPath: StoreSearchPath,
+	}
+}
+
+type suggestResponse struct {
+	Resources struct {
+		Results struct {
+			Products []suggestProduct `json:"products"`
+		} `json:"results"`
+	} `json:"resources"`
+}
+
+type suggestProduct struct {
+	Title         string   `json:"title"`
+	Handle        string   `json:"handle"`
+	URL           string   `json:"url"`
+	Price         string   `json:"price"`
+	Available     bool     `json:"available"`
+	Image         string   `json:"image"`
+	ProductType   string   `json:"type"`
+	Vendor        string   `json:"vendor"`
+	Tags          []string `json:"tags"`
+	FeaturedImage struct {
+		URL string `json:"url"`
+	} `json:"featured_image"`
+}
+
+func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
+	var cards []gateway.Card
+
+	apiURL := &url.URL{
+		Scheme: "https",
+		Host:   "fyendalhobby.com",
+		Path:   s.SearchPath,
+		RawQuery: url.Values{
+			"q":                {searchStr},
+			"resources[type]":  {"product"},
+			"resources[limit]": {predictiveSearchLimit},
+		}.Encode(),
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL.String(), nil)
+	if err != nil {
+		return cards, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", gateway.RandomBrowserUserAgent())
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return cards, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return cards, err
+	}
+
+	var res suggestResponse
+	if err := json.Unmarshal(body, &res); err != nil {
+		return cards, err
+	}
+
+	for _, product := range res.Resources.Results.Products {
+		if !product.Available {
+			continue
+		}
+		if !isMagicProduct(product.ProductType, product.Vendor, product.Tags) {
+			continue
+		}
+
+		price, err := util.ParsePrice(product.Price)
+		if err != nil {
+			log.Printf("error parsing price for %s with value [%s]: %v", s.Name, product.Price, err)
+			continue
+		}
+		if price <= 0 {
+			continue
+		}
+
+		name, isFoil := parseNameAndFoil(product.Title)
+
+		cleanPageURL, err := s.buildProductURL(product.Handle, product.URL)
+		if err != nil {
+			log.Printf("error parsing url for %s with handle [%s]: %v", s.Name, product.Handle, err)
+			continue
+		}
+
+		var extraInfo []string
+		if set := setFromTags(product.Tags); set != "" {
+			extraInfo = append(extraInfo, fmt.Sprintf("[%s]", set))
+		}
+
+		cards = append(cards, gateway.Card{
+			Name:      name,
+			Url:       cleanPageURL,
+			InStock:   true,
+			IsFoil:    isFoil,
+			Price:     price,
+			Source:    s.Name,
+			Img:       resolveImage(product),
+			ExtraInfo: extraInfo,
+		})
+	}
+
+	return cards, nil
+}
+
+// buildProductURL builds a clean product URL from the product handle, attaching
+// the UTM source. It falls back to the suggest-provided relative URL when a
+// handle is unavailable.
+func (s Store) buildProductURL(handle, suggestURL string) (string, error) {
+	path := strings.TrimSpace(suggestURL)
+	if handle != "" {
+		path = "/products/" + handle
+	}
+
+	cleanPageURL, err := url.Parse(strings.TrimSpace(s.BaseUrl + path))
+	if err != nil {
+		return "", err
+	}
+	cleanPageURL.RawQuery = url.Values{
+		"utm_source": []string{config.UtmSource},
+	}.Encode()
+
+	return cleanPageURL.String(), nil
+}
+
+func resolveImage(product suggestProduct) string {
+	if img := strings.TrimSpace(product.Image); img != "" {
+		return img
+	}
+	return strings.TrimSpace(product.FeaturedImage.URL)
+}
+
+// isMagicProduct reports whether a storefront product belongs to Magic: The
+// Gathering. Fyendal Hobby stocks multiple TCGs (Flesh and Blood, Grand Archive,
+// etc.), so non-MTG products must be filtered out.
+func isMagicProduct(productType, vendor string, tags []string) bool {
+	pt := strings.ToLower(productType)
+	if strings.Contains(pt, "mtg") || strings.Contains(pt, "magic the gathering") {
+		return true
+	}
+	if strings.Contains(strings.ToLower(vendor), "magic the gathering") {
+		return true
+	}
+	for _, tag := range tags {
+		if strings.EqualFold(strings.TrimSpace(tag), "MTG") {
+			return true
+		}
+	}
+	return false
+}
+
+// parseNameAndFoil strips the "[Foil]" listing prefix from a product title and
+// reports whether the listing is foil.
+func parseNameAndFoil(title string) (string, bool) {
+	trimmed := strings.TrimSpace(title)
+	if strings.HasPrefix(strings.ToLower(trimmed), foilTitlePrefix) {
+		return strings.TrimSpace(trimmed[len(foilTitlePrefix):]), true
+	}
+	return trimmed, false
+}
+
+// nonSetTags are tags that describe rarity, status, or category rather than the
+// card's set. They are excluded when inferring a card's set from its tags.
+var nonSetTags = map[string]struct{}{
+	"mtg":         {},
+	"new arrival": {},
+	"promo":       {},
+	"common":      {},
+	"uncommon":    {},
+	"uncommond":   {},
+	"rare":        {},
+	"mythic":      {},
+	"mythic rare": {},
+	"special":     {},
+	"land":        {},
+	"basic land":  {},
+	"foil":        {},
+	"preorder":    {},
+	"pre-order":   {},
+	"restock":     {},
+}
+
+// setFromTags infers the card's set name from its tags. To preserve data
+// integrity it only returns a set when exactly one candidate tag remains after
+// removing rarity/status tags; otherwise it returns an empty string rather than
+// risk emitting an incorrect set.
+func setFromTags(tags []string) string {
+	var candidates []string
+	for _, tag := range tags {
+		trimmed := strings.TrimSpace(tag)
+		if trimmed == "" {
+			continue
+		}
+		if _, skip := nonSetTags[strings.ToLower(trimmed)]; skip {
+			continue
+		}
+		candidates = append(candidates, trimmed)
+	}
+
+	if len(candidates) == 1 {
+		return candidates[0]
+	}
+	return ""
+}

--- a/api/gateway/fyendalhobby/search.go
+++ b/api/gateway/fyendalhobby/search.go
@@ -23,6 +23,13 @@ const StoreSearchPath = "/search/suggest.json"
 // search endpoint will return per request (the platform caps this at 10).
 const predictiveSearchLimit = "10"
 
+// mtgSingleProductType scopes the predictive search to Magic: The Gathering
+// single cards. Fyendal Hobby stocks several TCGs (Flesh and Blood, Grand
+// Archive, etc.), so the search query is filtered with
+// product_type:"MTG Single Cards" to keep results MTG-only and prevent the
+// 10-result predictive limit from being consumed by non-MTG products.
+const mtgSingleProductType = "MTG Single Cards"
+
 // foilTitlePrefix is the prefix Fyendal Hobby uses on foil single listings, e.g.
 // "[Foil] Cauldron of Essence". The non-foil counterpart has no prefix.
 const foilTitlePrefix = "[foil]"
@@ -67,12 +74,14 @@ type suggestProduct struct {
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
 	var cards []gateway.Card
 
+	searchQuery := fmt.Sprintf("product_type:%q AND %s", mtgSingleProductType, searchStr)
+
 	apiURL := &url.URL{
 		Scheme: "https",
 		Host:   "fyendalhobby.com",
 		Path:   s.SearchPath,
 		RawQuery: url.Values{
-			"q":                {searchStr},
+			"q":                {searchQuery},
 			"resources[type]":  {"product"},
 			"resources[limit]": {predictiveSearchLimit},
 		}.Encode(),
@@ -174,8 +183,9 @@ func resolveImage(product suggestProduct) string {
 }
 
 // isMagicProduct reports whether a storefront product belongs to Magic: The
-// Gathering. Fyendal Hobby stocks multiple TCGs (Flesh and Blood, Grand Archive,
-// etc.), so non-MTG products must be filtered out.
+// Gathering. The search query already scopes results to MTG single cards
+// server-side; this acts as a defensive secondary guard so non-MTG products are
+// never surfaced even if the upstream filter behaviour changes.
 func isMagicProduct(productType, vendor string, tags []string) bool {
 	pt := strings.ToLower(productType)
 	if strings.Contains(pt, "mtg") || strings.Contains(pt, "magic the gathering") {

--- a/api/gateway/fyendalhobby/search_test.go
+++ b/api/gateway/fyendalhobby/search_test.go
@@ -1,0 +1,60 @@
+package fyendalhobby
+
+import (
+	"context"
+	"testing"
+
+	"github.com/joho/godotenv"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	_ = godotenv.Load("../../.env")
+}
+
+func Test_Search(t *testing.T) {
+	s := NewLGS()
+	result, err := s.Search(context.Background(), "Cauldron of Essence")
+	require.NoError(t, err)
+	require.True(t, len(result) > 0)
+
+	for _, card := range result {
+		if card.InStock {
+			require.NotEmpty(t, card.Name)
+			require.NotEmpty(t, card.Source)
+			require.NotEmpty(t, card.Url)
+			require.NotEmpty(t, card.Img)
+			require.NotEmpty(t, card.Price)
+			require.Contains(t, card.Url, StoreBaseURL+"/products/")
+		}
+	}
+}
+
+func TestParseNameAndFoil(t *testing.T) {
+	name, isFoil := parseNameAndFoil("[Foil] Cauldron of Essence")
+	require.Equal(t, "Cauldron of Essence", name)
+	require.True(t, isFoil)
+
+	name, isFoil = parseNameAndFoil("Cauldron of Essence")
+	require.Equal(t, "Cauldron of Essence", name)
+	require.False(t, isFoil)
+}
+
+func TestIsMagicProduct(t *testing.T) {
+	require.True(t, isMagicProduct("MTG Single Cards", "Magic the Gathering", []string{"MTG"}))
+	require.True(t, isMagicProduct("Magic the Gathering Booster Box", "Magic the Gathering Sealed Products", nil))
+	require.True(t, isMagicProduct("", "", []string{"New Arrival", "MTG"}))
+	require.False(t, isMagicProduct("Flesh And Blood Single Cards", "Flesh and Blood", []string{"Common"}))
+	require.False(t, isMagicProduct("Grand Archive Single Cards", "Grand Archive", nil))
+}
+
+func TestSetFromTags(t *testing.T) {
+	require.Equal(t, "Foundations", setFromTags([]string{"Foundations", "MTG", "New Arrival", "Rare"}))
+	require.Equal(t, "Dominaria United Commander", setFromTags([]string{"Dominaria United Commander", "MTG", "Mythic", "New Arrival"}))
+
+	// Ambiguous (more than one candidate) returns empty to protect data integrity.
+	require.Equal(t, "", setFromTags([]string{"Mystical Archive", "Secrets of Strixhaven", "MTG", "Rare"}))
+
+	// No candidate set tag.
+	require.Equal(t, "", setFromTags([]string{"MTG", "New Arrival", "Rare"}))
+}

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -12,6 +12,7 @@ export const LGS_OPTIONS = [
   "Cards Citadel",
   "Dueller's Point",
   "Flagship Games",
+  "Fyendal Hobby",
   "Games Haven",
   "Grey Ogre Games",
   "Hideout",

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -82,6 +82,14 @@ export const LGS_MAP = [
     website: "https://www.flagshipgames.sg/",
   },
   {
+    id: "fyendal-hobby-map",
+    name: "Fyendal Hobby",
+    address: "86 Marine Parade Central, #04-305, Singapore 440086",
+    iframe:
+      "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3988.79!2d103.9067387!3d1.3017381!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x31da19a72dacf6d1%3A0x5ff49c2fc4a11159!2sFyendal%20Hobby!5e0!3m2!1sen!2ssg!4v1782000000000!5m2!1sen!2ssg",
+    website: "https://fyendalhobby.com/",
+  },
+  {
     id: "games-haven-pl-map",
     name: "Games Haven - Paya Lebar",
     address: "736 Geylang Rd, Singapore 389647",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements a new gateway for [Fyendal Hobby](https://fyendalhobby.com/collections/magic-the-gathering) and wires it into the search registry, the frontend store selector, and the store map.

Fyendal Hobby is a Shopify storefront (`fyendal-hobby.myshopify.com`) that stocks several TCGs (Magic, Flesh and Blood, Grand Archive, etc.). It is **not** a BinderPOS-powered store, so the gateway queries Shopify's native predictive search and scopes results to Magic: The Gathering single cards.

## Approach

- **Data source:** Shopify predictive search (`/search/suggest.json`), which ranks on product title/handle and gives far better precision than the standard search endpoint (which also matches card body text — e.g. "Sword" returned 686 body-text matches there).
- **Server-side MTG scoping:** The query is built as `product_type:"MTG Single Cards" AND <name>`, so Shopify returns only MTG single cards. This keeps results MTG-only at the source, prevents the 10-result predictive limit from being consumed by the store's other TCGs, and excludes sealed products. A client-side type/vendor/tag check (`isMagicProduct`) is retained as a defensive secondary guard.
- **Finish detection:** Foil singles are listed with a `[Foil]` title prefix and a `Foil` variant; the gateway strips the prefix for a clean card name and sets `IsFoil`.
- **Set inference (data-integrity-first):** The set is inferred from product tags only when exactly one candidate tag remains after removing rarity/status tags. When ambiguous (e.g. `Mystical Archive` + `Secrets of Strixhaven`), no set is emitted rather than risk an incorrect value.
- **Availability/price:** Uses the listing's `available` flag and variant price; only in-stock, positively-priced cards are returned.

## Changes

- `api/gateway/fyendalhobby/search.go` — new gateway implementation.
- `api/gateway/fyendalhobby/search_test.go` — live search test plus unit tests for foil parsing, MTG filtering, and set inference.
- `api/controller/search.go` — register `Fyendal Hobby` in the shop registry (non-BinderPOS).
- `frontend/src/constants.js` — add `Fyendal Hobby` to the selectable store list (`LGS_OPTIONS`) and to the store map (`LGS_MAP`) with its address and Google Maps embed.

## Validation

- `go build -mod=vendor ./...` and `go vet` pass.
- `go test -mod=vendor ./gateway/fyendalhobby/...` and `./controller/...` pass.
- `npx biome check src/constants.js` is clean (a pre-existing formatting warning in `App.jsx` is unrelated to this change).

Example live output after MTG scoping (other TCGs and sealed correctly excluded):

```
QUERY: Anthem
  name="Anthem of Champions (Borderless Mana)" foil=true  price=13.00 extra=[[Foundations]]
QUERY: Cauldron of Essence
  name="Cauldron of Essence"                   foil=false price=8.00  extra=[[Secrets of Strixhaven]]
  name="Cauldron of Essence"                   foil=true  price=7.50  extra=[[Secrets of Strixhaven]]
QUERY: Marvel        # (sealed-only term) -> 0 results
```

## UI screenshots

### Store selector

Desktop:

![Desktop store selector with Fyendal Hobby](https://cursor.com/artifacts/c/art-4fce6b4a-2db7-490e-af71-c132803fc914)

Mobile:

![Mobile store selector with Fyendal Hobby](https://cursor.com/artifacts/c/art-6789bff1-cdcc-4024-b999-00eaca304f3a)

### Store map entry

Desktop:

![Desktop store map entry for Fyendal Hobby](https://cursor.com/artifacts/c/art-5de1ea7d-2164-415f-9b7a-04cfe219db01)

Mobile:

![Mobile store map entry for Fyendal Hobby](https://cursor.com/artifacts/c/art-8751d766-abf5-45f6-95a6-9b25f67341dd)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e5ac860-6948-4911-9718-c18e9be543f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e5ac860-6948-4911-9718-c18e9be543f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

