### PR TITLE
Mark TCG Marketplace Surge Foil cards as foil

### DIFF
--- a/api/gateway/tcgmarketplace/search.go
+++ b/api/gateway/tcgmarketplace/search.go
@@ -130,6 +130,7 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 					"utm_source": []string{config.UtmSource},
 				}.Encode()
 
+				extraInfo := []string{fmt.Sprintf("[%s]", card.Setname)}
 				cards = append(cards, gateway.Card{
 					Name:      strings.TrimSpace(name),
 					Url:       cleanPageURL.String(),
@@ -137,12 +138,25 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 					Price:     price,
 					Source:    s.Name,
 					Img:       img,
-					ExtraInfo: []string{fmt.Sprintf("[%s]", card.Setname)},
+					IsFoil:    isSurgeFoil(extraInfo, name),
+					ExtraInfo: extraInfo,
 				})
 			}
 		}
 	}
 	return cards, nil
+}
+
+func isSurgeFoil(extraInfo []string, name string) bool {
+	if strings.Contains(name, "Surge Foil") {
+		return true
+	}
+	for _, info := range extraInfo {
+		if strings.Contains(info, "Surge Foil") {
+			return true
+		}
+	}
+	return false
 }
 
 func getApiResponse(ctx context.Context, payload []byte) (response, error) {

--- a/api/gateway/tcgmarketplace/search_test.go
+++ b/api/gateway/tcgmarketplace/search_test.go
@@ -12,6 +12,40 @@ func init() {
 	_ = godotenv.Load("../../.env")
 }
 
+func TestIsSurgeFoil(t *testing.T) {
+	tests := map[string]struct {
+		extraInfo []string
+		name      string
+		want      bool
+	}{
+		"surge foil in name": {
+			name: "Abaddon the Despoiler (V1)(Surge Foil)",
+			want: true,
+		},
+		"surge foil in extra info": {
+			extraInfo: []string{"[Warhammer 40,000 Commander]", "[Surge Foil]"},
+			name:      "Abaddon the Despoiler",
+			want:      true,
+		},
+		"non-foil card": {
+			extraInfo: []string{"[Double Masters]"},
+			name:      "Abrade",
+			want:      false,
+		},
+		"etched foil not surge": {
+			extraInfo: []string{"[Commander Masters]"},
+			name:      "Deflecting Swat (V2)(Etched foil)",
+			want:      false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tt.want, isSurgeFoil(tt.extraInfo, tt.name))
+		})
+	}
+}
+
 func Test_Search(t *testing.T) {
 	s := NewLGS()
 	result, err := s.Search(context.Background(), "abrade")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The TCG Marketplace API returns Surge Foil finish in card names (e.g. `Abaddon the Despoiler (V1)(Surge Foil)`), which ends up in extra info after controller name cleaning. These listings were not being flagged as foil.

This change detects `Surge Foil` in the card name or extra info and sets `IsFoil` accordingly.

## Changes

- Add `isSurgeFoil` helper in `api/gateway/tcgmarketplace/search.go`
- Set `IsFoil` when building TCG Marketplace cards
- Add unit tests covering name/extra-info detection and non-surge foil cases

## Testing

- `go test -mod=vendor -v -run 'TestIsSurgeFoil|Test_Search' ./gateway/tcgmarketplace/...`
- `go test -mod=vendor -failfast -timeout 5m ./gateway/tcgmarketplace/... ./controller/...`
- Verified live search: `Abaddon the Despoiler (V1)(Surge Foil)` now returns `IsFoil=true`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6feb3fac-997c-4204-912d-b9ba671bf714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6feb3fac-997c-4204-912d-b9ba671bf714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

