### PR TITLE
Add 150-character max length validation for card name searches

### DIFF
--- a/api/handler/search.go
+++ b/api/handler/search.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"os"
@@ -66,7 +67,10 @@ func Search(ctx context.Context, request events.APIGatewayProxyRequest) (events.
 		return validationErrorResponse(
 			apiRes,
 			origin,
-			"card name is too long (maximum 64 characters)",
+			fmt.Sprintf(
+				"card name is too long (maximum %d characters)",
+				config.MaxSearchStringLength,
+			),
 		)
 	}
 

--- a/api/handler/search.go
+++ b/api/handler/search.go
@@ -21,6 +21,10 @@ type WebResponse struct {
 	Errors []controller.StoreError `json:"errors"`
 }
 
+type ValidationErrorResponse struct {
+	Error string `json:"error"`
+}
+
 var searchFunc = controller.Search
 
 func Search(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
@@ -52,9 +56,18 @@ func Search(ctx context.Context, request events.APIGatewayProxyRequest) (events.
 		lgsString, _ = url.QueryUnescape("Flagship%20Games%2CGames%20Haven%2CGrey%20Ogre%20Games%2CHideout%2CMana%20Pro%2CMox%20%26%20Lotus%2COneMtg%2CSanctuary%20Gaming")
 	}
 
-	if searchString == "" || len(searchString) < 3 {
+	if searchString == "" || len(searchString) < config.MinSearchStringLength {
 		apiRes.StatusCode = http.StatusBadRequest
 		return lambdaApiResponse(apiRes, webRes, origin)
+	}
+
+	if len(searchString) > config.MaxSearchStringLength {
+		apiRes.StatusCode = http.StatusBadRequest
+		return validationErrorResponse(
+			apiRes,
+			origin,
+			"card name is too long (maximum 64 characters)",
+		)
 	}
 
 	if lgsString != "" {
@@ -80,6 +93,25 @@ func Search(ctx context.Context, request events.APIGatewayProxyRequest) (events.
 	}
 
 	return lambdaApiResponse(apiRes, webRes, origin)
+}
+
+func validationErrorResponse(
+	apiResponse events.APIGatewayProxyResponse,
+	origin string,
+	message string,
+) (events.APIGatewayProxyResponse, error) {
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+
+	if err := encoder.Encode(ValidationErrorResponse{Error: message}); err != nil {
+		apiResponse.StatusCode = http.StatusInternalServerError
+		apiResponse.Body = "err marshalling validation error"
+		return lambdaApiResponse(apiResponse, WebResponse{}, origin)
+	}
+
+	apiResponse.Body = buf.String()
+	return lambdaApiResponse(apiResponse, WebResponse{}, origin)
 }
 
 func lambdaApiResponse(apiResponse events.APIGatewayProxyResponse, webResponse WebResponse, origin string) (events.APIGatewayProxyResponse, error) {

--- a/api/handler/search_test.go
+++ b/api/handler/search_test.go
@@ -181,11 +181,11 @@ func Test_Search_Err(t *testing.T) {
 		"search string too long": {
 			givenAPIGatewayProxyRequest: events.APIGatewayProxyRequest{
 				QueryStringParameters: map[string]string{
-					"s": strings.Repeat("a", 65),
+					"s": strings.Repeat("a", 151),
 				},
 			},
 			expStatusCode: http.StatusBadRequest,
-			expBody:       `{"error":"card name is too long (maximum 64 characters)"}` + "\n",
+			expBody:       `{"error":"card name is too long (maximum 150 characters)"}` + "\n",
 		},
 		"controller error": {
 			givenAPIGatewayProxyRequest: events.APIGatewayProxyRequest{

--- a/api/handler/search_test.go
+++ b/api/handler/search_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 
 	"mtg-price-checker-sg/controller"
@@ -176,6 +177,15 @@ func Test_Search_Err(t *testing.T) {
 			},
 			expStatusCode: http.StatusBadRequest,
 			expBody:       "",
+		},
+		"search string too long": {
+			givenAPIGatewayProxyRequest: events.APIGatewayProxyRequest{
+				QueryStringParameters: map[string]string{
+					"s": strings.Repeat("a", 65),
+				},
+			},
+			expStatusCode: http.StatusBadRequest,
+			expBody:       `{"error":"card name is too long (maximum 64 characters)"}` + "\n",
 		},
 		"controller error": {
 			givenAPIGatewayProxyRequest: events.APIGatewayProxyRequest{

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -11,10 +11,10 @@ const (
 	UtmSource        = "gishathfetch"
 	// MinSearchStringLength is the minimum number of characters required for a search.
 	MinSearchStringLength = 3
-	// MaxSearchStringLength caps card name searches. The longest tournament-legal
-	// MTG card names are ~41 characters; 64 allows partial names with headroom
-	// while rejecting bot paragraph spam.
-	MaxSearchStringLength = 64
+	// MaxSearchStringLength caps card name searches. The longest MTG card name is
+	// ~141 characters (Unhinged); 150 allows any real card name while rejecting
+	// bot paragraph spam.
+	MaxSearchStringLength = 150
 	MaxPagesToSearch      = 3
 	EnvProd          = "prod"
 	EnvStaging       = "staging"

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -9,7 +9,13 @@ import (
 
 const (
 	UtmSource        = "gishathfetch"
-	MaxPagesToSearch = 3
+	// MinSearchStringLength is the minimum number of characters required for a search.
+	MinSearchStringLength = 3
+	// MaxSearchStringLength caps card name searches. The longest tournament-legal
+	// MTG card names are ~41 characters; 64 allows partial names with headroom
+	// while rejecting bot paragraph spam.
+	MaxSearchStringLength = 64
+	MaxPagesToSearch      = 3
 	EnvProd          = "prod"
 	EnvStaging       = "staging"
 	EnvLocal         = "local"

--- a/frontend/src/components/SearchForm.jsx
+++ b/frontend/src/components/SearchForm.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { MAX_SEARCH_LENGTH } from "../constants";
 import StoreSelector from "./StoreSelector";
 
 const TIP_DISMISSED_STORAGE_KEY = "search-form-tip-dismissed";
@@ -110,6 +111,7 @@ const SearchForm = ({
               onKeyDown={handleKeyDown}
               autoComplete="off"
               onFocus={onFocus}
+              maxLength={MAX_SEARCH_LENGTH}
               aria-autocomplete="list"
               aria-controls="suggestions"
               aria-expanded={showSuggestions && suggestions.length > 0}

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -147,6 +147,9 @@ export const LGS_MAP = [
 ];
 
 export const MIN_SEARCH_LENGTH = 3;
+// Longest tournament-legal MTG card names are ~41 characters; 64 allows partial
+// names with headroom while rejecting bot paragraph spam.
+export const MAX_SEARCH_LENGTH = 64;
 
 export const API_BASE_URL =
   window.location.hostname === "staging.gishathfetch.com" ||

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -147,9 +147,9 @@ export const LGS_MAP = [
 ];
 
 export const MIN_SEARCH_LENGTH = 3;
-// Longest tournament-legal MTG card names are ~41 characters; 64 allows partial
-// names with headroom while rejecting bot paragraph spam.
-export const MAX_SEARCH_LENGTH = 64;
+// Covers the longest MTG card name (~141 characters) with a small buffer while
+// rejecting bot paragraph spam.
+export const MAX_SEARCH_LENGTH = 150;
 
 export const API_BASE_URL =
   window.location.hostname === "staging.gishathfetch.com" ||

--- a/frontend/src/hooks/useSearch.js
+++ b/frontend/src/hooks/useSearch.js
@@ -3,8 +3,11 @@ import {
   API_BASE_URL,
   BASE_URL,
   LGS_OPTIONS,
+  MAX_SEARCH_LENGTH,
   MIN_SEARCH_LENGTH,
 } from "../constants";
+
+const SEARCH_TOO_LONG_ERROR = `Card name is too long (maximum ${MAX_SEARCH_LENGTH} characters).`;
 
 // Search configuration constants
 const AUTOCOMPLETE_DEBOUNCE_MS = 300;
@@ -76,6 +79,13 @@ export default function useSearch() {
     (query, stores) => {
       if (!query || query.length < MIN_SEARCH_LENGTH) return;
 
+      if (query.length > MAX_SEARCH_LENGTH) {
+        setHasSearched(true);
+        setSearchResults([]);
+        setSearchError(SEARCH_TOO_LONG_ERROR);
+        return;
+      }
+
       if (progressIntervalRef.current) {
         clearInterval(progressIntervalRef.current);
         progressIntervalRef.current = null;
@@ -114,8 +124,24 @@ export default function useSearch() {
       progressIntervalRef.current = progressInterval;
 
       fetch(searchUrl, { signal: searchAbortController.signal })
-        .then((res) => {
+        .then(async (res) => {
           if (!res.ok) {
+            let validationMessage = null;
+            if (res.status === 400) {
+              try {
+                const errorBody = await res.json();
+                if (typeof errorBody?.error === "string" && errorBody.error) {
+                  validationMessage = errorBody.error;
+                }
+              } catch {
+                // Ignore malformed validation responses.
+              }
+            }
+
+            if (validationMessage) {
+              throw new Error(`Validation error: ${validationMessage}`);
+            }
+
             throw new Error(`Server error: ${res.status} ${res.statusText}`);
           }
           return res.json();
@@ -149,6 +175,8 @@ export default function useSearch() {
             setSearchError(
               "Unable to connect to the server. Please check your internet connection and try again.",
             );
+          } else if (err.message.startsWith("Validation error: ")) {
+            setSearchError(err.message.slice("Validation error: ".length));
           } else if (err.message.includes("Server error")) {
             setSearchError(
               "The server is experiencing issues. Please try again later.",
@@ -189,7 +217,10 @@ export default function useSearch() {
       return;
     }
 
-    if (searchQuery.length > MIN_SEARCH_LENGTH - 1) {
+    if (
+      searchQuery.length > MIN_SEARCH_LENGTH - 1 &&
+      searchQuery.length <= MAX_SEARCH_LENGTH
+    ) {
       const timer = setTimeout(() => {
         if (skipSuggestionsRef.current) return;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **150-character maximum** for card name search queries on both frontend and backend to fail fast on bot paragraph spam before store scrapers run.

## Limit rationale

| Context | Length |
|---------|--------|
| Longest MTG card name (Unhinged joke card) | ~141 chars |
| Longest tournament-legal name | ~41 chars |
| Typical card names | 10–30 chars |

**150 characters** covers every real card name (including the longest Unhinged joke card) with a small buffer, while still rejecting paragraph-length bot queries.

## Changes

### Backend (`api/handler/search.go`)
- Reject searches longer than 150 characters with HTTP 400
- Return JSON body: `{"error":"card name is too long (maximum 150 characters)"}`
- Constants live in `api/pkg/config/config.go` (`MinSearchStringLength`, `MaxSearchStringLength`)

### Frontend
- `MAX_SEARCH_LENGTH = 150` in `constants.js`
- Client-side validation in `useSearch.js` — shows error immediately without hitting the API
- `maxLength` attribute on the search input to prevent typing beyond the limit
- Autocomplete skipped for over-limit queries
- Parses backend 400 validation errors and displays the message to the user

## Testing

- `go test -mod=vendor ./handler/...` — passes (includes "search string too long" test case)
- `npx biome check` on changed frontend files — passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a617c9f-3207-4f19-aebd-03bb139ca7b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a617c9f-3207-4f19-aebd-03bb139ca7b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

