### PR TITLE
Add syncedAt field for CK DynamoDB write timestamp

### DIFF
--- a/api/gateway/cardkingdom/types.go
+++ b/api/gateway/cardkingdom/types.go
@@ -21,4 +21,5 @@ type Listing struct {
 	Quantity  int     `json:"quantity"`
 	IsFoil    bool    `json:"isFoil"`
 	UpdatedAt string  `json:"updatedAt,omitempty"`
+	SyncedAt  string  `json:"syncedAt,omitempty"`
 }

--- a/api/store/ckprices/dynamodb.go
+++ b/api/store/ckprices/dynamodb.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"mtg-price-checker-sg/gateway/cardkingdom"
 	"mtg-price-checker-sg/pkg/config"
@@ -27,6 +28,7 @@ type dynamoRecord struct {
 	Quantity  int     `dynamodbav:"quantity"`
 	IsFoil    bool    `dynamodbav:"isFoil"`
 	UpdatedAt string  `dynamodbav:"updatedAt"`
+	SyncedAt  string  `dynamodbav:"syncedAt"`
 }
 
 type DynamoDBStore struct {
@@ -78,22 +80,15 @@ func (s *DynamoDBStore) GetByNameKey(ctx context.Context, nameKey string) (*card
 		Quantity:  record.Quantity,
 		IsFoil:    record.IsFoil,
 		UpdatedAt: record.UpdatedAt,
+		SyncedAt:  record.SyncedAt,
 	}, nil
 }
 
 func (s *DynamoDBStore) PutAll(ctx context.Context, listings map[string]cardkingdom.Listing) error {
+	syncedAt := time.Now().UTC().Format(time.RFC3339)
 	writeRequests := make([]types.WriteRequest, 0, len(listings))
 	for nameKey, listing := range listings {
-		record := dynamoRecord{
-			NameKey:   nameKey,
-			CardName:  listing.CardName,
-			Edition:   listing.Edition,
-			PriceUsd:  listing.PriceUsd,
-			URL:       listing.URL,
-			Quantity:  listing.Quantity,
-			IsFoil:    listing.IsFoil,
-			UpdatedAt: listing.UpdatedAt,
-		}
+		record := dynamoRecordFromListing(nameKey, listing, syncedAt)
 		item, err := attributevalue.MarshalMap(record)
 		if err != nil {
 			return err
@@ -115,6 +110,20 @@ func (s *DynamoDBStore) PutAll(ctx context.Context, listings map[string]cardking
 	}
 
 	return nil
+}
+
+func dynamoRecordFromListing(nameKey string, listing cardkingdom.Listing, syncedAt string) dynamoRecord {
+	return dynamoRecord{
+		NameKey:   nameKey,
+		CardName:  listing.CardName,
+		Edition:   listing.Edition,
+		PriceUsd:  listing.PriceUsd,
+		URL:       listing.URL,
+		Quantity:  listing.Quantity,
+		IsFoil:    listing.IsFoil,
+		UpdatedAt: listing.UpdatedAt,
+		SyncedAt:  syncedAt,
+	}
 }
 
 func (s *DynamoDBStore) writeBatch(ctx context.Context, batch []types.WriteRequest) error {

--- a/api/store/ckprices/dynamodb_test.go
+++ b/api/store/ckprices/dynamodb_test.go
@@ -1,0 +1,27 @@
+package ckprices
+
+import (
+	"testing"
+	"time"
+
+	"mtg-price-checker-sg/gateway/cardkingdom"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDynamoRecordFromListing(t *testing.T) {
+	syncedAt := time.Date(2026, 6, 28, 15, 30, 0, 0, time.UTC).Format(time.RFC3339)
+	record := dynamoRecordFromListing("lightning bolt", cardkingdom.Listing{
+		CardName:  "Lightning Bolt",
+		Edition:   "Fourth Edition",
+		PriceUsd:  1.49,
+		URL:       "https://www.cardkingdom.com/mtg/fourth-edition/lightning-bolt",
+		Quantity:  0,
+		IsFoil:    false,
+		UpdatedAt: "2026-06-28T00:00:00Z",
+	}, syncedAt)
+
+	require.Equal(t, "lightning bolt", record.NameKey)
+	require.Equal(t, "2026-06-28T00:00:00Z", record.UpdatedAt)
+	require.Equal(t, syncedAt, record.SyncedAt)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `syncedAt` field to CK price listings so you can distinguish:

- **`updatedAt`** — MTGJSON `AllPricesToday` price snapshot date (`meta.date`)
- **`syncedAt`** — when the listing was last written to DynamoDB during a refresh

## Changes

- Add `syncedAt` to `cardkingdom.Listing` (returned in search API as part of `cardKingdomPrice`)
- Persist `syncedAt` in DynamoDB on every `PutAll` upsert, stamped once per refresh batch
- Add unit test for record mapping

## Notes

- Existing DynamoDB rows will not have `syncedAt` until the next CK price refresh runs
- Freshness checks continue to use `updatedAt` (MTGJSON price date), unchanged
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-772f1bd2-1930-4920-b33e-0c217ad9c690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-772f1bd2-1930-4920-b33e-0c217ad9c690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

