### PR TITLE
Add USE_DYNAMIC_PROXY feature toggle

### DIFF
--- a/api/gateway/binderpos/storefront_proxy_client_test.go
+++ b/api/gateway/binderpos/storefront_proxy_client_test.go
@@ -46,6 +46,16 @@ func TestSearchByStorefrontAPIDynamicRequiresEnv(t *testing.T) {
 	}
 }
 
+func TestSearchByStorefrontAPIDynamicDisabledByToggle(t *testing.T) {
+	t.Setenv("DYNAMIC_PROXY", "dynamic-proxy|9000|dynamic-user|dynamic-pass")
+	t.Setenv("USE_DYNAMIC_PROXY", "false")
+
+	_, err := searchByStorefrontAPIDynamic(context.Background(), 1, "Store", "https://example.com", "shopify.example.com", "Abrade")
+	if err == nil || err.Error() != "no dynamic proxy configured for binderpos storefront api" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestNewHTTPClientWithProxyURL(t *testing.T) {
 	t.Run("returns error for invalid proxy URL", func(t *testing.T) {
 		_, err := newHTTPClientWithProxyURL("://invalid-proxy")

--- a/api/gateway/collector.go
+++ b/api/gateway/collector.go
@@ -378,6 +378,10 @@ func clearProxy(c *colly.Collector) (string, string) {
 }
 
 func DynamicProxyURL() string {
+	if !config.UseDynamicProxy() {
+		return ""
+	}
+
 	proxyURL, ok := util.BuildProxyURL(os.Getenv(config.DynamicProxyEnv))
 	if !ok {
 		return ""

--- a/api/gateway/collector_test.go
+++ b/api/gateway/collector_test.go
@@ -55,6 +55,17 @@ func TestInitialProxy(t *testing.T) {
 			t.Fatalf("unexpected dynamic proxy url: %q", proxyURL)
 		}
 	})
+
+	t.Run("skips dynamic when USE_DYNAMIC_PROXY is false", func(t *testing.T) {
+		c2 := colly.NewCollector()
+		t.Setenv("DYNAMIC_PROXY", "dynamic-proxy|9000|dynamic-user|dynamic-pass")
+		t.Setenv("USE_DYNAMIC_PROXY", "false")
+
+		mode, proxyURL := applyInitialProxy(c2, "")
+		if mode != "direct" || proxyURL != "" {
+			t.Fatalf("expected direct mode with no proxy, got mode=%q url=%q", mode, proxyURL)
+		}
+	})
 }
 
 func TestDedicatedProxyLeasePoolAcquireRelease(t *testing.T) {
@@ -253,6 +264,14 @@ func TestNewOptimizedCollectorNoRetryDynamic(t *testing.T) {
 		t.Setenv("DYNAMIC_PROXY", "://bad-dynamic-proxy")
 		if _, err := NewOptimizedCollectorNoRetryDynamic(context.Background()); err == nil {
 			t.Fatalf("expected invalid dynamic proxy to return error")
+		}
+	})
+
+	t.Run("returns error when USE_DYNAMIC_PROXY is false", func(t *testing.T) {
+		t.Setenv("DYNAMIC_PROXY", "dynamic-proxy|9000|dynamic-user|dynamic-pass")
+		t.Setenv("USE_DYNAMIC_PROXY", "false")
+		if _, err := NewOptimizedCollectorNoRetryDynamic(context.Background()); err == nil {
+			t.Fatalf("expected disabled dynamic proxy toggle to return error")
 		}
 	})
 }

--- a/api/gateway/shopifysuggest/proxy_fallback_test.go
+++ b/api/gateway/shopifysuggest/proxy_fallback_test.go
@@ -149,4 +149,10 @@ func TestBuildSearchAttemptsProxyConfiguration(t *testing.T) {
 	attempts = buildSearchAttempts()
 	require.Len(t, attempts, 3)
 	require.Equal(t, "dynamic", attempts[2].strategy)
+
+	t.Setenv("USE_DYNAMIC_PROXY", "false")
+	attempts = buildSearchAttempts()
+	require.Len(t, attempts, 2)
+	require.Equal(t, "direct", attempts[0].strategy)
+	require.Equal(t, "dedicated", attempts[1].strategy)
 }

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -22,6 +22,9 @@ const (
 	// dynamic-proxy fallback attempts, which BinderPOS now reserves for the
 	// final fallback after dedicated and direct/no-proxy attempts.
 	DynamicProxyEnv = "DYNAMIC_PROXY"
+	// UseDynamicProxyEnv toggles whether DYNAMIC_PROXY may be used for fallback
+	// attempts. When false, dynamic proxy is skipped even if configured.
+	UseDynamicProxyEnv = "USE_DYNAMIC_PROXY"
 	// UseBinderposSharedProxyFallbackEnv is reserved for future BinderPOS proxy
 	// routing options. It no longer changes scraper behavior (lookups are single-attempt).
 	UseBinderposSharedProxyFallbackEnv = "USE_BINDERPOS_SHARED_PROXY_FALLBACK"
@@ -33,6 +36,20 @@ const UseLeasedDedicatedProxy = false
 
 func UseBinderposStorefrontAPI() bool {
 	rawValue := strings.TrimSpace(os.Getenv(UseBinderposStorefrontAPIEnv))
+	if rawValue == "" {
+		return true
+	}
+
+	enabled, err := strconv.ParseBool(rawValue)
+	if err != nil {
+		return true
+	}
+
+	return enabled
+}
+
+func UseDynamicProxy() bool {
+	rawValue := strings.TrimSpace(os.Getenv(UseDynamicProxyEnv))
 	if rawValue == "" {
 		return true
 	}

--- a/api/pkg/config/config_test.go
+++ b/api/pkg/config/config_test.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestUseDynamicProxy(t *testing.T) {
+	t.Run("defaults to enabled when unset", func(t *testing.T) {
+		t.Setenv(UseDynamicProxyEnv, "")
+		if !UseDynamicProxy() {
+			t.Fatalf("expected dynamic proxy to be enabled by default")
+		}
+	})
+
+	t.Run("respects explicit true", func(t *testing.T) {
+		t.Setenv(UseDynamicProxyEnv, "true")
+		if !UseDynamicProxy() {
+			t.Fatalf("expected dynamic proxy to be enabled")
+		}
+	})
+
+	t.Run("respects explicit false", func(t *testing.T) {
+		t.Setenv(UseDynamicProxyEnv, "false")
+		if UseDynamicProxy() {
+			t.Fatalf("expected dynamic proxy to be disabled")
+		}
+	})
+
+	t.Run("defaults to enabled for invalid value", func(t *testing.T) {
+		t.Setenv(UseDynamicProxyEnv, "not-a-bool")
+		if !UseDynamicProxy() {
+			t.Fatalf("expected invalid toggle to default to enabled")
+		}
+	})
+}

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -30,6 +30,7 @@ This document records **where** the app configures search behavior, **timeouts**
 |------|--------|--------|
 | Configured slots | **`DEDICATED_PROXY_1`** … **`DEDICATED_PROXY_7`** | Each value is `host\|port\|username\|password` (pipe-separated). Empty or incomplete entries are ignored when building URLs. |
 | Dynamic fallback proxy | **`DYNAMIC_PROXY`** | Uses the same `host\|port\|username\|password` format as `DEDICATED_PROXY_*` (full proxy URLs are also accepted). BinderPOS reserves it for the final fallback after dedicated and direct/no-proxy attempts. |
+| Dynamic proxy toggle | **`USE_DYNAMIC_PROXY`** | When `false`, dynamic proxy fallback is disabled even if `DYNAMIC_PROXY` is set. Defaults to enabled when unset or invalid. |
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `USE_DYNAMIC_PROXY` environment variable to control whether the shared dynamic proxy (`DYNAMIC_PROXY`) is used for fallback attempts.

- **Default:** enabled when unset (preserves current behavior)
- **When `false`:** dynamic proxy is skipped everywhere, even if `DYNAMIC_PROXY` is configured

## Implementation

All dynamic proxy usage flows through `gateway.DynamicProxyURL()`, which now checks `config.UseDynamicProxy()` before reading `DYNAMIC_PROXY`. This gates:

- BinderPOS `decklist-dynamic` and `scrap-dynamic` strategies
- Shopify suggest fallback chain (direct → dedicated → dynamic)
- Colly `applyInitialProxy` fallback when no dedicated proxies are configured

## Usage

```bash
# Disable dynamic proxy fallback
USE_DYNAMIC_PROXY=false

# Enable (default)
USE_DYNAMIC_PROXY=true
```

`DYNAMIC_PROXY` must still be set for dynamic proxy to be used when the toggle is enabled.

## Testing

- Added `api/pkg/config/config_test.go` for toggle parsing
- Extended collector, shopifysuggest, and binderpos tests for disabled toggle
- Focused gateway/config tests pass

`make test` hit an unrelated flaky failure in `gateway/cardscentral` (`Test_Search` quality field mismatch against live site).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65c8a328-bf2b-46fb-b9b7-e1af610b0f54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65c8a328-bf2b-46fb-b9b7-e1af610b0f54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

