### PR TITLE
Add post-search filters, sorting, and empty states

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -152,6 +152,7 @@ export default function App() {
 
       <SearchResults
         results={searchResults}
+        searchQuery={searchQuery}
         isSearching={isSearching}
         hasSearched={hasSearched}
         searchError={searchError}

--- a/frontend/src/components/ResultFilters.jsx
+++ b/frontend/src/components/ResultFilters.jsx
@@ -3,6 +3,9 @@ import { Form } from "react-bootstrap";
 const ResultFilters = ({
   sortBy,
   onSortChange,
+  qualityFilter,
+  onQualityFilterChange,
+  availableQualities,
   foilOnly,
   onFoilOnlyChange,
   hasActiveFilters,
@@ -11,7 +14,7 @@ const ResultFilters = ({
   return (
     <div className="mb-3 text-start result-filters">
       <div className="row g-2 align-items-end">
-        <div className="col-12 col-md-6">
+        <div className="col-12 col-md-4">
           <Form.Label htmlFor="result-sort" className="small fw-semibold mb-1">
             Sort by
           </Form.Label>
@@ -26,7 +29,30 @@ const ResultFilters = ({
             <option value="store-asc">Store name</option>
           </Form.Select>
         </div>
-        <div className="col-12 col-md-6 d-flex flex-wrap align-items-center gap-3">
+        {availableQualities.length > 0 && (
+          <div className="col-12 col-md-4">
+            <Form.Label
+              htmlFor="quality-filter"
+              className="small fw-semibold mb-1"
+            >
+              Condition
+            </Form.Label>
+            <Form.Select
+              id="quality-filter"
+              size="sm"
+              value={qualityFilter}
+              onChange={(e) => onQualityFilterChange(e.target.value)}
+            >
+              <option value="all">All conditions</option>
+              {availableQualities.map((quality) => (
+                <option key={quality} value={quality}>
+                  {quality}
+                </option>
+              ))}
+            </Form.Select>
+          </div>
+        )}
+        <div className="col-12 col-md-4 d-flex flex-wrap align-items-center gap-3">
           <Form.Check
             type="checkbox"
             id="foil-only"

--- a/frontend/src/components/ResultFilters.jsx
+++ b/frontend/src/components/ResultFilters.jsx
@@ -1,0 +1,139 @@
+import { Form } from "react-bootstrap";
+
+const ResultFilters = ({
+  sortBy,
+  onSortChange,
+  foilOnly,
+  onFoilOnlyChange,
+  qualityFilter,
+  onQualityFilterChange,
+  availableQualities,
+  priceMin,
+  onPriceMinChange,
+  priceMax,
+  onPriceMaxChange,
+  availableStores,
+  isStoreSelected,
+  onToggleStore,
+  hasActiveFilters,
+  onClearFilters,
+}) => {
+  return (
+    <div className="mb-3 text-start result-filters">
+      <div className="row g-2 align-items-end mb-2">
+        <div className="col-12 col-md-4">
+          <Form.Label htmlFor="result-sort" className="small fw-semibold mb-1">
+            Sort by
+          </Form.Label>
+          <Form.Select
+            id="result-sort"
+            size="sm"
+            value={sortBy}
+            onChange={(e) => onSortChange(e.target.value)}
+          >
+            <option value="price-asc">Price (low to high)</option>
+            <option value="price-desc">Price (high to low)</option>
+            <option value="store-asc">Store name</option>
+          </Form.Select>
+        </div>
+        <div className="col-6 col-md-2">
+          <Form.Label htmlFor="price-min" className="small fw-semibold mb-1">
+            Min price
+          </Form.Label>
+          <Form.Control
+            id="price-min"
+            type="number"
+            size="sm"
+            min="0"
+            step="0.01"
+            placeholder="S$"
+            value={priceMin}
+            onChange={(e) => onPriceMinChange(e.target.value)}
+          />
+        </div>
+        <div className="col-6 col-md-2">
+          <Form.Label htmlFor="price-max" className="small fw-semibold mb-1">
+            Max price
+          </Form.Label>
+          <Form.Control
+            id="price-max"
+            type="number"
+            size="sm"
+            min="0"
+            step="0.01"
+            placeholder="S$"
+            value={priceMax}
+            onChange={(e) => onPriceMaxChange(e.target.value)}
+          />
+        </div>
+        <div className="col-12 col-md-4 d-flex flex-wrap align-items-center gap-3">
+          <Form.Check
+            type="checkbox"
+            id="foil-only"
+            label="Foil only"
+            checked={foilOnly}
+            onChange={(e) => onFoilOnlyChange(e.target.checked)}
+            className="mb-0"
+          />
+          {hasActiveFilters && (
+            <button
+              type="button"
+              className="btn btn-link btn-sm p-0 text-decoration-none"
+              onClick={onClearFilters}
+            >
+              Clear filters
+            </button>
+          )}
+        </div>
+      </div>
+
+      {availableQualities.length > 0 && (
+        <div className="mb-2">
+          <Form.Label
+            htmlFor="quality-filter"
+            className="small fw-semibold mb-1"
+          >
+            Condition
+          </Form.Label>
+          <Form.Select
+            id="quality-filter"
+            size="sm"
+            value={qualityFilter}
+            onChange={(e) => onQualityFilterChange(e.target.value)}
+          >
+            <option value="all">All conditions</option>
+            {availableQualities.map((quality) => (
+              <option key={quality} value={quality}>
+                {quality}
+              </option>
+            ))}
+          </Form.Select>
+        </div>
+      )}
+
+      {availableStores.length > 1 && (
+        <div>
+          <div className="small fw-semibold mb-1">Stores</div>
+          <div className="d-flex flex-wrap gap-1">
+            {availableStores.map((store) => {
+              const selected = isStoreSelected(store);
+              return (
+                <button
+                  key={store}
+                  type="button"
+                  className={`btn btn-sm ${selected ? "btn-primary" : "btn-outline-secondary"}`}
+                  onClick={() => onToggleStore(store)}
+                  aria-pressed={selected}
+                >
+                  {store}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ResultFilters;

--- a/frontend/src/components/ResultFilters.jsx
+++ b/frontend/src/components/ResultFilters.jsx
@@ -5,23 +5,13 @@ const ResultFilters = ({
   onSortChange,
   foilOnly,
   onFoilOnlyChange,
-  qualityFilter,
-  onQualityFilterChange,
-  availableQualities,
-  priceMin,
-  onPriceMinChange,
-  priceMax,
-  onPriceMaxChange,
-  availableStores,
-  isStoreSelected,
-  onToggleStore,
   hasActiveFilters,
   onClearFilters,
 }) => {
   return (
     <div className="mb-3 text-start result-filters">
-      <div className="row g-2 align-items-end mb-2">
-        <div className="col-12 col-md-4">
+      <div className="row g-2 align-items-end">
+        <div className="col-12 col-md-6">
           <Form.Label htmlFor="result-sort" className="small fw-semibold mb-1">
             Sort by
           </Form.Label>
@@ -36,37 +26,7 @@ const ResultFilters = ({
             <option value="store-asc">Store name</option>
           </Form.Select>
         </div>
-        <div className="col-6 col-md-2">
-          <Form.Label htmlFor="price-min" className="small fw-semibold mb-1">
-            Min price
-          </Form.Label>
-          <Form.Control
-            id="price-min"
-            type="number"
-            size="sm"
-            min="0"
-            step="0.01"
-            placeholder="S$"
-            value={priceMin}
-            onChange={(e) => onPriceMinChange(e.target.value)}
-          />
-        </div>
-        <div className="col-6 col-md-2">
-          <Form.Label htmlFor="price-max" className="small fw-semibold mb-1">
-            Max price
-          </Form.Label>
-          <Form.Control
-            id="price-max"
-            type="number"
-            size="sm"
-            min="0"
-            step="0.01"
-            placeholder="S$"
-            value={priceMax}
-            onChange={(e) => onPriceMaxChange(e.target.value)}
-          />
-        </div>
-        <div className="col-12 col-md-4 d-flex flex-wrap align-items-center gap-3">
+        <div className="col-12 col-md-6 d-flex flex-wrap align-items-center gap-3">
           <Form.Check
             type="checkbox"
             id="foil-only"
@@ -86,52 +46,6 @@ const ResultFilters = ({
           )}
         </div>
       </div>
-
-      {availableQualities.length > 0 && (
-        <div className="mb-2">
-          <Form.Label
-            htmlFor="quality-filter"
-            className="small fw-semibold mb-1"
-          >
-            Condition
-          </Form.Label>
-          <Form.Select
-            id="quality-filter"
-            size="sm"
-            value={qualityFilter}
-            onChange={(e) => onQualityFilterChange(e.target.value)}
-          >
-            <option value="all">All conditions</option>
-            {availableQualities.map((quality) => (
-              <option key={quality} value={quality}>
-                {quality}
-              </option>
-            ))}
-          </Form.Select>
-        </div>
-      )}
-
-      {availableStores.length > 1 && (
-        <div>
-          <div className="small fw-semibold mb-1">Stores</div>
-          <div className="d-flex flex-wrap gap-1">
-            {availableStores.map((store) => {
-              const selected = isStoreSelected(store);
-              return (
-                <button
-                  key={store}
-                  type="button"
-                  className={`btn btn-sm ${selected ? "btn-primary" : "btn-outline-secondary"}`}
-                  onClick={() => onToggleStore(store)}
-                  aria-pressed={selected}
-                >
-                  {store}
-                </button>
-              );
-            })}
-          </div>
-        </div>
-      )}
     </div>
   );
 };

--- a/frontend/src/components/SearchResults.jsx
+++ b/frontend/src/components/SearchResults.jsx
@@ -20,9 +20,9 @@ const EmptySearchState = () => (
 
 const EmptyFilteredState = ({ onClearFilters }) => (
   <div className="mb-3 text-center py-4 px-3">
-    <div className="fw-semibold mb-2">No foil results found</div>
+    <div className="fw-semibold mb-2">No results match your filters</div>
     <p className="small text-muted mb-3">
-      Try turning off foil only to see all printings.
+      Try a different condition, turning off foil only, or clear your filters.
     </p>
     <button
       type="button"
@@ -50,6 +50,9 @@ const SearchResults = ({
     filteredResults,
     sortBy,
     setSortBy,
+    qualityFilter,
+    setQualityFilter,
+    availableQualities,
     foilOnly,
     setFoilOnly,
     hasActiveFilters,
@@ -86,6 +89,9 @@ const SearchResults = ({
             <ResultFilters
               sortBy={sortBy}
               onSortChange={setSortBy}
+              qualityFilter={qualityFilter}
+              onQualityFilterChange={setQualityFilter}
+              availableQualities={availableQualities}
               foilOnly={foilOnly}
               onFoilOnlyChange={setFoilOnly}
               hasActiveFilters={hasActiveFilters}

--- a/frontend/src/components/SearchResults.jsx
+++ b/frontend/src/components/SearchResults.jsx
@@ -20,10 +20,9 @@ const EmptySearchState = () => (
 
 const EmptyFilteredState = ({ onClearFilters }) => (
   <div className="mb-3 text-center bg-body-secondary border rounded py-4 px-3">
-    <div className="fw-semibold mb-2">No results match your filters</div>
+    <div className="fw-semibold mb-2">No foil results found</div>
     <p className="small text-muted mb-3">
-      Try widening your price range, including more stores, or turning off foil
-      only.
+      Try turning off foil only to see all printings.
     </p>
     <button
       type="button"
@@ -53,16 +52,6 @@ const SearchResults = ({
     setSortBy,
     foilOnly,
     setFoilOnly,
-    qualityFilter,
-    setQualityFilter,
-    priceMin,
-    setPriceMin,
-    priceMax,
-    setPriceMax,
-    availableStores,
-    availableQualities,
-    toggleStore,
-    isStoreSelected,
     hasActiveFilters,
     clearFilters,
   } = useResultFilters(results, searchQuery);
@@ -99,16 +88,6 @@ const SearchResults = ({
               onSortChange={setSortBy}
               foilOnly={foilOnly}
               onFoilOnlyChange={setFoilOnly}
-              qualityFilter={qualityFilter}
-              onQualityFilterChange={setQualityFilter}
-              availableQualities={availableQualities}
-              priceMin={priceMin}
-              onPriceMinChange={setPriceMin}
-              priceMax={priceMax}
-              onPriceMaxChange={setPriceMax}
-              availableStores={availableStores}
-              isStoreSelected={isStoreSelected}
-              onToggleStore={toggleStore}
               hasActiveFilters={hasActiveFilters}
               onClearFilters={clearFilters}
             />

--- a/frontend/src/components/SearchResults.jsx
+++ b/frontend/src/components/SearchResults.jsx
@@ -9,7 +9,7 @@ import SkeletonCard from "./SkeletonCard";
 const AD_DISPLAY_INTERVAL = 8;
 
 const EmptySearchState = () => (
-  <div className="mb-3 text-center bg-body-secondary border rounded py-4 px-3">
+  <div className="mb-3 text-center py-4 px-3">
     <div className="fw-semibold mb-2">No results found</div>
     <p className="small text-muted mb-0">
       Try picking a card from the auto-suggest, using the full card name, or
@@ -19,7 +19,7 @@ const EmptySearchState = () => (
 );
 
 const EmptyFilteredState = ({ onClearFilters }) => (
-  <div className="mb-3 text-center bg-body-secondary border rounded py-4 px-3">
+  <div className="mb-3 text-center py-4 px-3">
     <div className="fw-semibold mb-2">No foil results found</div>
     <p className="small text-muted mb-3">
       Try turning off foil only to see all printings.

--- a/frontend/src/components/SearchResults.jsx
+++ b/frontend/src/components/SearchResults.jsx
@@ -1,13 +1,43 @@
 import React from "react";
+import useResultFilters from "../hooks/useResultFilters";
 import AdComponent from "./AdComponent";
 import Card from "./Card";
+import ResultFilters from "./ResultFilters";
 import SkeletonCard from "./SkeletonCard";
 
 // Display ad after every N results
 const AD_DISPLAY_INTERVAL = 8;
 
+const EmptySearchState = () => (
+  <div className="mb-3 text-center bg-body-secondary border rounded py-4 px-3">
+    <div className="fw-semibold mb-2">No results found</div>
+    <p className="small text-muted mb-0">
+      Try picking a card from the auto-suggest, using the full card name, or
+      selecting fewer stores for a faster, more accurate search.
+    </p>
+  </div>
+);
+
+const EmptyFilteredState = ({ onClearFilters }) => (
+  <div className="mb-3 text-center bg-body-secondary border rounded py-4 px-3">
+    <div className="fw-semibold mb-2">No results match your filters</div>
+    <p className="small text-muted mb-3">
+      Try widening your price range, including more stores, or turning off foil
+      only.
+    </p>
+    <button
+      type="button"
+      className="btn btn-outline-primary btn-sm"
+      onClick={onClearFilters}
+    >
+      Clear filters
+    </button>
+  </div>
+);
+
 const SearchResults = ({
   results,
+  searchQuery,
   isSearching,
   hasSearched,
   searchError,
@@ -17,58 +47,116 @@ const SearchResults = ({
   onSearchStore,
   baseUrl,
 }) => {
+  const {
+    filteredResults,
+    sortBy,
+    setSortBy,
+    foilOnly,
+    setFoilOnly,
+    qualityFilter,
+    setQualityFilter,
+    priceMin,
+    setPriceMin,
+    priceMax,
+    setPriceMax,
+    availableStores,
+    availableQualities,
+    toggleStore,
+    isStoreSelected,
+    hasActiveFilters,
+    clearFilters,
+  } = useResultFilters(results, searchQuery);
+
+  const resultCountLabel = hasActiveFilters
+    ? `Showing ${filteredResults.length} of ${results.length} result${results.length !== 1 ? "s" : ""}`
+    : `${results.length} result${results.length !== 1 ? "s" : ""} found`;
+
   return (
     <>
       {hasSearched &&
         !isSearching &&
         (searchError ? (
-          <div className="mb-3 text-center bg-danger-subtle text-dark rounded py-2">
+          <div
+            className="mb-3 text-center bg-danger-subtle text-dark rounded py-2"
+            role="alert"
+          >
             <strong>Error:</strong> {searchError}
           </div>
+        ) : results.length === 0 ? (
+          <EmptySearchState />
         ) : (
-          <div
-            id="resultCount"
-            className="mb-3 text-center bg-warning-subtle text-warning-emphasis rounded py-2"
-          >
-            {results?.length || 0} result{results?.length !== 1 ? "s" : ""}{" "}
-            found
-          </div>
+          <>
+            <div
+              id="resultCount"
+              className="mb-3 text-center bg-warning-subtle text-warning-emphasis rounded py-2"
+              aria-live="polite"
+            >
+              {resultCountLabel}
+            </div>
+
+            <ResultFilters
+              sortBy={sortBy}
+              onSortChange={setSortBy}
+              foilOnly={foilOnly}
+              onFoilOnlyChange={setFoilOnly}
+              qualityFilter={qualityFilter}
+              onQualityFilterChange={setQualityFilter}
+              availableQualities={availableQualities}
+              priceMin={priceMin}
+              onPriceMinChange={setPriceMin}
+              priceMax={priceMax}
+              onPriceMaxChange={setPriceMax}
+              availableStores={availableStores}
+              isStoreSelected={isStoreSelected}
+              onToggleStore={toggleStore}
+              hasActiveFilters={hasActiveFilters}
+              onClearFilters={clearFilters}
+            />
+
+            {filteredResults.length === 0 ? (
+              <EmptyFilteredState onClearFilters={clearFilters} />
+            ) : (
+              <div id="result" className="mb-3 text-center">
+                <div className="row">
+                  {filteredResults.map((card, i) => {
+                    const showAd =
+                      filteredResults.length > AD_DISPLAY_INTERVAL &&
+                      (i + 1) % AD_DISPLAY_INTERVAL === 0 &&
+                      i + 1 !== filteredResults.length;
+                    return (
+                      <React.Fragment
+                        key={`${card.src}-${card.url}-${card.price}-${card.quality}`}
+                      >
+                        <Card
+                          card={card}
+                          index={i}
+                          isCardInCart={isCardInCart}
+                          addToCart={addToCart}
+                          removeFromCart={removeFromCart}
+                          onSearchStore={onSearchStore}
+                          baseUrl={baseUrl}
+                        />
+                        {showAd && (
+                          <div className="col-12 mb-4">
+                            <AdComponent />
+                          </div>
+                        )}
+                      </React.Fragment>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+          </>
         ))}
 
-      {((results && results.length > 0) || isSearching) && (
+      {isSearching && (
         <div id="result" className="mb-3 text-center">
           <div className="row">
-            {results.map((card, i) => {
-              const showAd =
-                results.length > AD_DISPLAY_INTERVAL &&
-                (i + 1) % AD_DISPLAY_INTERVAL === 0 &&
-                i + 1 !== results.length;
-              return (
-                // biome-ignore lint/suspicious/noArrayIndexKey: List is derived from results which are stable for this render
-                <React.Fragment key={i}>
-                  <Card
-                    card={card}
-                    index={i}
-                    isCardInCart={isCardInCart}
-                    addToCart={addToCart}
-                    removeFromCart={removeFromCart}
-                    onSearchStore={onSearchStore}
-                    baseUrl={baseUrl}
-                  />
-                  {showAd && (
-                    <div className="col-12 mb-4">
-                      <AdComponent />
-                    </div>
-                  )}
-                </React.Fragment>
-              );
-            })}
-
-            {isSearching &&
-              [...Array(4)].map((_, i) => (
-                // biome-ignore lint/suspicious/noArrayIndexKey: Skeleton loaders are static
-                <SkeletonCard key={`skeleton-${i}`} />
-              ))}
+            {[...Array(4)].map((_, i) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: Skeleton loaders are static
+              <SkeletonCard key={`skeleton-${i}`} />
+            ))}
           </div>
         </div>
       )}

--- a/frontend/src/hooks/useResultFilters.js
+++ b/frontend/src/hooks/useResultFilters.js
@@ -1,0 +1,142 @@
+import { useEffect, useMemo, useState } from "react";
+
+const DEFAULT_SORT = "price-asc";
+
+export default function useResultFilters(results, searchQuery) {
+  const [sortBy, setSortBy] = useState(DEFAULT_SORT);
+  const [foilOnly, setFoilOnly] = useState(false);
+  const [selectedStores, setSelectedStores] = useState(null);
+  const [qualityFilter, setQualityFilter] = useState("all");
+  const [priceMin, setPriceMin] = useState("");
+  const [priceMax, setPriceMax] = useState("");
+
+  // Reset filters when the user runs a new search.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: searchQuery triggers filter reset on new search
+  useEffect(() => {
+    setSortBy(DEFAULT_SORT);
+    setFoilOnly(false);
+    setSelectedStores(null);
+    setQualityFilter("all");
+    setPriceMin("");
+    setPriceMax("");
+  }, [searchQuery]);
+
+  const availableStores = useMemo(() => {
+    const stores = new Set();
+    for (const card of results) {
+      if (card.src) {
+        stores.add(card.src);
+      }
+    }
+    return [...stores].sort();
+  }, [results]);
+
+  const availableQualities = useMemo(() => {
+    const qualities = new Set();
+    for (const card of results) {
+      if (card.quality) {
+        qualities.add(card.quality);
+      }
+    }
+    return [...qualities].sort();
+  }, [results]);
+
+  const filteredResults = useMemo(() => {
+    let filtered = [...results];
+
+    if (foilOnly) {
+      filtered = filtered.filter((card) => card.isFoil);
+    }
+
+    if (selectedStores !== null) {
+      filtered = filtered.filter((card) => selectedStores.includes(card.src));
+    }
+
+    if (qualityFilter !== "all") {
+      filtered = filtered.filter((card) => card.quality === qualityFilter);
+    }
+
+    const min = priceMin !== "" ? Number.parseFloat(priceMin) : null;
+    const max = priceMax !== "" ? Number.parseFloat(priceMax) : null;
+    if (min !== null && !Number.isNaN(min)) {
+      filtered = filtered.filter((card) => card.price >= min);
+    }
+    if (max !== null && !Number.isNaN(max)) {
+      filtered = filtered.filter((card) => card.price <= max);
+    }
+
+    filtered.sort((a, b) => {
+      switch (sortBy) {
+        case "price-desc":
+          return b.price - a.price;
+        case "store-asc":
+          return a.src.localeCompare(b.src) || a.price - b.price;
+        default:
+          return a.price - b.price;
+      }
+    });
+
+    return filtered;
+  }, [
+    results,
+    sortBy,
+    foilOnly,
+    selectedStores,
+    qualityFilter,
+    priceMin,
+    priceMax,
+  ]);
+
+  const hasActiveFilters =
+    foilOnly ||
+    selectedStores !== null ||
+    qualityFilter !== "all" ||
+    priceMin !== "" ||
+    priceMax !== "";
+
+  const clearFilters = () => {
+    setFoilOnly(false);
+    setSelectedStores(null);
+    setQualityFilter("all");
+    setPriceMin("");
+    setPriceMax("");
+  };
+
+  const toggleStore = (store) => {
+    setSelectedStores((prev) => {
+      const current = prev ?? availableStores;
+      const next = current.includes(store)
+        ? current.filter((s) => s !== store)
+        : [...current, store];
+      if (next.length === availableStores.length) {
+        return null;
+      }
+      return next;
+    });
+  };
+
+  const isStoreSelected = (store) => {
+    const current = selectedStores ?? availableStores;
+    return current.includes(store);
+  };
+
+  return {
+    filteredResults,
+    sortBy,
+    setSortBy,
+    foilOnly,
+    setFoilOnly,
+    qualityFilter,
+    setQualityFilter,
+    priceMin,
+    setPriceMin,
+    priceMax,
+    setPriceMax,
+    availableStores,
+    availableQualities,
+    toggleStore,
+    isStoreSelected,
+    hasActiveFilters,
+    clearFilters,
+  };
+}

--- a/frontend/src/hooks/useResultFilters.js
+++ b/frontend/src/hooks/useResultFilters.js
@@ -4,19 +4,37 @@ const DEFAULT_SORT = "price-asc";
 
 export default function useResultFilters(results, searchQuery) {
   const [sortBy, setSortBy] = useState(DEFAULT_SORT);
+  const [qualityFilter, setQualityFilter] = useState("all");
   const [foilOnly, setFoilOnly] = useState(false);
 
   // Reset filters when the user runs a new search.
   // biome-ignore lint/correctness/useExhaustiveDependencies: searchQuery triggers filter reset on new search
   useEffect(() => {
     setSortBy(DEFAULT_SORT);
+    setQualityFilter("all");
     setFoilOnly(false);
   }, [searchQuery]);
 
+  const availableQualities = useMemo(() => {
+    const qualities = new Set();
+    for (const card of results) {
+      if (card.quality) {
+        qualities.add(card.quality);
+      }
+    }
+    return [...qualities].sort();
+  }, [results]);
+
   const filteredResults = useMemo(() => {
-    const filtered = foilOnly
-      ? results.filter((card) => card.isFoil)
-      : [...results];
+    let filtered = [...results];
+
+    if (qualityFilter !== "all") {
+      filtered = filtered.filter((card) => card.quality === qualityFilter);
+    }
+
+    if (foilOnly) {
+      filtered = filtered.filter((card) => card.isFoil);
+    }
 
     filtered.sort((a, b) => {
       switch (sortBy) {
@@ -30,9 +48,12 @@ export default function useResultFilters(results, searchQuery) {
     });
 
     return filtered;
-  }, [results, sortBy, foilOnly]);
+  }, [results, sortBy, qualityFilter, foilOnly]);
+
+  const hasActiveFilters = qualityFilter !== "all" || foilOnly;
 
   const clearFilters = () => {
+    setQualityFilter("all");
     setFoilOnly(false);
   };
 
@@ -40,9 +61,12 @@ export default function useResultFilters(results, searchQuery) {
     filteredResults,
     sortBy,
     setSortBy,
+    qualityFilter,
+    setQualityFilter,
+    availableQualities,
     foilOnly,
     setFoilOnly,
-    hasActiveFilters: foilOnly,
+    hasActiveFilters,
     clearFilters,
   };
 }

--- a/frontend/src/hooks/useResultFilters.js
+++ b/frontend/src/hooks/useResultFilters.js
@@ -5,65 +5,18 @@ const DEFAULT_SORT = "price-asc";
 export default function useResultFilters(results, searchQuery) {
   const [sortBy, setSortBy] = useState(DEFAULT_SORT);
   const [foilOnly, setFoilOnly] = useState(false);
-  const [selectedStores, setSelectedStores] = useState(null);
-  const [qualityFilter, setQualityFilter] = useState("all");
-  const [priceMin, setPriceMin] = useState("");
-  const [priceMax, setPriceMax] = useState("");
 
   // Reset filters when the user runs a new search.
   // biome-ignore lint/correctness/useExhaustiveDependencies: searchQuery triggers filter reset on new search
   useEffect(() => {
     setSortBy(DEFAULT_SORT);
     setFoilOnly(false);
-    setSelectedStores(null);
-    setQualityFilter("all");
-    setPriceMin("");
-    setPriceMax("");
   }, [searchQuery]);
 
-  const availableStores = useMemo(() => {
-    const stores = new Set();
-    for (const card of results) {
-      if (card.src) {
-        stores.add(card.src);
-      }
-    }
-    return [...stores].sort();
-  }, [results]);
-
-  const availableQualities = useMemo(() => {
-    const qualities = new Set();
-    for (const card of results) {
-      if (card.quality) {
-        qualities.add(card.quality);
-      }
-    }
-    return [...qualities].sort();
-  }, [results]);
-
   const filteredResults = useMemo(() => {
-    let filtered = [...results];
-
-    if (foilOnly) {
-      filtered = filtered.filter((card) => card.isFoil);
-    }
-
-    if (selectedStores !== null) {
-      filtered = filtered.filter((card) => selectedStores.includes(card.src));
-    }
-
-    if (qualityFilter !== "all") {
-      filtered = filtered.filter((card) => card.quality === qualityFilter);
-    }
-
-    const min = priceMin !== "" ? Number.parseFloat(priceMin) : null;
-    const max = priceMax !== "" ? Number.parseFloat(priceMax) : null;
-    if (min !== null && !Number.isNaN(min)) {
-      filtered = filtered.filter((card) => card.price >= min);
-    }
-    if (max !== null && !Number.isNaN(max)) {
-      filtered = filtered.filter((card) => card.price <= max);
-    }
+    const filtered = foilOnly
+      ? results.filter((card) => card.isFoil)
+      : [...results];
 
     filtered.sort((a, b) => {
       switch (sortBy) {
@@ -77,47 +30,10 @@ export default function useResultFilters(results, searchQuery) {
     });
 
     return filtered;
-  }, [
-    results,
-    sortBy,
-    foilOnly,
-    selectedStores,
-    qualityFilter,
-    priceMin,
-    priceMax,
-  ]);
-
-  const hasActiveFilters =
-    foilOnly ||
-    selectedStores !== null ||
-    qualityFilter !== "all" ||
-    priceMin !== "" ||
-    priceMax !== "";
+  }, [results, sortBy, foilOnly]);
 
   const clearFilters = () => {
     setFoilOnly(false);
-    setSelectedStores(null);
-    setQualityFilter("all");
-    setPriceMin("");
-    setPriceMax("");
-  };
-
-  const toggleStore = (store) => {
-    setSelectedStores((prev) => {
-      const current = prev ?? availableStores;
-      const next = current.includes(store)
-        ? current.filter((s) => s !== store)
-        : [...current, store];
-      if (next.length === availableStores.length) {
-        return null;
-      }
-      return next;
-    });
-  };
-
-  const isStoreSelected = (store) => {
-    const current = selectedStores ?? availableStores;
-    return current.includes(store);
   };
 
   return {
@@ -126,17 +42,7 @@ export default function useResultFilters(results, searchQuery) {
     setSortBy,
     foilOnly,
     setFoilOnly,
-    qualityFilter,
-    setQualityFilter,
-    priceMin,
-    setPriceMin,
-    priceMax,
-    setPriceMax,
-    availableStores,
-    availableQualities,
-    toggleStore,
-    isStoreSelected,
-    hasActiveFilters,
+    hasActiveFilters: foilOnly,
     clearFilters,
   };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements suggestion **#1 — improve the post-search experience** with client-side sorting, filters, and empty states.

### Features
- **Sort control**: price (low→high), price (high→low), store name
- **Condition filter**: dropdown between sort and foil (populated from result qualities)
- **Foil-only toggle**
- **Result count**: shows "Showing X of Y results" when filters are active
- **Empty state (no API results)**: guidance to use auto-suggest, full card name, or fewer stores
- **Empty filtered state**: message + "Clear filters" when filters hide all cards
- Filters reset automatically on each new search query

### New files
- `frontend/src/hooks/useResultFilters.js` — filter/sort logic
- `frontend/src/components/ResultFilters.jsx` — filter toolbar UI

## Screenshots

### Desktop — sort, condition, and foil filters
![Desktop view showing sort, condition, and foil-only controls with card results](https://cursor.com/artifacts/c/art-f644ae32-39b4-4c48-8bf5-26e411831f91)

### Mobile — foil filter applied (2 of 5 shown)
![Mobile view with sort, condition, foil-only filter, and filtered results](https://cursor.com/artifacts/c/art-cd3cf2e6-0011-470c-8608-b44be4fe50b9)

### Desktop — empty search state
![Desktop empty state with tips when no results are returned from the API](https://cursor.com/artifacts/c/art-fe97f9e3-aa7c-49a2-88d1-84738a024b22)

## Test plan

- [x] `npx biome check` on changed files
- [x] `npm run build`
- [ ] Manual: run search → verify sort, condition, and foil-only filters
- [ ] Manual: apply filters that hide all cards → empty filtered state + clear filters
- [ ] Manual: search with no matches → empty search state with tips
- [ ] Manual: new search resets filters
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-589fea7a-7956-4119-a30c-ebbbd33c7a7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-589fea7a-7956-4119-a30c-ebbbd33c7a7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

