### PR TITLE
Honor Retry-After for Shopify suggest requests

### DIFF
--- a/api/gateway/shopifysuggest/proxy_fallback.go
+++ b/api/gateway/shopifysuggest/proxy_fallback.go
@@ -29,10 +29,11 @@ type searchAttempt struct {
 }
 
 // searchWithProxyFallback runs the suggest request through an ordered set of
-// transports, returning the first successful result. Each attempt only runs
-// when the previous one errors, so a healthy direct connection never incurs
-// proxy cost while a rate-limited endpoint still resolves via dedicated and
-// then dynamic proxies.
+// transports, returning the first successful result. Each transport retries
+// transient rate-limit/5xx responses on the same connection (honoring
+// Retry-After) before the chain advances, so a healthy direct connection never
+// incurs proxy cost while a rate-limited endpoint still resolves via dedicated
+// and then dynamic proxies.
 func searchWithProxyFallback(ctx context.Context, opts Options, apiURL string) ([]gateway.Card, error) {
 	return runSearchAttempts(ctx, buildSearchAttempts(), opts, apiURL)
 }

--- a/api/gateway/shopifysuggest/proxy_fallback_test.go
+++ b/api/gateway/shopifysuggest/proxy_fallback_test.go
@@ -27,7 +27,9 @@ const sampleSuggestBody = `{
 }`
 
 func TestFetchProductsRateLimited(t *testing.T) {
+	var calls atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
 		w.WriteHeader(http.StatusTooManyRequests)
 	}))
 	defer srv.Close()
@@ -35,6 +37,7 @@ func TestFetchProductsRateLimited(t *testing.T) {
 	_, err := fetchProducts(context.Background(), srv.Client(), srv.URL)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "429")
+	require.Equal(t, int32(suggestRetryMaxAttempts), calls.Load())
 }
 
 func TestFetchProductsSuccess(t *testing.T) {
@@ -50,15 +53,13 @@ func TestFetchProductsSuccess(t *testing.T) {
 	require.Equal(t, "Opt", products[0].Title)
 }
 
-// TestRunSearchAttemptsFallsBackOnRateLimit verifies that a rate-limited first
-// attempt falls through to the next transport, which succeeds. All attempts hit
-// the same endpoint (as they do in production), so the server returns 429 on
-// the first request and a valid body afterwards.
+// TestRunSearchAttemptsFallsBackOnRateLimit verifies that when one transport
+// exhausts its Retry-After/backoff retries, the next transport succeeds.
 func TestRunSearchAttemptsFallsBackOnRateLimit(t *testing.T) {
 	var hits atomic.Int32
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if hits.Add(1) == 1 {
+		if hits.Add(1) <= int32(suggestRetryMaxAttempts) {
 			w.WriteHeader(http.StatusTooManyRequests)
 			return
 		}
@@ -74,7 +75,7 @@ func TestRunSearchAttemptsFallsBackOnRateLimit(t *testing.T) {
 	cards, err := runSearchAttempts(context.Background(), attempts, Options{Config: Config{StoreName: "Test"}, MapProduct: mapAllProducts}, srv.URL)
 	require.NoError(t, err)
 	require.Len(t, cards, 1)
-	require.Equal(t, int32(2), hits.Load(), "expected fallback to retry after the first 429")
+	require.Equal(t, int32(suggestRetryMaxAttempts+1), hits.Load(), "expected direct retries then dedicated success")
 }
 
 // TestRunSearchAttemptsReturnsLastError verifies that when every transport

--- a/api/gateway/shopifysuggest/retry.go
+++ b/api/gateway/shopifysuggest/retry.go
@@ -1,0 +1,178 @@
+package shopifysuggest
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"mtg-price-checker-sg/gateway"
+)
+
+const (
+	// suggestRetryMaxAttempts bounds how many times a single suggest or product
+	// JSON request is sent (initial try plus retries) when Shopify responds with
+	// a transient rate-limit/5xx status or a network error.
+	suggestRetryMaxAttempts = 3
+	// suggestRetryBaseDelay is the first backoff step when Retry-After is absent.
+	suggestRetryBaseDelay = 300 * time.Millisecond
+	// suggestRetryMaxDelay caps a single backoff/Retry-After wait so a large or
+	// hostile Retry-After value cannot stall the attempt.
+	suggestRetryMaxDelay = 2500 * time.Millisecond
+)
+
+// retriableSuggestStatuses are upstream responses that signal a transient load
+// or rate-limit condition on a Shopify storefront. They are retried with
+// backoff honoring Retry-After instead of immediately failing over to the next
+// transport, which reduces unnecessary proxy churn.
+var retriableSuggestStatuses = map[int]struct{}{
+	http.StatusTooManyRequests:     {}, // 429
+	http.StatusInternalServerError: {}, // 500
+	http.StatusBadGateway:          {}, // 502
+	http.StatusServiceUnavailable:  {}, // 503
+	http.StatusGatewayTimeout:      {}, // 504
+}
+
+func isRetriableSuggestStatus(status int) bool {
+	_, ok := retriableSuggestStatuses[status]
+	return ok
+}
+
+// doSuggestGETWithRetry sends a GET request, retrying transient rate-limit/5xx
+// responses and network errors with jittered exponential backoff bounded by
+// ctx. Each send uses a fresh User-Agent. On success it returns the response
+// body. On failure it returns the last observed error.
+func doSuggestGETWithRetry(ctx context.Context, client *http.Client, requestURL string) ([]byte, error) {
+	var lastErr error
+
+	for attempt := 0; attempt < suggestRetryMaxAttempts; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set("User-Agent", gateway.RandomBrowserUserAgent())
+
+		resp, err := client.Do(req)
+		if err != nil {
+			lastErr = err
+			if isLastSuggestRetryAttempt(attempt) || !waitBeforeSuggestRetry(ctx, suggestBackoffDelay(attempt)) {
+				return nil, lastErr
+			}
+			continue
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			lastErr = err
+			if isLastSuggestRetryAttempt(attempt) || !waitBeforeSuggestRetry(ctx, suggestBackoffDelay(attempt)) {
+				return nil, lastErr
+			}
+			continue
+		}
+
+		if resp.StatusCode == http.StatusOK {
+			return body, nil
+		}
+
+		lastErr = fmt.Errorf("shopifysuggest: unexpected status %d", resp.StatusCode)
+		if !isRetriableSuggestStatus(resp.StatusCode) || isLastSuggestRetryAttempt(attempt) {
+			return nil, lastErr
+		}
+
+		delay := parseSuggestRetryAfter(resp.Header.Get("Retry-After"))
+		if delay <= 0 {
+			delay = suggestBackoffDelay(attempt)
+		}
+		if !waitBeforeSuggestRetry(ctx, delay) {
+			return nil, lastErr
+		}
+	}
+
+	return nil, lastErr
+}
+
+func isLastSuggestRetryAttempt(attempt int) bool {
+	return attempt >= suggestRetryMaxAttempts-1
+}
+
+// suggestBackoffDelay returns an equal-jitter exponential backoff for the given
+// zero-based attempt, capped at suggestRetryMaxDelay.
+func suggestBackoffDelay(attempt int) time.Duration {
+	if attempt < 0 {
+		attempt = 0
+	}
+
+	base := suggestRetryBaseDelay << attempt
+	if base <= 0 || base > suggestRetryMaxDelay {
+		base = suggestRetryMaxDelay
+	}
+
+	half := base / 2
+	if half <= 0 {
+		return base
+	}
+	return half + time.Duration(rand.Int64N(int64(half)+1))
+}
+
+// waitBeforeSuggestRetry sleeps for delay unless ctx is cancelled or the
+// remaining ctx budget cannot accommodate it.
+func waitBeforeSuggestRetry(ctx context.Context, delay time.Duration) bool {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if delay <= 0 {
+		return ctx.Err() == nil
+	}
+	if deadline, ok := ctx.Deadline(); ok && time.Until(deadline) <= delay {
+		return false
+	}
+
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// parseSuggestRetryAfter parses a Retry-After header expressed either as a
+// number of seconds or an HTTP date. It returns 0 when the header is absent or
+// unparseable, and caps the wait so a huge value cannot stall the attempt.
+func parseSuggestRetryAfter(value string) time.Duration {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+
+	if seconds, err := strconv.Atoi(value); err == nil {
+		if seconds <= 0 {
+			return 0
+		}
+		return capSuggestRetryAfter(time.Duration(seconds) * time.Second)
+	}
+
+	if when, err := http.ParseTime(value); err == nil {
+		delay := time.Until(when)
+		if delay <= 0 {
+			return 0
+		}
+		return capSuggestRetryAfter(delay)
+	}
+
+	return 0
+}
+
+func capSuggestRetryAfter(delay time.Duration) time.Duration {
+	if delay > suggestRetryMaxDelay {
+		return suggestRetryMaxDelay
+	}
+	return delay
+}

--- a/api/gateway/shopifysuggest/retry_test.go
+++ b/api/gateway/shopifysuggest/retry_test.go
@@ -1,0 +1,181 @@
+package shopifysuggest
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestIsRetriableSuggestStatus(t *testing.T) {
+	retriable := []int{
+		http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout,
+	}
+	for _, status := range retriable {
+		if !isRetriableSuggestStatus(status) {
+			t.Fatalf("expected status %d to be retriable", status)
+		}
+	}
+
+	notRetriable := []int{
+		http.StatusOK,
+		http.StatusBadRequest,
+		http.StatusUnauthorized,
+		http.StatusForbidden,
+		http.StatusNotFound,
+	}
+	for _, status := range notRetriable {
+		if isRetriableSuggestStatus(status) {
+			t.Fatalf("expected status %d to not be retriable", status)
+		}
+	}
+}
+
+func TestParseSuggestRetryAfter(t *testing.T) {
+	t.Run("empty returns zero", func(t *testing.T) {
+		if d := parseSuggestRetryAfter(""); d != 0 {
+			t.Fatalf("expected 0, got %s", d)
+		}
+	})
+
+	t.Run("parses seconds", func(t *testing.T) {
+		if d := parseSuggestRetryAfter("2"); d != 2*time.Second {
+			t.Fatalf("expected 2s, got %s", d)
+		}
+	})
+
+	t.Run("non-positive seconds returns zero", func(t *testing.T) {
+		if d := parseSuggestRetryAfter("0"); d != 0 {
+			t.Fatalf("expected 0, got %s", d)
+		}
+	})
+
+	t.Run("caps large seconds at max", func(t *testing.T) {
+		if d := parseSuggestRetryAfter("3600"); d != suggestRetryMaxDelay {
+			t.Fatalf("expected cap %s, got %s", suggestRetryMaxDelay, d)
+		}
+	})
+
+	t.Run("parses http date in the future", func(t *testing.T) {
+		when := time.Now().Add(1 * time.Second).UTC().Format(http.TimeFormat)
+		d := parseSuggestRetryAfter(when)
+		if d <= 0 || d > suggestRetryMaxDelay {
+			t.Fatalf("expected positive capped delay, got %s", d)
+		}
+	})
+
+	t.Run("past http date returns zero", func(t *testing.T) {
+		when := time.Now().Add(-1 * time.Hour).UTC().Format(http.TimeFormat)
+		if d := parseSuggestRetryAfter(when); d != 0 {
+			t.Fatalf("expected 0 for past date, got %s", d)
+		}
+	})
+
+	t.Run("garbage returns zero", func(t *testing.T) {
+		if d := parseSuggestRetryAfter("soon"); d != 0 {
+			t.Fatalf("expected 0 for unparseable value, got %s", d)
+		}
+	})
+}
+
+func TestDoSuggestGETWithRetry_SucceedsAfter429WithRetryAfter(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if calls.Add(1) == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sampleSuggestBody))
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), suggestAttemptTimeout)
+	defer cancel()
+
+	body, err := doSuggestGETWithRetry(ctx, server.Client(), server.URL)
+	if err != nil {
+		t.Fatalf("expected success after Retry-After retry, got %v", err)
+	}
+	if !strings.Contains(string(body), "Opt") {
+		t.Fatalf("expected suggest body, got %q", string(body))
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("expected 2 calls (429 + success), got %d", got)
+	}
+}
+
+func TestDoSuggestGETWithRetry_SucceedsAfterTransient503(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if calls.Add(1) <= 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sampleSuggestBody))
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), suggestAttemptTimeout)
+	defer cancel()
+
+	_, err := doSuggestGETWithRetry(ctx, server.Client(), server.URL)
+	if err != nil {
+		t.Fatalf("expected success after retries, got %v", err)
+	}
+	if got := calls.Load(); got != 3 {
+		t.Fatalf("expected 3 calls (2 failures + success), got %d", got)
+	}
+}
+
+func TestDoSuggestGETWithRetry_ExhaustsRetriesOnPersistent429(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), suggestAttemptTimeout)
+	defer cancel()
+
+	_, err := doSuggestGETWithRetry(ctx, server.Client(), server.URL)
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	if !strings.Contains(err.Error(), "429") {
+		t.Fatalf("expected status=429 in error, got %v", err)
+	}
+	if got := calls.Load(); got != int32(suggestRetryMaxAttempts) {
+		t.Fatalf("expected %d calls, got %d", suggestRetryMaxAttempts, got)
+	}
+}
+
+func TestDoSuggestGETWithRetry_DoesNotRetryNonRetriableStatus(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), suggestAttemptTimeout)
+	defer cancel()
+
+	_, err := doSuggestGETWithRetry(ctx, server.Client(), server.URL)
+	if err == nil {
+		t.Fatal("expected error for 404 response")
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 call for non-retriable status, got %d", got)
+	}
+}

--- a/api/gateway/shopifysuggest/search.go
+++ b/api/gateway/shopifysuggest/search.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -76,11 +75,13 @@ type suggestResponse struct {
 // products into cards using the supplied options.
 //
 // Shopify's predictive search endpoint can rate limit (HTTP 429) or otherwise
-// throttle direct traffic, so the request is attempted through an ordered
-// fallback chain: a direct connection first, then a dedicated proxy, and
-// finally the shared dynamic proxy. The first attempt that succeeds wins;
-// later attempts only run when the previous one errors (network failure,
-// non-200 status such as 429, or an unparsable body).
+// throttle direct traffic. Each transport retries transient failures on the
+// same connection, honoring Retry-After when present, before the request is
+// attempted through an ordered fallback chain: a direct connection first, then
+// a dedicated proxy, and finally the shared dynamic proxy. The first transport
+// that succeeds wins; later transports only run when the previous one exhausts
+// its retries (network failure, persistent non-200 status such as 429, or an
+// unparsable body).
 func Search(ctx context.Context, opts Options) ([]gateway.Card, error) {
 	if opts.MapProduct == nil {
 		return nil, fmt.Errorf("shopifysuggest: MapProduct is required")
@@ -122,30 +123,14 @@ func buildSuggestURL(opts Options) (string, error) {
 	return apiURL.String(), nil
 }
 
-// fetchProducts performs a single suggest request with the supplied client and
-// returns the raw products. A non-200 status (e.g. 429 Too Many Requests) is
-// reported as an error so the caller can fall back to another transport.
+// fetchProducts performs a suggest request with the supplied client and returns
+// the raw products. Transient rate-limit/5xx responses are retried on the same
+// transport, honoring Retry-After when Shopify provides it. Persistent failures
+// are reported as errors so the caller can fall back to another transport.
 func fetchProducts(ctx context.Context, client *http.Client, apiURL string) ([]Product, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	body, err := doSuggestGETWithRetry(ctx, client, apiURL)
 	if err != nil {
 		return nil, err
-	}
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("User-Agent", gateway.RandomBrowserUserAgent())
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("shopifysuggest: unexpected status %d", resp.StatusCode)
 	}
 
 	var res suggestResponse

--- a/api/gateway/shopifysuggest/variant.go
+++ b/api/gateway/shopifysuggest/variant.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -94,26 +93,9 @@ func fetchProductDetail(ctx context.Context, client *http.Client, baseURL, handl
 	detailURL.RawQuery = ""
 	detailURL.Fragment = ""
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, detailURL.String(), nil)
+	body, err := doSuggestGETWithRetry(ctx, client, detailURL.String())
 	if err != nil {
 		return productDetail{}, err
-	}
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("User-Agent", gateway.RandomBrowserUserAgent())
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return productDetail{}, err
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return productDetail{}, err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return productDetail{}, fmt.Errorf("shopifysuggest: unexpected status %d for %s", resp.StatusCode, detailURL.String())
 	}
 
 	var detail productDetail


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Shopify predictive search (`/search/suggest.json`) and product JSON (`/products/{handle}.js`) requests now retry transient rate-limit/5xx responses on the same transport before falling back to the next proxy tier.

This mirrors the existing BinderPOS decklist retry behavior:

- Honors `Retry-After` (seconds or HTTP-date), capped at 2.5s
- Falls back to equal-jitter exponential backoff when the header is absent
- Retries up to 3 times per transport on 429/500/502/503/504
- Uses a fresh `User-Agent` on each send
- Proxy fallback (direct → dedicated → dynamic) only runs after retries are exhausted

## Changes

- Added `api/gateway/shopifysuggest/retry.go` with shared GET retry helper
- Wired `fetchProducts` and `fetchProductDetail` through the retry helper
- Added unit tests for `Retry-After` parsing, retry success/failure paths, and updated proxy-fallback expectations

## Testing

- `go test -mod=vendor ./gateway/shopifysuggest/...` — pass
- `make test` — `shopifysuggest` pass; unrelated live gateway failures on Card Affinity (proxy) and Cards Central (upstream data drift)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-610cd33b-3c61-42a8-aebe-50213d7313e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-610cd33b-3c61-42a8-aebe-50213d7313e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

