### PR TITLE
Add dedicated/dynamic proxy fallback to Shopify suggest search

### DIFF
--- a/api/gateway/shopifysuggest/proxy_fallback.go
+++ b/api/gateway/shopifysuggest/proxy_fallback.go
@@ -1,0 +1,144 @@
+package shopifysuggest
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sync/atomic"
+	"time"
+
+	"mtg-price-checker-sg/gateway"
+	"mtg-price-checker-sg/gateway/util"
+)
+
+// suggestAttemptTimeout bounds a single suggest endpoint attempt so a slow or
+// throttling upstream cannot stall the whole fallback chain.
+const suggestAttemptTimeout = 10 * time.Second
+
+// shopifySuggestDedicatedProxySeq advances once per dedicated-proxy suggest
+// attempt so traffic round-robins evenly across the configured dedicated
+// proxies instead of always hammering the first one.
+var shopifySuggestDedicatedProxySeq atomic.Uint32
+
+// searchAttempt pairs a human-readable strategy name (used for error
+// annotation) with the HTTP client that performs that attempt.
+type searchAttempt struct {
+	strategy string
+	client   *http.Client
+}
+
+// searchWithProxyFallback runs the suggest request through an ordered set of
+// transports, returning the first successful result. Each attempt only runs
+// when the previous one errors, so a healthy direct connection never incurs
+// proxy cost while a rate-limited endpoint still resolves via dedicated and
+// then dynamic proxies.
+func searchWithProxyFallback(ctx context.Context, cfg Config, apiURL string, mapProduct func(cfg Config, product Product) (gateway.Card, bool)) ([]gateway.Card, error) {
+	return runSearchAttempts(ctx, buildSearchAttempts(), cfg, apiURL, mapProduct)
+}
+
+// runSearchAttempts executes the ordered attempts, returning the first result
+// that succeeds (a nil error, even with zero cards). Each attempt's error is
+// annotated with its position and strategy name so the final error reflects the
+// last transport tried.
+func runSearchAttempts(ctx context.Context, attempts []searchAttempt, cfg Config, apiURL string, mapProduct func(cfg Config, product Product) (gateway.Card, bool)) ([]gateway.Card, error) {
+	var (
+		cards []gateway.Card
+		err   error
+	)
+	for idx, attempt := range attempts {
+		cards, err = fetchAndMapProducts(ctx, attempt.client, apiURL, cfg, mapProduct)
+		err = annotateSuggestAttemptError(idx+1, attempt.strategy, err)
+		if err == nil {
+			return cards, nil
+		}
+	}
+	return cards, err
+}
+
+// buildSearchAttempts builds the ordered fallback chain. The direct attempt is
+// always present; the dedicated and dynamic proxy attempts are appended only
+// when their respective proxies are configured.
+func buildSearchAttempts() []searchAttempt {
+	attempts := []searchAttempt{
+		{
+			strategy: "direct",
+			client:   &http.Client{Timeout: suggestAttemptTimeout},
+		},
+	}
+
+	if client, ok := dedicatedProxyClient(); ok {
+		attempts = append(attempts, searchAttempt{strategy: "dedicated", client: client})
+	}
+
+	if client, ok := dynamicProxyClient(); ok {
+		attempts = append(attempts, searchAttempt{strategy: "dynamic", client: client})
+	}
+
+	return attempts
+}
+
+// dedicatedProxyClient returns an HTTP client bound to the next dedicated proxy
+// in round-robin order, or ok=false when none are configured.
+func dedicatedProxyClient() (*http.Client, bool) {
+	proxyURLs := util.GetDedicatedProxyURLs()
+	if len(proxyURLs) == 0 {
+		return nil, false
+	}
+
+	client, err := newProxyClient(nextDedicatedProxyURL(proxyURLs))
+	if err != nil {
+		return nil, false
+	}
+	return client, true
+}
+
+// dynamicProxyClient returns an HTTP client bound to the shared dynamic proxy,
+// or ok=false when it is not configured.
+func dynamicProxyClient() (*http.Client, bool) {
+	proxyURL := gateway.DynamicProxyURL()
+	if proxyURL == "" {
+		return nil, false
+	}
+
+	client, err := newProxyClient(proxyURL)
+	if err != nil {
+		return nil, false
+	}
+	return client, true
+}
+
+// nextDedicatedProxyURL returns the next dedicated proxy URL in round-robin order.
+func nextDedicatedProxyURL(proxyURLs []string) string {
+	v := shopifySuggestDedicatedProxySeq.Add(1) - 1
+	return proxyURLs[int(v%uint32(len(proxyURLs)))]
+}
+
+func newProxyClient(proxyURL string) (*http.Client, error) {
+	parsedProxyURL, err := url.Parse(proxyURL)
+	if err != nil {
+		return nil, err
+	}
+
+	return &http.Client{
+		Timeout: suggestAttemptTimeout,
+		Transport: &http.Transport{
+			Proxy: http.ProxyURL(parsedProxyURL),
+		},
+	}, nil
+}
+
+func fetchAndMapProducts(ctx context.Context, client *http.Client, apiURL string, cfg Config, mapProduct func(cfg Config, product Product) (gateway.Card, bool)) ([]gateway.Card, error) {
+	products, err := fetchProducts(ctx, client, apiURL)
+	if err != nil {
+		return nil, err
+	}
+	return mapProducts(cfg, products, mapProduct), nil
+}
+
+func annotateSuggestAttemptError(attempt int, strategy string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("attempt %d (%s): %w", attempt, strategy, err)
+}

--- a/api/gateway/shopifysuggest/proxy_fallback_test.go
+++ b/api/gateway/shopifysuggest/proxy_fallback_test.go
@@ -1,0 +1,151 @@
+package shopifysuggest
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"mtg-price-checker-sg/gateway"
+)
+
+func mapAllProducts(cfg Config, product Product) (gateway.Card, bool) {
+	return gateway.Card{Name: product.Title, Source: cfg.StoreName, InStock: true}, true
+}
+
+const sampleSuggestBody = `{
+  "resources": {
+    "results": {
+      "products": [
+        {"title": "Opt", "available": true, "type": "MTG Single Cards", "price": "0.50"}
+      ]
+    }
+  }
+}`
+
+func TestFetchProductsRateLimited(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	_, err := fetchProducts(context.Background(), srv.Client(), srv.URL)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "429")
+}
+
+func TestFetchProductsSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(sampleSuggestBody))
+	}))
+	defer srv.Close()
+
+	products, err := fetchProducts(context.Background(), srv.Client(), srv.URL)
+	require.NoError(t, err)
+	require.Len(t, products, 1)
+	require.Equal(t, "Opt", products[0].Title)
+}
+
+// TestRunSearchAttemptsFallsBackOnRateLimit verifies that a rate-limited first
+// attempt falls through to the next transport, which succeeds. All attempts hit
+// the same endpoint (as they do in production), so the server returns 429 on
+// the first request and a valid body afterwards.
+func TestRunSearchAttemptsFallsBackOnRateLimit(t *testing.T) {
+	var hits atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if hits.Add(1) == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		_, _ = w.Write([]byte(sampleSuggestBody))
+	}))
+	defer srv.Close()
+
+	attempts := []searchAttempt{
+		{strategy: "direct", client: srv.Client()},
+		{strategy: "dedicated", client: srv.Client()},
+	}
+
+	cards, err := runSearchAttempts(context.Background(), attempts, Config{StoreName: "Test"}, srv.URL, mapAllProducts)
+	require.NoError(t, err)
+	require.Len(t, cards, 1)
+	require.Equal(t, int32(2), hits.Load(), "expected fallback to retry after the first 429")
+}
+
+// TestRunSearchAttemptsReturnsLastError verifies that when every transport
+// fails, the final (last attempt) error is surfaced.
+func TestRunSearchAttemptsReturnsLastError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	attempts := []searchAttempt{
+		{strategy: "direct", client: srv.Client()},
+		{strategy: "dedicated", client: srv.Client()},
+		{strategy: "dynamic", client: srv.Client()},
+	}
+
+	cards, err := runSearchAttempts(context.Background(), attempts, Config{StoreName: "Test"}, srv.URL, mapAllProducts)
+	require.Error(t, err)
+	require.Empty(t, cards)
+	require.Contains(t, err.Error(), "attempt 3 (dynamic)")
+}
+
+// TestRunSearchAttemptsStopsAtFirstSuccess verifies that a successful attempt
+// short-circuits the chain so later transports are never used.
+func TestRunSearchAttemptsStopsAtFirstSuccess(t *testing.T) {
+	var secondHits atomic.Int32
+
+	healthy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(sampleSuggestBody))
+	}))
+	defer healthy.Close()
+
+	shouldNotBeHit := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		secondHits.Add(1)
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer shouldNotBeHit.Close()
+
+	attempts := []searchAttempt{
+		{strategy: "direct", client: healthy.Client()},
+		{strategy: "dedicated", client: shouldNotBeHit.Client()},
+	}
+
+	cards, err := runSearchAttempts(context.Background(), attempts, Config{StoreName: "Test"}, healthy.URL, mapAllProducts)
+	require.NoError(t, err)
+	require.Len(t, cards, 1)
+	require.Zero(t, secondHits.Load(), "second transport should not be tried after first success")
+}
+
+func TestBuildSearchAttemptsProxyConfiguration(t *testing.T) {
+	t.Setenv("DEDICATED_PROXY_1", "")
+	t.Setenv("DEDICATED_PROXY_2", "")
+	t.Setenv("DEDICATED_PROXY_3", "")
+	t.Setenv("DEDICATED_PROXY_4", "")
+	t.Setenv("DEDICATED_PROXY_5", "")
+	t.Setenv("DEDICATED_PROXY_6", "")
+	t.Setenv("DEDICATED_PROXY_7", "")
+	t.Setenv("DYNAMIC_PROXY", "")
+
+	attempts := buildSearchAttempts()
+	require.Len(t, attempts, 1)
+	require.Equal(t, "direct", attempts[0].strategy)
+
+	t.Setenv("DEDICATED_PROXY_1", "1.2.3.4|8080|user|pass")
+	attempts = buildSearchAttempts()
+	require.Len(t, attempts, 2)
+	require.Equal(t, "direct", attempts[0].strategy)
+	require.Equal(t, "dedicated", attempts[1].strategy)
+
+	t.Setenv("DYNAMIC_PROXY", "http://5.6.7.8:9090")
+	attempts = buildSearchAttempts()
+	require.Len(t, attempts, 3)
+	require.Equal(t, "dynamic", attempts[2].strategy)
+}

--- a/api/gateway/shopifysuggest/search.go
+++ b/api/gateway/shopifysuggest/search.go
@@ -64,11 +64,33 @@ type suggestResponse struct {
 
 // Search queries a Shopify storefront's predictive search endpoint and maps
 // products into cards using the supplied options.
+//
+// Shopify's predictive search endpoint can rate limit (HTTP 429) or otherwise
+// throttle direct traffic, so the request is attempted through an ordered
+// fallback chain: a direct connection first, then a dedicated proxy, and
+// finally the shared dynamic proxy. The first attempt that succeeds wins;
+// later attempts only run when the previous one errors (network failure,
+// non-200 status such as 429, or an unparsable body).
 func Search(ctx context.Context, opts Options) ([]gateway.Card, error) {
-	cfg := opts.Config
-	host, err := hostFromBaseURL(cfg.BaseURL)
+	mapProduct := opts.MapProduct
+	if mapProduct == nil {
+		return nil, fmt.Errorf("shopifysuggest: MapProduct is required")
+	}
+
+	apiURL, err := buildSuggestURL(opts)
 	if err != nil {
 		return nil, err
+	}
+
+	return searchWithProxyFallback(ctx, opts.Config, apiURL, mapProduct)
+}
+
+// buildSuggestURL assembles the full predictive search endpoint URL from the
+// store config and query-shaping options.
+func buildSuggestURL(opts Options) (string, error) {
+	host, err := hostFromBaseURL(opts.Config.BaseURL)
+	if err != nil {
+		return "", err
 	}
 
 	searchQuery := strings.TrimSpace(opts.SearchStr)
@@ -88,15 +110,21 @@ func Search(ctx context.Context, opts Options) ([]gateway.Card, error) {
 		Path:     SearchPath,
 		RawQuery: values.Encode(),
 	}
+	return apiURL.String(), nil
+}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL.String(), nil)
+// fetchProducts performs a single suggest request with the supplied client and
+// returns the raw products. A non-200 status (e.g. 429 Too Many Requests) is
+// reported as an error so the caller can fall back to another transport.
+func fetchProducts(ctx context.Context, client *http.Client, apiURL string) ([]Product, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", gateway.RandomBrowserUserAgent())
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -107,18 +135,22 @@ func Search(ctx context.Context, opts Options) ([]gateway.Card, error) {
 		return nil, err
 	}
 
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("shopifysuggest: unexpected status %d", resp.StatusCode)
+	}
+
 	var res suggestResponse
 	if err := json.Unmarshal(body, &res); err != nil {
 		return nil, err
 	}
+	return res.Resources.Results.Products, nil
+}
 
-	mapProduct := opts.MapProduct
-	if mapProduct == nil {
-		return nil, fmt.Errorf("shopifysuggest: MapProduct is required")
-	}
-
-	cards := make([]gateway.Card, 0, len(res.Resources.Results.Products))
-	for _, product := range res.Resources.Results.Products {
+// mapProducts filters the suggest products down to in-stock Magic cards and
+// maps them into gateway cards using the supplied mapper.
+func mapProducts(cfg Config, products []Product, mapProduct func(cfg Config, product Product) (gateway.Card, bool)) []gateway.Card {
+	cards := make([]gateway.Card, 0, len(products))
+	for _, product := range products {
 		if !product.Available {
 			continue
 		}
@@ -132,8 +164,7 @@ func Search(ctx context.Context, opts Options) ([]gateway.Card, error) {
 		}
 		cards = append(cards, card)
 	}
-
-	return cards, nil
+	return cards
 }
 
 func hostFromBaseURL(baseURL string) (string, error) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Shops that search via Shopify's predictive search endpoint (`/search/suggest.json`) currently issue a single direct request with `http.DefaultClient`. That endpoint can rate limit direct traffic (HTTP 429), and the previous code never inspected the response status — a throttled response would silently parse into zero cards rather than triggering a retry.

This adds an ordered proxy fallback chain to `shopifysuggest.Search`, mirroring the approach already used for BinderPOS storefront calls:

1. **direct** — plain `http.Client` (unchanged default path)
2. **dedicated** — next configured dedicated proxy, round-robin across the pool
3. **dynamic** — the shared dynamic proxy

The first attempt that succeeds wins. Later attempts only run when the previous one errors. Crucially, a non-200 status (e.g. `429 Too Many Requests`) or an unparsable body now counts as an error and triggers fallback, instead of being swallowed as an empty result.

Proxy attempts are only added when the corresponding proxy is configured, so in environments without proxies the behavior is identical to before (direct only).

## Affected stores

All Shopify-suggest-backed stores benefit automatically:
- Fyendal Hobby
- Grey Ogre Games
- MTG Asia

## Changes

- `api/gateway/shopifysuggest/search.go`: extracted URL building (`buildSuggestURL`), product fetching (`fetchProducts`, now with status-code check), and mapping (`mapProducts`); `Search` now delegates to the fallback runner.
- `api/gateway/shopifysuggest/proxy_fallback.go` (new): ordered `direct → dedicated → dynamic` fallback chain, round-robin dedicated proxy selection, and per-attempt timeout.
- `api/gateway/shopifysuggest/proxy_fallback_test.go` (new): tests for 429 detection, successful parse, fallback-on-rate-limit, short-circuit on first success, last-error propagation, and proxy-configuration-driven attempt construction.

## Testing

- `go build ./...` and `go vet` on affected packages — pass
- `go test ./gateway/shopifysuggest/...` — pass
- `go test ./controller/...` — pass
- `go test ./gateway/fyendalhobby/... ./gateway/mtgasia/...` — pass
- `go test ./gateway/gog/...` — fails on an image assertion (`card.Img` empty for the live "Abrade" listing); confirmed this failure is **pre-existing on `master`** and is a live-store data issue unrelated to this change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db61f6fe-1e54-4911-9994-7be21e076219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db61f6fe-1e54-4911-9994-7be21e076219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

