### PR TITLE
UI improvements: auto-search, a11y, theme icons, lazy map iframes

### DIFF
--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,3 +1,5 @@
+import { Moon, Sun } from "react-feather";
+
 const Header = ({ theme, onToggleTheme }) => {
   const isDarkMode = theme === "dark";
 
@@ -13,9 +15,11 @@ const Header = ({ theme, onToggleTheme }) => {
             title={`Switch to ${isDarkMode ? "light" : "dark"} mode`}
             aria-pressed={isDarkMode}
           >
-            <span className="theme-toggle-icon" aria-hidden="true">
-              💡
-            </span>
+            {isDarkMode ? (
+              <Sun size={16} aria-hidden="true" />
+            ) : (
+              <Moon size={16} aria-hidden="true" />
+            )}
           </button>
         </div>
         <div>

--- a/frontend/src/components/LazyMapIframe.jsx
+++ b/frontend/src/components/LazyMapIframe.jsx
@@ -1,0 +1,55 @@
+import { useEffect, useRef, useState } from "react";
+
+const LazyMapIframe = ({ src, title, isActive }) => {
+  const containerRef = useRef(null);
+  const [shouldLoad, setShouldLoad] = useState(false);
+
+  useEffect(() => {
+    if (!isActive || shouldLoad) {
+      return;
+    }
+
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setShouldLoad(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: "200px" },
+    );
+
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [isActive, shouldLoad]);
+
+  return (
+    <div ref={containerRef} className="mb-3" style={{ minHeight: "450px" }}>
+      {shouldLoad ? (
+        <iframe
+          className="w-100 border border-dark"
+          style={{ minHeight: "450px" }}
+          src={src}
+          allowFullScreen=""
+          loading="lazy"
+          referrerPolicy="no-referrer-when-downgrade"
+          title={title}
+        />
+      ) : (
+        <div
+          className="w-100 border border-dark d-flex align-items-center justify-content-center text-muted"
+          style={{ minHeight: "450px" }}
+        >
+          Loading map…
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default LazyMapIframe;

--- a/frontend/src/components/Modals.jsx
+++ b/frontend/src/components/Modals.jsx
@@ -1,4 +1,5 @@
 import { Button, Modal } from "react-bootstrap";
+import LazyMapIframe from "./LazyMapIframe";
 
 const Modals = ({
   showMap,
@@ -40,15 +41,11 @@ const Modals = ({
                   {shop.website}
                 </a>
               </div>
-              <iframe
-                className="w-100 border border-dark mb-3"
-                style={{ minHeight: "450px" }}
+              <LazyMapIframe
                 src={shop.iframe}
-                allowFullScreen=""
-                loading="lazy"
-                referrerPolicy="no-referrer-when-downgrade"
                 title={shop.name}
-              ></iframe>
+                isActive={showMap}
+              />
               <div>
                 <Button
                   variant="primary"

--- a/frontend/src/components/SearchForm.jsx
+++ b/frontend/src/components/SearchForm.jsx
@@ -100,11 +100,11 @@ const SearchForm = ({
       <form id="searchForm" onSubmit={onSearchSubmit}>
         <div className="mb-3 position-relative">
           <div className="form-floating">
-            {/* biome-ignore lint/a11y/useAriaPropsSupportedByRole: Controlled input behaves like combobox */}
             <input
               type="search"
               className="form-control"
               id="search"
+              role="combobox"
               placeholder="lightning bolt"
               value={searchQuery}
               onChange={onQueryChange}
@@ -115,6 +115,9 @@ const SearchForm = ({
               aria-autocomplete="list"
               aria-controls="suggestions"
               aria-expanded={showSuggestions && suggestions.length > 0}
+              aria-activedescendant={
+                selectedIndex >= 0 ? `suggestion-${selectedIndex}` : undefined
+              }
             />
             <label htmlFor="search">Card Name</label>
           </div>
@@ -139,6 +142,7 @@ const SearchForm = ({
                   // biome-ignore lint/a11y/useKeyWithClickEvents: Keyboard navigation is handled by input
                   <div
                     key={s}
+                    id={`suggestion-${suggestionIndex}`}
                     className={`suggestion-item${selectedIndex === suggestionIndex ? " selected" : ""}`}
                     onClick={() => {
                       onSuggestionClick(s);

--- a/frontend/src/hooks/useSearch.js
+++ b/frontend/src/hooks/useSearch.js
@@ -304,8 +304,9 @@ export default function useSearch() {
     setSearchQuery(suggestion);
     setShowSuggestions(false);
 
-    // Auto-select all stores if none selected (for when user clicks Search button)
+    let storesToSearch = selectedStores;
     if (selectedStores.length === 0) {
+      storesToSearch = LGS_OPTIONS;
       setSelectedStores(LGS_OPTIONS);
       try {
         localStorage.setItem(
@@ -316,7 +317,8 @@ export default function useSearch() {
         console.error("Failed to save selected stores:", err);
       }
     }
-    // Note: Search is NOT triggered automatically - user must click Search button or press Enter
+
+    performSearch(suggestion, storesToSearch);
   };
 
   const handleSearchSubmit = (e) => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -13,7 +13,7 @@
 }
 
 body {
-  font-family: "Barlow", serif;
+  font-family: "Barlow", sans-serif;
   background-color: var(--bs-body-bg);
   color: var(--bs-body-color);
 }
@@ -112,15 +112,7 @@ body {
 }
 
 #suggestions div:nth-child(even) {
-  background-color: #fbfbfb;
-}
-
-[data-bs-theme="dark"] #suggestions div:nth-child(even) {
-  background-color: color-mix(
-    in srgb,
-    var(--bs-body-bg) 92%,
-    var(--bs-body-color) 8%
-  );
+  background-color: var(--bs-tertiary-bg);
 }
 
 #suggestions div:not(:last-child) {
@@ -129,13 +121,13 @@ body {
 
 #suggestions div.suggestion-item:hover,
 #suggestions div.suggestion-item.selected {
-  background: #0d6efd;
-  color: #fff;
+  background: var(--bs-primary);
+  color: var(--bs-white);
 }
 
-input#search:focus {
-  box-shadow: none;
-  border-color: #dee2e6;
+input#search:focus-visible {
+  border-color: var(--bs-primary);
+  box-shadow: 0 0 0 0.25rem rgba(var(--bs-primary-rgb), 0.25);
 }
 
 @media (min-width: 1400px) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements five UI improvements from the UX review:

1. **Auto-search on autocomplete selection** — Picking a Scryfall suggestion now immediately runs the search (same store-selection logic as the Search button).
2. **Theme toggle icons** — Replaced the emoji toggle with Feather `Sun`/`Moon` icons for consistency with the rest of the UI.
3. **CSS polish** — Fixed Barlow `sans-serif` fallback, restored a visible `:focus-visible` ring on the search input, and switched suggestion hover/selected colors to Bootstrap CSS variables for proper dark-mode support.
4. **Combobox accessibility** — Added `role="combobox"`, per-option `id`s, and `aria-activedescendant` on the search input.
5. **Lazy-loaded map iframes** — New `LazyMapIframe` component uses `IntersectionObserver` to defer loading Google Maps embeds until each shop section scrolls into view (with a 200px root margin). Observing is gated on the map modal being open.

## Test plan

- [x] `npm run build` (frontend)
- [x] `npx biome check` on changed files (pre-existing Modals.jsx format warning unrelated to this diff)
- [ ] `make test` — `gateway/cardscentral` live scraper test failed transiently on upstream data (`Near Mint` vs `DMG`); unrelated to frontend changes
- [ ] Manual: select autocomplete suggestion → search starts automatically
- [ ] Manual: theme toggle shows Sun in dark mode, Moon in light mode
- [ ] Manual: keyboard navigate suggestions with visible focus ring; screen reader gets active option via `aria-activedescendant`
- [ ] Manual: open Map modal → only visible shop maps load; scroll loads additional iframes

## Screenshots

UI changes affect search autocomplete, theme toggle, and map modal. Desktop/mobile screenshots to be captured during review.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-589fea7a-7956-4119-a30c-ebbbd33c7a7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-589fea7a-7956-4119-a30c-ebbbd33c7a7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

