### PR TITLE
fix(shopifysuggest): report cheapest in-stock variant price for MTG Asia and Grey Ogre

### DIFF
--- a/api/gateway/gog/search.go
+++ b/api/gateway/gog/search.go
@@ -28,9 +28,10 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 			StoreName: s.Name,
 			BaseURL:   s.BaseUrl,
 		},
-		SearchStr:   searchStr,
-		BuildQuery:  shopifysuggest.PlainQuery,
-		QueryValues: shopifysuggest.BinderposQueryValues,
-		MapProduct:  shopifysuggest.MapBinderposSetExtraProduct,
+		SearchStr:       searchStr,
+		BuildQuery:      shopifysuggest.PlainQuery,
+		QueryValues:     shopifysuggest.BinderposQueryValues,
+		MapProduct:      shopifysuggest.MapBinderposSetExtraProduct,
+		ResolveVariants: true,
 	})
 }

--- a/api/gateway/mtgasia/search.go
+++ b/api/gateway/mtgasia/search.go
@@ -28,9 +28,10 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 			StoreName: s.Name,
 			BaseURL:   s.BaseUrl,
 		},
-		SearchStr:   searchStr,
-		BuildQuery:  shopifysuggest.PlainQuery,
-		QueryValues: shopifysuggest.BinderposQueryValues,
-		MapProduct:  shopifysuggest.MapBinderposFullTitleProduct,
+		SearchStr:       searchStr,
+		BuildQuery:      shopifysuggest.PlainQuery,
+		QueryValues:     shopifysuggest.BinderposQueryValues,
+		MapProduct:      shopifysuggest.MapBinderposFullTitleProduct,
+		ResolveVariants: true,
 	})
 }

--- a/api/gateway/shopifysuggest/product.go
+++ b/api/gateway/shopifysuggest/product.go
@@ -1,6 +1,7 @@
 package shopifysuggest
 
 import (
+	"fmt"
 	"log"
 	"net/url"
 	"strings"
@@ -30,12 +31,18 @@ func BuildProductURL(baseURL, handle, suggestURL string) (string, error) {
 	return cleanPageURL.String(), nil
 }
 
-// ResolveImage returns the best available image URL from a suggest product.
+// ResolveImage returns the best available image URL from a suggest product. When
+// the store provides no image (some listings, e.g. "The List" reprints, have
+// none), it falls back to a titled placeholder so a card never carries an empty
+// image, mirroring the BinderPOS scrape/decklist behavior.
 func ResolveImage(product Product) string {
 	if img := strings.TrimSpace(product.Image); img != "" {
 		return img
 	}
-	return strings.TrimSpace(product.FeaturedImage.URL)
+	if img := strings.TrimSpace(product.FeaturedImage.URL); img != "" {
+		return img
+	}
+	return fmt.Sprintf("https://placehold.co/304x424?text=%s", url.QueryEscape(strings.TrimSpace(product.Title)))
 }
 
 // IsMagicProduct reports whether a storefront product belongs to Magic: The

--- a/api/gateway/shopifysuggest/proxy_fallback.go
+++ b/api/gateway/shopifysuggest/proxy_fallback.go
@@ -33,21 +33,21 @@ type searchAttempt struct {
 // when the previous one errors, so a healthy direct connection never incurs
 // proxy cost while a rate-limited endpoint still resolves via dedicated and
 // then dynamic proxies.
-func searchWithProxyFallback(ctx context.Context, cfg Config, apiURL string, mapProduct func(cfg Config, product Product) (gateway.Card, bool)) ([]gateway.Card, error) {
-	return runSearchAttempts(ctx, buildSearchAttempts(), cfg, apiURL, mapProduct)
+func searchWithProxyFallback(ctx context.Context, opts Options, apiURL string) ([]gateway.Card, error) {
+	return runSearchAttempts(ctx, buildSearchAttempts(), opts, apiURL)
 }
 
 // runSearchAttempts executes the ordered attempts, returning the first result
 // that succeeds (a nil error, even with zero cards). Each attempt's error is
 // annotated with its position and strategy name so the final error reflects the
 // last transport tried.
-func runSearchAttempts(ctx context.Context, attempts []searchAttempt, cfg Config, apiURL string, mapProduct func(cfg Config, product Product) (gateway.Card, bool)) ([]gateway.Card, error) {
+func runSearchAttempts(ctx context.Context, attempts []searchAttempt, opts Options, apiURL string) ([]gateway.Card, error) {
 	var (
 		cards []gateway.Card
 		err   error
 	)
 	for idx, attempt := range attempts {
-		cards, err = fetchAndMapProducts(ctx, attempt.client, apiURL, cfg, mapProduct)
+		cards, err = fetchAndMapProducts(ctx, attempt.client, apiURL, opts)
 		err = annotateSuggestAttemptError(idx+1, attempt.strategy, err)
 		if err == nil {
 			return cards, nil
@@ -128,12 +128,12 @@ func newProxyClient(proxyURL string) (*http.Client, error) {
 	}, nil
 }
 
-func fetchAndMapProducts(ctx context.Context, client *http.Client, apiURL string, cfg Config, mapProduct func(cfg Config, product Product) (gateway.Card, bool)) ([]gateway.Card, error) {
+func fetchAndMapProducts(ctx context.Context, client *http.Client, apiURL string, opts Options) ([]gateway.Card, error) {
 	products, err := fetchProducts(ctx, client, apiURL)
 	if err != nil {
 		return nil, err
 	}
-	return mapProducts(cfg, products, mapProduct), nil
+	return mapProducts(ctx, client, opts, products), nil
 }
 
 func annotateSuggestAttemptError(attempt int, strategy string, err error) error {

--- a/api/gateway/shopifysuggest/proxy_fallback_test.go
+++ b/api/gateway/shopifysuggest/proxy_fallback_test.go
@@ -71,7 +71,7 @@ func TestRunSearchAttemptsFallsBackOnRateLimit(t *testing.T) {
 		{strategy: "dedicated", client: srv.Client()},
 	}
 
-	cards, err := runSearchAttempts(context.Background(), attempts, Config{StoreName: "Test"}, srv.URL, mapAllProducts)
+	cards, err := runSearchAttempts(context.Background(), attempts, Options{Config: Config{StoreName: "Test"}, MapProduct: mapAllProducts}, srv.URL)
 	require.NoError(t, err)
 	require.Len(t, cards, 1)
 	require.Equal(t, int32(2), hits.Load(), "expected fallback to retry after the first 429")
@@ -91,7 +91,7 @@ func TestRunSearchAttemptsReturnsLastError(t *testing.T) {
 		{strategy: "dynamic", client: srv.Client()},
 	}
 
-	cards, err := runSearchAttempts(context.Background(), attempts, Config{StoreName: "Test"}, srv.URL, mapAllProducts)
+	cards, err := runSearchAttempts(context.Background(), attempts, Options{Config: Config{StoreName: "Test"}, MapProduct: mapAllProducts}, srv.URL)
 	require.Error(t, err)
 	require.Empty(t, cards)
 	require.Contains(t, err.Error(), "attempt 3 (dynamic)")
@@ -118,7 +118,7 @@ func TestRunSearchAttemptsStopsAtFirstSuccess(t *testing.T) {
 		{strategy: "dedicated", client: shouldNotBeHit.Client()},
 	}
 
-	cards, err := runSearchAttempts(context.Background(), attempts, Config{StoreName: "Test"}, healthy.URL, mapAllProducts)
+	cards, err := runSearchAttempts(context.Background(), attempts, Options{Config: Config{StoreName: "Test"}, MapProduct: mapAllProducts}, healthy.URL)
 	require.NoError(t, err)
 	require.Len(t, cards, 1)
 	require.Zero(t, secondHits.Load(), "second transport should not be tried after first success")

--- a/api/gateway/shopifysuggest/search.go
+++ b/api/gateway/shopifysuggest/search.go
@@ -36,6 +36,16 @@ type Options struct {
 	QueryValues func(searchStr string) url.Values
 	// MapProduct converts one suggest product into a card. Return false to skip.
 	MapProduct func(cfg Config, product Product) (gateway.Card, bool)
+	// ResolveVariants, when true, follows each suggest product with a request to
+	// its Shopify product JSON endpoint (/products/<handle>.js) to emit one card
+	// per in-stock variant using the variant's real price and condition.
+	//
+	// Shopify's predictive search reports a product-level price equal to the
+	// cheapest variant regardless of stock (price_min), so a product whose only
+	// cheap variants are sold out surfaces a price that cannot be purchased.
+	// Variant resolution reads per-variant price and availability (absent from
+	// predictive search) so the cheapest *in-stock* price is reported instead.
+	ResolveVariants bool
 }
 
 // Product is one item from Shopify's /search/suggest.json response.
@@ -72,8 +82,7 @@ type suggestResponse struct {
 // later attempts only run when the previous one errors (network failure,
 // non-200 status such as 429, or an unparsable body).
 func Search(ctx context.Context, opts Options) ([]gateway.Card, error) {
-	mapProduct := opts.MapProduct
-	if mapProduct == nil {
+	if opts.MapProduct == nil {
 		return nil, fmt.Errorf("shopifysuggest: MapProduct is required")
 	}
 
@@ -82,7 +91,7 @@ func Search(ctx context.Context, opts Options) ([]gateway.Card, error) {
 		return nil, err
 	}
 
-	return searchWithProxyFallback(ctx, opts.Config, apiURL, mapProduct)
+	return searchWithProxyFallback(ctx, opts, apiURL)
 }
 
 // buildSuggestURL assembles the full predictive search endpoint URL from the
@@ -147,8 +156,14 @@ func fetchProducts(ctx context.Context, client *http.Client, apiURL string) ([]P
 }
 
 // mapProducts filters the suggest products down to in-stock Magic cards and
-// maps them into gateway cards using the supplied mapper.
-func mapProducts(cfg Config, products []Product, mapProduct func(cfg Config, product Product) (gateway.Card, bool)) []gateway.Card {
+// maps them into gateway cards. When opts.ResolveVariants is set, each product
+// is expanded into one card per in-stock variant (see resolveVariantCards);
+// otherwise a single card is emitted from the predictive-search fields.
+//
+// The HTTP client is threaded through so variant resolution reuses the same
+// transport that won the suggest fallback (direct, dedicated, or dynamic
+// proxy), avoiding a fresh, possibly-throttled connection per product.
+func mapProducts(ctx context.Context, client *http.Client, opts Options, products []Product) []gateway.Card {
 	cards := make([]gateway.Card, 0, len(products))
 	for _, product := range products {
 		if !product.Available {
@@ -158,11 +173,17 @@ func mapProducts(cfg Config, products []Product, mapProduct func(cfg Config, pro
 			continue
 		}
 
-		card, ok := mapProduct(cfg, product)
+		base, ok := opts.MapProduct(opts.Config, product)
 		if !ok {
 			continue
 		}
-		cards = append(cards, card)
+
+		if !opts.ResolveVariants {
+			cards = append(cards, base)
+			continue
+		}
+
+		cards = append(cards, resolveVariantCards(ctx, client, opts.Config, product, base)...)
 	}
 	return cards
 }

--- a/api/gateway/shopifysuggest/variant.go
+++ b/api/gateway/shopifysuggest/variant.go
@@ -1,0 +1,138 @@
+package shopifysuggest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"mtg-price-checker-sg/gateway"
+	"mtg-price-checker-sg/gateway/util"
+)
+
+// productJSONPathFormat builds the path to a Shopify product's JSON document
+// from its handle. Unlike predictive search, this document exposes per-variant
+// price and stock.
+const productJSONPathFormat = "/products/%s.js"
+
+// productDetail is the subset of Shopify's /products/<handle>.js document used
+// to recover the per-variant price and availability that predictive search
+// omits.
+type productDetail struct {
+	Variants []productVariant `json:"variants"`
+}
+
+type productVariant struct {
+	ID    int64  `json:"id"`
+	Title string `json:"title"`
+	// Price is reported in the store's minor currency unit (cents).
+	Price     int64 `json:"price"`
+	Available bool  `json:"available"`
+}
+
+// resolveVariantCards expands a single suggest product into one card per
+// in-stock variant, sourcing the real price and condition from the product's
+// JSON document. The base card supplies the fields that are constant across a
+// product's variants (name, set, image, URL); the variant supplies price,
+// stock, condition, and foil.
+//
+// If the detail request fails, the predictive-search card is returned as a
+// resilience fallback so a transient upstream error does not drop the store
+// from results. That fallback price is the predictive-search price_min, which
+// is the pre-existing (pre-resolution) behavior.
+func resolveVariantCards(ctx context.Context, client *http.Client, cfg Config, product Product, base gateway.Card) []gateway.Card {
+	detail, err := fetchProductDetail(ctx, client, cfg.BaseURL, product.Handle)
+	if err != nil {
+		log.Printf("shopifysuggest: variant resolution failed for %s [%s]: %v", cfg.StoreName, product.Handle, err)
+		return []gateway.Card{base}
+	}
+
+	cards := make([]gateway.Card, 0, len(detail.Variants))
+	for _, variant := range detail.Variants {
+		if !variant.Available || variant.Price <= 0 {
+			continue
+		}
+
+		card := base
+		card.Price = float64(variant.Price) / 100
+		card.InStock = true
+		card.IsFoil = strings.Contains(strings.ToLower(variant.Title), "foil")
+		card.Quality = util.MapQuality(strings.TrimSpace(strings.ReplaceAll(variant.Title, "Foil", "")))
+		card.Url = withVariantParam(base.Url, variant.ID)
+		cards = append(cards, card)
+	}
+
+	return cards
+}
+
+// fetchProductDetail retrieves and decodes a Shopify product JSON document for
+// the given handle using the supplied client (which carries whichever transport
+// won the suggest fallback).
+func fetchProductDetail(ctx context.Context, client *http.Client, baseURL, handle string) (productDetail, error) {
+	handle = strings.TrimSpace(handle)
+	if handle == "" {
+		return productDetail{}, fmt.Errorf("shopifysuggest: empty product handle")
+	}
+
+	base, err := url.Parse(strings.TrimSpace(baseURL))
+	if err != nil {
+		return productDetail{}, fmt.Errorf("shopifysuggest: invalid base URL %q: %w", baseURL, err)
+	}
+	if base.Host == "" {
+		return productDetail{}, fmt.Errorf("shopifysuggest: invalid base URL %q: missing host", baseURL)
+	}
+
+	// Preserve the base URL's scheme and host; only the path identifies the
+	// product JSON document.
+	detailURL := *base
+	detailURL.Path = fmt.Sprintf(productJSONPathFormat, handle)
+	detailURL.RawQuery = ""
+	detailURL.Fragment = ""
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, detailURL.String(), nil)
+	if err != nil {
+		return productDetail{}, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", gateway.RandomBrowserUserAgent())
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return productDetail{}, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return productDetail{}, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return productDetail{}, fmt.Errorf("shopifysuggest: unexpected status %d for %s", resp.StatusCode, detailURL.String())
+	}
+
+	var detail productDetail
+	if err := json.Unmarshal(body, &detail); err != nil {
+		return productDetail{}, err
+	}
+	return detail, nil
+}
+
+// withVariantParam adds a variant query parameter to an existing product URL,
+// preserving any parameters already present (e.g. utm_source). On a parse
+// failure it returns the original URL unchanged so a card is still produced.
+func withVariantParam(rawURL string, variantID int64) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	query := u.Query()
+	query.Set("variant", strconv.FormatInt(variantID, 10))
+	u.RawQuery = query.Encode()
+	return u.String()
+}

--- a/api/gateway/shopifysuggest/variant_test.go
+++ b/api/gateway/shopifysuggest/variant_test.go
@@ -1,0 +1,130 @@
+package shopifysuggest
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"mtg-price-checker-sg/gateway"
+)
+
+// borosFuryShieldDetail mirrors the real MTG Asia /products/<handle>.js payload
+// for "Boros Fury-Shield": every cheap non-foil condition is out of stock and
+// the only purchasable variant is the Near Mint Foil at 1.40. Predictive search
+// would otherwise report 0.13 (the Damaged non-foil price_min).
+const borosFuryShieldDetail = `{
+  "variants": [
+    {"id": 1, "title": "Near Mint", "price": 25, "available": false},
+    {"id": 2, "title": "Lightly Played", "price": 23, "available": false},
+    {"id": 3, "title": "Damaged", "price": 13, "available": false},
+    {"id": 4, "title": "Near Mint Foil", "price": 140, "available": true},
+    {"id": 5, "title": "Damaged Foil", "price": 70, "available": false}
+  ]
+}`
+
+func newDetailServer(t *testing.T, body string, status int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/products/") || !strings.HasSuffix(r.URL.Path, ".js") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+func baseCardFor(srv *httptest.Server) gateway.Card {
+	return gateway.Card{
+		Name:    "Boros Fury-Shield [Ravnica: City of Guilds]",
+		Url:     srv.URL + "/products/boros-fury-shield-ravnica-city-of-guilds?utm_source=test",
+		InStock: true,
+		IsFoil:  true, // a tag-derived guess that variant resolution must correct per variant
+		Price:   0.13,
+		Source:  "MTG Asia",
+	}
+}
+
+// TestResolveVariantCardsKeepsOnlyInStock verifies that only purchasable
+// variants survive and that each card carries the variant's real price,
+// condition, and foil flag rather than the predictive-search price_min.
+func TestResolveVariantCardsKeepsOnlyInStock(t *testing.T) {
+	srv := newDetailServer(t, borosFuryShieldDetail, http.StatusOK)
+	defer srv.Close()
+
+	cfg := Config{StoreName: "MTG Asia", BaseURL: srv.URL}
+	product := Product{Handle: "boros-fury-shield-ravnica-city-of-guilds"}
+
+	cards := resolveVariantCards(context.Background(), srv.Client(), cfg, product, baseCardFor(srv))
+
+	require.Len(t, cards, 1, "only the in-stock Near Mint Foil variant should remain")
+	card := cards[0]
+	require.Equal(t, 1.40, card.Price)
+	require.Equal(t, "Near Mint", card.Quality)
+	require.True(t, card.IsFoil)
+	require.True(t, card.InStock)
+	require.Contains(t, card.Url, "variant=4")
+	require.Contains(t, card.Url, "utm_source=test")
+}
+
+// TestResolveVariantCardsCorrectsFoilPerVariant verifies that the per-variant
+// foil flag overrides the product-level guess: a non-foil in-stock variant is
+// reported as non-foil even when the base card guessed foil from tags.
+func TestResolveVariantCardsCorrectsFoilPerVariant(t *testing.T) {
+	const body = `{"variants": [
+		{"id": 10, "title": "Near Mint", "price": 100, "available": true},
+		{"id": 11, "title": "Near Mint Foil", "price": 140, "available": true}
+	]}`
+	srv := newDetailServer(t, body, http.StatusOK)
+	defer srv.Close()
+
+	cfg := Config{StoreName: "MTG Asia", BaseURL: srv.URL}
+	product := Product{Handle: "card-handle"}
+
+	cards := resolveVariantCards(context.Background(), srv.Client(), cfg, product, baseCardFor(srv))
+
+	require.Len(t, cards, 2)
+	require.Equal(t, 1.00, cards[0].Price)
+	require.False(t, cards[0].IsFoil)
+	require.Equal(t, 1.40, cards[1].Price)
+	require.True(t, cards[1].IsFoil)
+}
+
+// TestResolveVariantCardsFallsBackOnError verifies that a failed detail fetch
+// preserves the predictive-search card so a transient upstream error does not
+// drop the store from the results.
+func TestResolveVariantCardsFallsBackOnError(t *testing.T) {
+	srv := newDetailServer(t, "", http.StatusInternalServerError)
+	defer srv.Close()
+
+	cfg := Config{StoreName: "MTG Asia", BaseURL: srv.URL}
+	product := Product{Handle: "card-handle"}
+	base := baseCardFor(srv)
+
+	cards := resolveVariantCards(context.Background(), srv.Client(), cfg, product, base)
+
+	require.Len(t, cards, 1)
+	require.Equal(t, base.Price, cards[0].Price)
+}
+
+// TestResolveVariantCardsDropsWhenAllOutOfStock verifies that a product whose
+// every variant is out of stock yields no cards, even though predictive search
+// flagged the product as available.
+func TestResolveVariantCardsDropsWhenAllOutOfStock(t *testing.T) {
+	const body = `{"variants": [
+		{"id": 20, "title": "Near Mint", "price": 100, "available": false},
+		{"id": 21, "title": "Damaged", "price": 13, "available": false}
+	]}`
+	srv := newDetailServer(t, body, http.StatusOK)
+	defer srv.Close()
+
+	cfg := Config{StoreName: "MTG Asia", BaseURL: srv.URL}
+	product := Product{Handle: "card-handle"}
+
+	cards := resolveVariantCards(context.Background(), srv.Client(), cfg, product, baseCardFor(srv))
+	require.Empty(t, cards)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Searching a card like **Boros Fury-Shield** on **MTG Asia** returned `0.13` as the cheapest price, but the real purchasable price is `1.40`.

Root cause: MTG Asia and Grey Ogre source results from Shopify's predictive search (`/search/suggest.json`). That endpoint reports a **product-level `price` equal to `price_min`** — the cheapest variant **regardless of stock**. For Boros Fury-Shield the `0.13` belongs to a *Damaged (non-foil)* variant that is out of stock; the only in-stock variant is *Near Mint Foil* at `1.40`.

I verified the endpoint cannot solve this on its own:
- `resources[options][unavailable_products]=hide` only hides fully out-of-stock **products** (this product is "available" because one foil variant is in stock), price still `0.13`.
- `resources[options][fields]=...variants.price` / `variants.available` / `variants.url` → all `422 Invalid option`. Only `variants.title` is accepted, and the `variants` array comes back empty.

Predictive search simply does not expose per-variant price/stock.

## Fix

Add an opt-in `ResolveVariants` step to the shared `shopifysuggest` gateway. When enabled, each suggest product is followed by a request to its Shopify product JSON document (`/products/<handle>.js`), which **does** expose per-variant `price` and `available`. We then emit **one card per in-stock variant** using the variant's real price, condition (`Quality`), and foil flag, plus a `variant=<id>` URL — matching the existing BinderPOS scrape/decklist behavior.

- Enabled for **MTG Asia** and **Grey Ogre Games**; other Shopify-suggest stores (e.g. Fyendal Hobby) are unchanged unless they opt in.
- The variant request reuses the same HTTP transport that won the suggest fallback (direct → dedicated → dynamic proxy), so it does not open a fresh, possibly-throttled connection per product.
- On a detail-fetch error, the predictive-search card is preserved as a resilience fallback (so a transient upstream error never drops the store).
- Products whose every variant is out of stock are dropped (predictive search may flag them "available" via a single in-stock variant elsewhere).

Also hardened `ResolveImage` to fall back to a titled `placehold.co` placeholder when a listing has no image (some reprints, e.g. "The List", have none), mirroring the BinderPOS paths, so in-stock cards never carry an empty image.

## Verification

End-to-end against live MTG Asia for `Boros Fury-Shield`:

```
price=1.40 inStock=true foil=true quality="Near Mint" name="Boros Fury-Shield [Ravnica: City of Guilds]" url=.../products/boros-fury-shield-ravnica-city-of-guilds?utm_source=gishathfetch&variant=40897125613639
```

The unpurchasable `0.13` is gone; the correct in-stock `1.40` is reported.

Tests:
- New unit tests in `variant_test.go` cover: only-in-stock survival, per-variant foil correction, all-out-of-stock drop, and detail-fetch error fallback.
- `go test ./gateway/shopifysuggest/... ./gateway/mtgasia/... ./gateway/gog/...` pass (GOG live test now stable thanks to the image placeholder).
- `go test ./controller/...` pass.
- `gofmt`/`go vet` clean for touched files.

## Trade-offs

Adds up to ~10 extra lightweight requests per search (predictive search caps at 10 products; for an exact card name it is usually 1–3). Per the repo priority order, correctness and data integrity outweigh this added latency.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0f4c34d-769f-4271-9f2d-4946b170570a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0f4c34d-769f-4271-9f2d-4946b170570a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

