### PR TITLE
Surface store failures, shareable URLs, back navigation, cheapest-per-store

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -39,6 +39,8 @@ export default function App() {
     searchResults,
     searchProgress,
     searchError,
+    searchStoreErrors,
+    onDismissStoreErrors,
     storesWarning,
     suggestions,
     showSuggestions,
@@ -163,6 +165,8 @@ export default function App() {
         isSearching={isSearching}
         hasSearched={hasSearched}
         searchError={searchError}
+        searchStoreErrors={searchStoreErrors}
+        onDismissStoreErrors={onDismissStoreErrors}
         onRetrySearch={retrySearch}
         isCardInCart={isCardInCart}
         addToCart={addToCart}

--- a/frontend/src/components/ResultFilters.jsx
+++ b/frontend/src/components/ResultFilters.jsx
@@ -8,6 +8,8 @@ const ResultFilters = ({
   availableQualities,
   foilOnly,
   onFoilOnlyChange,
+  cheapestPerStore,
+  onCheapestPerStoreChange,
   hasActiveFilters,
   onClearFilters,
 }) => {
@@ -58,6 +60,14 @@ const ResultFilters = ({
             label="Foil only"
             checked={foilOnly}
             onChange={(e) => onFoilOnlyChange(e.target.checked)}
+            className="mb-0"
+          />
+          <Form.Check
+            type="checkbox"
+            id="cheapest-per-store"
+            label="Cheapest per store"
+            checked={cheapestPerStore}
+            onChange={(e) => onCheapestPerStoreChange(e.target.checked)}
             className="mb-0"
           />
           {hasActiveFilters && (

--- a/frontend/src/components/SearchResults.jsx
+++ b/frontend/src/components/SearchResults.jsx
@@ -23,7 +23,8 @@ const EmptyFilteredState = ({ onClearFilters }) => (
   <div className="mb-3 text-center py-4 px-3">
     <div className="fw-semibold mb-2">No results match your filters</div>
     <p className="small text-muted mb-3">
-      Try a different condition, turning off foil only, or clear your filters.
+      Try a different condition, turning off foil only or cheapest per store, or
+      clear your filters.
     </p>
     <button
       type="button"
@@ -60,6 +61,8 @@ const SearchResults = ({
     availableQualities,
     foilOnly,
     setFoilOnly,
+    cheapestPerStore,
+    setCheapestPerStore,
     hasActiveFilters,
     clearFilters,
   } = useResultFilters(results, searchQuery);
@@ -136,6 +139,8 @@ const SearchResults = ({
                   availableQualities={availableQualities}
                   foilOnly={foilOnly}
                   onFoilOnlyChange={setFoilOnly}
+                  cheapestPerStore={cheapestPerStore}
+                  onCheapestPerStoreChange={setCheapestPerStore}
                   hasActiveFilters={hasActiveFilters}
                   onClearFilters={clearFilters}
                 />

--- a/frontend/src/components/SearchResults.jsx
+++ b/frontend/src/components/SearchResults.jsx
@@ -4,6 +4,7 @@ import AdComponent from "./AdComponent";
 import Card from "./Card";
 import ResultFilters from "./ResultFilters";
 import SkeletonCard from "./SkeletonCard";
+import StoreErrorsBanner from "./StoreErrorsBanner";
 
 // Display ad after every N results
 const AD_DISPLAY_INTERVAL = 8;
@@ -40,6 +41,8 @@ const SearchResults = ({
   isSearching,
   hasSearched,
   searchError,
+  searchStoreErrors,
+  onDismissStoreErrors,
   onRetrySearch,
   isCardInCart,
   addToCart,
@@ -102,64 +105,77 @@ const SearchResults = ({
               </div>
             )}
           </div>
-        ) : results.length === 0 ? (
+        ) : results.length === 0 && searchStoreErrors.length === 0 ? (
           <EmptySearchState />
         ) : (
           <>
-            <div
-              id="resultCount"
-              className="mb-3 text-center bg-warning-subtle text-warning-emphasis rounded py-2"
-              aria-live="polite"
-            >
-              {resultCountLabel}
-            </div>
+            {searchStoreErrors.length > 0 && (
+              <StoreErrorsBanner
+                storeErrors={searchStoreErrors}
+                onDismiss={onDismissStoreErrors}
+              />
+            )}
 
-            <ResultFilters
-              sortBy={sortBy}
-              onSortChange={setSortBy}
-              qualityFilter={qualityFilter}
-              onQualityFilterChange={setQualityFilter}
-              availableQualities={availableQualities}
-              foilOnly={foilOnly}
-              onFoilOnlyChange={setFoilOnly}
-              hasActiveFilters={hasActiveFilters}
-              onClearFilters={clearFilters}
-            />
-
-            {filteredResults.length === 0 ? (
-              <EmptyFilteredState onClearFilters={clearFilters} />
+            {results.length === 0 ? (
+              <EmptySearchState />
             ) : (
-              <div id="result" className="mb-3 text-center">
-                <div className="row">
-                  {filteredResults.map((card, i) => {
-                    const showAd =
-                      filteredResults.length > AD_DISPLAY_INTERVAL &&
-                      (i + 1) % AD_DISPLAY_INTERVAL === 0 &&
-                      i + 1 !== filteredResults.length;
-                    return (
-                      <React.Fragment
-                        key={`${card.src}-${card.url}-${card.price}-${card.quality}`}
-                      >
-                        <Card
-                          card={card}
-                          index={i}
-                          isCardInCart={isCardInCart}
-                          addToCart={addToCart}
-                          removeFromCart={removeFromCart}
-                          removeFromCartByCard={removeFromCartByCard}
-                          onSearchStore={onSearchStore}
-                          baseUrl={baseUrl}
-                        />
-                        {showAd && (
-                          <div className="col-12 mb-4">
-                            <AdComponent />
-                          </div>
-                        )}
-                      </React.Fragment>
-                    );
-                  })}
+              <>
+                <div
+                  id="resultCount"
+                  className="mb-3 text-center bg-warning-subtle text-warning-emphasis rounded py-2"
+                  aria-live="polite"
+                >
+                  {resultCountLabel}
                 </div>
-              </div>
+
+                <ResultFilters
+                  sortBy={sortBy}
+                  onSortChange={setSortBy}
+                  qualityFilter={qualityFilter}
+                  onQualityFilterChange={setQualityFilter}
+                  availableQualities={availableQualities}
+                  foilOnly={foilOnly}
+                  onFoilOnlyChange={setFoilOnly}
+                  hasActiveFilters={hasActiveFilters}
+                  onClearFilters={clearFilters}
+                />
+
+                {filteredResults.length === 0 ? (
+                  <EmptyFilteredState onClearFilters={clearFilters} />
+                ) : (
+                  <div id="result" className="mb-3 text-center">
+                    <div className="row">
+                      {filteredResults.map((card, i) => {
+                        const showAd =
+                          filteredResults.length > AD_DISPLAY_INTERVAL &&
+                          (i + 1) % AD_DISPLAY_INTERVAL === 0 &&
+                          i + 1 !== filteredResults.length;
+                        return (
+                          <React.Fragment
+                            key={`${card.src}-${card.url}-${card.price}-${card.quality}`}
+                          >
+                            <Card
+                              card={card}
+                              index={i}
+                              isCardInCart={isCardInCart}
+                              addToCart={addToCart}
+                              removeFromCart={removeFromCart}
+                              removeFromCartByCard={removeFromCartByCard}
+                              onSearchStore={onSearchStore}
+                              baseUrl={baseUrl}
+                            />
+                            {showAd && (
+                              <div className="col-12 mb-4">
+                                <AdComponent />
+                              </div>
+                            )}
+                          </React.Fragment>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
+              </>
             )}
           </>
         ))}

--- a/frontend/src/components/StoreErrorsBanner.jsx
+++ b/frontend/src/components/StoreErrorsBanner.jsx
@@ -1,18 +1,10 @@
-import { useState } from "react";
-import { Alert, Button, Collapse } from "react-bootstrap";
-import {
-  formatStoreErrorDetail,
-  formatStoreErrorsSummary,
-} from "../utils/storeErrors";
+import { Alert } from "react-bootstrap";
+import { formatStoreErrorsSummary } from "../utils/storeErrors";
 
 const StoreErrorsBanner = ({ storeErrors, onDismiss }) => {
-  const [showDetails, setShowDetails] = useState(false);
-
   if (!storeErrors?.length) {
     return null;
   }
-
-  const summary = formatStoreErrorsSummary(storeErrors);
 
   return (
     <Alert
@@ -23,29 +15,7 @@ const StoreErrorsBanner = ({ storeErrors, onDismiss }) => {
       dismissible={!!onDismiss}
       onClose={onDismiss}
     >
-      <div className="d-flex flex-wrap align-items-center gap-2">
-        <span>{summary}</span>
-        <Button
-          type="button"
-          variant="link"
-          size="sm"
-          className="p-0 align-baseline"
-          onClick={() => setShowDetails((current) => !current)}
-          aria-expanded={showDetails}
-          aria-controls="store-errors-details"
-        >
-          {showDetails ? "Hide details" : "Show details"}
-        </Button>
-      </div>
-      <Collapse in={showDetails}>
-        <div id="store-errors-details" className="mt-2">
-          <ul className="mb-0 small ps-3">
-            {storeErrors.map((entry) => (
-              <li key={entry.store}>{formatStoreErrorDetail(entry)}</li>
-            ))}
-          </ul>
-        </div>
-      </Collapse>
+      {formatStoreErrorsSummary(storeErrors)}
     </Alert>
   );
 };

--- a/frontend/src/components/StoreErrorsBanner.jsx
+++ b/frontend/src/components/StoreErrorsBanner.jsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import { Alert, Button, Collapse } from "react-bootstrap";
+import {
+  formatStoreErrorDetail,
+  formatStoreErrorsSummary,
+} from "../utils/storeErrors";
+
+const StoreErrorsBanner = ({ storeErrors, onDismiss }) => {
+  const [showDetails, setShowDetails] = useState(false);
+
+  if (!storeErrors?.length) {
+    return null;
+  }
+
+  const summary = formatStoreErrorsSummary(storeErrors);
+
+  return (
+    <Alert
+      variant="warning"
+      className="mb-3"
+      role="status"
+      aria-live="polite"
+      dismissible={!!onDismiss}
+      onClose={onDismiss}
+    >
+      <div className="d-flex flex-wrap align-items-center gap-2">
+        <span>{summary}</span>
+        <Button
+          type="button"
+          variant="link"
+          size="sm"
+          className="p-0 align-baseline"
+          onClick={() => setShowDetails((current) => !current)}
+          aria-expanded={showDetails}
+          aria-controls="store-errors-details"
+        >
+          {showDetails ? "Hide details" : "Show details"}
+        </Button>
+      </div>
+      <Collapse in={showDetails}>
+        <div id="store-errors-details" className="mt-2">
+          <ul className="mb-0 small ps-3">
+            {storeErrors.map((entry) => (
+              <li key={entry.store}>{formatStoreErrorDetail(entry)}</li>
+            ))}
+          </ul>
+        </div>
+      </Collapse>
+    </Alert>
+  );
+};
+
+export default StoreErrorsBanner;

--- a/frontend/src/hooks/useResultFilters.js
+++ b/frontend/src/hooks/useResultFilters.js
@@ -6,6 +6,7 @@ export default function useResultFilters(results, searchQuery) {
   const [sortBy, setSortBy] = useState(DEFAULT_SORT);
   const [qualityFilter, setQualityFilter] = useState("all");
   const [foilOnly, setFoilOnly] = useState(false);
+  const [cheapestPerStore, setCheapestPerStore] = useState(false);
 
   // Reset filters when the user runs a new search.
   // biome-ignore lint/correctness/useExhaustiveDependencies: searchQuery triggers filter reset on new search
@@ -13,6 +14,7 @@ export default function useResultFilters(results, searchQuery) {
     setSortBy(DEFAULT_SORT);
     setQualityFilter("all");
     setFoilOnly(false);
+    setCheapestPerStore(false);
   }, [searchQuery]);
 
   const availableQualities = useMemo(() => {
@@ -36,6 +38,18 @@ export default function useResultFilters(results, searchQuery) {
       filtered = filtered.filter((card) => card.isFoil);
     }
 
+    if (cheapestPerStore) {
+      const cheapestByStore = new Map();
+      for (const card of filtered) {
+        const storeName = card.src || "Unknown Store";
+        const existing = cheapestByStore.get(storeName);
+        if (!existing || card.price < existing.price) {
+          cheapestByStore.set(storeName, card);
+        }
+      }
+      filtered = [...cheapestByStore.values()];
+    }
+
     filtered.sort((a, b) => {
       if (sortBy === "price-desc") {
         return b.price - a.price;
@@ -44,13 +58,15 @@ export default function useResultFilters(results, searchQuery) {
     });
 
     return filtered;
-  }, [results, sortBy, qualityFilter, foilOnly]);
+  }, [results, sortBy, qualityFilter, foilOnly, cheapestPerStore]);
 
-  const hasActiveFilters = qualityFilter !== "all" || foilOnly;
+  const hasActiveFilters =
+    qualityFilter !== "all" || foilOnly || cheapestPerStore;
 
   const clearFilters = () => {
     setQualityFilter("all");
     setFoilOnly(false);
+    setCheapestPerStore(false);
   };
 
   return {
@@ -62,6 +78,8 @@ export default function useResultFilters(results, searchQuery) {
     availableQualities,
     foilOnly,
     setFoilOnly,
+    cheapestPerStore,
+    setCheapestPerStore,
     hasActiveFilters,
     clearFilters,
   };

--- a/frontend/src/hooks/useSearch.js
+++ b/frontend/src/hooks/useSearch.js
@@ -5,11 +5,14 @@ import {
   LGS_OPTIONS,
   MAX_SEARCH_LENGTH,
   MIN_SEARCH_LENGTH,
+  PAGE_TITLE,
 } from "../constants";
 import {
+  buildSearchHistoryState,
   buildSearchUrl,
   getInitialSelectedStores,
   getStoresFromUrl,
+  isSearchHistoryState,
   persistSelectedStores,
 } from "../utils/searchUrl";
 
@@ -64,21 +67,30 @@ export default function useSearch() {
   const resultsBeforeSearchRef = useRef([]);
   const userCancelledRef = useRef(false);
   const lastSearchRef = useRef({ query: "", stores: [] });
+  const skipHistorySyncRef = useRef(false);
+  const restoringHistoryRef = useRef(false);
+  const performSearchRef = useRef(() => {});
 
   useEffect(() => {
     searchResultsRef.current = searchResults;
   }, [searchResults]);
 
-  const updateUrlAndTitle = useCallback((query, stores) => {
-    if (window.location.hostname !== "localhost") {
-      const newUrl = buildSearchUrl(BASE_URL, query, stores);
-      window.history.pushState(
-        { query, stores },
-        `${query} @ Gishath Fetch`,
-        newUrl,
-      );
-      document.title = `${query} @ Gishath Fetch`;
+  const syncSearchHistory = useCallback((snapshot) => {
+    if (window.location.hostname === "localhost") {
+      return;
     }
+
+    const newUrl = buildSearchUrl(BASE_URL, snapshot.query, snapshot.stores);
+    const title = snapshot.query
+      ? `${snapshot.query} @ Gishath Fetch`
+      : PAGE_TITLE;
+    const state = buildSearchHistoryState(snapshot);
+    const historyMethod = isSearchHistoryState(window.history.state)
+      ? "pushState"
+      : "replaceState";
+
+    window.history[historyMethod](state, title, newUrl);
+    document.title = title;
   }, []);
 
   const resolveStoresToSearch = useCallback((stores) => {
@@ -191,7 +203,17 @@ export default function useSearch() {
               : [];
             setSearchStoreErrors(storeErrors);
             setDismissedStoreErrorsKey(null);
-            updateUrlAndTitle(query, stores);
+            if (!skipHistorySyncRef.current) {
+              syncSearchHistory({
+                query,
+                stores,
+                results: result.data || [],
+                storeErrors,
+                hasSearched: true,
+                searchError: null,
+              });
+            }
+            skipHistorySyncRef.current = false;
             if (window.gtag) {
               window.gtag("event", "view_search_results", {
                 search_term: query,
@@ -223,25 +245,36 @@ export default function useSearch() {
           setSearchStoreErrors([]);
           setDismissedStoreErrorsKey(null);
 
+          let nextSearchError;
           // Set user-friendly error message
           if (
             err.message.includes("Failed to fetch") ||
             err.name === "TypeError"
           ) {
-            setSearchError(
-              "Unable to connect to the server. Please check your internet connection and try again.",
-            );
+            nextSearchError =
+              "Unable to connect to the server. Please check your internet connection and try again.";
           } else if (err.message.startsWith("Error (")) {
-            setSearchError(err.message);
+            nextSearchError = err.message;
           } else if (err.message.includes("Server error")) {
-            setSearchError(
-              "The server is experiencing issues. Please try again later.",
-            );
+            nextSearchError =
+              "The server is experiencing issues. Please try again later.";
           } else {
-            setSearchError(
-              "An error occurred while searching. Please try again.",
-            );
+            nextSearchError =
+              "An error occurred while searching. Please try again.";
           }
+          setSearchError(nextSearchError);
+
+          if (!skipHistorySyncRef.current) {
+            syncSearchHistory({
+              query,
+              stores,
+              results: [],
+              storeErrors: [],
+              hasSearched: true,
+              searchError: nextSearchError,
+            });
+          }
+          skipHistorySyncRef.current = false;
         })
         .finally(() => {
           clearInterval(progressInterval);
@@ -259,8 +292,75 @@ export default function useSearch() {
           skipSuggestionsRef.current = false;
         });
     },
-    [updateUrlAndTitle],
+    [syncSearchHistory],
   );
+
+  performSearchRef.current = performSearch;
+
+  const applyHistoryState = useCallback((state) => {
+    restoringHistoryRef.current = true;
+    skipSuggestionsRef.current = true;
+    setShowSuggestions(false);
+
+    if (!isSearchHistoryState(state)) {
+      const urlParams = new URLSearchParams(window.location.search);
+      const query =
+        urlParams.has("s") && urlParams.get("s") !== ""
+          ? decodeURIComponent(urlParams.get("s"))
+          : "";
+      const urlStores = getStoresFromUrl(urlParams);
+      const stores = urlStores ?? getInitialSelectedStores(urlParams);
+
+      setSearchQuery(query);
+      setSelectedStores(stores);
+      persistSelectedStores(stores);
+      setSearchResults([]);
+      setSearchStoreErrors([]);
+      setSearchError(null);
+      setDismissedStoreErrorsKey(null);
+      setHasSearched(false);
+      setIsSearching(false);
+      setSearchProgress("Search");
+      document.title = PAGE_TITLE;
+
+      if (
+        query.length >= MIN_SEARCH_LENGTH &&
+        query.length <= MAX_SEARCH_LENGTH
+      ) {
+        skipHistorySyncRef.current = true;
+        restoringHistoryRef.current = false;
+        performSearchRef.current(query, stores);
+        return;
+      }
+
+      restoringHistoryRef.current = false;
+      return;
+    }
+
+    setSearchQuery(state.query || "");
+    setSelectedStores(state.stores || LGS_OPTIONS);
+    persistSelectedStores(state.stores || LGS_OPTIONS);
+    setSearchResults(state.results || []);
+    setSearchStoreErrors(state.storeErrors || []);
+    setHasSearched(!!state.hasSearched);
+    setSearchError(state.searchError || null);
+    setDismissedStoreErrorsKey(null);
+    setIsSearching(false);
+    setSearchProgress("Search");
+    document.title = state.query
+      ? `${state.query} @ Gishath Fetch`
+      : PAGE_TITLE;
+    restoringHistoryRef.current = false;
+  }, []);
+
+  useEffect(() => {
+    const onPopState = (event) => {
+      applyHistoryState(event.state);
+    };
+
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, [applyHistoryState]);
 
   const cancelSearch = useCallback(() => {
     if (!searchAbortControllerRef.current) return;

--- a/frontend/src/hooks/useSearch.js
+++ b/frontend/src/hooks/useSearch.js
@@ -6,6 +6,12 @@ import {
   MAX_SEARCH_LENGTH,
   MIN_SEARCH_LENGTH,
 } from "../constants";
+import {
+  buildSearchUrl,
+  getInitialSelectedStores,
+  getStoresFromUrl,
+  persistSelectedStores,
+} from "../utils/searchUrl";
 
 const SEARCH_TOO_LONG_ERROR = `Card name is too long (maximum ${MAX_SEARCH_LENGTH} characters).`;
 const SEARCH_TOO_SHORT_ERROR = `Enter at least ${MIN_SEARCH_LENGTH} characters to search.`;
@@ -42,34 +48,9 @@ export default function useSearch() {
   const [searchStoreErrors, setSearchStoreErrors] = useState([]);
   const [dismissedStoreErrorsKey, setDismissedStoreErrorsKey] = useState(null);
   const [storesWarning, setStoresWarning] = useState(null);
-  const [selectedStores, setSelectedStores] = useState(() => {
-    // First check URL parameters for store override
-    const urlParams = new URLSearchParams(window.location.search);
-    if (
-      urlParams.has("src") &&
-      LGS_OPTIONS.includes(decodeURIComponent(urlParams.get("src")))
-    ) {
-      const stores = [decodeURIComponent(urlParams.get("src"))];
-      // Save to localStorage for URL-based navigation
-      try {
-        localStorage.setItem(
-          "lgsSelected",
-          encodeURIComponent(stores.join(",")),
-        );
-      } catch (err) {
-        console.error("Failed to save selected stores:", err);
-      }
-      return stores;
-    }
-
-    // Otherwise check localStorage
-    const storedLgs = localStorage.getItem("lgsSelected");
-    if (storedLgs !== null) {
-      const decoded = decodeURIComponent(storedLgs);
-      return decoded === "" ? [] : decoded.split(",");
-    }
-    return LGS_OPTIONS;
-  });
+  const [selectedStores, setSelectedStores] = useState(() =>
+    getInitialSelectedStores(),
+  );
 
   // --- Helpers ---
   const skipSuggestionsRef = useRef(
@@ -88,10 +69,14 @@ export default function useSearch() {
     searchResultsRef.current = searchResults;
   }, [searchResults]);
 
-  const updateUrlAndTitle = useCallback((query) => {
+  const updateUrlAndTitle = useCallback((query, stores) => {
     if (window.location.hostname !== "localhost") {
-      const newUrl = `${BASE_URL}?s=${encodeURIComponent(query)}`;
-      window.history.pushState(query, `${query} @ Gishath Fetch`, newUrl);
+      const newUrl = buildSearchUrl(BASE_URL, query, stores);
+      window.history.pushState(
+        { query, stores },
+        `${query} @ Gishath Fetch`,
+        newUrl,
+      );
       document.title = `${query} @ Gishath Fetch`;
     }
   }, []);
@@ -104,14 +89,7 @@ export default function useSearch() {
 
     setStoresWarning(NO_STORES_WARNING);
     setSelectedStores(LGS_OPTIONS);
-    try {
-      localStorage.setItem(
-        "lgsSelected",
-        encodeURIComponent(LGS_OPTIONS.join(",")),
-      );
-    } catch (err) {
-      console.error("Failed to save selected stores:", err);
-    }
+    persistSelectedStores(LGS_OPTIONS);
     return LGS_OPTIONS;
   }, []);
 
@@ -213,7 +191,7 @@ export default function useSearch() {
               : [];
             setSearchStoreErrors(storeErrors);
             setDismissedStoreErrorsKey(null);
-            updateUrlAndTitle(query);
+            updateUrlAndTitle(query, stores);
             if (window.gtag) {
               window.gtag("event", "view_search_results", {
                 search_term: query,
@@ -436,37 +414,19 @@ export default function useSearch() {
       ? selectedStores.filter((s) => s !== store)
       : [...selectedStores, store];
     setSelectedStores(newStores);
-    try {
-      localStorage.setItem(
-        "lgsSelected",
-        encodeURIComponent(newStores.join(",")),
-      );
-    } catch (err) {
-      console.error("Failed to save selected stores:", err);
-    }
+    persistSelectedStores(newStores);
   };
 
   const selectAllStores = () => {
     setStoresWarning(null);
     setSelectedStores(LGS_OPTIONS);
-    try {
-      localStorage.setItem(
-        "lgsSelected",
-        encodeURIComponent(LGS_OPTIONS.join(",")),
-      );
-    } catch (err) {
-      console.error("Failed to save selected stores:", err);
-    }
+    persistSelectedStores(LGS_OPTIONS);
   };
 
   const selectNoStores = () => {
     setStoresWarning(null);
     setSelectedStores([]);
-    try {
-      localStorage.setItem("lgsSelected", encodeURIComponent(""));
-    } catch (err) {
-      console.error("Failed to save selected stores:", err);
-    }
+    persistSelectedStores([]);
   };
 
   // --- Initialization ---
@@ -483,12 +443,8 @@ export default function useSearch() {
       const q = decodeURIComponent(urlParams.get("s"));
       skipSuggestionsRef.current = true;
 
-      // Determine which stores to search (URL param takes precedence, already set in state initialization)
-      const stores =
-        urlParams.has("src") &&
-        LGS_OPTIONS.includes(decodeURIComponent(urlParams.get("src")))
-          ? [decodeURIComponent(urlParams.get("src"))]
-          : selectedStores;
+      const urlStores = getStoresFromUrl(urlParams);
+      const stores = urlStores ?? selectedStores;
 
       setTimeout(() => performSearch(q, stores), 100);
     }

--- a/frontend/src/hooks/useSearch.js
+++ b/frontend/src/hooks/useSearch.js
@@ -39,6 +39,8 @@ export default function useSearch() {
   const [suggestions, setSuggestions] = useState([]);
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [searchError, setSearchError] = useState(null);
+  const [searchStoreErrors, setSearchStoreErrors] = useState([]);
+  const [dismissedStoreErrorsKey, setDismissedStoreErrorsKey] = useState(null);
   const [storesWarning, setStoresWarning] = useState(null);
   const [selectedStores, setSelectedStores] = useState(() => {
     // First check URL parameters for store override
@@ -152,6 +154,8 @@ export default function useSearch() {
       setSearchResults([]);
       setHasSearched(true);
       setSearchError(null);
+      setSearchStoreErrors([]);
+      setDismissedStoreErrorsKey(null);
 
       if (window.gtag) {
         window.gtag("event", "search", { search_term: query });
@@ -204,6 +208,11 @@ export default function useSearch() {
           if (result && Object.hasOwn(result, "data")) {
             // Treat null data as empty array
             setSearchResults(result.data || []);
+            const storeErrors = Array.isArray(result.errors)
+              ? result.errors
+              : [];
+            setSearchStoreErrors(storeErrors);
+            setDismissedStoreErrorsKey(null);
             updateUrlAndTitle(query);
             if (window.gtag) {
               window.gtag("event", "view_search_results", {
@@ -224,6 +233,8 @@ export default function useSearch() {
               setSearchResults(previousResults);
               setHasSearched(previousResults.length > 0);
               setSearchError(null);
+              setSearchStoreErrors([]);
+              setDismissedStoreErrorsKey(null);
               userCancelledRef.current = false;
             }
             return;
@@ -231,6 +242,8 @@ export default function useSearch() {
           if (requestId !== activeSearchRequestIdRef.current) return;
           console.error("Search error:", err);
           setSearchResults([]);
+          setSearchStoreErrors([]);
+          setDismissedStoreErrorsKey(null);
 
           // Set user-friendly error message
           if (
@@ -294,6 +307,18 @@ export default function useSearch() {
       performSearch(query, stores);
     }
   }, [performSearch]);
+
+  const storeErrorsKey = searchStoreErrors
+    .map((entry) => `${entry.store}:${entry.error}`)
+    .join("|");
+  const visibleStoreErrors =
+    searchStoreErrors.length > 0 && dismissedStoreErrorsKey !== storeErrorsKey
+      ? searchStoreErrors
+      : [];
+
+  const dismissStoreErrors = useCallback(() => {
+    setDismissedStoreErrorsKey(storeErrorsKey);
+  }, [storeErrorsKey]);
 
   // --- Handlers ---
   const handleQueryChange = (e) => {
@@ -477,6 +502,8 @@ export default function useSearch() {
     searchResults,
     searchProgress,
     searchError,
+    searchStoreErrors: visibleStoreErrors,
+    onDismissStoreErrors: dismissStoreErrors,
     storesWarning,
     suggestions,
     showSuggestions,

--- a/frontend/src/utils/searchUrl.js
+++ b/frontend/src/utils/searchUrl.js
@@ -1,6 +1,46 @@
 import { LGS_OPTIONS } from "../constants";
 
 /**
+ * @typedef {{
+ *   query: string,
+ *   stores: string[],
+ *   results: object[],
+ *   storeErrors: object[],
+ *   hasSearched: boolean,
+ *   searchError: string | null,
+ * }} SearchHistoryState
+ */
+
+/**
+ * @param {SearchHistoryState} snapshot
+ * @returns {SearchHistoryState}
+ */
+export function buildSearchHistoryState(snapshot) {
+  return {
+    query: snapshot.query,
+    stores: snapshot.stores,
+    results: snapshot.results,
+    storeErrors: snapshot.storeErrors,
+    hasSearched: snapshot.hasSearched,
+    searchError: snapshot.searchError,
+  };
+}
+
+/**
+ * @param {unknown} state
+ * @returns {state is SearchHistoryState}
+ */
+export function isSearchHistoryState(state) {
+  return (
+    !!state &&
+    typeof state === "object" &&
+    "query" in state &&
+    "stores" in state &&
+    "results" in state
+  );
+}
+
+/**
  * @param {string} lgsParam
  * @returns {string[]}
  */

--- a/frontend/src/utils/searchUrl.js
+++ b/frontend/src/utils/searchUrl.js
@@ -1,0 +1,105 @@
+import { LGS_OPTIONS } from "../constants";
+
+/**
+ * @param {string} lgsParam
+ * @returns {string[]}
+ */
+export function parseStoresFromUrlParam(lgsParam) {
+  if (!lgsParam) {
+    return [];
+  }
+
+  const stores = lgsParam
+    .split(",")
+    .map((store) => store.trim())
+    .filter((store) => store.length > 0 && LGS_OPTIONS.includes(store));
+
+  return [...new Set(stores)];
+}
+
+/**
+ * @param {string} query
+ * @param {string[]} stores
+ * @returns {URLSearchParams}
+ */
+export function buildSearchUrlParams(query, stores) {
+  const params = new URLSearchParams();
+  params.set("s", query);
+
+  const validStores = stores.filter((store) => LGS_OPTIONS.includes(store));
+  const isAllStores =
+    validStores.length === LGS_OPTIONS.length &&
+    LGS_OPTIONS.every((store) => validStores.includes(store));
+
+  if (validStores.length > 0 && !isAllStores) {
+    params.set("lgs", validStores.join(","));
+  }
+
+  return params;
+}
+
+/**
+ * @param {string} baseUrl
+ * @param {string} query
+ * @param {string[]} stores
+ * @returns {string}
+ */
+export function buildSearchUrl(baseUrl, query, stores) {
+  const params = buildSearchUrlParams(query, stores);
+  return `${baseUrl}?${params.toString()}`;
+}
+
+/**
+ * @param {URLSearchParams} urlParams
+ * @returns {string[] | null}
+ */
+export function getStoresFromUrl(urlParams) {
+  if (
+    urlParams.has("src") &&
+    LGS_OPTIONS.includes(decodeURIComponent(urlParams.get("src")))
+  ) {
+    return [decodeURIComponent(urlParams.get("src"))];
+  }
+
+  if (urlParams.has("lgs")) {
+    const stores = parseStoresFromUrlParam(
+      decodeURIComponent(urlParams.get("lgs")),
+    );
+    return stores.length > 0 ? stores : null;
+  }
+
+  return null;
+}
+
+/**
+ * @param {string[]} stores
+ */
+export function persistSelectedStores(stores) {
+  try {
+    localStorage.setItem("lgsSelected", encodeURIComponent(stores.join(",")));
+  } catch (err) {
+    console.error("Failed to save selected stores:", err);
+  }
+}
+
+/**
+ * @param {URLSearchParams} [urlParams]
+ * @returns {string[]}
+ */
+export function getInitialSelectedStores(
+  urlParams = new URLSearchParams(window.location.search),
+) {
+  const urlStores = getStoresFromUrl(urlParams);
+  if (urlStores) {
+    persistSelectedStores(urlStores);
+    return urlStores;
+  }
+
+  const storedLgs = localStorage.getItem("lgsSelected");
+  if (storedLgs !== null) {
+    const decoded = decodeURIComponent(storedLgs);
+    return decoded === "" ? [] : decoded.split(",");
+  }
+
+  return LGS_OPTIONS;
+}

--- a/frontend/src/utils/storeErrors.js
+++ b/frontend/src/utils/storeErrors.js
@@ -16,14 +16,3 @@ export function formatStoreErrorsSummary(storeErrors) {
   const noun = count === 1 ? "store" : "stores";
   return `${count} ${noun} couldn't be searched: ${storeNames}`;
 }
-
-/**
- * @param {StoreError[]} storeErrors
- * @returns {string}
- */
-export function formatStoreErrorDetail({ store, error, statusCode }) {
-  if (statusCode && !error.includes(`(${statusCode})`)) {
-    return `${store}: ${error}`;
-  }
-  return `${store}: ${error}`;
-}

--- a/frontend/src/utils/storeErrors.js
+++ b/frontend/src/utils/storeErrors.js
@@ -1,0 +1,29 @@
+/**
+ * @typedef {{ store: string, error: string, statusCode?: number }} StoreError
+ */
+
+/**
+ * @param {StoreError[]} storeErrors
+ * @returns {string}
+ */
+export function formatStoreErrorsSummary(storeErrors) {
+  if (!storeErrors?.length) {
+    return "";
+  }
+
+  const storeNames = storeErrors.map((entry) => entry.store).join(", ");
+  const count = storeErrors.length;
+  const noun = count === 1 ? "store" : "stores";
+  return `${count} ${noun} couldn't be searched: ${storeNames}`;
+}
+
+/**
+ * @param {StoreError[]} storeErrors
+ * @returns {string}
+ */
+export function formatStoreErrorDetail({ store, error, statusCode }) {
+  if (statusCode && !error.includes(`(${statusCode})`)) {
+    return `${store}: ${error}`;
+  }
+  return `${store}: ${error}`;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Four frontend QoL improvements, each in its own commit:

1. **Partial store failure banner** — surfaces the API `errors` array after a successful search
2. **Shareable store URLs** — syncs `?lgs=` alongside `?s=` in the browser URL
3. **Back/forward navigation** — restores query, stores, results, and errors from history state
4. **Cheapest per store filter** — optional toggle to show only the lowest-price listing per store

## Partial failure messages (commit 1)

When some stores fail but the search still returns `200`, users see a dismissible warning banner with only a summary line:

- `1 store couldn't be searched: Hideout`
- `2 stores couldn't be searched: Hideout, Mana Pro`

No per-store technical error details are shown.

## Screenshots

### 1. Partial store failures

Desktop:

![Partial store failures desktop](https://cursor.com/artifacts/c/art-d9218c96-b419-4d92-8689-e889e997f0dc)

Mobile:

![Partial store failures mobile](https://cursor.com/artifacts/c/art-2e555e22-e6e8-4e36-81d4-4281ed86d1a5)

### 2. Shareable URL with `?lgs=`

Desktop:

![Shareable lgs URL desktop](https://cursor.com/artifacts/c/art-3550d279-1ee0-47c6-9582-c5fa15a571bd)

Mobile:

![Shareable lgs URL mobile](https://cursor.com/artifacts/c/art-d612f320-1ca6-4a80-bade-64d105986c46)

### 3. Browser back navigation

Desktop:

![Browser back navigation desktop](https://cursor.com/artifacts/c/art-cfc3956a-9591-4a0a-8f6a-677554392bff)

Mobile:

![Browser back navigation mobile](https://cursor.com/artifacts/c/art-4670863c-a357-4270-ab4a-0ab0775bb68b)

### 4. Cheapest per store filter

Desktop:

![Cheapest per store desktop](https://cursor.com/artifacts/c/art-995ccf1d-af67-47f6-bf4e-944de2f3c054)

Mobile:

![Cheapest per store mobile](https://cursor.com/artifacts/c/art-b5ef79ce-a7fa-41e1-b104-c70ba4b93ba0)

## Shareable URLs (commit 2)

After a successful search, the URL becomes e.g. `?s=Lightning+Bolt&lgs=Hideout,Mana+Pro`. When all stores are selected, `lgs` is omitted (default = all). `?src=` deep links from cart still work and take precedence on load.

## Back/forward (commit 3)

History entries store full snapshots (query, stores, results, store errors, error state). Browser back/forward restores instantly without refetching. Bookmarks without history state fall back to parsing the URL and re-running the search.

## Cheapest per store (commit 4)

New checkbox in result filters. Applies after condition/foil filters; keeps the lowest-price card per `src`.

## Test plan

- [x] Frontend lint on changed files
- [x] UI screenshots captured (desktop + mobile for each change)
- [ ] `make test` — `gateway/cardscentral` live scrape test failed transiently (unrelated to this PR)
- [ ] Manual: search with all stores, confirm partial-failure banner when API returns `errors`
- [ ] Manual: search with subset of stores, confirm URL includes `lgs`
- [ ] Manual: search twice, use browser back to restore first search without refetch
- [ ] Manual: enable "Cheapest per store" and confirm one card per store

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0f536fbc-031c-4889-8c06-d084fd4017e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0f536fbc-031c-4889-8c06-d084fd4017e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

