### PR TITLE
Add Hideyoshi gateway using Shopify suggest

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ Resulting attempt order:
 | Decklist | `decklist-dedicated` → `decklist-direct` → `scrap-dedicated` → `scrap-direct` → `decklist-dynamic` → `scrap-dynamic` |
 | Scrape | `scrap-dedicated` → `scrap-direct` → `decklist-dedicated` → `decklist-direct` → `scrap-dynamic` → `decklist-dynamic` |
 
-Stores without a Shopify domain mapping can only be scraped, so the decklist
-portal is skipped entirely: `scrap-dedicated` → `scrap-direct` → `scrap-dynamic`.
+Stores without a Shopify domain mapping, or with `ScrapOnly` set, skip the decklist
+portal and only scrape: `scrap-dedicated` → `scrap-direct` → `scrap-dynamic`.
 
 ### Fallback rules
 

--- a/api/controller/search.go
+++ b/api/controller/search.go
@@ -19,6 +19,7 @@ import (
 	"mtg-price-checker-sg/gateway/gameshaven"
 	"mtg-price-checker-sg/gateway/gog"
 	"mtg-price-checker-sg/gateway/hideout"
+	"mtg-price-checker-sg/gateway/hideyoshi"
 	"mtg-price-checker-sg/gateway/manapro"
 	"mtg-price-checker-sg/gateway/moxandlotus"
 	"mtg-price-checker-sg/gateway/mtgasia"
@@ -78,6 +79,7 @@ var shopRegistry = []shopSpec{
 	{name: gameshaven.StoreName, newLGS: gameshaven.NewLGS, isBinderpos: true},
 	{name: gog.StoreName, newLGS: gog.NewLGS},
 	{name: hideout.StoreName, newLGS: hideout.NewLGS, isBinderpos: true},
+	{name: hideyoshi.StoreName, newLGS: hideyoshi.NewLGS},
 	{name: manapro.StoreName, newLGS: manapro.NewLGS, isBinderpos: true},
 	{name: moxandlotus.StoreName, newLGS: moxandlotus.NewLGS},
 	{name: mtgasia.StoreName, newLGS: mtgasia.NewLGS},

--- a/api/controller/search.go
+++ b/api/controller/search.go
@@ -79,7 +79,7 @@ var shopRegistry = []shopSpec{
 	{name: gameshaven.StoreName, newLGS: gameshaven.NewLGS, isBinderpos: true},
 	{name: gog.StoreName, newLGS: gog.NewLGS},
 	{name: hideout.StoreName, newLGS: hideout.NewLGS, isBinderpos: true},
-	{name: hideyoshi.StoreName, newLGS: hideyoshi.NewLGS},
+	{name: hideyoshi.StoreName, newLGS: hideyoshi.NewLGS, isBinderpos: true},
 	{name: manapro.StoreName, newLGS: manapro.NewLGS, isBinderpos: true},
 	{name: moxandlotus.StoreName, newLGS: moxandlotus.NewLGS},
 	{name: mtgasia.StoreName, newLGS: mtgasia.NewLGS},

--- a/api/gateway/arcanesanctum/search.go
+++ b/api/gateway/arcanesanctum/search.go
@@ -2,13 +2,19 @@ package arcanesanctum
 
 import (
 	"context"
+
 	"mtg-price-checker-sg/gateway"
 	"mtg-price-checker-sg/gateway/binderpos"
 )
 
 const StoreName = binderpos.ArcaneSanctumStoreName
 const StoreBaseURL = "https://arcanesanctumtcg.com"
+const StoreShopifyDomain = "30uetm-1y.myshopify.com"
 const StoreSearchURL = "/search?q=%s"
+
+// ScrapOnly skips the shared BinderPOS decklist portal while retaining the
+// Shopify domain mapping for documentation and live integration tests.
+const ScrapOnly = true
 
 type Store struct {
 	Name         string
@@ -31,8 +37,9 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 		5,
 		s.Name,
 		s.BaseUrl,
-		"",
+		StoreShopifyDomain,
 		s.SearchUrl,
 		searchStr,
+		ScrapOnly,
 	)
 }

--- a/api/gateway/binderpos/new.go
+++ b/api/gateway/binderpos/new.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Gateway interface {
-	Search(ctx context.Context, scrapVariant int, storeName, baseUrl, shopifyDomain, searchUrl, searchStr string) ([]gateway.Card, error)
+	Search(ctx context.Context, scrapVariant int, storeName, baseUrl, shopifyDomain, searchUrl, searchStr string, scrapOnly bool) ([]gateway.Card, error)
 	Scrap(ctx context.Context, scrapVariant int, storeName, baseUrl, searchUrl, searchStr string) ([]gateway.Card, error)
 }
 

--- a/api/gateway/binderpos/storefront_search.go
+++ b/api/gateway/binderpos/storefront_search.go
@@ -17,7 +17,7 @@ type storefrontStrategy struct {
 	run  func(ctx context.Context) ([]gateway.Card, error)
 }
 
-func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, shopifyDomain, searchURL, searchStr string) ([]gateway.Card, error) {
+func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, shopifyDomain, searchURL, searchStr string, scrapOnly bool) ([]gateway.Card, error) {
 	scrap := [3]storefrontStrategy{
 		{
 			name: "scrap-dedicated",
@@ -37,12 +37,6 @@ func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, 
 				return i.scrapDynamic(attemptCtx, scrapVariant, storeName, baseURL, searchURL, searchStr)
 			},
 		},
-	}
-
-	// Stores without a Shopify/BinderPOS domain mapping (e.g. Arcane Sanctum)
-	// can only be scraped, so the decklist portal is skipped entirely.
-	if strings.TrimSpace(shopifyDomain) == "" {
-		return runStorefrontStrategies(ctx, scrap[:]...)
 	}
 
 	decklist := [3]storefrontStrategy{
@@ -66,7 +60,17 @@ func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, 
 		},
 	}
 
-	return runStorefrontStrategies(ctx, orderDecklistAndScrap(decklist, scrap)...)
+	// ScrapOnly skips the shared decklist portal while keeping shopifyDomain
+	// available for documentation and live integration tests. An empty domain
+	// also forces scrape-only for backward compatibility.
+	return runStorefrontStrategies(ctx, selectStorefrontStrategies(scrapOnly, shopifyDomain, scrap, decklist)...)
+}
+
+func selectStorefrontStrategies(scrapOnly bool, shopifyDomain string, scrap, decklist [3]storefrontStrategy) []storefrontStrategy {
+	if scrapOnly || strings.TrimSpace(shopifyDomain) == "" {
+		return []storefrontStrategy{scrap[0], scrap[1], scrap[2]}
+	}
+	return orderDecklistAndScrap(decklist, scrap)
 }
 
 // orderDecklistAndScrap interleaves the decklist and scrap strategy families.

--- a/api/gateway/binderpos/storefront_search_test.go
+++ b/api/gateway/binderpos/storefront_search_test.go
@@ -170,14 +170,58 @@ func binderposStoreSearchCases() []binderposStoreSearchCase {
 			query:         "Abrade",
 		},
 		{
+			storeName:     "Hideyoshi",
+			baseURL:       "https://hideyoshitcg.com",
+			shopifyDomain: "bposacct-9.myshopify.com",
+			searchURL:     "/search?q=%s",
+			scrapVariant:  2,
+			query:         "Abrade",
+		},
+		{
 			storeName:     "Arcane Sanctum",
 			baseURL:       "https://arcanesanctumtcg.com",
-			shopifyDomain: "",
+			shopifyDomain: "30uetm-1y.myshopify.com",
 			searchURL:     "/search?q=%s",
 			scrapVariant:  5,
 			query:         "signet",
 		},
 	}
+}
+
+func TestSelectStorefrontStrategies_ScrapOnly(t *testing.T) {
+	scrap := [3]storefrontStrategy{
+		{name: "scrap-dedicated"},
+		{name: "scrap-direct"},
+		{name: "scrap-dynamic"},
+	}
+	decklist := [3]storefrontStrategy{
+		{name: "decklist-dedicated"},
+		{name: "decklist-direct"},
+		{name: "decklist-dynamic"},
+	}
+
+	t.Run("scrapOnly with domain keeps scrape strategies only", func(t *testing.T) {
+		got := selectStorefrontStrategies(true, "shop.example.com", scrap, decklist)
+		assertStrategyOrder(t, []string{"scrap-dedicated", "scrap-direct", "scrap-dynamic"}, strategyNames(got))
+	})
+
+	t.Run("empty domain keeps scrape strategies only", func(t *testing.T) {
+		got := selectStorefrontStrategies(false, "", scrap, decklist)
+		assertStrategyOrder(t, []string{"scrap-dedicated", "scrap-direct", "scrap-dynamic"}, strategyNames(got))
+	})
+
+	t.Run("domain without scrapOnly uses decklist and scrap", func(t *testing.T) {
+		previousSelector := shouldStartWithDecklist
+		shouldStartWithDecklist = func() bool { return true }
+		t.Cleanup(func() { shouldStartWithDecklist = previousSelector })
+
+		got := selectStorefrontStrategies(false, "shop.example.com", scrap, decklist)
+		assertStrategyOrder(t, []string{
+			"decklist-dedicated", "decklist-direct",
+			"scrap-dedicated", "scrap-direct",
+			"decklist-dynamic", "scrap-dynamic",
+		}, strategyNames(got))
+	})
 }
 
 func normalizeCardName(name string) string {

--- a/api/gateway/cardaffinity/search.go
+++ b/api/gateway/cardaffinity/search.go
@@ -35,5 +35,6 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 		StoreShopifyDomain,
 		s.SearchUrl,
 		searchStr,
+		false,
 	)
 }

--- a/api/gateway/cardscitadel/search.go
+++ b/api/gateway/cardscitadel/search.go
@@ -28,5 +28,5 @@ func NewLGS() gateway.LGS {
 }
 
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
-	return s.BinderposGwy.Search(ctx, 1, s.Name, s.BaseUrl, StoreShopifyDomain, s.SearchUrl, searchStr)
+	return s.BinderposGwy.Search(ctx, 1, s.Name, s.BaseUrl, StoreShopifyDomain, s.SearchUrl, searchStr, false)
 }

--- a/api/gateway/flagship/search.go
+++ b/api/gateway/flagship/search.go
@@ -29,5 +29,5 @@ func NewLGS() gateway.LGS {
 }
 
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
-	return s.BinderposGwy.Search(ctx, 2, s.Name, s.BaseUrl, StoreShopifyDomain, s.SearchUrl, searchStr)
+	return s.BinderposGwy.Search(ctx, 2, s.Name, s.BaseUrl, StoreShopifyDomain, s.SearchUrl, searchStr, false)
 }

--- a/api/gateway/gameshaven/search.go
+++ b/api/gateway/gameshaven/search.go
@@ -35,5 +35,6 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 		StoreShopifyDomain,
 		s.SearchUrl,
 		searchStr,
+		false,
 	)
 }

--- a/api/gateway/hideout/search.go
+++ b/api/gateway/hideout/search.go
@@ -35,5 +35,6 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 		StoreShopifyDomain,
 		s.SearchUrl,
 		searchStr,
+		false,
 	)
 }

--- a/api/gateway/hideyoshi/search.go
+++ b/api/gateway/hideyoshi/search.go
@@ -1,0 +1,37 @@
+package hideyoshi
+
+import (
+	"context"
+
+	"mtg-price-checker-sg/gateway"
+	"mtg-price-checker-sg/gateway/shopifysuggest"
+)
+
+const StoreName = "Hideyoshi"
+const StoreBaseURL = "https://hideyoshitcg.com"
+
+type Store struct {
+	Name    string
+	BaseUrl string
+}
+
+func NewLGS() gateway.LGS {
+	return Store{
+		Name:    StoreName,
+		BaseUrl: StoreBaseURL,
+	}
+}
+
+func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
+	return shopifysuggest.Search(ctx, shopifysuggest.Options{
+		Config: shopifysuggest.Config{
+			StoreName: s.Name,
+			BaseURL:   s.BaseUrl,
+		},
+		SearchStr:       searchStr,
+		BuildQuery:      shopifysuggest.PlainQuery,
+		QueryValues:     shopifysuggest.BinderposQueryValues,
+		MapProduct:      shopifysuggest.MapBinderposFullTitleProduct,
+		ResolveVariants: true,
+	})
+}

--- a/api/gateway/hideyoshi/search.go
+++ b/api/gateway/hideyoshi/search.go
@@ -4,34 +4,42 @@ import (
 	"context"
 
 	"mtg-price-checker-sg/gateway"
-	"mtg-price-checker-sg/gateway/shopifysuggest"
+	"mtg-price-checker-sg/gateway/binderpos"
 )
 
 const StoreName = "Hideyoshi"
 const StoreBaseURL = "https://hideyoshitcg.com"
+const StoreShopifyDomain = "bposacct-9.myshopify.com"
+const StoreSearchURL = "/search?q=%s"
+
+// ScrapOnly skips the shared BinderPOS decklist portal while retaining the
+// Shopify domain mapping for documentation and live integration tests.
+const ScrapOnly = true
 
 type Store struct {
-	Name    string
-	BaseUrl string
+	Name         string
+	BaseUrl      string
+	SearchUrl    string
+	BinderposGwy binderpos.Gateway
 }
 
 func NewLGS() gateway.LGS {
 	return Store{
-		Name:    StoreName,
-		BaseUrl: StoreBaseURL,
+		Name:         StoreName,
+		BaseUrl:      StoreBaseURL,
+		SearchUrl:    StoreSearchURL,
+		BinderposGwy: binderpos.New(),
 	}
 }
 
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
-	return shopifysuggest.Search(ctx, shopifysuggest.Options{
-		Config: shopifysuggest.Config{
-			StoreName: s.Name,
-			BaseURL:   s.BaseUrl,
-		},
-		SearchStr:       searchStr,
-		BuildQuery:      shopifysuggest.PlainQuery,
-		QueryValues:     shopifysuggest.BinderposQueryValues,
-		MapProduct:      shopifysuggest.MapBinderposFullTitleProduct,
-		ResolveVariants: true,
-	})
+	return s.BinderposGwy.Search(ctx,
+		2,
+		s.Name,
+		s.BaseUrl,
+		StoreShopifyDomain,
+		s.SearchUrl,
+		searchStr,
+		ScrapOnly,
+	)
 }

--- a/api/gateway/hideyoshi/search_test.go
+++ b/api/gateway/hideyoshi/search_test.go
@@ -1,0 +1,31 @@
+package hideyoshi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/joho/godotenv"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	_ = godotenv.Load("../../.env")
+}
+
+func Test_Search(t *testing.T) {
+	s := NewLGS()
+	result, err := s.Search(context.Background(), "Abrade")
+	require.NoError(t, err)
+	require.True(t, len(result) > 0)
+
+	for _, card := range result {
+		if card.InStock {
+			require.NotEmpty(t, card.Name)
+			require.NotEmpty(t, card.Source)
+			require.NotEmpty(t, card.Url)
+			require.NotEmpty(t, card.Img)
+			require.NotEmpty(t, card.Price)
+			require.Contains(t, card.Url, StoreBaseURL+"/products/")
+		}
+	}
+}

--- a/api/gateway/manapro/search.go
+++ b/api/gateway/manapro/search.go
@@ -29,5 +29,5 @@ func NewLGS() gateway.LGS {
 }
 
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
-	return s.BinderposGwy.Search(ctx, 2, s.Name, s.BaseUrl, StoreShopifyDomain, s.SearchUrl, searchStr)
+	return s.BinderposGwy.Search(ctx, 2, s.Name, s.BaseUrl, StoreShopifyDomain, s.SearchUrl, searchStr, false)
 }

--- a/api/gateway/onemtg/search.go
+++ b/api/gateway/onemtg/search.go
@@ -35,5 +35,6 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 		StoreShopifyDomain,
 		s.SearchUrl,
 		searchStr,
+		false,
 	)
 }

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -47,7 +47,7 @@ Some tests in `api/gateway/binderpos/*_test.go` hit real stores and proxies. The
 | Scenario | Order of strategies (each step is one attempt) | Per-step attempt timeout / HTTP client |
 |----------|--------------------------------------------------|----------------------------------------|
 | `shopifyDomain` **non-empty** (normal) | 1) **api-dedicated** → 2) **api-direct** → 3) **scrap-dedicated** → 4) **scrap-direct** → 5) **api-dynamic** → 6) **scrap-dynamic** | **10s** per step: `binderposAttemptTimeout` in `api/gateway/binderpos/storefront.go`; `runWithAttemptTimeout` in `storefront_search.go`. HTTP clients in `storefront_client.go` use the same `binderposAttemptTimeout`. |
-| `shopifyDomain` **empty** | **scrap-dedicated** → **scrap-direct** → **scrap-dynamic** (three `runWithAttemptTimeout` steps in `searchWithScrapDedicatedThenDirectThenDynamic`) | **10s** per step (same constant). No API attempts. |
+| `shopifyDomain` **empty** or **`ScrapOnly`** | **scrap-dedicated** → **scrap-direct** → **scrap-dynamic** (three `runWithAttemptTimeout` steps) | **10s** per step (same constant). No API attempts. |
 
 | Item | Value | Source | Notes |
 |------|--------|--------|--------|

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -16,6 +16,7 @@ export const LGS_OPTIONS = [
   "Games Haven",
   "Grey Ogre Games",
   "Hideout",
+  "Hideyoshi",
   "Mana Pro",
   "Mox & Lotus",
   "MTG Asia",
@@ -103,6 +104,14 @@ export const LGS_MAP = [
     iframe:
       "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3988.8199964760065!2d103.84085797576442!3d1.2817574584814586!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x31da190d242b70db%3A0x965b932c3bc19eda!2sGrey%20Ogre%20Games!5e0!3m2!1sen!2ssg!4v1702821297360!5m2!1sen!2ssg",
     website: "https://www.greyogregames.com/",
+  },
+  {
+    id: "hideyoshi-map",
+    name: "Hideyoshi",
+    address: "504 Jurong West Street 51, #04-211, Hong Kah Court, Singapore 640504",
+    iframe:
+      "https://maps.google.com/maps?q=504+Jurong+West+Street+51,+Singapore+640504&output=embed",
+    website: "https://hideyoshitcg.com/",
   },
   {
     id: "hideout-map",

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -110,7 +110,7 @@ export const LGS_MAP = [
     name: "Hideyoshi",
     address: "504 Jurong West Street 51, #04-211, Hong Kah Court, Singapore 640504",
     iframe:
-      "https://maps.google.com/maps?q=504+Jurong+West+Street+51,+Singapore+640504&output=embed",
+      "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d63838.71666448266!2d103.7192003!3d1.3492252!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x31da0f00180a50f3%3A0xedf0967d08ff8944!2sHideyoshi!5e0!3m2!1sen!2ssg!4v1782000000000!5m2!1sen!2ssg",
     website: "https://hideyoshitcg.com/",
   },
   {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds [Hideyoshi TCG](https://hideyoshitcg.com/) as a searchable store using the shared **BinderPOS scrape-only** path.

The site is a BinderPOS Shopify storefront (`bposacct-9.myshopify.com`). Product titles use full-title bracket format (variant 2).

## Changes

### Backend
- New `scrapOnly` parameter on `binderpos.Gateway.Search` — stores can keep their `shopifyDomain` while skipping the shared decklist portal
- **Hideyoshi**: BinderPOS scrap variant 2, `ScrapOnly = true`, registered with `isBinderpos: true`
- **Arcane Sanctum**: same `ScrapOnly` pattern; Shopify domain restored (`30uetm-1y.myshopify.com`)

### Frontend
- **Hideyoshi** added to `LGS_OPTIONS` (store checkbox / search selection)
- **Hideyoshi** added to `LGS_MAP` with address and Google Maps embed from [maps.app.goo.gl/bo8rwUMQ1m2iLU636](https://maps.app.goo.gl/bo8rwUMQ1m2iLU636)

## Testing

- `go test ./gateway/binderpos/... ./gateway/hideyoshi/... ./controller/...` — pass
- `TestSelectStorefrontStrategies_ScrapOnly` — pass
- `Test_Search` (hideyoshi live scrape) — pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae50ac61-0238-445f-b544-afd9857238fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae50ac61-0238-445f-b544-afd9857238fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

