### PR TITLE
Add background and padding to post-search result filters

### DIFF
--- a/frontend/src/components/ResultFilters.jsx
+++ b/frontend/src/components/ResultFilters.jsx
@@ -14,7 +14,7 @@ const ResultFilters = ({
   onClearFilters,
 }) => {
   return (
-    <div className="mb-3 text-start result-filters bg-body-tertiary rounded py-3 px-3">
+    <div className="mb-3 text-start result-filters rounded py-3 px-3">
       <div className="row g-2 align-items-end">
         <div className="col-12 col-md-4">
           <Form.Label htmlFor="result-sort" className="small fw-semibold mb-1">

--- a/frontend/src/components/ResultFilters.jsx
+++ b/frontend/src/components/ResultFilters.jsx
@@ -14,7 +14,7 @@ const ResultFilters = ({
   onClearFilters,
 }) => {
   return (
-    <div className="mb-3 text-start result-filters">
+    <div className="mb-3 text-start result-filters bg-secondary-subtle rounded py-3 px-3">
       <div className="row g-2 align-items-end">
         <div className="col-12 col-md-4">
           <Form.Label htmlFor="result-sort" className="small fw-semibold mb-1">

--- a/frontend/src/components/ResultFilters.jsx
+++ b/frontend/src/components/ResultFilters.jsx
@@ -14,7 +14,7 @@ const ResultFilters = ({
   onClearFilters,
 }) => {
   return (
-    <div className="mb-3 text-start result-filters bg-secondary-subtle rounded py-3 px-3">
+    <div className="mb-3 text-start result-filters bg-body-tertiary rounded py-3 px-3">
       <div className="row g-2 align-items-end">
         <div className="col-12 col-md-4">
           <Form.Label htmlFor="result-sort" className="small fw-semibold mb-1">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -176,3 +176,11 @@ ins.adsbygoogle iframe {
 .scroll-margin-top {
   scroll-margin-top: 1rem;
 }
+
+.result-filters {
+  background-color: color-mix(
+    in srgb,
+    var(--bs-secondary-bg-subtle) 35%,
+    var(--bs-body-bg)
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a subtle background with padding to the post-search result filters, matching the styling pattern used elsewhere on the results page (e.g. the result count banner).

## Changes

- Applied `rounded`, `py-3`, and `px-3` to the `ResultFilters` container.
- Added a custom `.result-filters` background using a light mix of `--bs-secondary-bg-subtle` and `--bs-body-bg` so the panel is softer than the initial `bg-secondary-subtle` treatment.

## Screenshots

### Desktop (1280px)

![Post-search filters with lighter background on desktop](https://cursor.com/artifacts/c/art-a9ac462f-9af9-4206-aa0f-7ff399888e23)

### Mobile (390px)

![Post-search filters with lighter background on mobile](https://cursor.com/artifacts/c/art-41330967-4c27-4604-927b-7e2eb3ee6e1f)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1a4b837-8e7f-40fa-960f-5c01b1760994"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1a4b837-8e7f-40fa-960f-5c01b1760994"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

