### PR TITLE
Log when Web Bot Auth is successfully enabled

### DIFF
--- a/api/gateway/bot_auth.go
+++ b/api/gateway/bot_auth.go
@@ -158,14 +158,23 @@ func loadWebBotAuth() {
 		userAgent = customUA
 	}
 
+	keyID := webbotauth.Ed25519JWKThumbprint(privateKey.Public().(ed25519.PublicKey))
+	ttl := config.WebBotAuthTTL()
 	webBotAuth = webBotAuthState{
 		enabled:           true,
 		privateKey:        privateKey,
-		keyID:             webbotauth.Ed25519JWKThumbprint(privateKey.Public().(ed25519.PublicKey)),
+		keyID:             keyID,
 		signatureAgentURL: signatureAgentURL,
 		userAgent:         userAgent,
-		ttl:               config.WebBotAuthTTL(),
+		ttl:               ttl,
 	}
+	log.Printf(
+		"Web Bot Auth enabled: signature_agent=%s key_id=%s user_agent=%q ttl=%s",
+		signatureAgentURL,
+		keyID,
+		userAgent,
+		ttl,
+	)
 }
 
 func newWebBotAuthNonce() (string, error) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a startup log when Web Bot Auth loads successfully, so CloudWatch shows when outbound request signing is active and configured correctly.

Previously, Web Bot Auth only logged on failure or misconfiguration. A healthy setup was silent.

## What you'll see

On the first outbound gateway request (when `loadWebBotAuth` runs), CloudWatch will include a line like:

```
Web Bot Auth enabled: signature_agent=https://gishathfetch.com/.well-known/http-message-signatures-directory key_id=<thumbprint> user_agent="GishathFetch/1.0 (+https://gishathfetch.com; mtg price checker)" ttl=24h0m0s
```

No private key material is logged — only the public key thumbprint (`key_id`).

## Testing

- `go test -mod=vendor -failfast -timeout 5m ./gateway/... -run 'TestWebBotAuth|TestSignWebBotAuth'` — passed
- Full `make test` hit an unrelated live `cardscentral` scraper assertion (`Near Mint` vs `DMG`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec1047d0-4b19-4677-b508-c99483df0b1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec1047d0-4b19-4677-b508-c99483df0b1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

