### PR TITLE
Remove /ck-price/refresh HTTP endpoint

### DIFF
--- a/api/handler/ck_refresh.go
+++ b/api/handler/ck_refresh.go
@@ -2,64 +2,20 @@ package handler
 
 import (
 	"context"
-	"crypto/subtle"
-	"encoding/json"
 	"log"
-	"net/http"
-	"os"
-	"strings"
 
 	"mtg-price-checker-sg/controller/ckprice"
-	"mtg-price-checker-sg/pkg/config"
 	"mtg-price-checker-sg/store/ckprices"
-
-	"github.com/aws/aws-lambda-go/events"
-	"github.com/aws/aws-sdk-go-v2/aws"
-	awsconfig "github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/service/lambda"
-	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
 )
 
 const ckPriceRefreshRunAction = "ck-price-refresh-run"
-
-type CKRefreshResponse struct {
-	Refreshed int `json:"refreshed"`
-}
-
-type CKRefreshAcceptedResponse struct {
-	Status string `json:"status"`
-}
 
 var (
 	newCKRefreshStoreFunc = func(ctx context.Context) (ckprices.Store, error) {
 		return ckprices.NewDynamoDBStore(ctx)
 	}
 	refreshCKPricesFunc = ckprice.RefreshPrices
-	enqueueCKPriceRefreshFunc = enqueueCKPriceRefresh
 )
-
-func CKPriceRefresh(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
-	var apiRes events.APIGatewayProxyResponse
-
-	if request.HTTPMethod == http.MethodOptions {
-		return optionsResponse(request.Headers["origin"])
-	}
-
-	if request.HTTPMethod != http.MethodPost {
-		return errorResponse(apiRes, "", "method not allowed", http.StatusMethodNotAllowed)
-	}
-
-	if !isValidRefreshAPIKey(request.Headers["x-api-key"]) {
-		return errorResponse(apiRes, "", "unauthorized", http.StatusUnauthorized)
-	}
-
-	if err := enqueueCKPriceRefreshFunc(ctx); err != nil {
-		log.Printf("ck price refresh enqueue failed: %v", err)
-		return errorResponse(apiRes, "", "err refreshing card kingdom prices", http.StatusInternalServerError)
-	}
-
-	return jsonResponse(apiRes, "", http.StatusAccepted, CKRefreshAcceptedResponse{Status: "accepted"})
-}
 
 func runCKPriceRefresh(ctx context.Context) error {
 	log.Printf("ck price refresh: started")
@@ -77,40 +33,4 @@ func runCKPriceRefresh(ctx context.Context) error {
 
 	log.Printf("ck price refresh: finished refreshed=%d", count)
 	return nil
-}
-
-func enqueueCKPriceRefresh(ctx context.Context) error {
-	functionName := strings.TrimSpace(os.Getenv("AWS_LAMBDA_FUNCTION_NAME"))
-	if functionName == "" {
-		return runCKPriceRefresh(ctx)
-	}
-
-	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(config.AWSRegion))
-	if err != nil {
-		return err
-	}
-
-	payload, err := json.Marshal(map[string]string{"action": ckPriceRefreshRunAction})
-	if err != nil {
-		return err
-	}
-
-	_, err = lambda.NewFromConfig(cfg).Invoke(ctx, &lambda.InvokeInput{
-		FunctionName:   aws.String(functionName),
-		InvocationType: lambdatypes.InvocationTypeEvent,
-		Payload:        payload,
-	})
-	if err != nil {
-		return err
-	}
-	log.Printf("ck price refresh: queued async job function=%s", functionName)
-	return nil
-}
-
-func isValidRefreshAPIKey(provided string) bool {
-	expected := strings.TrimSpace(os.Getenv(config.CKRefreshAPIKeyEnv))
-	if expected == "" {
-		return os.Getenv("ENV") != config.EnvProd
-	}
-	return subtle.ConstantTimeCompare([]byte(provided), []byte(expected)) == 1
 }

--- a/api/handler/ck_refresh_test.go
+++ b/api/handler/ck_refresh_test.go
@@ -3,16 +3,10 @@ package handler
 import (
 	"context"
 	"encoding/json"
-	"net/http"
-	"os"
 	"testing"
 
 	"mtg-price-checker-sg/gateway/cardkingdom"
-	"mtg-price-checker-sg/pkg/config"
 	"mtg-price-checker-sg/store/ckprices"
-
-	"github.com/aws/aws-lambda-go/events"
-	"github.com/stretchr/testify/require"
 )
 
 type mockCKRefreshStore struct{}
@@ -23,41 +17,6 @@ func (m *mockCKRefreshStore) GetByNameKey(_ context.Context, _ string) (*cardkin
 
 func (m *mockCKRefreshStore) PutAll(_ context.Context, _ map[string]cardkingdom.Listing) error {
 	return nil
-}
-
-func TestCKPriceRefresh_Accepted(t *testing.T) {
-	originalEnqueueFunc := enqueueCKPriceRefreshFunc
-	defer func() { enqueueCKPriceRefreshFunc = originalEnqueueFunc }()
-
-	enqueueCKPriceRefreshFunc = func(_ context.Context) error {
-		return nil
-	}
-
-	require.NoError(t, os.Setenv(config.CKRefreshAPIKeyEnv, "test-secret"))
-	require.NoError(t, os.Setenv("ENV", config.EnvProd))
-
-	result, err := CKPriceRefresh(context.Background(), events.APIGatewayProxyRequest{
-		HTTPMethod: http.MethodPost,
-		Headers:    map[string]string{"x-api-key": "test-secret"},
-	})
-	require.NoError(t, err)
-	require.Equal(t, http.StatusAccepted, result.StatusCode)
-
-	var response CKRefreshAcceptedResponse
-	require.NoError(t, json.Unmarshal([]byte(result.Body), &response))
-	require.Equal(t, "accepted", response.Status)
-}
-
-func TestCKPriceRefresh_Unauthorized(t *testing.T) {
-	require.NoError(t, os.Setenv(config.CKRefreshAPIKeyEnv, "test-secret"))
-	require.NoError(t, os.Setenv("ENV", config.EnvProd))
-
-	result, err := CKPriceRefresh(context.Background(), events.APIGatewayProxyRequest{
-		HTTPMethod: http.MethodPost,
-		Headers:    map[string]string{"x-api-key": "wrong"},
-	})
-	require.NoError(t, err)
-	require.Equal(t, http.StatusUnauthorized, result.StatusCode)
 }
 
 func TestHandle_RoutesCKPriceRefreshRun(t *testing.T) {
@@ -76,34 +35,11 @@ func TestHandle_RoutesCKPriceRefreshRun(t *testing.T) {
 	}
 
 	event, err := json.Marshal(map[string]string{"action": ckPriceRefreshRunAction})
-	require.NoError(t, err)
-
-	_, err = Handle(context.Background(), event)
-	require.NoError(t, err)
-}
-
-func TestHandle_RoutesCKPriceRefresh(t *testing.T) {
-	originalEnqueueFunc := enqueueCKPriceRefreshFunc
-	defer func() { enqueueCKPriceRefreshFunc = originalEnqueueFunc }()
-
-	enqueueCKPriceRefreshFunc = func(_ context.Context) error {
-		return nil
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
 	}
 
-	require.NoError(t, os.Setenv(config.CKRefreshAPIKeyEnv, "test-secret"))
-	require.NoError(t, os.Setenv("ENV", config.EnvProd))
-
-	event, err := json.Marshal(events.APIGatewayProxyRequest{
-		HTTPMethod: http.MethodPost,
-		Path:       "/ck-price/refresh",
-		Headers:    map[string]string{"x-api-key": "test-secret"},
-	})
-	require.NoError(t, err)
-
-	response, err := Handle(context.Background(), event)
-	require.NoError(t, err)
-
-	apiResponse, ok := response.(events.APIGatewayProxyResponse)
-	require.True(t, ok)
-	require.Equal(t, http.StatusAccepted, apiResponse.StatusCode)
+	if _, err = Handle(context.Background(), event); err != nil {
+		t.Fatalf("handle event: %v", err)
+	}
 }

--- a/api/handler/router.go
+++ b/api/handler/router.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"context"
 	"encoding/json"
-	"strings"
 
 	"github.com/aws/aws-lambda-go/events"
 )
@@ -20,11 +19,6 @@ func Handle(ctx context.Context, event json.RawMessage) (any, error) {
 	var apiRequest events.APIGatewayProxyRequest
 	if err := json.Unmarshal(event, &apiRequest); err != nil {
 		return events.APIGatewayProxyResponse{}, err
-	}
-
-	path := strings.TrimSuffix(strings.ToLower(apiRequest.Path), "/")
-	if path == "/ck-price/refresh" || strings.HasSuffix(path, "/ck-price/refresh") {
-		return CKPriceRefresh(ctx, apiRequest)
 	}
 
 	return Search(ctx, apiRequest)

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -42,8 +42,6 @@ const (
 	WebBotAuthTTLEnv = "WEB_BOT_AUTH_TTL_SECONDS"
 	// CKDynamoDBTableEnv is the DynamoDB table storing cheapest Card Kingdom prices by card name.
 	CKDynamoDBTableEnv = "CK_DYNAMODB_TABLE"
-	// CKRefreshAPIKeyEnv protects the scheduled CK pricelist refresh endpoint.
-	CKRefreshAPIKeyEnv = "CK_REFRESH_API_KEY"
 	// CKPriceLookupEnabledEnv toggles Card Kingdom price lookup on search responses.
 	CKPriceLookupEnabledEnv = "CK_PRICE_LOOKUP_ENABLED"
 	// CKPriceMaxAge is how old a DynamoDB CK listing may be before search omits it.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the legacy `POST /ck-price/refresh` HTTP endpoint from the search Lambda. CK price refresh is now owned by the dedicated `mtg-price-ck-refresh` Lambda, triggered by EventBridge or direct invoke.

## Why

After splitting refresh into its own Lambda, the HTTP route was misleading:

- It lived on the search API (`mtg-price-scrapper` via API Gateway).
- It async-invoked `AWS_LAMBDA_FUNCTION_NAME` (the search Lambda), not `mtg-price-ck-refresh`.
- EventBridge already invokes the refresh Lambda directly with `{"action":"ck-price-refresh-run"}`.

## Changes

- Remove `/ck-price/refresh` routing from `handler/router.go`
- Remove HTTP handler, enqueue helper, and API key auth from `handler/ck_refresh.go`
- Remove `CK_REFRESH_API_KEY` config constant
- Drop HTTP-related tests; keep action-routing test for `ck-price-refresh-run`

## Manual refresh (replacement)

```bash
aws lambda invoke \
  --region ap-southeast-1 \
  --function-name mtg-price-ck-refresh \
  --invocation-type Event \
  --payload '{"action":"ck-price-refresh-run"}' \
  /dev/stdout
```

## Follow-up (AWS console)

Remove the `/ck-price/refresh` API Gateway route if it still exists, and drop the `CK_REFRESH_API_KEY` env var from the search Lambda configuration.

## Testing

- `go test -mod=vendor ./handler/... ./pkg/config/...` — pass
- Full `make test` — unrelated live scraper flake in `gateway/cardscentral` (`Test_Search` condition mismatch)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c9422d8-6435-4b43-90ed-949bbb1770fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c9422d8-6435-4b43-90ed-949bbb1770fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

