### PR TITLE
Move cancel button below search button during active search

### DIFF
--- a/frontend/src/components/SearchForm.jsx
+++ b/frontend/src/components/SearchForm.jsx
@@ -213,9 +213,9 @@ const SearchForm = ({
           </div>
         )}
 
-        <div className="mb-3 d-grid">
+        <div className="mb-3 d-grid gap-2">
           {isSearching ? (
-            <div className="btn-group">
+            <>
               <button
                 id="searchBtn"
                 type="button"
@@ -231,7 +231,7 @@ const SearchForm = ({
               >
                 Cancel
               </button>
-            </div>
+            </>
           ) : (
             <button
               id="searchBtn"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

During an active search, the Cancel control now appears on its own line beneath the progress button instead of beside it in a horizontal button group.

## Changes

- Updated `SearchForm.jsx` to replace the `btn-group` layout with a stacked `d-grid gap-2` layout while searching.
- Both buttons remain full width for consistent tap targets on mobile.

## Screenshots

### Desktop

![Cancel button stacked below search progress button on desktop](https://cursor.com/artifacts/c/art-bbcd7003-03cd-4354-a029-6d0d7c15dd01)

### Mobile

![Cancel button stacked below search progress button on mobile](https://cursor.com/artifacts/c/art-a94c7ee9-ddc1-4777-bf5b-d4a9307e7a99)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9838bd29-0f7a-49f8-b455-354402f6b841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9838bd29-0f7a-49f8-b455-354402f6b841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

