### PR TITLE
Remove LGS shop count subtitle from header

### DIFF
--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,5 +1,5 @@
 import { Moon, Sun } from "react-feather";
-import { LGS_OPTIONS, SITE_TAGLINE } from "../constants";
+import { SITE_TAGLINE } from "../constants";
 
 const Header = ({ theme, onToggleTheme }) => {
   const isDarkMode = theme === "dark";
@@ -38,10 +38,6 @@ const Header = ({ theme, onToggleTheme }) => {
         <h1 className="fw-medium fs-4">
           - Gishath Fetch -<br />
           {SITE_TAGLINE}
-          <br />
-          <span className="fs-6 fw-normal">
-            Search {LGS_OPTIONS.length} LGS and online shops at once
-          </span>
         </h1>
       </div>
     </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the "Search {N} LGS and online shops at once" line displayed under the main title in the site header.

## Changes

- Removed the subtitle `<span>` from `Header.jsx`
- Dropped the unused `LGS_OPTIONS` import from the header component

## Testing

- Verified `Header.jsx` has no new linter issues
- Frontend lint was run; existing unrelated formatting warnings remain in other files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c70dd5e3-fa7f-4af4-9d09-911b3bd19505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c70dd5e3-fa7f-4af4-9d09-911b3bd19505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

