### PR TITLE
Fix MTGJSON AllPrintings fetch timeout on CK refresh

### DIFF
--- a/api/gateway/cardkingdom/mtgjson_fetch.go
+++ b/api/gateway/cardkingdom/mtgjson_fetch.go
@@ -19,7 +19,11 @@ import (
 const (
 	defaultAllPricesTodayURL = "https://mtgjson.com/api/v5/AllPricesToday.json.bz2"
 	defaultAllPrintingsURL   = "https://mtgjson.com/api/v5/AllPrintings.json.bz2"
-	mtgjsonDownloadTimeout   = 3 * time.Minute
+	// mtgjsonFetchTimeout bounds the full MTGJSON download + parse path. AllPrintings
+	// alone can take several minutes on Lambda; keep Lambda timeout at 600s.
+	mtgjsonFetchTimeout            = 8 * time.Minute
+	mtgjsonAllPricesTodayHTTPTimeout = 2 * time.Minute
+	mtgjsonAllPrintingsHTTPTimeout  = 7 * time.Minute
 )
 
 type ckUUIDPrice struct {
@@ -37,12 +41,12 @@ type mtgjsonCard struct {
 }
 
 func fetchCheapestFromMTGJSON(ctx context.Context) (map[string]Listing, error) {
-	ctx, cancel := context.WithTimeout(ctx, mtgjsonDownloadTimeout)
+	ctx, cancel := context.WithTimeout(ctx, mtgjsonFetchTimeout)
 	defer cancel()
 
 	log.Printf("ck price refresh: downloading AllPricesToday from %s", allPricesTodayURL())
 	pricesStarted := time.Now()
-	pricesRaw, err := downloadMTGJSONBzip2(ctx, allPricesTodayURL(), mtgjsonDownloadTimeout)
+	pricesRaw, err := downloadMTGJSONBzip2(ctx, allPricesTodayURL(), mtgjsonAllPricesTodayHTTPTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("all prices today: %w", err)
 	}
@@ -167,7 +171,7 @@ func streamAllPrintingsSets(
 	pricesByUUID map[string]ckUUIDPrice,
 	updatedAt time.Time,
 ) (map[string]Listing, error) {
-	client := &http.Client{Timeout: mtgjsonDownloadTimeout}
+	client := &http.Client{Timeout: mtgjsonAllPrintingsHTTPTimeout}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes `context deadline exceeded` during MTGJSON AllPrintings streaming (prior 3-minute code deadline was too short for the ~120MB file on Lambda).

Rebased onto `master` (#163 already merged).

## Changes

- **8 min** — full MTGJSON fetch context
- **7 min** — AllPrintings HTTP stream timeout
- **2 min** — AllPricesToday download timeout

Lambda should remain **1024 MB / 600s**.

## Verify

After deploy, refresh should pass `streaming AllPrintings` and log `ck price refresh: finished refreshed=N`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9ebd580-80e5-41e7-b69c-21b8b9db7786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9ebd580-80e5-41e7-b69c-21b8b9db7786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

