### PR TITLE
Add CK sync metadata row and log syncedAt on DynamoDB writes

### DIFF
--- a/api/controller/ckprice/ckprice.go
+++ b/api/controller/ckprice/ckprice.go
@@ -63,10 +63,11 @@ func RefreshPrices(ctx context.Context, store ckprices.Store) (int, error) {
 
 	log.Printf("ck price refresh: writing dynamodb listings=%d", len(listings))
 	writeStarted := time.Now()
-	if err := store.PutAll(ctx, listings); err != nil {
+	syncedAt, err := store.PutAll(ctx, listings)
+	if err != nil {
 		return 0, err
 	}
-	log.Printf("ck price refresh: wrote dynamodb listings=%d duration=%s", len(listings), time.Since(writeStarted).Round(time.Millisecond))
+	log.Printf("ck price refresh: wrote dynamodb listings=%d syncedAt=%s duration=%s", len(listings), syncedAt, time.Since(writeStarted).Round(time.Millisecond))
 
 	return len(listings), nil
 }

--- a/api/controller/ckprice/ckprice_test.go
+++ b/api/controller/ckprice/ckprice_test.go
@@ -20,8 +20,8 @@ func (m *mockStore) GetByNameKey(_ context.Context, nameKey string) (*cardkingdo
 	return m.listing, nil
 }
 
-func (m *mockStore) PutAll(_ context.Context, _ map[string]cardkingdom.Listing) error {
-	return nil
+func (m *mockStore) PutAll(_ context.Context, _ map[string]cardkingdom.Listing) (string, error) {
+	return "", nil
 }
 
 func TestGetLatestPrice_UsesVerifiedName(t *testing.T) {

--- a/api/handler/ck_refresh_test.go
+++ b/api/handler/ck_refresh_test.go
@@ -15,8 +15,8 @@ func (m *mockCKRefreshStore) GetByNameKey(_ context.Context, _ string) (*cardkin
 	return nil, nil
 }
 
-func (m *mockCKRefreshStore) PutAll(_ context.Context, _ map[string]cardkingdom.Listing) error {
-	return nil
+func (m *mockCKRefreshStore) PutAll(_ context.Context, _ map[string]cardkingdom.Listing) (string, error) {
+	return "", nil
 }
 
 func TestHandle_RoutesCKPriceRefreshRun(t *testing.T) {

--- a/api/store/ckprices/dynamodb.go
+++ b/api/store/ckprices/dynamodb.go
@@ -17,7 +17,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
 
-const batchWriteLimit = 25
+const (
+	batchWriteLimit   = 25
+	syncMetadataKey   = "__sync__"
+	syncMetadataLabel = "CK price sync metadata"
+)
 
 type dynamoRecord struct {
 	NameKey   string  `dynamodbav:"nameKey"`
@@ -29,6 +33,13 @@ type dynamoRecord struct {
 	IsFoil    bool    `dynamodbav:"isFoil"`
 	UpdatedAt string  `dynamodbav:"updatedAt"`
 	SyncedAt  string  `dynamodbav:"syncedAt"`
+}
+
+type syncMetadataRecord struct {
+	NameKey       string `dynamodbav:"nameKey"`
+	CardName      string `dynamodbav:"cardName"`
+	SyncedAt      string `dynamodbav:"syncedAt"`
+	ListingCount  int    `dynamodbav:"listingCount"`
 }
 
 type DynamoDBStore struct {
@@ -84,19 +95,32 @@ func (s *DynamoDBStore) GetByNameKey(ctx context.Context, nameKey string) (*card
 	}, nil
 }
 
-func (s *DynamoDBStore) PutAll(ctx context.Context, listings map[string]cardkingdom.Listing) error {
+func (s *DynamoDBStore) PutAll(ctx context.Context, listings map[string]cardkingdom.Listing) (string, error) {
 	syncedAt := time.Now().UTC().Format(time.RFC3339)
-	writeRequests := make([]types.WriteRequest, 0, len(listings))
+	writeRequests := make([]types.WriteRequest, 0, len(listings)+1)
 	for nameKey, listing := range listings {
 		record := dynamoRecordFromListing(nameKey, listing, syncedAt)
 		item, err := attributevalue.MarshalMap(record)
 		if err != nil {
-			return err
+			return "", err
 		}
 		writeRequests = append(writeRequests, types.WriteRequest{
 			PutRequest: &types.PutRequest{Item: item},
 		})
 	}
+
+	metadataItem, err := attributevalue.MarshalMap(syncMetadataRecord{
+		NameKey:      syncMetadataKey,
+		CardName:     syncMetadataLabel,
+		SyncedAt:     syncedAt,
+		ListingCount: len(listings),
+	})
+	if err != nil {
+		return "", err
+	}
+	writeRequests = append(writeRequests, types.WriteRequest{
+		PutRequest: &types.PutRequest{Item: metadataItem},
+	})
 
 	for start := 0; start < len(writeRequests); start += batchWriteLimit {
 		end := start + batchWriteLimit
@@ -105,11 +129,11 @@ func (s *DynamoDBStore) PutAll(ctx context.Context, listings map[string]cardking
 		}
 		batch := writeRequests[start:end]
 		if err := s.writeBatch(ctx, batch); err != nil {
-			return err
+			return "", err
 		}
 	}
 
-	return nil
+	return syncedAt, nil
 }
 
 func dynamoRecordFromListing(nameKey string, listing cardkingdom.Listing, syncedAt string) dynamoRecord {

--- a/api/store/ckprices/dynamodb_test.go
+++ b/api/store/ckprices/dynamodb_test.go
@@ -6,6 +6,8 @@ import (
 
 	"mtg-price-checker-sg/gateway/cardkingdom"
 
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,4 +26,28 @@ func TestDynamoRecordFromListing(t *testing.T) {
 	require.Equal(t, "lightning bolt", record.NameKey)
 	require.Equal(t, "2026-06-28T00:00:00Z", record.UpdatedAt)
 	require.Equal(t, syncedAt, record.SyncedAt)
+}
+
+func TestDynamoRecordMarshalIncludesSyncedAt(t *testing.T) {
+	syncedAt := time.Date(2026, 6, 28, 15, 30, 0, 0, time.UTC).Format(time.RFC3339)
+	record := dynamoRecordFromListing("lightning bolt", cardkingdom.Listing{UpdatedAt: "2026-06-28T00:00:00Z"}, syncedAt)
+	item, err := attributevalue.MarshalMap(record)
+	require.NoError(t, err)
+	require.Contains(t, item, "syncedAt")
+	av, ok := item["syncedAt"].(*types.AttributeValueMemberS)
+	require.True(t, ok)
+	require.Equal(t, syncedAt, av.Value)
+}
+
+func TestSyncMetadataRecordMarshal(t *testing.T) {
+	syncedAt := time.Date(2026, 6, 28, 15, 30, 0, 0, time.UTC).Format(time.RFC3339)
+	item, err := attributevalue.MarshalMap(syncMetadataRecord{
+		NameKey:      syncMetadataKey,
+		CardName:     syncMetadataLabel,
+		SyncedAt:     syncedAt,
+		ListingCount: 12345,
+	})
+	require.NoError(t, err)
+	require.Contains(t, item, "syncedAt")
+	require.Contains(t, item, "listingCount")
 }

--- a/api/store/ckprices/store.go
+++ b/api/store/ckprices/store.go
@@ -9,5 +9,5 @@ import (
 // Store persists Card Kingdom cheapest-by-name listings.
 type Store interface {
 	GetByNameKey(ctx context.Context, nameKey string) (*cardkingdom.Listing, error)
-	PutAll(ctx context.Context, listings map[string]cardkingdom.Listing) error
+	PutAll(ctx context.Context, listings map[string]cardkingdom.Listing) (syncedAt string, err error)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Writes a `__sync__` metadata item to the CK DynamoDB table on every refresh, with `syncedAt` and `listingCount`, so the last sync time is easy to find in the console.
- Returns `syncedAt` from `PutAll` and logs it when the refresh finishes (`ck price refresh: wrote dynamodb ... syncedAt=...`).
- Adds marshal tests to confirm `syncedAt` is included in DynamoDB attribute maps.

## Context

`syncedAt` was added in #166 to record when each listing row was written (separate from `updatedAt`, which is the MTGJSON price snapshot date). If you still don't see it on records, the likely cause is operational:

1. **#168** fixed `make deploy` so `mtg-price-ck-refresh` is updated alongside `mtg-price-scrapper`. Before that, the refresh Lambda could keep running older code without `syncedAt`.
2. A **new refresh run** is required after deploy before existing rows get `syncedAt`.

After this merges and deploys, look up `nameKey = __sync__` in DynamoDB for the latest sync timestamp, or check any card row for its per-listing `syncedAt`.

## Test plan

- [x] `go test -mod=vendor ./store/ckprices/... ./controller/ckprice/... ./handler/...`
- [ ] After deploy, invoke `mtg-price-ck-refresh` (or wait for the daily EventBridge schedule) and confirm `syncedAt` on card rows and on the `__sync__` metadata item
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91d9dfeb-704f-4132-b0d1-6ba949d0f55b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91d9dfeb-704f-4132-b0d1-6ba949d0f55b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

