### PR TITLE
Filter Pokemon/non-MTG products from Hideyoshi BinderPOS search

### DIFF
--- a/api/gateway/agora/search.go
+++ b/api/gateway/agora/search.go
@@ -17,6 +17,7 @@ import (
 const StoreName = "Agora Hobby"
 const StoreBaseURL = "https://agorahobby.com"
 const StoreSearchPath = "/store/search"
+const storeCategoryMTG = "mtg"
 
 type Store struct {
 	Name       string
@@ -43,7 +44,7 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 		Host:   baseURL.Host,
 		Path:   s.SearchPath,
 		RawQuery: url.Values{
-			"category":    {"mtg"},
+			"category":    {storeCategoryMTG},
 			"searchfield": {searchStr},
 		}.Encode(),
 	}
@@ -97,7 +98,7 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 				return
 			}
 			cleanPageURL.RawQuery = url.Values{
-				"category":    []string{"mtg"},
+				"category":    []string{storeCategoryMTG},
 				"searchfield": []string{searchStr},
 				"utm_source":  []string{config.UtmSource},
 			}.Encode()

--- a/api/gateway/agora/search.go
+++ b/api/gateway/agora/search.go
@@ -103,19 +103,21 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 				"utm_source":  []string{config.UtmSource},
 			}.Encode()
 
-			if price > 0 {
-				cards = append(cards, gateway.Card{
-					Name:      strings.TrimSpace(name),
-					Url:       strings.TrimSpace(cleanPageURL.String()),
-					InStock:   isInstock,
-					IsFoil:    strings.Contains(name, "FOIL"), // case sensitive
-					Price:     price,
-					Source:    s.Name,
-					Img:       strings.TrimSpace(el.ChildAttr("div.store-item-img", "data-img")),
-					Quality:   util.MapQuality(quality),
-					ExtraInfo: extraInfo,
-				})
+			if !isInstock || price <= 0 {
+				return
 			}
+
+			cards = append(cards, gateway.Card{
+				Name:      strings.TrimSpace(name),
+				Url:       strings.TrimSpace(cleanPageURL.String()),
+				InStock:   true,
+				IsFoil:    strings.Contains(name, "FOIL"), // case sensitive
+				Price:     price,
+				Source:    s.Name,
+				Img:       strings.TrimSpace(el.ChildAttr("div.store-item-img", "data-img")),
+				Quality:   util.MapQuality(quality),
+				ExtraInfo: extraInfo,
+			})
 		})
 	})
 

--- a/api/gateway/agora/search_test.go
+++ b/api/gateway/agora/search_test.go
@@ -15,14 +15,13 @@ func Test_Search(t *testing.T) {
 	require.True(t, len(result) > 0)
 
 	for _, card := range result {
-		if card.InStock {
-			require.NotEmpty(t, card.Name)
-			require.NotEmpty(t, card.Source)
-			require.NotEmpty(t, card.Url)
-			require.NotEmpty(t, card.Img)
-			require.NotEmpty(t, card.Price)
-			require.Contains(t, card.Url, StoreBaseURL+"/store/search?category="+storeCategoryMTG+"&searchfield=")
-		}
+		require.True(t, card.InStock, "gateway should only return in-stock listings")
+		require.NotEmpty(t, card.Name)
+		require.NotEmpty(t, card.Source)
+		require.NotEmpty(t, card.Url)
+		require.NotEmpty(t, card.Img)
+		require.NotEmpty(t, card.Price)
+		require.Contains(t, card.Url, StoreBaseURL+"/store/search?category="+storeCategoryMTG+"&searchfield=")
 	}
 }
 
@@ -32,6 +31,7 @@ func Test_Search_FiltersMTGCategory(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, card := range result {
+		require.True(t, card.InStock, "gateway should only return in-stock listings")
 		require.Contains(t, card.Url, "category="+storeCategoryMTG,
 			"Agora product links should stay scoped to the MTG category")
 		lower := strings.ToLower(card.Name)

--- a/api/gateway/agora/search_test.go
+++ b/api/gateway/agora/search_test.go
@@ -2,6 +2,7 @@ package agora
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -20,7 +21,23 @@ func Test_Search(t *testing.T) {
 			require.NotEmpty(t, card.Url)
 			require.NotEmpty(t, card.Img)
 			require.NotEmpty(t, card.Price)
-			require.Contains(t, card.Url, StoreBaseURL+"/store/search?category=mtg&searchfield=")
+			require.Contains(t, card.Url, StoreBaseURL+"/store/search?category="+storeCategoryMTG+"&searchfield=")
 		}
+	}
+}
+
+func Test_Search_FiltersMTGCategory(t *testing.T) {
+	s := NewLGS()
+	result, err := s.Search(context.Background(), "Bulbasaur")
+	require.NoError(t, err)
+
+	for _, card := range result {
+		require.Contains(t, card.Url, "category="+storeCategoryMTG,
+			"Agora product links should stay scoped to the MTG category")
+		lower := strings.ToLower(card.Name)
+		require.NotContains(t, lower, "pokemon",
+			"Pokemon inventory should not appear when category=mtg is set")
+		require.NotContains(t, lower, "holofoil",
+			"Pokemon condition labels should not appear when category=mtg is set")
 	}
 }

--- a/api/gateway/binderpos/product_filter.go
+++ b/api/gateway/binderpos/product_filter.go
@@ -3,8 +3,6 @@ package binderpos
 import (
 	"encoding/json"
 	"strings"
-
-	"mtg-price-checker-sg/gateway/shopifysuggest"
 )
 
 // shouldIncludeBinderposProduct reports whether a scraped BinderPOS product
@@ -17,7 +15,20 @@ func shouldIncludeBinderposProduct(productType, productTagsJSON string) bool {
 	if productType == "" {
 		return true
 	}
-	return shopifysuggest.IsMagicProduct(productType, "", parseProductTags(productTagsJSON))
+	return isMagicProductType(productType, parseProductTags(productTagsJSON))
+}
+
+func isMagicProductType(productType string, tags []string) bool {
+	pt := strings.ToLower(productType)
+	if strings.Contains(pt, "mtg") || strings.Contains(pt, "magic the gathering") {
+		return true
+	}
+	for _, tag := range tags {
+		if strings.EqualFold(strings.TrimSpace(tag), "MTG") {
+			return true
+		}
+	}
+	return false
 }
 
 func parseProductTags(productTagsJSON string) []string {

--- a/api/gateway/binderpos/product_filter.go
+++ b/api/gateway/binderpos/product_filter.go
@@ -1,0 +1,34 @@
+package binderpos
+
+import (
+	"encoding/json"
+	"strings"
+
+	"mtg-price-checker-sg/gateway/shopifysuggest"
+)
+
+// shouldIncludeBinderposProduct reports whether a scraped BinderPOS product
+// should be surfaced. Multi-game storefronts (e.g. Hideyoshi) tag each product
+// with data-product-type; when present we only keep Magic listings so Pokemon
+// and other TCG inventory is excluded. Stores that omit the attribute are left
+// unchanged for backward compatibility.
+func shouldIncludeBinderposProduct(productType, productTagsJSON string) bool {
+	productType = strings.TrimSpace(productType)
+	if productType == "" {
+		return true
+	}
+	return shopifysuggest.IsMagicProduct(productType, "", parseProductTags(productTagsJSON))
+}
+
+func parseProductTags(productTagsJSON string) []string {
+	productTagsJSON = strings.TrimSpace(productTagsJSON)
+	if productTagsJSON == "" {
+		return nil
+	}
+
+	var tags []string
+	if err := json.Unmarshal([]byte(productTagsJSON), &tags); err != nil {
+		return nil
+	}
+	return tags
+}

--- a/api/gateway/binderpos/product_filter_test.go
+++ b/api/gateway/binderpos/product_filter_test.go
@@ -1,0 +1,24 @@
+package binderpos
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldIncludeBinderposProduct(t *testing.T) {
+	require.True(t, shouldIncludeBinderposProduct("MTG Single", ""))
+	require.True(t, shouldIncludeBinderposProduct("MTG Single Cards", `["MTG","Rare"]`))
+	require.False(t, shouldIncludeBinderposProduct("Pokemon Single", ""))
+	require.False(t, shouldIncludeBinderposProduct("Grand Archive Single", ""))
+	require.False(t, shouldIncludeBinderposProduct("Lorcana Single", ""))
+
+	// Missing product type: do not filter (legacy storefronts).
+	require.True(t, shouldIncludeBinderposProduct("", ""))
+}
+
+func TestParseProductTags(t *testing.T) {
+	require.Equal(t, []string{"MTG", "Rare"}, parseProductTags(`["MTG","Rare"]`))
+	require.Nil(t, parseProductTags(""))
+	require.Nil(t, parseProductTags("not-json"))
+}

--- a/api/gateway/binderpos/product_filter_test.go
+++ b/api/gateway/binderpos/product_filter_test.go
@@ -17,6 +17,14 @@ func TestShouldIncludeBinderposProduct(t *testing.T) {
 	require.True(t, shouldIncludeBinderposProduct("", ""))
 }
 
+func TestIsMagicProductType(t *testing.T) {
+	require.True(t, isMagicProductType("MTG Single Cards", []string{"Common"}))
+	require.True(t, isMagicProductType("Magic the Gathering Booster Box", nil))
+	require.True(t, isMagicProductType("", []string{"New Arrival", "MTG"}))
+	require.False(t, isMagicProductType("Pokemon Single", nil))
+	require.False(t, isMagicProductType("Grand Archive Single", nil))
+}
+
 func TestParseProductTags(t *testing.T) {
 	require.Equal(t, []string{"MTG", "Rare"}, parseProductTags(`["MTG","Rare"]`))
 	require.Nil(t, parseProductTags(""))

--- a/api/gateway/binderpos/scrap.go
+++ b/api/gateway/binderpos/scrap.go
@@ -261,6 +261,10 @@ func scrapVariant2(ctx context.Context, storeName, baseUrl, searchUrl, searchStr
 				if err == nil {
 					if len(cardInfo) > 0 && len(pageUrl) > 0 && len(imgUrl) > 0 {
 						for _, card := range cardInfo {
+							if !card.Available {
+								continue
+							}
+
 							// url with variant (quality)
 							cleanPageURL, err := url.Parse(strings.TrimSpace(baseUrl + pageUrl))
 							if err != nil {

--- a/api/gateway/binderpos/scrap.go
+++ b/api/gateway/binderpos/scrap.go
@@ -245,6 +245,10 @@ func scrapVariant2(ctx context.Context, storeName, baseUrl, searchUrl, searchStr
 		e.ForEach("div", func(_ int, el *colly.HTMLElement) {
 			cardInfoStr := el.Attr("data-product-variants")
 			if len(cardInfoStr) > 0 {
+				if !shouldIncludeBinderposProduct(el.Attr("data-product-type"), el.Attr("data-product-tags")) {
+					return
+				}
+
 				productId := el.Attr("data-product-id")
 				var pageUrl, imgUrl string
 				if len(productId) > 0 {

--- a/api/gateway/binderpos/storefront_decklist.go
+++ b/api/gateway/binderpos/storefront_decklist.go
@@ -99,7 +99,7 @@ func mapDecklistLinesToCards(scrapVariant int, storeName, baseURL string, lines 
 
 			image := buildCardImageURL(product.Image, productTitle)
 			for _, variant := range product.Variants {
-				if variant.Price <= 0 {
+				if variant.Price <= 0 || variant.Quantity <= 0 {
 					continue
 				}
 				if variant.ShopifyID <= 0 || productPath == "" {

--- a/api/gateway/binderpos/storefront_decklist_test.go
+++ b/api/gateway/binderpos/storefront_decklist_test.go
@@ -118,6 +118,31 @@ func TestMapDecklistLinesToCards(t *testing.T) {
 		}
 	})
 
+	t.Run("skips out of stock variants", func(t *testing.T) {
+		outOfStock := []storefrontDecklistLine{
+			{
+				Products: []storefrontDecklistProduct{
+					{
+						Title:  "Abrade [Foundations]",
+						Handle: "abrade-foundations",
+						Variants: []storefrontDecklistStock{
+							{
+								ShopifyID: 222,
+								Title:     "Near Mint",
+								Price:     0.40,
+								Quantity:  0,
+							},
+						},
+					},
+				},
+			},
+		}
+		cards := mapDecklistLinesToCards(2, "Store", "https://store.example", outOfStock)
+		if len(cards) != 0 {
+			t.Fatalf("expected no cards for out-of-stock variant, got %+v", cards)
+		}
+	})
+
 	t.Run("skips product when title and name are empty", func(t *testing.T) {
 		skipName := []storefrontDecklistLine{
 			{

--- a/api/gateway/hideyoshi/search_test.go
+++ b/api/gateway/hideyoshi/search_test.go
@@ -20,14 +20,13 @@ func Test_Search(t *testing.T) {
 	require.True(t, len(result) > 0)
 
 	for _, card := range result {
-		if card.InStock {
-			require.NotEmpty(t, card.Name)
-			require.NotEmpty(t, card.Source)
-			require.NotEmpty(t, card.Url)
-			require.NotEmpty(t, card.Img)
-			require.NotEmpty(t, card.Price)
-			require.Contains(t, card.Url, StoreBaseURL+"/products/")
-		}
+		require.True(t, card.InStock, "gateway should only return in-stock variants")
+		require.NotEmpty(t, card.Name)
+		require.NotEmpty(t, card.Source)
+		require.NotEmpty(t, card.Url)
+		require.NotEmpty(t, card.Img)
+		require.NotEmpty(t, card.Price)
+		require.Contains(t, card.Url, StoreBaseURL+"/products/")
 	}
 }
 
@@ -37,6 +36,7 @@ func Test_Search_ExcludesPokemonInventory(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, card := range result {
+		require.True(t, card.InStock, "gateway should only return in-stock variants")
 		lower := strings.ToLower(card.Name)
 		require.NotContains(t, lower, "mega evolution: base set",
 			"Pokemon Bulbasaur inventory should not appear in MTG search results")

--- a/api/gateway/hideyoshi/search_test.go
+++ b/api/gateway/hideyoshi/search_test.go
@@ -2,6 +2,7 @@ package hideyoshi
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/joho/godotenv"
@@ -27,5 +28,19 @@ func Test_Search(t *testing.T) {
 			require.NotEmpty(t, card.Price)
 			require.Contains(t, card.Url, StoreBaseURL+"/products/")
 		}
+	}
+}
+
+func Test_Search_ExcludesPokemonInventory(t *testing.T) {
+	s := NewLGS()
+	result, err := s.Search(context.Background(), "Bulbasaur")
+	require.NoError(t, err)
+
+	for _, card := range result {
+		lower := strings.ToLower(card.Name)
+		require.NotContains(t, lower, "mega evolution: base set",
+			"Pokemon Bulbasaur inventory should not appear in MTG search results")
+		require.NotContains(t, lower, "near mint holofoil",
+			"Pokemon condition labels should not appear in MTG search results")
 	}
 }

--- a/api/gateway/shopifysuggest/product_test.go
+++ b/api/gateway/shopifysuggest/product_test.go
@@ -24,6 +24,7 @@ func TestIsMagicProduct(t *testing.T) {
 	require.False(t, IsMagicProduct("Flesh And Blood Single Cards", "Flesh and Blood", []string{"Common"}))
 	require.False(t, IsMagicProduct("Grand Archive Single Cards", "Grand Archive", nil))
 	require.False(t, IsMagicProduct("Lorcana Single", "Disney Lorcana", nil))
+	require.False(t, IsMagicProduct("Pokemon Single", "Pokemon", nil))
 }
 
 func TestSetFromTags(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hideyoshi sells multiple TCGs (Pokemon, Grand Archive, MTG, etc.). After switching from `shopifysuggest` to BinderPOS scrape-only, search results could include non-MTG inventory because the HTML scraper returned every product with `data-product-variants`, with no game filter.

This PR also drops out-of-stock rows at the gateway layer (BinderPOS scrape/decklist and Agora) so less data is processed downstream.

Agora already scoped search to `category=mtg`; this PR documents that with a named constant and regression test.

## Problem

- Hideyoshi product pages tag inventory as `Pokemon Single`, `Grand Archive Single`, `MTG Single`, etc.
- `scrapVariant2` appended ` mtg` to the query but still parsed all matching products from the HTML.
- Without filtering, Pokemon singles could appear in MTG price-check results.
- BinderPOS scrap variant 2 and the decklist mapper emitted every condition variant, including out-of-stock ones. The controller already filtered to `InStock`, but gateways still parsed and forwarded ~90% dead rows (e.g. Hideyoshi `Abrade` returned ~85 variants, only ~12 in stock).
- Agora scraped all listings with `price > 0`, including `Stock: 0` rows (~30 for `Abrade`, only ~15 in stock).

## Solution

- Add a local `shouldIncludeBinderposProduct` helper in `binderpos` that gates products by scraped `data-product-type` (and tags when present). This is pure string/tag matching on HTML attributes — **no Shopify suggest API calls**.
- Apply the filter in `scrapVariant2` before mapping variants to cards.
- Skip unavailable scrape variants (`!card.Available`) and decklist rows with `quantity <= 0`.
- Document Agora's existing `category=mtg` query parameter with `storeCategoryMTG` and a Bulbasaur regression test.
- Drop Agora listings when `Stock: 0` before appending cards.
- Add unit coverage for Pokemon/Grand Archive exclusion, MTG inclusion, and out-of-stock decklist skipping.
- Add live Hideyoshi regression tests for `Bulbasaur` (no Pokemon leakage) and in-stock-only gateway output.

## Testing

- `go test ./gateway/binderpos/... ./gateway/hideyoshi/... ./gateway/agora/... ./controller/...`
- Live Bulbasaur verification: Hideyoshi's storefront returns Pokemon `Bulbasaur` as `Pokemon Single`, but our search returns only MTG cards with zero Pokemon leakage.
- Live in-stock verification: Hideyoshi `Abrade` now returns 12 in-stock cards (was ~85 variants including out-of-stock conditions).
- Agora `Abrade` now returns 15 in-stock cards (was ~30 scraped rows including `Stock: 0`).
- Agora `Bulbasaur` returns no Pokemon results; all product URLs include `category=mtg`.

## Notes

- The ` mtg` query suffix can still produce broad MTG false positives for unrelated terms (e.g. searching `Bulbasaur` may return MTG cards with loosely matching names). This PR specifically prevents **Pokemon/non-MTG product types** from leaking into results.
- Controller in-stock filtering remains as a safety net; gateways now do the heavy lifting earlier.
- The scrap path does not import or call `shopifysuggest`; MTG filtering reads only `data-product-type` / `data-product-tags` already present in the scraped HTML.
- Agora search was already MTG-scoped via `category=mtg` on both the scrape URL and outbound product links.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95cc81cf-e4cd-4e4b-8cc7-410327eda7ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95cc81cf-e4cd-4e4b-8cc7-410327eda7ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

