### PR TITLE
Fix CK pricelist 403: minimal headers and all dedicated proxies

### DIFF
--- a/api/gateway/cardkingdom/pricelist.go
+++ b/api/gateway/cardkingdom/pricelist.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"time"
 
 	"mtg-price-checker-sg/gateway"
@@ -18,14 +17,9 @@ const (
 )
 
 var fetchPricelistResponse = func(ctx context.Context) (*http.Response, error) {
-	storeBase, err := url.Parse(listingBaseURL)
-	if err != nil {
-		return nil, err
-	}
-
 	return gateway.DoOutboundGET(ctx, pricelistURL, gateway.OutboundRequestOptions{
-		Style:          gateway.OutboundStyleJSON,
-		StoreBase:      storeBase,
+		Accept:         "application/json",
+		SkipDirect:     true,
 		SkipWebBotAuth: true,
 	}, pricelistTimeout)
 }

--- a/api/gateway/outbound_get.go
+++ b/api/gateway/outbound_get.go
@@ -3,16 +3,14 @@ package gateway
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"mtg-price-checker-sg/gateway/util"
 )
-
-var outboundDedicatedProxySeq atomic.Uint32
 
 type outboundAttempt struct {
 	strategy string
@@ -28,7 +26,7 @@ func DoOutboundGET(
 	timeout time.Duration,
 ) (*http.Response, error) {
 	var failures []string
-	for _, attempt := range buildOutboundGETAttempts(timeout) {
+	for _, attempt := range buildOutboundGETAttempts(timeout, opts.SkipDirect) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
 		if err != nil {
 			return nil, err
@@ -43,8 +41,7 @@ func DoOutboundGET(
 			continue
 		}
 		if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests {
-			failures = append(failures, fmt.Sprintf("%s: status %d", attempt.strategy, resp.StatusCode))
-			resp.Body.Close()
+			failures = append(failures, outboundStatusFailure(attempt.strategy, resp))
 			continue
 		}
 		return resp, nil
@@ -55,14 +52,27 @@ func DoOutboundGET(
 	return nil, fmt.Errorf("outbound get failed: %s", strings.Join(failures, "; "))
 }
 
-func buildOutboundGETAttempts(timeout time.Duration) []outboundAttempt {
-	attempts := []outboundAttempt{{
-		strategy: "direct",
-		client:   &http.Client{Timeout: timeout},
-	}}
+func buildOutboundGETAttempts(timeout time.Duration, skipDirect bool) []outboundAttempt {
+	var attempts []outboundAttempt
+	if !skipDirect {
+		attempts = append(attempts, outboundAttempt{
+			strategy: "direct",
+			client:   &http.Client{Timeout: timeout},
+		})
+	}
 
-	if client, ok := dedicatedProxyHTTPClient(timeout); ok {
-		attempts = append(attempts, outboundAttempt{strategy: "dedicated", client: client})
+	for idx, proxyURL := range util.GetDedicatedProxyURLs() {
+		if proxyURL == "" {
+			continue
+		}
+		client, err := newProxyHTTPClient(proxyURL, timeout)
+		if err != nil {
+			continue
+		}
+		attempts = append(attempts, outboundAttempt{
+			strategy: fmt.Sprintf("dedicated-%d", idx+1),
+			client:   client,
+		})
 	}
 
 	if client, ok := dynamicProxyHTTPClient(timeout); ok {
@@ -70,19 +80,6 @@ func buildOutboundGETAttempts(timeout time.Duration) []outboundAttempt {
 	}
 
 	return attempts
-}
-
-func dedicatedProxyHTTPClient(timeout time.Duration) (*http.Client, bool) {
-	proxyURLs := util.GetDedicatedProxyURLs()
-	if len(proxyURLs) == 0 {
-		return nil, false
-	}
-
-	client, err := newProxyHTTPClient(nextOutboundDedicatedProxyURL(proxyURLs), timeout)
-	if err != nil {
-		return nil, false
-	}
-	return client, true
 }
 
 func dynamicProxyHTTPClient(timeout time.Duration) (*http.Client, bool) {
@@ -98,9 +95,26 @@ func dynamicProxyHTTPClient(timeout time.Duration) (*http.Client, bool) {
 	return client, true
 }
 
-func nextOutboundDedicatedProxyURL(proxyURLs []string) string {
-	v := outboundDedicatedProxySeq.Add(1) - 1
-	return proxyURLs[int(v%uint32(len(proxyURLs)))]
+func outboundStatusFailure(strategy string, resp *http.Response) string {
+	msg := fmt.Sprintf("%s: status %d", strategy, resp.StatusCode)
+	if resp == nil {
+		return msg
+	}
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 200))
+	resp.Body.Close()
+
+	if cfRay := resp.Header.Get("cf-ray"); cfRay != "" {
+		msg += " cf-ray=" + cfRay
+	}
+	trimmed := strings.TrimSpace(string(body))
+	if trimmed == "" {
+		return msg
+	}
+	if len(trimmed) > 120 {
+		trimmed = trimmed[:120] + "..."
+	}
+	return msg + " (" + trimmed + ")"
 }
 
 func newProxyHTTPClient(proxyURL string, timeout time.Duration) (*http.Client, error) {

--- a/api/gateway/outbound_get_test.go
+++ b/api/gateway/outbound_get_test.go
@@ -38,6 +38,27 @@ func TestDoOutboundGET_DirectSuccess(t *testing.T) {
 	require.NoError(t, resp.Body.Close())
 }
 
+func TestBuildOutboundGETAttempts_TriesEachDedicatedProxy(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("DEDICATED_PROXY_1", "1.2.3.4|8080|user|pass")
+	t.Setenv("DEDICATED_PROXY_2", "5.6.7.8|8080|user|pass")
+
+	attempts := buildOutboundGETAttempts(2*time.Second, false)
+	require.GreaterOrEqual(t, len(attempts), 3)
+	require.Equal(t, "direct", attempts[0].strategy)
+	require.Equal(t, "dedicated-1", attempts[1].strategy)
+	require.Equal(t, "dedicated-2", attempts[2].strategy)
+}
+
+func TestBuildOutboundGETAttempts_SkipDirect(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("DEDICATED_PROXY_1", "1.2.3.4|8080|user|pass")
+
+	attempts := buildOutboundGETAttempts(2*time.Second, true)
+	require.Len(t, attempts, 1)
+	require.Equal(t, "dedicated-1", attempts[0].strategy)
+}
+
 func TestDoOutboundGET_DirectForbiddenWithoutProxy(t *testing.T) {
 	clearProxyEnv(t)
 
@@ -49,9 +70,9 @@ func TestDoOutboundGET_DirectForbiddenWithoutProxy(t *testing.T) {
 	_, err := DoOutboundGET(
 		context.Background(),
 		server.URL,
-		OutboundRequestOptions{Style: OutboundStyleJSON},
+		OutboundRequestOptions{Accept: "application/json", SkipWebBotAuth: true},
 		2*time.Second,
 	)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "403")
+	require.Contains(t, err.Error(), "direct: status 403")
 }

--- a/api/gateway/outbound_request.go
+++ b/api/gateway/outbound_request.go
@@ -20,6 +20,10 @@ type OutboundRequestOptions struct {
 	Style     OutboundRequestStyle
 	PageURL   *url.URL
 	StoreBase *url.URL
+	// Accept sets an optional Accept header after style-specific headers apply.
+	Accept string
+	// SkipDirect omits the direct transport from DoOutboundGET fallback chains.
+	SkipDirect bool
 	// SkipWebBotAuth uses a browser User-Agent and omits Web Bot Auth signing.
 	SkipWebBotAuth bool
 }
@@ -44,6 +48,10 @@ func PrepareOutboundRequest(ctx context.Context, req *http.Request, opts Outboun
 			storeBase = opts.PageURL
 		}
 		ApplyBrowserLikeJSONFetchHeaders(&req.Header, storeBase)
+	}
+
+	if opts.Accept != "" {
+		req.Header.Set("Accept", opts.Accept)
 	}
 
 	if opts.SkipWebBotAuth {

--- a/api/gateway/outbound_request_test.go
+++ b/api/gateway/outbound_request_test.go
@@ -1,0 +1,44 @@
+package gateway
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrepareOutboundRequest_CKMinimalPricelistHeaders(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "https://api.cardkingdom.com/api/v2/pricelist", nil)
+	require.NoError(t, err)
+
+	err = PrepareOutboundRequest(context.Background(), req, OutboundRequestOptions{
+		Accept:         "application/json",
+		SkipWebBotAuth: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "application/json", req.Header.Get("Accept"))
+	require.NotEmpty(t, req.Header.Get("User-Agent"))
+	require.Empty(t, req.Header.Get("Origin"))
+	require.Empty(t, req.Header.Get("Referer"))
+	require.Empty(t, req.Header.Get("Signature"))
+	require.Empty(t, req.Header.Get("Signature-Input"))
+}
+
+func TestPrepareOutboundRequest_JSONStyleSetsOrigin(t *testing.T) {
+	storeBase, err := url.Parse("https://www.cardkingdom.com/")
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodGet, "https://api.cardkingdom.com/api/v2/pricelist", nil)
+	require.NoError(t, err)
+
+	err = PrepareOutboundRequest(context.Background(), req, OutboundRequestOptions{
+		Style:          OutboundStyleJSON,
+		StoreBase:      storeBase,
+		SkipWebBotAuth: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "https://www.cardkingdom.com/", req.Header.Get("Referer"))
+	require.Equal(t, "https://www.cardkingdom.com", req.Header.Get("Origin"))
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes Card Kingdom price refresh failures (`dynamic: status 403`) by matching how the public CK API client fetches the pricelist and improving proxy fallback.

Rebased onto `master` (#158 already merged).

## Changes

- **Minimal CK headers** — only `Accept: application/json` + browser `User-Agent` (no fake `Origin`/`Referer` that likely triggered Cloudflare through proxies).
- **Skip direct** — CK pricelist refresh goes straight to proxies (Lambda IPs are blocked).
- **Try all dedicated proxies** — rotates through every `DEDICATED_PROXY_*` before dynamic, not just one round-robin pick.
- **Richer 403 errors** — includes `cf-ray` and response body snippet in `ck price outbound` logs.

## Deploy / verify

After merge + `make deploy`, retry refresh and check CloudWatch for `ck price outbound` or `refreshed N card kingdom prices`.

Ensure Lambda has `DEDICATED_PROXY_*` env vars set (same as other scrapers).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9ebd580-80e5-41e7-b69c-21b8b9db7786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9ebd580-80e5-41e7-b69c-21b8b9db7786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

