### PR TITLE
MTGJSON CK price refresh with phased CloudWatch logging

### DIFF
--- a/api/controller/ckprice/ckprice.go
+++ b/api/controller/ckprice/ckprice.go
@@ -2,6 +2,7 @@ package ckprice
 
 import (
 	"context"
+	"log"
 	"strings"
 	"time"
 
@@ -50,12 +51,22 @@ func listingIsFresh(listing *cardkingdom.Listing, now time.Time) bool {
 
 // RefreshPrices downloads Card Kingdom retail prices from MTGJSON and upserts the DynamoDB index.
 func RefreshPrices(ctx context.Context, store ckprices.Store) (int, error) {
+	log.Printf("ck price refresh: fetching mtgjson prices")
+	fetchStarted := time.Now()
+
 	listings, err := fetchCheapestFunc(ctx)
 	if err != nil {
 		return 0, err
 	}
+
+	log.Printf("ck price refresh: fetched mtgjson prices listings=%d duration=%s", len(listings), time.Since(fetchStarted).Round(time.Millisecond))
+
+	log.Printf("ck price refresh: writing dynamodb listings=%d", len(listings))
+	writeStarted := time.Now()
 	if err := store.PutAll(ctx, listings); err != nil {
 		return 0, err
 	}
+	log.Printf("ck price refresh: wrote dynamodb listings=%d duration=%s", len(listings), time.Since(writeStarted).Round(time.Millisecond))
+
 	return len(listings), nil
 }

--- a/api/gateway/cardkingdom/mtgjson_fetch.go
+++ b/api/gateway/cardkingdom/mtgjson_fetch.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -39,10 +40,13 @@ func fetchCheapestFromMTGJSON(ctx context.Context) (map[string]Listing, error) {
 	ctx, cancel := context.WithTimeout(ctx, mtgjsonDownloadTimeout)
 	defer cancel()
 
+	log.Printf("ck price refresh: downloading AllPricesToday from %s", allPricesTodayURL())
+	pricesStarted := time.Now()
 	pricesRaw, err := downloadMTGJSONBzip2(ctx, allPricesTodayURL(), mtgjsonDownloadTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("all prices today: %w", err)
 	}
+	log.Printf("ck price refresh: downloaded AllPricesToday bytes=%d duration=%s", len(pricesRaw), time.Since(pricesStarted).Round(time.Millisecond))
 
 	pricesByUUID, updatedAt, err := parseCKPricesByUUID(pricesRaw)
 	if err != nil {
@@ -51,8 +55,17 @@ func fetchCheapestFromMTGJSON(ctx context.Context) (map[string]Listing, error) {
 	if len(pricesByUUID) == 0 {
 		return nil, fmt.Errorf("parse all prices today: no card kingdom prices found")
 	}
+	log.Printf("ck price refresh: parsed AllPricesToday uuid_prices=%d price_date=%s", len(pricesByUUID), updatedAt.Format("2006-01-02"))
 
-	return streamAllPrintingsSets(ctx, allPrintingsURL(), pricesByUUID, updatedAt)
+	log.Printf("ck price refresh: streaming AllPrintings from %s", allPrintingsURL())
+	printingsStarted := time.Now()
+	listings, err := streamAllPrintingsSets(ctx, allPrintingsURL(), pricesByUUID, updatedAt)
+	if err != nil {
+		return nil, err
+	}
+	log.Printf("ck price refresh: streamed AllPrintings listings=%d duration=%s", len(listings), time.Since(printingsStarted).Round(time.Millisecond))
+
+	return listings, nil
 }
 
 func allPricesTodayURL() string {

--- a/api/handler/ck_refresh.go
+++ b/api/handler/ck_refresh.go
@@ -62,18 +62,20 @@ func CKPriceRefresh(ctx context.Context, request events.APIGatewayProxyRequest) 
 }
 
 func runCKPriceRefresh(ctx context.Context) error {
+	log.Printf("ck price refresh: started")
 	store, err := newCKRefreshStoreFunc(ctx)
 	if err != nil {
+		log.Printf("ck price refresh: failed opening dynamodb store: %v", err)
 		return err
 	}
 
 	count, err := refreshCKPricesFunc(ctx, store)
 	if err != nil {
-		log.Printf("ck price mtgjson: %v", err)
+		log.Printf("ck price refresh: failed: %v", err)
 		return err
 	}
 
-	log.Printf("refreshed %d card kingdom prices", count)
+	log.Printf("ck price refresh: finished refreshed=%d", count)
 	return nil
 }
 
@@ -98,7 +100,11 @@ func enqueueCKPriceRefresh(ctx context.Context) error {
 		InvocationType: lambdatypes.InvocationTypeEvent,
 		Payload:        payload,
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	log.Printf("ck price refresh: queued async job function=%s", functionName)
+	return nil
 }
 
 func isValidRefreshAPIKey(provided string) bool {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds phased CloudWatch logging for the MTGJSON CK price refresh job (already on `master` via #162).

Rebased onto `master`.

## Logging

Filter on **`ck price refresh`**:

| Log line | Meaning |
|----------|---------|
| `queued async job` | POST handler enqueued background Lambda |
| `started` | Background job began |
| `downloading AllPricesToday` / `downloaded AllPricesToday` | Price file download |
| `parsed AllPricesToday` | UUID price map built |
| `streaming AllPrintings` / `streamed AllPrintings` | Printings join + cheapest-by-name |
| `writing dynamodb` / `wrote dynamodb` | DynamoDB upsert |
| `finished refreshed=N` | Success |
| `failed:` | Job error |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9ebd580-80e5-41e7-b69c-21b8b9db7786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9ebd580-80e5-41e7-b69c-21b8b9db7786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

