### PR TITLE
Deploy container image to both Lambdas on make deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,10 @@ lambda-update:
       --function-name mtg-price-scrapper \
       --image-uri 206363131200.dkr.ecr.ap-southeast-1.amazonaws.com/mtg-price-scrapper:latest \
       --output text > /dev/null
+	export AWS_PAGER="" && aws lambda update-function-code \
+      --function-name mtg-price-ck-refresh \
+      --image-uri 206363131200.dkr.ecr.ap-southeast-1.amazonaws.com/mtg-price-scrapper:latest \
+      --output text > /dev/null
 
 aws-login:
 	aws ecr get-login-password --region ap-southeast-1 | docker login --username AWS --password-stdin 206363131200.dkr.ecr.ap-southeast-1.amazonaws.com


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates `lambda-update` so `make deploy` rolls out the shared ECR image to both Lambda functions:

- `mtg-price-scrapper` (search API)
- `mtg-price-ck-refresh` (daily CK price refresh)

Both functions use the same container image; pushing to ECR alone does not update running Lambdas, so each function needs its own `update-function-code` call.

## Test plan

- [x] `make test` — failed on unrelated live gateway test (`gateway/cardscentral`: upstream condition changed from "Near Mint" to "DMG"); no code under test changed
- [ ] Merge and verify `make deploy` updates both Lambdas in AWS
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fa76c05-e90b-46ab-a335-3b7ae51bfcfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fa76c05-e90b-46ab-a335-3b7ae51bfcfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

