### PR TITLE
Move Card Kingdom price banner below result count

### DIFF
--- a/frontend/src/components/CardKingdomPrice.jsx
+++ b/frontend/src/components/CardKingdomPrice.jsx
@@ -15,7 +15,10 @@ const formatDataDate = (value) => {
   }
 
   const day = String(date.getUTCDate()).padStart(2, "0");
-  const month = date.getUTCMonth() + 1;
+  const month = new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    timeZone: "UTC",
+  }).format(date);
   const year = date.getUTCFullYear();
 
   return `${day} ${month} ${year}`;

--- a/frontend/src/components/CardKingdomPrice.jsx
+++ b/frontend/src/components/CardKingdomPrice.jsx
@@ -4,10 +4,30 @@ const formatUsd = (value) =>
     currency: "USD",
   }).format(value);
 
+const formatDataDate = (value) => {
+  if (!value) {
+    return null;
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  }).format(date);
+};
+
 const CardKingdomPrice = ({ price }) => {
   if (!price) {
     return null;
   }
+
+  const dataDate = formatDataDate(price.updatedAt);
 
   return (
     <div
@@ -18,6 +38,7 @@ const CardKingdomPrice = ({ price }) => {
         Card Kingdom from {formatUsd(price.priceUsd)}
         {price.edition ? ` · ${price.edition}` : ""}
         {price.isFoil ? " · Foil" : ""}
+        {dataDate ? ` · as of ${dataDate}` : ""}
         {" · "}
         <a
           href={price.url}

--- a/frontend/src/components/CardKingdomPrice.jsx
+++ b/frontend/src/components/CardKingdomPrice.jsx
@@ -14,12 +14,11 @@ const formatDataDate = (value) => {
     return null;
   }
 
-  return new Intl.DateTimeFormat("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-    timeZone: "UTC",
-  }).format(date);
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  const month = date.getUTCMonth() + 1;
+  const year = date.getUTCFullYear();
+
+  return `${day} ${month} ${year}`;
 };
 
 const CardKingdomPrice = ({ price }) => {

--- a/frontend/src/components/SearchResults.jsx
+++ b/frontend/src/components/SearchResults.jsx
@@ -124,10 +124,11 @@ const SearchResults = ({
               />
             )}
 
-            <CardKingdomPrice price={cardKingdomPrice} />
-
             {results.length === 0 ? (
-              <EmptySearchState />
+              <>
+                <CardKingdomPrice price={cardKingdomPrice} />
+                <EmptySearchState />
+              </>
             ) : (
               <>
                 <div
@@ -137,6 +138,8 @@ const SearchResults = ({
                 >
                   {resultCountLabel}
                 </div>
+
+                <CardKingdomPrice price={cardKingdomPrice} />
 
                 <ResultFilters
                   sortBy={sortBy}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Moves the Card Kingdom reference price banner so it appears **below** the yellow "X results found" strip, and shows the **MTGJSON price date** (`updatedAt`) in the banner.

## Changes

- Reordered `CardKingdomPrice` in `SearchResults.jsx` to render after the result count banner when local results exist.
- When there are no local results, the CK banner still appears above the empty-state message (there is no result count to show).
- Added `as of [date]` to the CK banner using `updatedAt` from the API (UTC, e.g. `Jun 27, 2026`).

## Example copy

> Card Kingdom from **$1.25** · **Fourth Edition** · **as of Jun 27, 2026** · **View listing**

## Screenshots

### Desktop
![CK price with date on desktop](https://cursor.com/artifacts/c/art-25fa11c8-65f1-4a5d-9697-124e42376ec2)

### Mobile
![CK price with date on mobile](https://cursor.com/artifacts/c/art-b74748f6-62ea-49d2-bae0-901c2429a5ff)

## Test plan

- [x] `cd frontend && npm run lint`
- [x] Verified layout in browser with mocked CK price data (desktop + mobile screenshots)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b527c8cb-ee80-495c-9935-5c51d329a48b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b527c8cb-ee80-495c-9935-5c51d329a48b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

