### PR TITLE
Fix bottom nav icon alignment

### DIFF
--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -60,7 +60,9 @@ const Footer = ({ cartCount, onShowCart, onShowMap, onShowFaq }) => {
             onClick={onShowCart}
           >
             <div className="px-2 py-1 d-inline-flex align-items-center">
-              <FolderPlus size={14} className="me-1" aria-hidden="true" />
+              <span className="bottom-nav-icon">
+                <FolderPlus size={14} aria-hidden="true" />
+              </span>
               <span>Saved {cartCount > 0 && `(${cartCount})`}</span>
             </div>
           </button>
@@ -71,7 +73,9 @@ const Footer = ({ cartCount, onShowCart, onShowMap, onShowFaq }) => {
             onClick={onShowMap}
           >
             <div className="px-2 py-1 d-inline-flex align-items-center">
-              <MapIcon size={14} className="me-1" aria-hidden="true" />
+              <span className="bottom-nav-icon">
+                <MapIcon size={14} aria-hidden="true" />
+              </span>
               <span>Map</span>
             </div>
           </button>
@@ -82,7 +86,9 @@ const Footer = ({ cartCount, onShowCart, onShowMap, onShowFaq }) => {
             onClick={onShowFaq}
           >
             <div className="px-2 py-1 d-inline-flex align-items-center">
-              <HelpCircle size={14} className="me-1" aria-hidden="true" />
+              <span className="bottom-nav-icon">
+                <HelpCircle size={14} aria-hidden="true" />
+              </span>
               <span>FAQs</span>
             </div>
           </button>
@@ -92,7 +98,9 @@ const Footer = ({ cartCount, onShowCart, onShowMap, onShowFaq }) => {
             className="py-1 link-light link-offset-2 link-underline-opacity-0"
           >
             <div className="px-2 py-1 d-inline-flex align-items-center">
-              <ArrowUp size={14} className="me-1" aria-hidden="true" />
+              <span className="bottom-nav-icon">
+                <ArrowUp size={14} aria-hidden="true" />
+              </span>
               <span>Top</span>
             </div>
           </a>

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -59,9 +59,9 @@ const Footer = ({ cartCount, onShowCart, onShowMap, onShowFaq }) => {
             className="btn btn-link py-1 link-light link-offset-2 link-underline-opacity-0 text-decoration-none border-0"
             onClick={onShowCart}
           >
-            <div className="px-2 py-1">
-              <FolderPlus size={14} className="me-1 mb-1" /> Saved{" "}
-              {cartCount > 0 && `(${cartCount})`}
+            <div className="px-2 py-1 d-inline-flex align-items-center">
+              <FolderPlus size={14} className="me-1" aria-hidden="true" />
+              <span>Saved {cartCount > 0 && `(${cartCount})`}</span>
             </div>
           </button>
           <button
@@ -70,8 +70,9 @@ const Footer = ({ cartCount, onShowCart, onShowMap, onShowFaq }) => {
             className="btn btn-link py-1 link-light link-offset-2 link-underline-opacity-0 text-decoration-none border-0"
             onClick={onShowMap}
           >
-            <div className="px-2 py-1">
-              <MapIcon size={14} className="me-1" /> Map
+            <div className="px-2 py-1 d-inline-flex align-items-center">
+              <MapIcon size={14} className="me-1" aria-hidden="true" />
+              <span>Map</span>
             </div>
           </button>
           <button
@@ -80,8 +81,9 @@ const Footer = ({ cartCount, onShowCart, onShowMap, onShowFaq }) => {
             className="btn btn-link py-1 link-light link-offset-2 link-underline-opacity-0 text-decoration-none border-0"
             onClick={onShowFaq}
           >
-            <div className="px-2 py-1">
-              <HelpCircle size={14} className="me-1 mb-1" /> FAQs
+            <div className="px-2 py-1 d-inline-flex align-items-center">
+              <HelpCircle size={14} className="me-1" aria-hidden="true" />
+              <span>FAQs</span>
             </div>
           </button>
           <a
@@ -89,8 +91,9 @@ const Footer = ({ cartCount, onShowCart, onShowMap, onShowFaq }) => {
             aria-label="Scroll to top of page"
             className="py-1 link-light link-offset-2 link-underline-opacity-0"
           >
-            <div className="px-2 py-1">
-              <ArrowUp size={14} className="me-1" /> Top
+            <div className="px-2 py-1 d-inline-flex align-items-center">
+              <ArrowUp size={14} className="me-1" aria-hidden="true" />
+              <span>Top</span>
             </div>
           </a>
         </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -173,6 +173,16 @@ ins.adsbygoogle iframe {
   display: block;
 }
 
+.bottom-nav-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  margin-right: 0.25rem;
+}
+
 .scroll-margin-top {
   scroll-margin-top: 1rem;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The bottom navigation icons were not vertically aligned consistently. Two of the four icons (`FolderPlus` and `HelpCircle`) had an extra `mb-1` margin that `MapIcon` and `ArrowUp` did not, which pushed those icons out of line with their labels and each other.

## Fix

- Removed the inconsistent `mb-1` margins from individual icons
- Wrapped each nav item's icon + label in `d-inline-flex align-items-center` so they share a common vertical center line
- Added a `.bottom-nav-icon` CSS class that gives each icon a fixed 14×14 flex container, so icons with different visual bounds (e.g. arrow vs folder) align uniformly

## Screenshots

### Desktop (1280×800)

![Bottom nav at desktop resolution](https://cursor.com/artifacts/c/art-c83c4373-40aa-4f38-8e34-0d01d2ddf76b)

### Mobile (390×844)

![Bottom nav at mobile resolution](https://cursor.com/artifacts/c/art-3a016454-c063-4808-9e74-9f8c839fddf1)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b61245c-b038-4880-a687-197771a6f014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b61245c-b038-4880-a687-197771a6f014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

