### PR TITLE
Write only latest.json for analytics keywords export

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,13 +106,12 @@ sequenceDiagram
     FE->>GA: gtag event search (search_term)
     EB->>L: daily analytics-keywords-export-run
     L->>GA: GA4 Data API RunReport
-    L->>S3: latest.json + YYYY-MM-DD.json
+    L->>S3: latest.json
 ```
 
 S3 output (default prefix `analytics/top-search-keywords/`):
 
 - `latest.json` — most recent export
-- `YYYY-MM-DD.json` — dated snapshot for the export run
 
 Example report shape:
 

--- a/api/store/analyticsreport/s3.go
+++ b/api/store/analyticsreport/s3.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	"mtg-price-checker-sg/controller/analyticskeywords"
 	"mtg-price-checker-sg/pkg/config"
@@ -71,26 +70,15 @@ func (w *S3Writer) Write(ctx context.Context, report *analyticskeywords.Report) 
 		return err
 	}
 
-	generatedDate, err := ParseGeneratedAtDate(report.GeneratedAt)
+	key := w.objectKey("latest.json")
+	_, err = w.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:      aws.String(w.bucket),
+		Key:         aws.String(key),
+		Body:        bytes.NewReader(payload),
+		ContentType: aws.String("application/json"),
+	})
 	if err != nil {
-		return err
-	}
-
-	keys := []string{
-		w.objectKey("latest.json"),
-		w.objectKey(generatedDate + ".json"),
-	}
-
-	for _, key := range keys {
-		_, err = w.client.PutObject(ctx, &s3.PutObjectInput{
-			Bucket:      aws.String(w.bucket),
-			Key:         aws.String(key),
-			Body:        bytes.NewReader(payload),
-			ContentType: aws.String("application/json"),
-		})
-		if err != nil {
-			return fmt.Errorf("analyticsreport: put s3://%s/%s: %w", w.bucket, key, err)
-		}
+		return fmt.Errorf("analyticsreport: put s3://%s/%s: %w", w.bucket, key, err)
 	}
 
 	return nil
@@ -98,13 +86,4 @@ func (w *S3Writer) Write(ctx context.Context, report *analyticskeywords.Report) 
 
 func (w *S3Writer) objectKey(name string) string {
 	return w.prefix + "/" + name
-}
-
-// ParseGeneratedAtDate extracts the YYYY-MM-DD portion from an RFC3339 timestamp.
-func ParseGeneratedAtDate(generatedAt string) (string, error) {
-	parsed, err := time.Parse(time.RFC3339, generatedAt)
-	if err != nil {
-		return "", err
-	}
-	return parsed.UTC().Format("2006-01-02"), nil
 }

--- a/api/store/analyticsreport/s3_test.go
+++ b/api/store/analyticsreport/s3_test.go
@@ -29,7 +29,7 @@ func (m *mockS3Client) PutObject(_ context.Context, input *s3.PutObjectInput, _ 
 	return &s3.PutObjectOutput{}, nil
 }
 
-func TestS3Writer_WriteUploadsLatestAndDatedObjects(t *testing.T) {
+func TestS3Writer_WriteUploadsLatestObject(t *testing.T) {
 	mockClient := &mockS3Client{}
 	writer := &S3Writer{
 		client: mockClient,
@@ -52,17 +52,13 @@ func TestS3Writer_WriteUploadsLatestAndDatedObjects(t *testing.T) {
 		t.Fatalf("write report: %v", err)
 	}
 
-	if len(mockClient.objects) != 2 {
-		t.Fatalf("expected 2 objects, got %d", len(mockClient.objects))
+	if len(mockClient.objects) != 1 {
+		t.Fatalf("expected 1 object, got %d", len(mockClient.objects))
 	}
 
 	latestKey := "analytics/top-search-keywords/latest.json"
-	datedKey := "analytics/top-search-keywords/2026-06-28.json"
 	if _, ok := mockClient.objects[latestKey]; !ok {
 		t.Fatalf("missing latest object")
-	}
-	if _, ok := mockClient.objects[datedKey]; !ok {
-		t.Fatalf("missing dated object")
 	}
 
 	var decoded analyticskeywords.Report
@@ -71,15 +67,5 @@ func TestS3Writer_WriteUploadsLatestAndDatedObjects(t *testing.T) {
 	}
 	if decoded.PropertyID != "123456789" {
 		t.Fatalf("unexpected decoded report: %+v", decoded)
-	}
-}
-
-func TestParseGeneratedAtDate(t *testing.T) {
-	got, err := ParseGeneratedAtDate("2026-06-28T01:02:03Z")
-	if err != nil {
-		t.Fatalf("parse generated at: %v", err)
-	}
-	if got != "2026-06-28" {
-		t.Fatalf("expected 2026-06-28, got %s", got)
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The analytics keywords export now writes a single S3 object (`latest.json`) instead of also creating a dated `YYYY-MM-DD.json` snapshot on each run.

## Changes

- Update `S3Writer.Write` to upload only `latest.json`
- Remove the unused `ParseGeneratedAtDate` helper and its test
- Update README documentation to reflect the simplified S3 output

## Testing

- `go test -mod=vendor -failfast -timeout 5m ./store/analyticsreport/...`
- `make test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c38234e8-f2e2-47fb-b9f5-ab695d66b5c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c38234e8-f2e2-47fb-b9f5-ab695d66b5c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

