### PR TITLE
docs: document Shopify suggest in search flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,16 +45,49 @@ before being returned.
   the same `portal.binderpos.com`, so this extra gate prevents bursts that
   trigger 429/503 throttling.
 
-### Two kinds of stores
+### Three kinds of stores
 
 **Non-BinderPOS stores** (e.g. Agora, Cards Central, Cards & Collections,
 Dueller's Point, 5 Mana, Mox & Lotus, TCG Marketplace) each implement a single
 bespoke `Search` — a custom JSON API call or one HTML scrape — with no
 multi-strategy fallback. On failure the store simply contributes nothing.
 
+**Shopify suggest stores** (Fyendal Hobby, MTG Asia, Grey Ogre Games) query each
+storefront's Shopify predictive search endpoint (`/search/suggest.json`) through
+a shared gateway. Results are filtered to in-stock Magic singles and mapped into
+cards using store-specific title/tag conventions (Fyendal Hobby additionally
+scopes suggest to its MTG singles product type). On error the chain advances
+through proxy tiers (**direct → dedicated → dynamic**); an empty but error-free
+response counts as success and stops the chain. Each attempt is bounded by a 10s
+timeout (`suggestAttemptTimeout`).
+
+MTG Asia and Grey Ogre Games additionally **resolve variants**: after suggest
+returns a product, a follow-up request to `/products/<handle>.js` emits one card
+per in-stock variant with the variant's real price and condition. Shopify's
+predictive search only reports a product-level `price_min` (the cheapest variant
+regardless of stock), so variant resolution ensures the cheapest *purchasable*
+price is reported. If the detail request fails, the suggest card is kept as a
+resilience fallback.
+
+```mermaid
+flowchart TD
+    A[Shopify suggest store search] --> B[GET /search/suggest.json]
+    B --> C{error?}
+    C -- direct failed --> D[dedicated proxy]
+    C -- success --> E[filter in-stock Magic products]
+    D --> F{error?}
+    F -- dedicated failed --> G[dynamic proxy]
+    F -- success --> E
+    G --> E
+    E --> H{ResolveVariants?}
+    H -- yes --> I[GET /products/handle.js per product]
+    I --> J[one card per in-stock variant]
+    H -- no --> K[one card per suggest product]
+```
+
 **BinderPOS stores** (e.g. Card Affinity, Cards Citadel, Flagship, Game's Haven,
-Grey Ogre Games, Hideout, Mana Pro, MTG Asia, OneMTG) share one gateway that can
-read listings from two sources:
+Hideout, Mana Pro, OneMTG) share one gateway that can read listings from two
+sources:
 
 - **Decklist** — a POST to the shared `portal.binderpos.com` decklist endpoint.
 - **Scrape** — an HTML scrape of the store's own storefront.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the README search flow section to reflect the Shopify suggest gateway introduced in recent PRs (#124–#127).

## Changes

- Renames "Two kinds of stores" to **Three kinds of stores**.
- Adds a **Shopify suggest** category covering Fyendal Hobby, MTG Asia, and Grey Ogre Games:
  - Predictive search via `/search/suggest.json`
  - Proxy fallback chain: direct → dedicated → dynamic
  - Variant resolution for MTG Asia and Grey Ogre Games (`/products/<handle>.js`)
  - Mermaid flowchart for the suggest path
- Removes MTG Asia and Grey Ogre Games from the BinderPOS store list (they no longer use that gateway).

## Testing

- Docs-only change; no code or test updates required.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5f1afac7-2bbb-4ab7-ab4a-6d1317ae2ca0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f1afac7-2bbb-4ab7-ab4a-6d1317ae2ca0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

