### PR TITLE
Publish Web Bot Auth signature directory at well-known URI

### DIFF
--- a/.github/workflows/deploy-on-merge.yml
+++ b/.github/workflows/deploy-on-merge.yml
@@ -48,5 +48,22 @@ jobs:
           aws-region: ap-southeast-1
 
       - name: Deploy
-        # --silent: do not print each shell recipe (avoids echoing export lines and command noise in logs)
-        run: make --silent deploy
+        env:
+          WEB_BOT_AUTH_PRIVATE_KEY: ${{ secrets.WEB_BOT_AUTH_PRIVATE_KEY }}
+        run: |
+          set +x
+          KEY_FILE=""
+          cleanup() {
+            if [ -n "$KEY_FILE" ]; then
+              rm -f "$KEY_FILE"
+            fi
+          }
+          trap cleanup EXIT
+          if [ -n "${WEB_BOT_AUTH_PRIVATE_KEY:-}" ]; then
+            KEY_FILE="$(mktemp)"
+            chmod 600 "$KEY_FILE"
+            printf '%s' "$WEB_BOT_AUTH_PRIVATE_KEY" > "$KEY_FILE"
+            unset WEB_BOT_AUTH_PRIVATE_KEY
+            export WEB_BOT_AUTH_PRIVATE_KEY_FILE="$KEY_FILE"
+          fi
+          make --silent deploy

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .env
 mtg-price-checker-sg
 .DS_Store
+.cache/

--- a/Makefile
+++ b/Makefile
@@ -22,15 +22,35 @@ docker-push-staging:
 frontend-dev:
 	cd frontend && npm install && npm run dev
 
-frontend-build:
+frontend-build: generate-signature-directory
 	cd frontend && npm install && npm run build
 
+generate-signature-directory:
+	@if [ -n "$$WEB_BOT_AUTH_PRIVATE_KEY" ]; then \
+		mkdir -p frontend/public/.well-known && \
+		cd api && go run -mod=vendor ./cmd/signature-directory -out ../frontend/public/.well-known/http-message-signatures-directory; \
+	else \
+		echo "Skipping signature directory generation: WEB_BOT_AUTH_PRIVATE_KEY not set"; \
+	fi
+
 frontend-update: frontend-build
-	aws s3 sync frontend/dist s3://gishathfetch.com
+	aws s3 sync frontend/dist s3://gishathfetch.com --exclude ".well-known/http-message-signatures-directory"
+	@if [ -f frontend/dist/.well-known/http-message-signatures-directory ]; then \
+		export AWS_PAGER="" && aws s3 cp frontend/dist/.well-known/http-message-signatures-directory \
+			s3://gishathfetch.com/.well-known/http-message-signatures-directory \
+			--content-type "application/http-message-signatures-directory+json" \
+			--cache-control "max-age=86400"; \
+	fi
 	export AWS_PAGER="" && aws cloudfront create-invalidation --distribution-id E3NPGUM21YCN36 --paths "/*"
 
 frontend-update-staging: frontend-build
-	aws s3 sync frontend/dist s3://staging.gishathfetch.com
+	aws s3 sync frontend/dist s3://staging.gishathfetch.com --exclude ".well-known/http-message-signatures-directory"
+	@if [ -f frontend/dist/.well-known/http-message-signatures-directory ]; then \
+		export AWS_PAGER="" && aws s3 cp frontend/dist/.well-known/http-message-signatures-directory \
+			s3://staging.gishathfetch.com/.well-known/http-message-signatures-directory \
+			--content-type "application/http-message-signatures-directory+json" \
+			--cache-control "max-age=86400"; \
+	fi
 	export AWS_PAGER="" && aws cloudfront create-invalidation --distribution-id E33AK6HADX83U0 --paths "/*"
 
 lambda-create:

--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,15 @@ frontend-dev:
 frontend-build: generate-signature-directory
 	cd frontend && npm install && npm run build
 
+SIGNATURE_DIRECTORY_BIN=.cache/signature-directory
+
 generate-signature-directory:
-	@if [ -n "$$WEB_BOT_AUTH_PRIVATE_KEY" ]; then \
-		mkdir -p frontend/public/.well-known && \
-		cd api && go run -mod=vendor ./cmd/signature-directory -out ../frontend/public/.well-known/http-message-signatures-directory; \
+	@if [ -n "$$WEB_BOT_AUTH_PRIVATE_KEY" ] || { [ -n "$$WEB_BOT_AUTH_PRIVATE_KEY_FILE" ] && [ -s "$$WEB_BOT_AUTH_PRIVATE_KEY_FILE" ]; }; then \
+		mkdir -p frontend/public/.well-known .cache && \
+		cd api && go build -mod=vendor -o ../$(SIGNATURE_DIRECTORY_BIN) ./cmd/signature-directory && \
+		../$(SIGNATURE_DIRECTORY_BIN) -out ../frontend/public/.well-known/http-message-signatures-directory; \
 	else \
-		echo "Skipping signature directory generation: WEB_BOT_AUTH_PRIVATE_KEY not set"; \
+		echo "Skipping signature directory generation: Web Bot Auth private key not configured"; \
 	fi
 
 frontend-update: frontend-build

--- a/api/cmd/signature-directory/main.go
+++ b/api/cmd/signature-directory/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"mtg-price-checker-sg/pkg/config"
+	"mtg-price-checker-sg/pkg/webbotauth"
+)
+
+func main() {
+	outPath := flag.String("out", "frontend/public/.well-known/http-message-signatures-directory", "output file path")
+	flag.Parse()
+
+	pemData := strings.TrimSpace(os.Getenv(config.WebBotAuthPrivateKeyEnv))
+	if pemData == "" {
+		log.Fatalf("%s is required", config.WebBotAuthPrivateKeyEnv)
+	}
+
+	privateKey, err := webbotauth.ParseEd25519PrivateKeyPEM(pemData)
+	if err != nil {
+		log.Fatalf("parse %s: %v", config.WebBotAuthPrivateKeyEnv, err)
+	}
+
+	body, err := webbotauth.DirectoryJSON(privateKey)
+	if err != nil {
+		log.Fatalf("build signature directory: %v", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(*outPath), 0o755); err != nil {
+		log.Fatalf("create output directory: %v", err)
+	}
+	if err := os.WriteFile(*outPath, body, 0o644); err != nil {
+		log.Fatalf("write %s: %v", *outPath, err)
+	}
+
+	fmt.Fprintf(os.Stderr, "wrote %s (%d bytes)\n", *outPath, len(body))
+}

--- a/api/cmd/signature-directory/main.go
+++ b/api/cmd/signature-directory/main.go
@@ -6,9 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strings"
 
-	"mtg-price-checker-sg/pkg/config"
 	"mtg-price-checker-sg/pkg/webbotauth"
 )
 
@@ -16,14 +14,14 @@ func main() {
 	outPath := flag.String("out", "frontend/public/.well-known/http-message-signatures-directory", "output file path")
 	flag.Parse()
 
-	pemData := strings.TrimSpace(os.Getenv(config.WebBotAuthPrivateKeyEnv))
-	if pemData == "" {
-		log.Fatalf("%s is required", config.WebBotAuthPrivateKeyEnv)
+	pemData, err := webbotauth.LoadPrivateKeyPEM()
+	if err != nil {
+		log.Fatalf("load signing key: %v", err)
 	}
 
 	privateKey, err := webbotauth.ParseEd25519PrivateKeyPEM(pemData)
 	if err != nil {
-		log.Fatalf("parse %s: %v", config.WebBotAuthPrivateKeyEnv, err)
+		log.Fatalf("parse signing key: %v", err)
 	}
 
 	body, err := webbotauth.DirectoryJSON(privateKey)

--- a/api/gateway/bot_auth.go
+++ b/api/gateway/bot_auth.go
@@ -4,11 +4,7 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
-	"crypto/sha256"
-	"crypto/x509"
 	"encoding/base64"
-	"encoding/json"
-	"encoding/pem"
 	"fmt"
 	"log"
 	"net/http"
@@ -19,6 +15,7 @@ import (
 	"time"
 
 	"mtg-price-checker-sg/pkg/config"
+	"mtg-price-checker-sg/pkg/webbotauth"
 
 	"github.com/gocolly/colly/v2"
 	"github.com/lestrrat-go/htmsig"
@@ -152,7 +149,7 @@ func loadWebBotAuth() {
 		return
 	}
 
-	privateKey, err := parseEd25519PrivateKeyPEM(pemData)
+	privateKey, err := webbotauth.ParseEd25519PrivateKeyPEM(pemData)
 	if err != nil {
 		log.Printf("invalid %s: %v; Web Bot Auth disabled", config.WebBotAuthPrivateKeyEnv, err)
 		return
@@ -166,48 +163,11 @@ func loadWebBotAuth() {
 	webBotAuth = webBotAuthState{
 		enabled:           true,
 		privateKey:        privateKey,
-		keyID:             ed25519JWKThumbprint(privateKey.Public().(ed25519.PublicKey)),
+		keyID:             webbotauth.Ed25519JWKThumbprint(privateKey.Public().(ed25519.PublicKey)),
 		signatureAgentURL: signatureAgentURL,
 		userAgent:         userAgent,
 		ttl:               config.WebBotAuthTTL(),
 	}
-}
-
-func parseEd25519PrivateKeyPEM(raw string) (ed25519.PrivateKey, error) {
-	pemData := raw
-	if !strings.Contains(raw, "BEGIN") {
-		decoded, err := base64.StdEncoding.DecodeString(raw)
-		if err != nil {
-			return nil, fmt.Errorf("decode base64 private key: %w", err)
-		}
-		pemData = string(decoded)
-	}
-
-	block, _ := pem.Decode([]byte(pemData))
-	if block == nil {
-		return nil, fmt.Errorf("failed to decode PEM block")
-	}
-
-	keyIface, err := x509.ParsePKCS8PrivateKey(block.Bytes)
-	if err != nil {
-		return nil, fmt.Errorf("parse PKCS8 private key: %w", err)
-	}
-	privateKey, ok := keyIface.(ed25519.PrivateKey)
-	if !ok {
-		return nil, fmt.Errorf("expected ed25519 private key, got %T", keyIface)
-	}
-	return privateKey, nil
-}
-
-func ed25519JWKThumbprint(pub ed25519.PublicKey) string {
-	jwk := map[string]string{
-		"crv": "Ed25519",
-		"kty": "OKP",
-		"x":   base64.RawURLEncoding.EncodeToString(pub),
-	}
-	payload, _ := json.Marshal(jwk)
-	sum := sha256.Sum256(payload)
-	return base64.RawURLEncoding.EncodeToString(sum[:])
 }
 
 func newWebBotAuthNonce() (string, error) {

--- a/api/gateway/bot_auth.go
+++ b/api/gateway/bot_auth.go
@@ -137,21 +137,19 @@ func loadWebBotAuth() {
 		return
 	}
 
-	pemData := strings.TrimSpace(os.Getenv(config.WebBotAuthPrivateKeyEnv))
+	pemData, keyErr := webbotauth.LoadPrivateKeyPEM()
 	signatureAgentURL := strings.TrimSpace(os.Getenv(config.WebBotAuthSignatureAgentEnv))
-	if pemData == "" || signatureAgentURL == "" {
+	if keyErr != nil || signatureAgentURL == "" {
 		log.Printf(
-			"%s is true but %s and/or %s are unset; Web Bot Auth disabled",
+			"%s is true but signing credentials are not fully configured; Web Bot Auth disabled",
 			config.WebBotAuthEnabledEnv,
-			config.WebBotAuthPrivateKeyEnv,
-			config.WebBotAuthSignatureAgentEnv,
 		)
 		return
 	}
 
 	privateKey, err := webbotauth.ParseEd25519PrivateKeyPEM(pemData)
 	if err != nil {
-		log.Printf("invalid %s: %v; Web Bot Auth disabled", config.WebBotAuthPrivateKeyEnv, err)
+		log.Printf("invalid Web Bot Auth signing key: %v; Web Bot Auth disabled", err)
 		return
 	}
 

--- a/api/gateway/bot_auth_test.go
+++ b/api/gateway/bot_auth_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"mtg-price-checker-sg/pkg/config"
+	"mtg-price-checker-sg/pkg/webbotauth"
 
 	"github.com/stretchr/testify/require"
 )
@@ -46,18 +47,8 @@ func TestSignWebBotAuthRequestAddsHeaders(t *testing.T) {
 	require.Contains(t, req.Header.Get("Signature"), "sig=:")
 	require.NotEmpty(t, req.Header.Get("Signature"))
 
-	thumbprint := ed25519JWKThumbprint(privateKey.Public().(ed25519.PublicKey))
+	thumbprint := webbotauth.Ed25519JWKThumbprint(privateKey.Public().(ed25519.PublicKey))
 	require.Contains(t, req.Header.Get("Signature-Input"), thumbprint)
-}
-
-func TestEd25519JWKThumbprintMatchesRFC9421TestKey(t *testing.T) {
-	privateKey, err := parseEd25519PrivateKeyPEM(`-----BEGIN PRIVATE KEY-----
-MC4CAQAwBQYDK2VwBCIEIJ+DYvh6SEqVTm50DFtMDoQikTmiCqirVv9mWG9qfSnF
------END PRIVATE KEY-----`)
-	require.NoError(t, err)
-
-	thumbprint := ed25519JWKThumbprint(privateKey.Public().(ed25519.PublicKey))
-	require.Equal(t, "poqkLGiymh_W0uP6PZFw-dvez3QJT5SolqXBCW38r0U", thumbprint)
 }
 
 func TestPrepareOutboundRequestHTML(t *testing.T) {

--- a/api/gateway/bot_auth_test.go
+++ b/api/gateway/bot_auth_test.go
@@ -82,6 +82,7 @@ func TestMain(m *testing.M) {
 	for _, key := range []string{
 		config.WebBotAuthEnabledEnv,
 		config.WebBotAuthPrivateKeyEnv,
+		config.WebBotAuthPrivateKeyFileEnv,
 		config.WebBotAuthSignatureAgentEnv,
 		config.WebBotAuthUserAgentEnv,
 		config.WebBotAuthTTLEnv,

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -38,6 +38,9 @@ const (
 	WebBotAuthEnabledEnv = "WEB_BOT_AUTH_ENABLED"
 	// WebBotAuthPrivateKeyEnv holds a PEM (or base64-encoded PEM) Ed25519 PKCS8 private key.
 	WebBotAuthPrivateKeyEnv = "WEB_BOT_AUTH_PRIVATE_KEY"
+	// WebBotAuthPrivateKeyFileEnv holds a filesystem path to PEM key material.
+	// Prefer this in CI so the raw key is not kept in process environment variables.
+	WebBotAuthPrivateKeyFileEnv = "WEB_BOT_AUTH_PRIVATE_KEY_FILE"
 	// WebBotAuthSignatureAgentEnv is the Signature-Agent directory URL published by this bot.
 	WebBotAuthSignatureAgentEnv = "WEB_BOT_AUTH_SIGNATURE_AGENT"
 	// WebBotAuthUserAgentEnv optionally overrides the stable bot User-Agent when signing is enabled.

--- a/api/pkg/webbotauth/directory.go
+++ b/api/pkg/webbotauth/directory.go
@@ -1,0 +1,43 @@
+package webbotauth
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+)
+
+const directoryMediaType = "application/http-message-signatures-directory+json"
+
+// DirectoryMediaType is the Content-Type for HTTP Message Signatures directories.
+func DirectoryMediaType() string {
+	return directoryMediaType
+}
+
+type directoryKey struct {
+	Kty string `json:"kty"`
+	Crv string `json:"crv"`
+	Kid string `json:"kid"`
+	X   string `json:"x"`
+	Use string `json:"use"`
+	Alg string `json:"alg"`
+}
+
+type directoryDocument struct {
+	Keys []directoryKey `json:"keys"`
+}
+
+// DirectoryJSON builds the JWKS document for /.well-known/http-message-signatures-directory.
+func DirectoryJSON(privateKey ed25519.PrivateKey) ([]byte, error) {
+	pub := privateKey.Public().(ed25519.PublicKey)
+	doc := directoryDocument{
+		Keys: []directoryKey{{
+			Kty: "OKP",
+			Crv: "Ed25519",
+			Kid: Ed25519JWKThumbprint(pub),
+			X:   base64.RawURLEncoding.EncodeToString(pub),
+			Use: "sig",
+			Alg: "ed25519",
+		}},
+	}
+	return json.MarshalIndent(doc, "", "  ")
+}

--- a/api/pkg/webbotauth/keys.go
+++ b/api/pkg/webbotauth/keys.go
@@ -1,0 +1,53 @@
+package webbotauth
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"strings"
+)
+
+// ParseEd25519PrivateKeyPEM parses an Ed25519 PKCS8 private key from PEM or
+// base64-encoded PEM text.
+func ParseEd25519PrivateKeyPEM(raw string) (ed25519.PrivateKey, error) {
+	pemData := raw
+	if !strings.Contains(raw, "BEGIN") {
+		decoded, err := base64.StdEncoding.DecodeString(raw)
+		if err != nil {
+			return nil, fmt.Errorf("decode base64 private key: %w", err)
+		}
+		pemData = string(decoded)
+	}
+
+	block, _ := pem.Decode([]byte(pemData))
+	if block == nil {
+		return nil, fmt.Errorf("failed to decode PEM block")
+	}
+
+	keyIface, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse PKCS8 private key: %w", err)
+	}
+	privateKey, ok := keyIface.(ed25519.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("expected ed25519 private key, got %T", keyIface)
+	}
+	return privateKey, nil
+}
+
+// Ed25519JWKThumbprint returns the base64url JWK SHA-256 thumbprint for an
+// Ed25519 public key, as used for HTTP Message Signatures keyid values.
+func Ed25519JWKThumbprint(pub ed25519.PublicKey) string {
+	jwk := map[string]string{
+		"crv": "Ed25519",
+		"kty": "OKP",
+		"x":   base64.RawURLEncoding.EncodeToString(pub),
+	}
+	payload, _ := json.Marshal(jwk)
+	sum := sha256.Sum256(payload)
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}

--- a/api/pkg/webbotauth/keys_test.go
+++ b/api/pkg/webbotauth/keys_test.go
@@ -1,0 +1,31 @@
+package webbotauth
+
+import (
+	"crypto/ed25519"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEd25519JWKThumbprintMatchesRFC9421TestKey(t *testing.T) {
+	privateKey, err := ParseEd25519PrivateKeyPEM(`-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIJ+DYvh6SEqVTm50DFtMDoQikTmiCqirVv9mWG9qfSnF
+-----END PRIVATE KEY-----`)
+	require.NoError(t, err)
+
+	thumbprint := Ed25519JWKThumbprint(privateKey.Public().(ed25519.PublicKey))
+	require.Equal(t, "poqkLGiymh_W0uP6PZFw-dvez3QJT5SolqXBCW38r0U", thumbprint)
+}
+
+func TestDirectoryJSON(t *testing.T) {
+	privateKey, err := ParseEd25519PrivateKeyPEM(`-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIJ+DYvh6SEqVTm50DFtMDoQikTmiCqirVv9mWG9qfSnF
+-----END PRIVATE KEY-----`)
+	require.NoError(t, err)
+
+	body, err := DirectoryJSON(privateKey)
+	require.NoError(t, err)
+	require.Contains(t, string(body), `"kid": "poqkLGiymh_W0uP6PZFw-dvez3QJT5SolqXBCW38r0U"`)
+	require.Contains(t, string(body), `"alg": "ed25519"`)
+	require.Contains(t, string(body), `"use": "sig"`)
+}

--- a/api/pkg/webbotauth/load.go
+++ b/api/pkg/webbotauth/load.go
@@ -1,0 +1,38 @@
+package webbotauth
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"mtg-price-checker-sg/pkg/config"
+)
+
+// LoadPrivateKeyPEM reads signing key material from WEB_BOT_AUTH_PRIVATE_KEY_FILE
+// or WEB_BOT_AUTH_PRIVATE_KEY. Prefer the file path in CI so the raw key is not
+// kept in the process environment longer than necessary.
+func LoadPrivateKeyPEM() (string, error) {
+	if keyFile := strings.TrimSpace(os.Getenv(config.WebBotAuthPrivateKeyFileEnv)); keyFile != "" {
+		data, err := os.ReadFile(keyFile)
+		if err != nil {
+			return "", fmt.Errorf("read %s: %w", config.WebBotAuthPrivateKeyFileEnv, err)
+		}
+		return strings.TrimSpace(string(data)), nil
+	}
+
+	if pemData := strings.TrimSpace(os.Getenv(config.WebBotAuthPrivateKeyEnv)); pemData != "" {
+		return pemData, nil
+	}
+
+	return "", fmt.Errorf("%s or %s is required", config.WebBotAuthPrivateKeyFileEnv, config.WebBotAuthPrivateKeyEnv)
+}
+
+// PrivateKeyConfigured reports whether signing key material is available.
+func PrivateKeyConfigured() bool {
+	if keyFile := strings.TrimSpace(os.Getenv(config.WebBotAuthPrivateKeyFileEnv)); keyFile != "" {
+		if _, err := os.Stat(keyFile); err == nil {
+			return true
+		}
+	}
+	return strings.TrimSpace(os.Getenv(config.WebBotAuthPrivateKeyEnv)) != ""
+}

--- a/api/pkg/webbotauth/load_test.go
+++ b/api/pkg/webbotauth/load_test.go
@@ -1,0 +1,46 @@
+package webbotauth
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"mtg-price-checker-sg/pkg/config"
+
+	"github.com/stretchr/testify/require"
+)
+
+const testPrivateKeyPEM = `-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIJ+DYvh6SEqVTm50DFtMDoQikTmiCqirVv9mWG9qfSnF
+-----END PRIVATE KEY-----`
+
+func TestLoadPrivateKeyPEMFromFile(t *testing.T) {
+	t.Setenv(config.WebBotAuthPrivateKeyEnv, "")
+	t.Setenv(config.WebBotAuthPrivateKeyFileEnv, "")
+
+	keyFile := filepath.Join(t.TempDir(), "web-bot-auth.key")
+	require.NoError(t, os.WriteFile(keyFile, []byte(testPrivateKeyPEM), 0o600))
+	t.Setenv(config.WebBotAuthPrivateKeyFileEnv, keyFile)
+
+	got, err := LoadPrivateKeyPEM()
+	require.NoError(t, err)
+	require.Equal(t, testPrivateKeyPEM, got)
+}
+
+func TestLoadPrivateKeyPEMFromEnv(t *testing.T) {
+	t.Setenv(config.WebBotAuthPrivateKeyFileEnv, "")
+	t.Setenv(config.WebBotAuthPrivateKeyEnv, testPrivateKeyPEM)
+
+	got, err := LoadPrivateKeyPEM()
+	require.NoError(t, err)
+	require.Equal(t, testPrivateKeyPEM, got)
+}
+
+func TestPrivateKeyConfigured(t *testing.T) {
+	t.Setenv(config.WebBotAuthPrivateKeyEnv, "")
+	t.Setenv(config.WebBotAuthPrivateKeyFileEnv, "")
+	require.False(t, PrivateKeyConfigured())
+
+	t.Setenv(config.WebBotAuthPrivateKeyEnv, testPrivateKeyPEM)
+	require.True(t, PrivateKeyConfigured())
+}

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+public/.well-known/http-message-signatures-directory
 
 # Editor directories and files
 .vscode/*

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,8 +1,33 @@
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
+const signatureDirectoryPath = "/.well-known/http-message-signatures-directory";
+const signatureDirectoryMediaType =
+  "application/http-message-signatures-directory+json";
+
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    {
+      name: "well-known-signature-directory-content-type",
+      configureServer(server) {
+        server.middlewares.use((req, res, next) => {
+          if (req.url === signatureDirectoryPath) {
+            res.setHeader("Content-Type", signatureDirectoryMediaType);
+          }
+          next();
+        });
+      },
+      configurePreviewServer(server) {
+        server.middlewares.use((req, res, next) => {
+          if (req.url === signatureDirectoryPath) {
+            res.setHeader("Content-Type", signatureDirectoryMediaType);
+          }
+          next();
+        });
+      },
+    },
+  ],
   base: "",
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the 404 at `/.well-known/http-message-signatures-directory` by generating and deploying the HTTP Message Signatures directory required for Web Bot Auth.

- Add `api/pkg/webbotauth` helpers to derive the Ed25519 JWKS from the signing key
- Add `api/cmd/signature-directory` to write the directory document during frontend builds
- Update `Makefile` to build a small generator binary (not `go run`) and upload the directory to S3/CloudFront with `Content-Type: application/http-message-signatures-directory+json`
- Set the correct media type in Vite dev/preview servers
- Harden deploy so the private key is not exposed in GitHub Actions logs

## Deploy / secret handling

- Add `WEB_BOT_AUTH_PRIVATE_KEY` as a GitHub Actions secret
- The deploy workflow writes the secret to a `600` temp file, unsets `WEB_BOT_AUTH_PRIVATE_KEY`, and passes only `WEB_BOT_AUTH_PRIVATE_KEY_FILE` to `make`
- `make --silent` and `set +x` avoid echoing shell recipes or tracing
- Error paths log generic messages and never include key material

## Testing

- `go test -mod=vendor ./pkg/webbotauth/... ./gateway -run 'WebBot|BotAuth|Ed25519|Directory|PrepareOutbound|LoadPrivate|PrivateKey'`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59a0cb9c-03b2-4306-9d4d-efb513b24157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59a0cb9c-03b2-4306-9d4d-efb513b24157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

