### PR TITLE
Fix Shopify suggest gzip JSON parsing for MTG Asia and Grey Ogre

### DIFF
--- a/api/gateway/browser_headers.go
+++ b/api/gateway/browser_headers.go
@@ -43,5 +43,4 @@ func ApplyBrowserLikeJSONFetchHeaders(h *http.Header, storeBase *url.URL) {
 	}
 	h.Set("Accept", browserLikeAcceptJSON)
 	h.Set("Accept-Language", browserLikeAcceptLanguage)
-	h.Set("Accept-Encoding", "gzip")
 }

--- a/api/gateway/browser_headers_test.go
+++ b/api/gateway/browser_headers_test.go
@@ -47,8 +47,8 @@ func TestApplyBrowserLikeJSONFetchHeaders(t *testing.T) {
 	if got := h.Get("Accept"); got != browserLikeAcceptJSON {
 		t.Fatalf("Accept: got %q", got)
 	}
-	if got := h.Get("Accept-Encoding"); got != "gzip" {
-		t.Fatalf("Accept-Encoding: got %q", got)
+	if got := h.Get("Accept-Encoding"); got != "" {
+		t.Fatalf("Accept-Encoding should be left unset for Go client auto-decompression, got %q", got)
 	}
 }
 

--- a/api/gateway/http_response.go
+++ b/api/gateway/http_response.go
@@ -1,0 +1,52 @@
+package gateway
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// ReadResponseBody reads an HTTP response body, transparently decompressing gzip
+// when needed. Go's net/http does not auto-decompress when the request sets
+// Accept-Encoding manually (as browser-like headers do), so callers that set
+// Accept-Encoding must use this helper before parsing JSON or HTML.
+func ReadResponseBody(resp *http.Response) ([]byte, error) {
+	if resp == nil || resp.Body == nil {
+		return nil, fmt.Errorf("gateway: nil response body")
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.Uncompressed {
+		return body, nil
+	}
+	return decompressGzipIfNeeded(body, resp.Header.Get("Content-Encoding"))
+}
+
+func decompressGzipIfNeeded(body []byte, contentEncoding string) ([]byte, error) {
+	if len(body) == 0 {
+		return body, nil
+	}
+	if !isGzipBody(body, contentEncoding) {
+		return body, nil
+	}
+
+	zr, err := gzip.NewReader(bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	defer zr.Close()
+	return io.ReadAll(zr)
+}
+
+func isGzipBody(body []byte, contentEncoding string) bool {
+	if strings.Contains(strings.ToLower(contentEncoding), "gzip") {
+		return true
+	}
+	return len(body) >= 2 && body[0] == 0x1f && body[1] == 0x8b
+}

--- a/api/gateway/http_response_test.go
+++ b/api/gateway/http_response_test.go
@@ -1,0 +1,75 @@
+package gateway
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestReadResponseBody_plainJSON(t *testing.T) {
+	body := []byte(`{"ok":true}`)
+	resp := &http.Response{
+		Body:          io.NopCloser(bytes.NewReader(body)),
+		Uncompressed:  true,
+		Header:        make(http.Header),
+	}
+	got, err := ReadResponseBody(resp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Fatalf("got %q, want %q", got, body)
+	}
+}
+
+func TestReadResponseBody_gzipJSON(t *testing.T) {
+	plain := []byte(`{"resources":{"results":{"products":[]}}}`)
+	var compressed bytes.Buffer
+	zw := gzip.NewWriter(&compressed)
+	if _, err := zw.Write(plain); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := &http.Response{
+		Body: io.NopCloser(bytes.NewReader(compressed.Bytes())),
+		Header: http.Header{
+			"Content-Encoding": []string{"gzip"},
+		},
+	}
+	got, err := ReadResponseBody(resp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != string(plain) {
+		t.Fatalf("got %q, want %q", got, plain)
+	}
+}
+
+func TestReadResponseBody_gzipMagicWithoutHeader(t *testing.T) {
+	plain := []byte(`{"ok":true}`)
+	var compressed bytes.Buffer
+	zw := gzip.NewWriter(&compressed)
+	if _, err := zw.Write(plain); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := &http.Response{
+		Body:   io.NopCloser(bytes.NewReader(compressed.Bytes())),
+		Header: make(http.Header),
+	}
+	got, err := ReadResponseBody(resp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != string(plain) {
+		t.Fatalf("got %q, want %q", got, plain)
+	}
+}

--- a/api/gateway/shopifysuggest/proxy_fallback_test.go
+++ b/api/gateway/shopifysuggest/proxy_fallback_test.go
@@ -1,6 +1,8 @@
 package shopifysuggest
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"net/http"
 	"net/http/httptest"
@@ -44,6 +46,20 @@ func TestFetchProductsSuccess(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(sampleSuggestBody))
+	}))
+	defer srv.Close()
+
+	products, err := fetchProducts(context.Background(), srv.Client(), srv.URL)
+	require.NoError(t, err)
+	require.Len(t, products, 1)
+	require.Equal(t, "Opt", products[0].Title)
+}
+
+func TestFetchProductsSuccessGzip(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Encoding", "gzip")
+		_, _ = w.Write(gzipJSON(t, sampleSuggestBody))
 	}))
 	defer srv.Close()
 
@@ -155,4 +171,14 @@ func TestBuildSearchAttemptsProxyConfiguration(t *testing.T) {
 	require.Len(t, attempts, 2)
 	require.Equal(t, "direct", attempts[0].strategy)
 	require.Equal(t, "dedicated", attempts[1].strategy)
+}
+
+func gzipJSON(t *testing.T, body string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	_, err := zw.Write([]byte(body))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	return buf.Bytes()
 }

--- a/api/gateway/shopifysuggest/retry.go
+++ b/api/gateway/shopifysuggest/retry.go
@@ -3,7 +3,6 @@ package shopifysuggest
 import (
 	"context"
 	"fmt"
-	"io"
 	"math/rand/v2"
 	"net/http"
 	"net/url"
@@ -73,7 +72,7 @@ func doSuggestGETWithRetry(ctx context.Context, client *http.Client, requestURL 
 			continue
 		}
 
-		body, err := io.ReadAll(resp.Body)
+		body, err := gateway.ReadResponseBody(resp)
 		resp.Body.Close()
 		if err != nil {
 			lastErr = err


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Searching MTG Asia and Grey Ogre Games failed with:

```
invalid character '\x1f' looking for beginning of value
```

Both stores use the shared `shopifysuggest` gateway. Shopify's `/search/suggest.json` endpoint returns gzip-compressed JSON. Our browser-like JSON fetch headers manually set `Accept-Encoding: gzip`, which disables Go `net/http` automatic decompression. The raw gzip bytes were passed to `json.Unmarshal`, producing the `\x1f` (gzip magic byte) parse error.

## Fix

- Add `gateway.ReadResponseBody` to transparently decompress gzip response bodies when needed.
- Use it in `shopifysuggest` suggest/product JSON requests.
- Stop setting `Accept-Encoding` on JSON fetch headers so Go's default transport can also handle gzip when appropriate.

## Testing

- `go test ./gateway/... -run 'TestReadResponseBody|TestFetchProducts|TestApplyBrowserLikeJSON'`
- `go test -run Test_Search ./gateway/mtgasia/... ./gateway/gog/...` (live upstream)
- `go test ./gateway/shopifysuggest/...`

Full `make test` still has unrelated flaky live-store failures in `cardscentral` and `duellerpoint`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68b13246-7278-4a2b-a4b1-58f416bfd1bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68b13246-7278-4a2b-a4b1-58f416bfd1bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

