### PR TITLE
Consolidate per-shop search logs into a single summary line

### DIFF
--- a/api/controller/search.go
+++ b/api/controller/search.go
@@ -136,7 +136,7 @@ func fetchCardsConcurrently(ctx context.Context, searchString string, shops map[
 	aggregator := newFetchResultAggregator(len(shops))
 	binderposGate := make(chan struct{}, binderposMaxConcurrent)
 
-	log.Printf("Start checking shops for [%s]...", searchString)
+	start := time.Now()
 
 	for shopName, lgs := range shops {
 		shopName := shopName
@@ -154,8 +154,13 @@ func fetchCardsConcurrently(ctx context.Context, searchString string, shops map[
 	if len(siteErrors) > 0 {
 		log.Printf("Shops with errors for [%s]: %d", searchString, len(siteErrors))
 	}
-	log.Println("End checking shops...")
+	log.Println(formatShopSearchSummary(searchString, time.Since(start), aggregator.shopDurationSnapshot()))
 	return cards, siteErrors
+}
+
+type shopSearchDuration struct {
+	name     string
+	duration time.Duration
 }
 
 type fetchResultAggregator struct {
@@ -163,6 +168,7 @@ type fetchResultAggregator struct {
 	cards                []gateway.Card
 	siteErrors           map[string]error
 	discordErrorMessages []string
+	shopDurations        []shopSearchDuration
 }
 
 func newFetchResultAggregator(shopCount int) *fetchResultAggregator {
@@ -194,6 +200,18 @@ func (f *fetchResultAggregator) addDiscordErrorMessage(message string) {
 	f.mu.Unlock()
 }
 
+func (f *fetchResultAggregator) addShopDuration(shopName string, duration time.Duration) {
+	f.mu.Lock()
+	f.shopDurations = append(f.shopDurations, shopSearchDuration{name: shopName, duration: duration})
+	f.mu.Unlock()
+}
+
+func (f *fetchResultAggregator) shopDurationSnapshot() []shopSearchDuration {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]shopSearchDuration(nil), f.shopDurations...)
+}
+
 func (f *fetchResultAggregator) snapshot() ([]gateway.Card, map[string]error, []string) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -219,7 +237,7 @@ func searchShop(
 	defer recoverShopPanic(shopName, aggregator)
 	start := time.Now()
 	defer func() {
-		log.Printf("Done searching [%s]. Took: [%s]", shopName, time.Since(start))
+		aggregator.addShopDuration(shopName, time.Since(start))
 	}()
 
 	shopCtx, cancel := context.WithTimeout(ctx, config.PerSiteTimeout)
@@ -258,6 +276,26 @@ func recordShopSearchError(searchString, shopName string, err error, aggregator 
 		aggregator.addDiscordErrorMessage(errMsg)
 	}
 	aggregator.addSiteError(shopName, err)
+}
+
+func formatShopSearchSummary(searchString string, totalDuration time.Duration, shopDurations []shopSearchDuration) string {
+	sortedDurations := append([]shopSearchDuration(nil), shopDurations...)
+	sort.Slice(sortedDurations, func(i, j int) bool {
+		return sortedDurations[i].name < sortedDurations[j].name
+	})
+
+	shopSummaries := make([]string, 0, len(sortedDurations))
+	for _, shopDuration := range sortedDurations {
+		shopSummaries = append(shopSummaries, fmt.Sprintf("[%s] %s", shopDuration.name, shopDuration.duration))
+	}
+
+	return fmt.Sprintf(
+		"Checked %d shops for [%s] in %s: %s",
+		len(sortedDurations),
+		searchString,
+		totalDuration,
+		strings.Join(shopSummaries, ", "),
+	)
 }
 
 func formatDiscordErrorSummary(searchString string, errorMessages []string) string {

--- a/api/controller/search_test.go
+++ b/api/controller/search_test.go
@@ -502,6 +502,30 @@ func TestFetchCardsConcurrently_CollatesDiscordErrors(t *testing.T) {
 	}
 }
 
+func TestFormatShopSearchSummary(t *testing.T) {
+	got := formatShopSearchSummary("Orthion, Hero of Lavabrink", 8*time.Second+240*time.Millisecond, []shopSearchDuration{
+		{name: "Agora Hobby", duration: 8*time.Second + 240*time.Millisecond},
+		{name: "Fyendal Hobby", duration: 222*time.Millisecond},
+		{name: "Cards & Collections", duration: 341*time.Millisecond},
+	})
+
+	if !strings.Contains(got, "Checked 3 shops for [Orthion, Hero of Lavabrink] in 8.24s:") {
+		t.Fatalf("expected summary header, got: %s", got)
+	}
+	if !strings.Contains(got, "[Agora Hobby] 8.24s") {
+		t.Fatalf("expected Agora Hobby duration, got: %s", got)
+	}
+	if !strings.Contains(got, "[Cards & Collections] 341ms") {
+		t.Fatalf("expected Cards & Collections duration, got: %s", got)
+	}
+	if !strings.Contains(got, "[Fyendal Hobby] 222ms") {
+		t.Fatalf("expected Fyendal Hobby duration, got: %s", got)
+	}
+	if strings.Index(got, "[Agora Hobby]") > strings.Index(got, "[Cards & Collections]") {
+		t.Fatalf("expected shops to be sorted alphabetically, got: %s", got)
+	}
+}
+
 func TestFormatDiscordErrorSummary(t *testing.T) {
 	got := formatDiscordErrorSummary("Uro, Titan of Nature's Wrath", []string{
 		"Error encountered searching [Tefuda] for [Uro, Titan of Nature's Wrath]: attempt 3 (scrap-direct): 503 Service Unavailable (proxy_mode=direct proxy=none)",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces the per-shop `Start checking shops` / `Done searching [Shop]` / `End checking shops` log lines with one consolidated summary emitted after all shops finish.

Example output:
```
Checked 19 shops for [Orthion, Hero of Lavabrink] in 8.24s: [5 Mana] 480ms, [Agora Hobby] 8.24s, [Card Affinity] 1.98s, ...
```

Shops are listed alphabetically with individual durations. The separate `Shops with errors` log is unchanged.

## Test plan

- [x] `go test -mod=vendor -failfast -timeout 5m ./controller/...`
- [x] Added `TestFormatShopSearchSummary` for the new formatter
- [ ] Full `make test` (cardscentral live scraper test failed unrelatedly: expected Near Mint, got DMG)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d69d53e8-8a7b-4797-941c-ce41a24464e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d69d53e8-8a7b-4797-941c-ce41a24464e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

