### PR TITLE
Remove unused Lambda environment variables

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ export PATH="/usr/local/go/bin:$PATH"
 
 ### Known test behaviour
 
-- The `gateway/arcanesanctum` test hits a live website that blocks direct requests without a proxy. It will fail with "Forbidden (proxy_mode=direct proxy=none)" unless `PROXY_URL` or `DEDICATED_PROXY_*` env vars are set. This is expected in environments without proxy credentials.
+- The `gateway/arcanesanctum` test hits a live website that blocks direct requests without a proxy. It will fail with "Forbidden (proxy_mode=direct proxy=none)" unless `DEDICATED_PROXY_*` env vars are set. This is expected in environments without proxy credentials.
 - Many gateway tests hit live upstream store websites, so transient network failures or rate-limiting can cause sporadic failures.
 
 ### Frontend API connection

--- a/api/gateway/collector.go
+++ b/api/gateway/collector.go
@@ -466,11 +466,6 @@ func resolveProxyLabel(mode, proxyURL string) string {
 			return config.DynamicProxyEnv
 		}
 		return "dynamic-configured"
-	case "shared":
-		if sharedProxyURL := os.Getenv("PROXY_URL"); sharedProxyURL != "" && sharedProxyURL == proxyURL {
-			return "PROXY_URL"
-		}
-		return "shared-configured"
 	case "dedicated":
 		if label := dedicatedProxyEnvLabel(proxyURL); label != "" {
 			return label

--- a/api/gateway/collector_test.go
+++ b/api/gateway/collector_test.go
@@ -190,14 +190,6 @@ func TestFormatProxyContext(t *testing.T) {
 		}
 	})
 
-	t.Run("uses shared proxy env label", func(t *testing.T) {
-		t.Setenv("PROXY_URL", "http://shared-proxy:8080")
-		got := formatProxyContext("shared", "http://shared-proxy:8080")
-		if got != "proxy_mode=shared proxy=PROXY_URL" {
-			t.Fatalf("unexpected proxy context: %q", got)
-		}
-	})
-
 	t.Run("uses dynamic proxy env label", func(t *testing.T) {
 		t.Setenv("DYNAMIC_PROXY", "dynamic-proxy|8080||")
 		got := formatProxyContext("dynamic", "http://dynamic-proxy:8080")
@@ -222,13 +214,6 @@ func TestResolveProxyLabel(t *testing.T) {
 		}
 	})
 
-	t.Run("matches shared env key by URL", func(t *testing.T) {
-		t.Setenv("PROXY_URL", "http://shared:3333")
-		if got := resolveProxyLabel("shared", "http://shared:3333"); got != "PROXY_URL" {
-			t.Fatalf("expected PROXY_URL, got %q", got)
-		}
-	})
-
 	t.Run("matches dynamic env key by URL", func(t *testing.T) {
 		t.Setenv("DYNAMIC_PROXY", "dynamic|4444||")
 		if got := resolveProxyLabel("dynamic", "http://dynamic:4444"); got != "DYNAMIC_PROXY" {
@@ -242,9 +227,6 @@ func TestResolveProxyLabel(t *testing.T) {
 		}
 		if got := resolveProxyLabel("dynamic", "http://unknown-dynamic:5555"); got != "dynamic-configured" {
 			t.Fatalf("expected dynamic-configured fallback, got %q", got)
-		}
-		if got := resolveProxyLabel("shared", "http://unknown:5555"); got != "shared-configured" {
-			t.Fatalf("expected shared-configured fallback, got %q", got)
 		}
 		if got := resolveProxyLabel("unknown", "http://unknown:6666"); got != "configured" {
 			t.Fatalf("expected configured fallback, got %q", got)

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -21,9 +21,6 @@ const (
 	EnvLocal         = "local"
 	UseProxy         = true
 	PerSiteTimeout   = 20 * time.Second
-	// UseBinderposStorefrontAPIEnv toggles BinderPOS storefront API search mode.
-	// Default is enabled; set to "false" to force legacy scraping.
-	UseBinderposStorefrontAPIEnv = "USE_BINDERPOS_STOREFRONT_API"
 	// DynamicProxyEnv contains an authenticated proxy URL used for explicit
 	// dynamic-proxy fallback attempts, which BinderPOS now reserves for the
 	// final fallback after dedicated and direct/no-proxy attempts.
@@ -31,9 +28,6 @@ const (
 	// UseDynamicProxyEnv toggles whether DYNAMIC_PROXY may be used for fallback
 	// attempts. When false, dynamic proxy is skipped even if configured.
 	UseDynamicProxyEnv = "USE_DYNAMIC_PROXY"
-	// UseBinderposSharedProxyFallbackEnv is reserved for future BinderPOS proxy
-	// routing options. It no longer changes scraper behavior (lookups are single-attempt).
-	UseBinderposSharedProxyFallbackEnv = "USE_BINDERPOS_SHARED_PROXY_FALLBACK"
 	// WebBotAuthEnabledEnv toggles RFC 9421 Web Bot Auth signing on outbound gateway requests.
 	WebBotAuthEnabledEnv = "WEB_BOT_AUTH_ENABLED"
 	// WebBotAuthPrivateKeyEnv holds a PEM (or base64-encoded PEM) Ed25519 PKCS8 private key.
@@ -49,20 +43,6 @@ const (
 // UseLeasedDedicatedProxy enables exclusive per-request leases from the dedicated proxy pool.
 // When false, each request picks a random dedicated proxy instead of acquiring a lease.
 const UseLeasedDedicatedProxy = false
-
-func UseBinderposStorefrontAPI() bool {
-	rawValue := strings.TrimSpace(os.Getenv(UseBinderposStorefrontAPIEnv))
-	if rawValue == "" {
-		return true
-	}
-
-	enabled, err := strconv.ParseBool(rawValue)
-	if err != nil {
-		return true
-	}
-
-	return enabled
-}
 
 func UseDynamicProxy() bool {
 	rawValue := strings.TrimSpace(os.Getenv(UseDynamicProxyEnv))
@@ -90,20 +70,6 @@ func WebBotAuthTTL() time.Duration {
 		return defaultTTL
 	}
 	return time.Duration(seconds) * time.Second
-}
-
-func UseBinderposSharedProxyFallback() bool {
-	rawValue := strings.TrimSpace(os.Getenv(UseBinderposSharedProxyFallbackEnv))
-	if rawValue == "" {
-		return false
-	}
-
-	enabled, err := strconv.ParseBool(rawValue)
-	if err != nil {
-		return false
-	}
-
-	return enabled
 }
 
 func GetAllowedOrigins() []string {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Audited all environment variables referenced in the Go backend (excluding vendor/AWS runtime auto-vars) and removed three that no longer affect runtime behavior. These are safe to delete from your Lambda configuration when re-populating env vars.

## Environment variable audit

### Removed from code (safe to delete from Lambda)

| Variable | Why unused |
|----------|------------|
| `USE_BINDERPOS_STOREFRONT_API` | `UseBinderposStorefrontAPI()` existed but was **never called**. BinderPOS always uses the hybrid decklist/scrape strategy flow in `storefront_search.go`. |
| `USE_BINDERPOS_SHARED_PROXY_FALLBACK` | Explicitly documented as reserved/no-op; `UseBinderposSharedProxyFallback()` was never called. |
| `PROXY_URL` | Legacy shared-proxy label only. No production code path sets `proxy_mode=shared` anymore (proxy tiers are `dedicated → direct → dynamic`). |

### Still required / actively used

| Variable | Purpose |
|----------|---------|
| `ENV` | `prod` / `staging` routing and CORS (`GetAllowedOrigins`) |
| `DEDICATED_PROXY_1` … `DEDICATED_PROXY_7` | Dedicated proxy pool (`host\|port\|user\|pass`) |
| `DYNAMIC_PROXY` | Dynamic fallback proxy URL |
| `USE_DYNAMIC_PROXY` | Toggle dynamic proxy fallback (default: enabled) |
| `WEB_BOT_AUTH_ENABLED` | Toggle RFC 9421 outbound request signing |
| `WEB_BOT_AUTH_PRIVATE_KEY` | Ed25519 PEM key (required when bot auth enabled) |
| `WEB_BOT_AUTH_SIGNATURE_AGENT` | Signature-Agent directory URL (required when enabled) |
| `WEB_BOT_AUTH_USER_AGENT` | Optional User-Agent override |
| `WEB_BOT_AUTH_TTL_SECONDS` | Optional signature TTL (default 24h) |
| `TCG_MARKETPLACE_ACCESS_TOKEN` | API token for The TCG Marketplace store |
| `DISCORD_WEBHOOK_URL` | Optional; error alerts (no-op if unset) |

### Test-only (do not set on Lambda)

| Variable | Purpose |
|----------|---------|
| `RUN_BINDERPOS_LIVE_TESTS` | Gates live BinderPOS integration tests (`make test` skips by default) |

### Auto-provided by Lambda runtime (do not configure)

`AWS_LAMBDA_*`, `AWS_REGION`, etc.

## Code changes

- Removed dead config helpers and constants from `api/pkg/config/config.go`
- Removed `PROXY_URL` lookup from proxy error labeling in `api/gateway/collector.go`
- Updated related tests and `AGENTS.md`

## Testing

- Focused tests pass: `./pkg/config/`, `./gateway/` (proxy label tests)
- Full `make test` hit an unrelated flaky live scrape failure in `gateway/cardscentral` (quality field mismatch from upstream HTML)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c677ff3-7994-4485-9611-af86afd72aba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c677ff3-7994-4485-9611-af86afd72aba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

