### PR TITLE
Fix CK pricelist 403: skip Web Bot Auth on refresh fetch

### DIFF
--- a/api/gateway/browser_headers.go
+++ b/api/gateway/browser_headers.go
@@ -40,6 +40,9 @@ func ApplyBrowserLikeJSONFetchHeaders(h *http.Header, storeBase *url.URL) {
 	}
 	if ref := navigationReferer(storeBase); ref != "" {
 		h.Set("Referer", ref)
+		if storeBase.Scheme != "" && storeBase.Host != "" {
+			h.Set("Origin", storeBase.Scheme+"://"+storeBase.Host)
+		}
 	}
 	h.Set("Accept", browserLikeAcceptJSON)
 	h.Set("Accept-Language", browserLikeAcceptLanguage)

--- a/api/gateway/cardkingdom/pricelist.go
+++ b/api/gateway/cardkingdom/pricelist.go
@@ -12,8 +12,9 @@ import (
 )
 
 const (
-	pricelistURL     = "https://api.cardkingdom.com/api/v2/pricelist"
-	pricelistTimeout = 3 * time.Minute
+	pricelistURL          = "https://api.cardkingdom.com/api/v2/pricelist"
+	pricelistTimeout      = 3 * time.Minute
+	outboundErrorPrefix   = "ck price outbound"
 )
 
 var fetchPricelistResponse = func(ctx context.Context) (*http.Response, error) {
@@ -33,12 +34,12 @@ var fetchPricelistResponse = func(ctx context.Context) (*http.Response, error) {
 func FetchCheapestByName(ctx context.Context) (map[string]Listing, error) {
 	resp, err := fetchPricelistResponse(ctx)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%s: %w", outboundErrorPrefix, err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("cardkingdom: pricelist status %d", resp.StatusCode)
+		return nil, fmt.Errorf("%s: pricelist status %d", outboundErrorPrefix, resp.StatusCode)
 	}
 
 	body, err := gateway.ReadResponseBody(resp)

--- a/api/gateway/cardkingdom/pricelist.go
+++ b/api/gateway/cardkingdom/pricelist.go
@@ -23,8 +23,9 @@ var fetchPricelistResponse = func(ctx context.Context) (*http.Response, error) {
 	}
 
 	return gateway.DoOutboundGET(ctx, pricelistURL, gateway.OutboundRequestOptions{
-		Style:     gateway.OutboundStyleJSON,
-		StoreBase: storeBase,
+		Style:          gateway.OutboundStyleJSON,
+		StoreBase:      storeBase,
+		SkipWebBotAuth: true,
 	}, pricelistTimeout)
 }
 

--- a/api/gateway/outbound_get.go
+++ b/api/gateway/outbound_get.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -26,7 +27,7 @@ func DoOutboundGET(
 	opts OutboundRequestOptions,
 	timeout time.Duration,
 ) (*http.Response, error) {
-	var lastErr error
+	var failures []string
 	for _, attempt := range buildOutboundGETAttempts(timeout) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
 		if err != nil {
@@ -38,20 +39,20 @@ func DoOutboundGET(
 
 		resp, err := attempt.client.Do(req)
 		if err != nil {
-			lastErr = fmt.Errorf("%s: %w", attempt.strategy, err)
+			failures = append(failures, fmt.Sprintf("%s: %v", attempt.strategy, err))
 			continue
 		}
 		if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests {
-			lastErr = fmt.Errorf("%s: status %d", attempt.strategy, resp.StatusCode)
+			failures = append(failures, fmt.Sprintf("%s: status %d", attempt.strategy, resp.StatusCode))
 			resp.Body.Close()
 			continue
 		}
 		return resp, nil
 	}
-	if lastErr == nil {
+	if len(failures) == 0 {
 		return nil, fmt.Errorf("outbound get failed")
 	}
-	return nil, lastErr
+	return nil, fmt.Errorf("outbound get failed: %s", strings.Join(failures, "; "))
 }
 
 func buildOutboundGETAttempts(timeout time.Duration) []outboundAttempt {

--- a/api/gateway/outbound_request.go
+++ b/api/gateway/outbound_request.go
@@ -20,6 +20,8 @@ type OutboundRequestOptions struct {
 	Style     OutboundRequestStyle
 	PageURL   *url.URL
 	StoreBase *url.URL
+	// SkipWebBotAuth uses a browser User-Agent and omits Web Bot Auth signing.
+	SkipWebBotAuth bool
 }
 
 // PrepareOutboundRequest applies per-domain pacing, browser-like headers, a
@@ -42,6 +44,11 @@ func PrepareOutboundRequest(ctx context.Context, req *http.Request, opts Outboun
 			storeBase = opts.PageURL
 		}
 		ApplyBrowserLikeJSONFetchHeaders(&req.Header, storeBase)
+	}
+
+	if opts.SkipWebBotAuth {
+		req.Header.Set("User-Agent", RandomBrowserUserAgent())
+		return nil
 	}
 
 	req.Header.Set("User-Agent", OutboundUserAgent())

--- a/api/handler/ck_refresh.go
+++ b/api/handler/ck_refresh.go
@@ -69,6 +69,7 @@ func runCKPriceRefresh(ctx context.Context) error {
 
 	count, err := refreshCKPricesFunc(ctx, store)
 	if err != nil {
+		log.Printf("ck price outbound: %v", err)
 		return err
 	}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes Card Kingdom price refresh failures (`dynamic: status 403`) by avoiding Web Bot Auth on the CK pricelist fetch and improving outbound GET error reporting.

Rebased onto `master` (prior refresh fixes already merged in #157).

## Changes

- **`SkipWebBotAuth`** on `OutboundRequestOptions` — CK pricelist uses a random browser User-Agent and skips Web Bot Auth signing (CK was blocking bot UA through proxies).
- **Origin header** on browser-like JSON fetch headers (same-origin XHR emulation).
- **`DoOutboundGET`** — aggregates failures from all strategies (`direct; dedicated; dynamic`) in the error message.
- **`ck price outbound:` prefix** on CK pricelist fetch errors and async refresh failure logs (searchable in CloudWatch).

## Deploy / verify

After merge + `make deploy`, retry:

```bash
curl -X POST https://api.gishathfetch.com/ck-price/refresh \
  -H "x-api-key: $CK_REFRESH_API_KEY"
```

Expect `202` immediately, then CloudWatch log: `refreshed N card kingdom prices`.

Ensure Lambda has `DEDICATED_PROXY_*` env vars set (same as other scrapers).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9ebd580-80e5-41e7-b69c-21b8b9db7786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9ebd580-80e5-41e7-b69c-21b8b9db7786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

