### PR TITLE
Fix Web Bot Auth private key parsing for GitHub secret formats

### DIFF
--- a/api/pkg/webbotauth/keys.go
+++ b/api/pkg/webbotauth/keys.go
@@ -12,23 +12,45 @@ import (
 )
 
 // ParseEd25519PrivateKeyPEM parses an Ed25519 PKCS8 private key from PEM or
-// base64-encoded PEM text.
+// base64-encoded PEM/PKCS8 text.
 func ParseEd25519PrivateKeyPEM(raw string) (ed25519.PrivateKey, error) {
-	pemData := raw
-	if !strings.Contains(raw, "BEGIN") {
-		decoded, err := base64.StdEncoding.DecodeString(raw)
-		if err != nil {
-			return nil, fmt.Errorf("decode base64 private key: %w", err)
-		}
-		pemData = string(decoded)
+	raw = NormalizePrivateKeyMaterial(raw)
+	if raw == "" {
+		return nil, fmt.Errorf("signing key is empty")
 	}
 
+	if key, err := parseEd25519PrivateKeyFromPEMText(raw); err == nil {
+		return key, nil
+	}
+
+	if !strings.Contains(raw, "BEGIN") {
+		der, err := decodeBase64KeyMaterial(raw)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode signing key: expected Ed25519 PKCS8 PEM or base64-encoded PKCS8")
+		}
+		if key, err := parseEd25519PrivateKeyFromDER(der); err == nil {
+			return key, nil
+		}
+		if pemText := string(der); strings.Contains(pemText, "BEGIN") {
+			if key, err := parseEd25519PrivateKeyFromPEMText(pemText); err == nil {
+				return key, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("failed to decode signing key: expected Ed25519 PKCS8 PEM or base64-encoded PKCS8")
+}
+
+func parseEd25519PrivateKeyFromPEMText(pemData string) (ed25519.PrivateKey, error) {
 	block, _ := pem.Decode([]byte(pemData))
 	if block == nil {
 		return nil, fmt.Errorf("failed to decode PEM block")
 	}
+	return parseEd25519PrivateKeyFromDER(block.Bytes)
+}
 
-	keyIface, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+func parseEd25519PrivateKeyFromDER(der []byte) (ed25519.PrivateKey, error) {
+	keyIface, err := x509.ParsePKCS8PrivateKey(der)
 	if err != nil {
 		return nil, fmt.Errorf("parse PKCS8 private key: %w", err)
 	}

--- a/api/pkg/webbotauth/keys_test.go
+++ b/api/pkg/webbotauth/keys_test.go
@@ -2,6 +2,7 @@ package webbotauth
 
 import (
 	"crypto/ed25519"
+	"encoding/base64"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -28,4 +29,32 @@ MC4CAQAwBQYDK2VwBCIEIJ+DYvh6SEqVTm50DFtMDoQikTmiCqirVv9mWG9qfSnF
 	require.Contains(t, string(body), `"kid": "poqkLGiymh_W0uP6PZFw-dvez3QJT5SolqXBCW38r0U"`)
 	require.Contains(t, string(body), `"alg": "ed25519"`)
 	require.Contains(t, string(body), `"use": "sig"`)
+}
+
+func TestParseEd25519PrivateKeyPEM_commonSecretFormats(t *testing.T) {
+	pem := `-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIJ+DYvh6SEqVTm50DFtMDoQikTmiCqirVv9mWG9qfSnF
+-----END PRIVATE KEY-----`
+	singleLine := "-----BEGIN PRIVATE KEY-----MC4CAQAwBQYDK2VwBCIEIJ+DYvh6SEqVTm50DFtMDoQikTmiCqirVv9mWG9qfSnF-----END PRIVATE KEY-----"
+	escaped := `-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIJ+DYvh6SEqVTm50DFtMDoQikTmiCqirVv9mWG9qfSnF\n-----END PRIVATE KEY-----`
+	quoted := `"-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIJ+DYvh6SEqVTm50DFtMDoQikTmiCqirVv9mWG9qfSnF\n-----END PRIVATE KEY-----"`
+	base64PEM := base64.StdEncoding.EncodeToString([]byte(pem))
+
+	for _, tc := range []struct {
+		name string
+		raw  string
+	}{
+		{name: "multiline pem", raw: pem},
+		{name: "single line pem", raw: singleLine},
+		{name: "escaped newlines", raw: escaped},
+		{name: "quoted escaped pem", raw: quoted},
+		{name: "base64 encoded pem", raw: base64PEM},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			privateKey, err := ParseEd25519PrivateKeyPEM(tc.raw)
+			require.NoError(t, err)
+			require.Equal(t, "poqkLGiymh_W0uP6PZFw-dvez3QJT5SolqXBCW38r0U",
+				Ed25519JWKThumbprint(privateKey.Public().(ed25519.PublicKey)))
+		})
+	}
 }

--- a/api/pkg/webbotauth/keys_test.go
+++ b/api/pkg/webbotauth/keys_test.go
@@ -36,6 +36,7 @@ func TestParseEd25519PrivateKeyPEM_commonSecretFormats(t *testing.T) {
 MC4CAQAwBQYDK2VwBCIEIJ+DYvh6SEqVTm50DFtMDoQikTmiCqirVv9mWG9qfSnF
 -----END PRIVATE KEY-----`
 	singleLine := "-----BEGIN PRIVATE KEY-----MC4CAQAwBQYDK2VwBCIEIJ+DYvh6SEqVTm50DFtMDoQikTmiCqirVv9mWG9qfSnF-----END PRIVATE KEY-----"
+	spacedSingleLine := "-----BEGIN PRIVATE KEY----- MC4CAQAwBQYDK2VwBCIEIJ+DYvh6SEqVTm50DFtMDoQikTmiCqirVv9mWG9qfSnF -----END PRIVATE KEY-----"
 	escaped := `-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIJ+DYvh6SEqVTm50DFtMDoQikTmiCqirVv9mWG9qfSnF\n-----END PRIVATE KEY-----`
 	quoted := `"-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIJ+DYvh6SEqVTm50DFtMDoQikTmiCqirVv9mWG9qfSnF\n-----END PRIVATE KEY-----"`
 	base64PEM := base64.StdEncoding.EncodeToString([]byte(pem))
@@ -46,6 +47,7 @@ MC4CAQAwBQYDK2VwBCIEIJ+DYvh6SEqVTm50DFtMDoQikTmiCqirVv9mWG9qfSnF
 	}{
 		{name: "multiline pem", raw: pem},
 		{name: "single line pem", raw: singleLine},
+		{name: "spaced single line pem", raw: spacedSingleLine},
 		{name: "escaped newlines", raw: escaped},
 		{name: "quoted escaped pem", raw: quoted},
 		{name: "base64 encoded pem", raw: base64PEM},

--- a/api/pkg/webbotauth/normalize.go
+++ b/api/pkg/webbotauth/normalize.go
@@ -1,0 +1,57 @@
+package webbotauth
+
+import (
+	"encoding/base64"
+	"regexp"
+	"strings"
+)
+
+var singleLinePEMRE = regexp.MustCompile(`-----BEGIN ([^-]+)-----[ \t]*(.+?)[ \t]*-----END [^-]+-----`)
+
+// NormalizePrivateKeyMaterial prepares secret key text copied from env vars or
+// secret managers for PEM parsing. It handles common CI formats such as quoted
+// values, escaped newlines, and single-line PEM blocks.
+func NormalizePrivateKeyMaterial(raw string) string {
+	s := strings.TrimSpace(raw)
+	s = strings.TrimPrefix(s, "\uFEFF")
+	s = strings.Trim(s, `"'`)
+
+	if strings.Contains(s, `\n`) || strings.Contains(s, `\r`) {
+		s = strings.ReplaceAll(s, `\r\n`, "\n")
+		s = strings.ReplaceAll(s, `\n`, "\n")
+		s = strings.ReplaceAll(s, `\r`, "\n")
+	}
+
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, "\r", "\n")
+
+	if !strings.Contains(s, "\n") {
+		if match := singleLinePEMRE.FindStringSubmatch(s); match != nil {
+			s = "-----BEGIN " + match[1] + "-----\n" +
+				strings.TrimSpace(match[2]) + "\n" +
+				"-----END " + match[1] + "-----"
+		}
+	}
+
+	return strings.TrimSpace(s)
+}
+
+func decodeBase64KeyMaterial(raw string) ([]byte, error) {
+	compact := strings.Map(func(r rune) rune {
+		switch r {
+		case '\n', '\r', '\t', ' ':
+			return -1
+		default:
+			return r
+		}
+	}, raw)
+
+	if compact == "" {
+		return nil, base64.CorruptInputError(0)
+	}
+
+	if decoded, err := base64.StdEncoding.DecodeString(compact); err == nil {
+		return decoded, nil
+	}
+	return base64.RawStdEncoding.DecodeString(compact)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes deploy failure during `generate-signature-directory`:

```
parse signing key: failed to decode PEM block
```

GitHub Actions secrets are often stored in formats that are valid key material but not strict multiline PEM (single line, escaped `\n`, surrounding quotes, or base64-wrapped PEM/PKCS8). The parser now normalizes these before decoding.

## Changes

- Add `NormalizePrivateKeyMaterial` for quoted values, escaped newlines, single-line PEM, and whitespace cleanup
- Extend `ParseEd25519PrivateKeyPEM` to accept base64-encoded PKCS8/PEM when PEM decoding fails
- Add tests for common secret storage formats

## Secret format reminder

`WEB_BOT_AUTH_PRIVATE_KEY` should be an **Ed25519 PKCS8** key, e.g.:

```
-----BEGIN PRIVATE KEY-----
MC4CAQAwBQYDK2VwBCIEI...
-----END PRIVATE KEY-----
```

Single-line, escaped-newline, quoted, or base64-encoded variants are now supported. OpenSSH `BEGIN OPENSSH PRIVATE KEY` keys are not supported.

## Testing

- `go test -mod=vendor ./pkg/webbotauth/...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59a0cb9c-03b2-4306-9d4d-efb513b24157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59a0cb9c-03b2-4306-9d4d-efb513b24157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

