### PR TITLE
Bold Card Kingdom store name and price in listing banner

### DIFF
--- a/frontend/src/components/CardKingdomPrice.jsx
+++ b/frontend/src/components/CardKingdomPrice.jsx
@@ -37,7 +37,8 @@ const CardKingdomPrice = ({ price }) => {
       aria-live="polite"
     >
       <span className="small">
-        Card Kingdom from {formatUsd(price.priceUsd)}
+        <strong>Card Kingdom</strong> from{" "}
+        <strong>{formatUsd(price.priceUsd)}</strong>
         {price.edition ? ` · ${price.edition}` : ""}
         {price.isFoil ? " · Foil" : ""}
         {dataDate ? ` · as of ${dataDate}` : ""}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bold **Card Kingdom** and the formatted USD price in the Card Kingdom listing banner so the store name and price stand out from the edition, date, and link text.

## Changes

- Wrap `Card Kingdom` and `{formatUsd(price.priceUsd)}` in `<strong>` tags in `CardKingdomPrice.jsx`.

## Screenshots

### Desktop

![Card Kingdom price banner on desktop](https://cursor.com/artifacts/c/art-fa67e0e6-7b6e-4665-807e-19870556bfac)

### Mobile

![Card Kingdom price banner on mobile](https://cursor.com/artifacts/c/art-0390983a-9e95-45da-9c62-3c0924244a8e)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f16e01aa-6ee9-4f62-ae07-9aa13dd69765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f16e01aa-6ee9-4f62-ae07-9aa13dd69765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

