### PR TITLE
Remove redundant mt-2 from Advertisement label

### DIFF
--- a/frontend/src/components/AdComponent.jsx
+++ b/frontend/src/components/AdComponent.jsx
@@ -95,7 +95,7 @@ const AdComponent = ({ variant = "leaderboard" }) => {
           data-full-width-responsive={isResponsive ? "true" : undefined}
         ></ins>
       </div>
-      <div className="text-secondary mt-2" style={{ fontSize: "11px" }}>
+      <div className="text-secondary" style={{ fontSize: "11px" }}>
         Advertisement
       </div>
     </div>

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -45,7 +45,7 @@ const Footer = ({ cartCount, onShowCart, onShowMap, onShowFaq }) => {
             data-ad-slot="6707964257"
           ></ins>
         </div>
-        <div className="text-secondary mt-2" style={{ fontSize: "11px" }}>
+        <div className="text-secondary" style={{ fontSize: "11px" }}>
           Advertisement
         </div>
       </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the `mt-2` class from the "Advertisement" label in both ad placements. The ad block above already provides spacing via `mb-2`, so the extra top margin on the label was redundant.

## Changes

- `frontend/src/components/AdComponent.jsx` — remove `mt-2` from Advertisement label
- `frontend/src/components/Footer.jsx` — remove `mt-2` from Advertisement label

## Testing

- Frontend lint run (`npm run lint`); no new issues in changed files (pre-existing formatter warnings elsewhere)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4422e53f-e6de-4ca5-b60e-d4ab9a924409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4422e53f-e6de-4ca5-b60e-d4ab9a924409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

