### PR TITLE
Remove store name from search result sort options

### DIFF
--- a/frontend/src/components/ResultFilters.jsx
+++ b/frontend/src/components/ResultFilters.jsx
@@ -26,7 +26,6 @@ const ResultFilters = ({
           >
             <option value="price-asc">Price (low to high)</option>
             <option value="price-desc">Price (high to low)</option>
-            <option value="store-asc">Store name</option>
           </Form.Select>
         </div>
         {availableQualities.length > 0 && (

--- a/frontend/src/hooks/useResultFilters.js
+++ b/frontend/src/hooks/useResultFilters.js
@@ -37,14 +37,10 @@ export default function useResultFilters(results, searchQuery) {
     }
 
     filtered.sort((a, b) => {
-      switch (sortBy) {
-        case "price-desc":
-          return b.price - a.price;
-        case "store-asc":
-          return a.src.localeCompare(b.src) || a.price - b.price;
-        default:
-          return a.price - b.price;
+      if (sortBy === "price-desc") {
+        return b.price - a.price;
       }
+      return a.price - b.price;
     });
 
     return filtered;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the "Store name" option from the post-search **Sort by** dropdown. Users can still sort results by price (low to high or high to low).

## Changes

- **`ResultFilters.jsx`**: Drop the `store-asc` select option.
- **`useResultFilters.js`**: Remove store-name sorting logic; price sort is unchanged.

## Testing

- Frontend lint run (`npm run lint`); only pre-existing issues in unrelated files.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-199cc525-d6ae-470a-a1d9-b60ee7db6f79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-199cc525-d6ae-470a-a1d9-b60ee7db6f79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

