### PR TITLE
Include HTTP status codes in all reported errors

### DIFF
--- a/api/controller/search.go
+++ b/api/controller/search.go
@@ -51,8 +51,9 @@ type Card struct {
 }
 
 type StoreError struct {
-	Store string `json:"store"`
-	Error string `json:"error"`
+	Store      string `json:"store"`
+	Error      string `json:"error"`
+	StatusCode int    `json:"statusCode,omitempty"`
 }
 
 const binderposMaxConcurrent = 12
@@ -247,7 +248,12 @@ func recoverShopPanic(shopName string, aggregator *fetchResultAggregator) {
 
 func recordShopSearchError(searchString, shopName string, err error, aggregator *fetchResultAggregator) {
 	if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
-		errMsg := fmt.Sprintf("Error encountered searching [%s] for [%s]: %v", shopName, searchString, err)
+		errMsg := fmt.Sprintf(
+			"Error encountered searching [%s] for [%s]: %s",
+			shopName,
+			searchString,
+			gateway.EnsureHTTPStatusInErrorMessage(err.Error()),
+		)
 		log.Println(errMsg)
 		aggregator.addDiscordErrorMessage(errMsg)
 	}
@@ -294,9 +300,11 @@ func buildStoreErrors(siteErrors map[string]error) []StoreError {
 		if err == nil {
 			continue
 		}
+		enrichedError := gateway.EnsureHTTPStatusInErrorMessage(err.Error())
 		storeErrors = append(storeErrors, StoreError{
-			Store: storeName,
-			Error: err.Error(),
+			Store:      storeName,
+			Error:      enrichedError,
+			StatusCode: gateway.ExtractHTTPStatusCode(enrichedError),
 		})
 	}
 

--- a/api/controller/search_test.go
+++ b/api/controller/search_test.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"mtg-price-checker-sg/gateway"
 	"mtg-price-checker-sg/gateway/agora"
 	"mtg-price-checker-sg/gateway/cardaffinity"
@@ -342,6 +343,37 @@ func TestSearchShops_IncludesStoreErrors(t *testing.T) {
 	}
 }
 
+func TestBuildStoreErrors_IncludesHTTPStatusCode(t *testing.T) {
+	storeErrors := buildStoreErrors(map[string]error{
+		"Arcane Sanctum": fmt.Errorf(
+			"attempt 2 (scrap-direct): Service Unavailable (proxy_mode=direct proxy=none)",
+		),
+		"Shopify Store": fmt.Errorf("shopifysuggest: unexpected status 429"),
+	})
+
+	if len(storeErrors) != 2 {
+		t.Fatalf("expected 2 store errors, got %d", len(storeErrors))
+	}
+
+	byStore := make(map[string]StoreError, len(storeErrors))
+	for _, storeError := range storeErrors {
+		byStore[storeError.Store] = storeError
+	}
+
+	arcane := byStore["Arcane Sanctum"]
+	if arcane.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected status 503 for Arcane Sanctum, got %d", arcane.StatusCode)
+	}
+	if !strings.Contains(arcane.Error, "503 Service Unavailable") {
+		t.Fatalf("expected enriched error message, got %q", arcane.Error)
+	}
+
+	shopify := byStore["Shopify Store"]
+	if shopify.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("expected status 429 for Shopify Store, got %d", shopify.StatusCode)
+	}
+}
+
 func TestIsBinderposStore(t *testing.T) {
 	tests := map[string]bool{
 		cardscitadel.StoreName: true,
@@ -472,18 +504,18 @@ func TestFetchCardsConcurrently_CollatesDiscordErrors(t *testing.T) {
 
 func TestFormatDiscordErrorSummary(t *testing.T) {
 	got := formatDiscordErrorSummary("Uro, Titan of Nature's Wrath", []string{
-		"Error encountered searching [Tefuda] for [Uro, Titan of Nature's Wrath]: attempt 3 (scrap-direct): Service Unavailable (proxy_mode=direct proxy=none)",
-		"Error encountered searching [Arcane Sanctum] for [Uro, Titan of Nature's Wrath]: attempt 2 (scrap-direct): Service Unavailable (proxy_mode=direct proxy=none)",
+		"Error encountered searching [Tefuda] for [Uro, Titan of Nature's Wrath]: attempt 3 (scrap-direct): 503 Service Unavailable (proxy_mode=direct proxy=none)",
+		"Error encountered searching [Arcane Sanctum] for [Uro, Titan of Nature's Wrath]: attempt 2 (scrap-direct): 503 Service Unavailable (proxy_mode=direct proxy=none)",
 		"Recovered from panic in shop [ShopPanic]: panic value",
 	})
 
 	if !strings.Contains(got, "Encountered 3 error(s) while searching [Uro, Titan of Nature's Wrath]:") {
 		t.Fatalf("expected summary header, got: %s", got)
 	}
-	if !strings.Contains(got, "- [Arcane Sanctum] attempt 2 (scrap-direct): Service Unavailable (proxy_mode=direct proxy=none)") {
+	if !strings.Contains(got, "- [Arcane Sanctum] attempt 2 (scrap-direct): 503 Service Unavailable (proxy_mode=direct proxy=none)") {
 		t.Fatalf("expected Arcane Sanctum concise line, got: %s", got)
 	}
-	if !strings.Contains(got, "- [Tefuda] attempt 3 (scrap-direct): Service Unavailable (proxy_mode=direct proxy=none)") {
+	if !strings.Contains(got, "- [Tefuda] attempt 3 (scrap-direct): 503 Service Unavailable (proxy_mode=direct proxy=none)") {
 		t.Fatalf("expected Tefuda concise line, got: %s", got)
 	}
 	if !strings.Contains(got, "- Recovered from panic in shop [ShopPanic]: panic value") {

--- a/api/gateway/collector.go
+++ b/api/gateway/collector.go
@@ -346,6 +346,7 @@ func VisitWithProxyInfo(c *colly.Collector, targetURL string) error {
 	var proxyMu sync.Mutex
 	var lastProxyMode string
 	var lastProxyURL string
+	var responseStatusCode int
 
 	c.OnRequest(func(r *colly.Request) {
 		if r == nil || r.Ctx == nil {
@@ -358,6 +359,16 @@ func VisitWithProxyInfo(c *colly.Collector, targetURL string) error {
 		proxyMu.Unlock()
 	})
 
+	c.OnError(func(r *colly.Response, _ error) {
+		if r == nil || r.StatusCode < 100 {
+			return
+		}
+
+		proxyMu.Lock()
+		responseStatusCode = r.StatusCode
+		proxyMu.Unlock()
+	})
+
 	err := c.Visit(targetURL)
 	if err == nil {
 		return nil
@@ -366,8 +377,10 @@ func VisitWithProxyInfo(c *colly.Collector, targetURL string) error {
 	proxyMu.Lock()
 	mode := lastProxyMode
 	proxyURL := lastProxyURL
+	statusCode := responseStatusCode
 	proxyMu.Unlock()
 
+	err = EnrichErrorWithHTTPStatus(err, statusCode)
 	return fmt.Errorf("%w (%s)", err, formatProxyContext(mode, proxyURL))
 }
 

--- a/api/gateway/http_status.go
+++ b/api/gateway/http_status.go
@@ -1,0 +1,109 @@
+package gateway
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var httpStatusPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)status[=:\s]+(\d{3})`),
+	regexp.MustCompile(`(?i)unexpected status (\d{3})`),
+	regexp.MustCompile(`\b(\d{3}) [A-Za-z]`),
+}
+
+// FormatHTTPStatus returns a human-readable HTTP status label such as "403 Forbidden".
+func FormatHTTPStatus(code int) string {
+	if code < 100 || code > 599 {
+		return ""
+	}
+
+	text := http.StatusText(code)
+	if text == "" {
+		return fmt.Sprintf("status=%d", code)
+	}
+
+	return fmt.Sprintf("%d %s", code, text)
+}
+
+// ErrorMessageHasHTTPStatus reports whether msg already includes an HTTP status code.
+func ErrorMessageHasHTTPStatus(msg string) bool {
+	return ExtractHTTPStatusCode(msg) > 0
+}
+
+// ExtractHTTPStatusCode returns the first HTTP status code found in msg, or 0.
+func ExtractHTTPStatusCode(msg string) int {
+	for _, pattern := range httpStatusPatterns {
+		matches := pattern.FindStringSubmatch(msg)
+		if len(matches) < 2 {
+			continue
+		}
+
+		code, err := strconv.Atoi(matches[1])
+		if err != nil || code < 100 || code > 599 {
+			continue
+		}
+
+		return code
+	}
+
+	return 0
+}
+
+// EnrichErrorWithHTTPStatus prefixes err with code and status text when statusCode
+// is known and the message does not already include a status code.
+func EnrichErrorWithHTTPStatus(err error, statusCode int) error {
+	if err == nil {
+		return nil
+	}
+
+	msg := err.Error()
+	if statusCode < 100 || statusCode > 599 || ErrorMessageHasHTTPStatus(msg) {
+		return err
+	}
+
+	statusLabel := FormatHTTPStatus(statusCode)
+	if statusLabel == "" {
+		return err
+	}
+
+	if msg == http.StatusText(statusCode) {
+		return errors.New(statusLabel)
+	}
+
+	return fmt.Errorf("%s: %w", statusLabel, err)
+}
+
+// EnsureHTTPStatusInErrorMessage adds a status code to msg when it only contains
+// a bare HTTP status phrase such as "Forbidden".
+func EnsureHTTPStatusInErrorMessage(msg string) string {
+	if ErrorMessageHasHTTPStatus(msg) {
+		return msg
+	}
+
+	for code := 100; code <= 599; code++ {
+		text := http.StatusText(code)
+		if text == "" {
+			continue
+		}
+
+		if msg == text {
+			return FormatHTTPStatus(code)
+		}
+
+		prefix := text + ": "
+		if strings.HasPrefix(msg, prefix) {
+			return FormatHTTPStatus(code) + msg[len(text):]
+		}
+
+		attemptPrefix := ": " + text
+		if idx := strings.LastIndex(msg, attemptPrefix); idx != -1 {
+			return msg[:idx+2] + FormatHTTPStatus(code) + msg[idx+2+len(text):]
+		}
+	}
+
+	return msg
+}

--- a/api/gateway/http_status_test.go
+++ b/api/gateway/http_status_test.go
@@ -1,0 +1,62 @@
+package gateway
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+)
+
+func TestFormatHTTPStatus(t *testing.T) {
+	if got := FormatHTTPStatus(http.StatusForbidden); got != "403 Forbidden" {
+		t.Fatalf("FormatHTTPStatus(403) = %q, want %q", got, "403 Forbidden")
+	}
+
+	if got := FormatHTTPStatus(150); got != "status=150" {
+		t.Fatalf("FormatHTTPStatus(150) = %q, want %q", got, "status=150")
+	}
+}
+
+func TestExtractHTTPStatusCode(t *testing.T) {
+	tests := map[string]int{
+		"shopifysuggest: unexpected status 429":                 429,
+		"binderpos decklist request failed status=503 body=...": 503,
+		"unexpected status for Cards Central: 503 Service Unavailable": 503,
+		"403 Forbidden (proxy_mode=direct proxy=none)":            403,
+		"Service Unavailable":                                     0,
+	}
+
+	for msg, want := range tests {
+		if got := ExtractHTTPStatusCode(msg); got != want {
+			t.Fatalf("ExtractHTTPStatusCode(%q) = %d, want %d", msg, got, want)
+		}
+	}
+}
+
+func TestEnrichErrorWithHTTPStatus(t *testing.T) {
+	err := EnrichErrorWithHTTPStatus(errors.New(http.StatusText(http.StatusForbidden)), http.StatusForbidden)
+	if got := err.Error(); got != "403 Forbidden" {
+		t.Fatalf("EnrichErrorWithHTTPStatus() = %q, want %q", got, "403 Forbidden")
+	}
+
+	alreadyHasCode := EnrichErrorWithHTTPStatus(
+		errors.New("shopifysuggest: unexpected status 429"),
+		http.StatusTooManyRequests,
+	)
+	if got := alreadyHasCode.Error(); got != "shopifysuggest: unexpected status 429" {
+		t.Fatalf("expected existing status to remain unchanged, got %q", got)
+	}
+}
+
+func TestEnsureHTTPStatusInErrorMessage(t *testing.T) {
+	if got := EnsureHTTPStatusInErrorMessage("Forbidden"); got != "403 Forbidden" {
+		t.Fatalf("EnsureHTTPStatusInErrorMessage(Forbidden) = %q", got)
+	}
+
+	if got := EnsureHTTPStatusInErrorMessage("attempt 2 (scrap-direct): Service Unavailable (proxy_mode=direct proxy=none)"); got != "attempt 2 (scrap-direct): 503 Service Unavailable (proxy_mode=direct proxy=none)" {
+		t.Fatalf("EnsureHTTPStatusInErrorMessage() = %q", got)
+	}
+
+	if got := EnsureHTTPStatusInErrorMessage("403 Forbidden (proxy_mode=direct proxy=none)"); got != "403 Forbidden (proxy_mode=direct proxy=none)" {
+		t.Fatalf("EnsureHTTPStatusInErrorMessage() should not double-prefix, got %q", got)
+	}
+}

--- a/api/handler/search.go
+++ b/api/handler/search.go
@@ -22,8 +22,9 @@ type WebResponse struct {
 	Errors []controller.StoreError `json:"errors"`
 }
 
-type ValidationErrorResponse struct {
-	Error string `json:"error"`
+type ErrorResponse struct {
+	Error      string `json:"error"`
+	StatusCode int    `json:"statusCode"`
 }
 
 var searchFunc = controller.Search
@@ -59,7 +60,14 @@ func Search(ctx context.Context, request events.APIGatewayProxyRequest) (events.
 
 	if searchString == "" || len(searchString) < config.MinSearchStringLength {
 		apiRes.StatusCode = http.StatusBadRequest
-		return lambdaApiResponse(apiRes, webRes, origin)
+		return errorResponse(
+			apiRes,
+			origin,
+			fmt.Sprintf(
+				"enter at least %d characters to search",
+				config.MinSearchStringLength,
+			),
+		)
 	}
 
 	if len(searchString) > config.MaxSearchStringLength {
@@ -84,8 +92,7 @@ func Search(ctx context.Context, request events.APIGatewayProxyRequest) (events.
 	})
 	if err != nil {
 		apiRes.StatusCode = http.StatusInternalServerError
-		apiRes.Body = "err searching for cards"
-		return lambdaApiResponse(apiRes, webRes, origin)
+		return errorResponse(apiRes, origin, "err searching for cards")
 	}
 
 	apiRes.StatusCode = http.StatusOK
@@ -104,14 +111,24 @@ func validationErrorResponse(
 	origin string,
 	message string,
 ) (events.APIGatewayProxyResponse, error) {
+	return errorResponse(apiResponse, origin, message)
+}
+
+func errorResponse(
+	apiResponse events.APIGatewayProxyResponse,
+	origin string,
+	message string,
+) (events.APIGatewayProxyResponse, error) {
 	var buf bytes.Buffer
 	encoder := json.NewEncoder(&buf)
 	encoder.SetEscapeHTML(false)
 
-	if err := encoder.Encode(ValidationErrorResponse{Error: message}); err != nil {
+	if err := encoder.Encode(ErrorResponse{
+		Error:      message,
+		StatusCode: apiResponse.StatusCode,
+	}); err != nil {
 		apiResponse.StatusCode = http.StatusInternalServerError
-		apiResponse.Body = "err marshalling validation error"
-		return lambdaApiResponse(apiResponse, WebResponse{}, origin)
+		return errorResponse(apiResponse, origin, "err marshalling error response")
 	}
 
 	apiResponse.Body = buf.String()
@@ -141,7 +158,17 @@ func lambdaApiResponse(apiResponse events.APIGatewayProxyResponse, webResponse W
 
 	if err := encoder.Encode(webResponse); err != nil {
 		apiResponse.StatusCode = http.StatusInternalServerError
-		apiResponse.Body = "err marshalling to json result"
+		var buf bytes.Buffer
+		encoder := json.NewEncoder(&buf)
+		encoder.SetEscapeHTML(false)
+		if encodeErr := encoder.Encode(ErrorResponse{
+			Error:      "err marshalling to json result",
+			StatusCode: http.StatusInternalServerError,
+		}); encodeErr != nil {
+			apiResponse.Body = "err marshalling to json result"
+			return apiResponse, nil
+		}
+		apiResponse.Body = buf.String()
 		return apiResponse, nil
 	}
 

--- a/api/handler/search_test.go
+++ b/api/handler/search_test.go
@@ -169,14 +169,14 @@ func Test_Search_Err(t *testing.T) {
 				QueryStringParameters: map[string]string{"s": ""},
 			},
 			expStatusCode: http.StatusBadRequest,
-			expBody:       "", // lambdaApiResponse returns body as is for error but empty webRes
+			expBody:       `{"error":"enter at least 3 characters to search","statusCode":400}` + "\n",
 		},
 		"less than 3 characters search string": {
 			givenAPIGatewayProxyRequest: events.APIGatewayProxyRequest{
 				QueryStringParameters: map[string]string{"s": "ab"},
 			},
 			expStatusCode: http.StatusBadRequest,
-			expBody:       "",
+			expBody:       `{"error":"enter at least 3 characters to search","statusCode":400}` + "\n",
 		},
 		"search string too long": {
 			givenAPIGatewayProxyRequest: events.APIGatewayProxyRequest{
@@ -185,7 +185,7 @@ func Test_Search_Err(t *testing.T) {
 				},
 			},
 			expStatusCode: http.StatusBadRequest,
-			expBody:       `{"error":"card name is too long (maximum 150 characters)"}` + "\n",
+			expBody:       `{"error":"card name is too long (maximum 150 characters)","statusCode":400}` + "\n",
 		},
 		"controller error": {
 			givenAPIGatewayProxyRequest: events.APIGatewayProxyRequest{
@@ -193,7 +193,7 @@ func Test_Search_Err(t *testing.T) {
 			},
 			mockSearchErr: errors.New("controller error"),
 			expStatusCode: http.StatusInternalServerError,
-			expBody:       "err searching for cards",
+			expBody:       `{"error":"err searching for cards","statusCode":500}` + "\n",
 		},
 	}
 	for s, tc := range tcs {

--- a/frontend/src/hooks/useSearch.js
+++ b/frontend/src/hooks/useSearch.js
@@ -12,6 +12,13 @@ const SEARCH_TOO_SHORT_ERROR = `Enter at least ${MIN_SEARCH_LENGTH} characters t
 const NO_STORES_WARNING =
   "No stores selected — searching all stores. Select specific stores to search faster.";
 
+function formatErrorWithStatusCode(message, statusCode) {
+  if (!statusCode) {
+    return message;
+  }
+  return `Error (${statusCode}): ${message}`;
+}
+
 // Search configuration constants
 const AUTOCOMPLETE_DEBOUNCE_MS = 300;
 const SEARCH_PROGRESS_INTERVAL_MS = 1000;
@@ -164,23 +171,31 @@ export default function useSearch() {
       fetch(searchUrl, { signal: searchAbortController.signal })
         .then(async (res) => {
           if (!res.ok) {
-            let validationMessage = null;
-            if (res.status === 400) {
-              try {
-                const errorBody = await res.json();
-                if (typeof errorBody?.error === "string" && errorBody.error) {
-                  validationMessage = errorBody.error;
-                }
-              } catch {
-                // Ignore malformed validation responses.
-              }
+            let errorBody = null;
+            try {
+              errorBody = await res.json();
+            } catch {
+              // Ignore malformed error responses.
             }
+
+            const validationMessage =
+              typeof errorBody?.error === "string" && errorBody.error
+                ? errorBody.error
+                : null;
+            const statusCode = errorBody?.statusCode || res.status;
 
             if (validationMessage) {
-              throw new Error(`Validation error: ${validationMessage}`);
+              throw new Error(
+                formatErrorWithStatusCode(validationMessage, statusCode),
+              );
             }
 
-            throw new Error(`Server error: ${res.status} ${res.statusText}`);
+            throw new Error(
+              formatErrorWithStatusCode(
+                res.statusText || "The server returned an error.",
+                statusCode,
+              ),
+            );
           }
           return res.json();
         })
@@ -225,8 +240,8 @@ export default function useSearch() {
             setSearchError(
               "Unable to connect to the server. Please check your internet connection and try again.",
             );
-          } else if (err.message.startsWith("Validation error: ")) {
-            setSearchError(err.message.slice("Validation error: ".length));
+          } else if (err.message.startsWith("Error (")) {
+            setSearchError(err.message);
           } else if (err.message.includes("Server error")) {
             setSearchError(
               "The server is experiencing issues. Please try again later.",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ensures HTTP status codes are included consistently across backend and frontend error reporting.

## Changes

### Backend
- Added `gateway` helpers to format, extract, and enrich HTTP status codes in error messages (`FormatHTTPStatus`, `ExtractHTTPStatusCode`, `EnsureHTTPStatusInErrorMessage`, etc.)
- Updated `VisitWithProxyInfo` to capture Colly response status codes and enrich errors like `Forbidden` → `403 Forbidden`
- Standardized API error responses as JSON with a `statusCode` field for 400/500 cases (including previously empty short-search responses)
- Added `statusCode` to `StoreError` and enriched per-store error messages in `buildStoreErrors`
- Enriched Discord/logged store search errors with HTTP status codes when available

### Frontend
- Updated search error handling to display API errors as `Error (400): ...` using the response `statusCode` when present

## Testing

- `go test ./handler/ ./controller/` — pass
- `go test ./gateway/` (new HTTP status helpers + collector tests) — pass
- `make test` — fails on pre-existing live `gateway/cardscentral` data assertion (`Near Mint` vs `DMG`), unrelated to this change
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95475be5-bf2c-45b4-b3fd-b8020f22cf40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95475be5-bf2c-45b4-b3fd-b8020f22cf40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

