### PR TITLE
Write analytics keywords latest.json to frontend S3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ flowchart TB
         AnalyticsLambda[Lambda mtg-analytics-keywords-export]
         EB[EventBridge daily schedule]
         DDB[(DynamoDB CK prices)]
-        AnalyticsS3[(S3 analytics reports)]
         ECR[ECR mtg-price-scrapper image]
     end
 
@@ -66,7 +65,7 @@ flowchart TB
     RefreshLambda -->|batch write cheapest CK retail| DDB
     EB -->|action: analytics-keywords-export-run| AnalyticsLambda
     AnalyticsLambda -->|GA4 Data API| GA4
-    AnalyticsLambda -->|write JSON reports| AnalyticsS3
+    AnalyticsLambda -->|write latest.json| S3
     ECR -.->|deploy| SearchLambda
     ECR -.->|deploy| RefreshLambda
     ECR -.->|deploy| AnalyticsLambda
@@ -100,18 +99,28 @@ sequenceDiagram
     participant GA as Google Analytics
     participant EB as EventBridge
     participant L as mtg-analytics-keywords-export
-    participant S3 as S3 analytics bucket
+    participant S3 as S3 gishathfetch.com
 
     U->>FE: search for card name
     FE->>GA: gtag event search (search_term)
     EB->>L: daily analytics-keywords-export-run
     L->>GA: GA4 Data API RunReport
-    L->>S3: latest.json
+    L->>S3: analytics/top-search-keywords/latest.json
+    FE->>S3: fetch latest.json via CloudFront
 ```
 
-S3 output (default prefix `analytics/top-search-keywords/`):
+S3 output (default bucket `gishathfetch.com`, prefix `analytics/top-search-keywords/`):
 
-- `latest.json` — most recent export
+- `latest.json` — most recent export, served at `https://gishathfetch.com/analytics/top-search-keywords/latest.json`
+
+The export Lambda writes to the same bucket as the frontend SPA so the report is
+available same-origin through CloudFront. The object is uploaded with
+`Cache-Control: public, max-age=3600` so edge caches can serve it between daily
+exports without a separate invalidation.
+
+If the Lambda still has `ANALYTICS_S3_BUCKET` set to a legacy analytics bucket,
+remove it or set it to `gishathfetch.com`, and ensure the Lambda role can
+`PutObject` on `arn:aws:s3:::gishathfetch.com/analytics/top-search-keywords/*`.
 
 Example report shape:
 

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -54,10 +54,17 @@ const (
 	GA4PropertyIDEnv = "GA4_PROPERTY_ID"
 	// GA4CredentialsJSONEnv holds a Google service account JSON key with Analytics read access.
 	GA4CredentialsJSONEnv = "GA4_CREDENTIALS_JSON"
-	// AnalyticsS3BucketEnv is the destination bucket for exported analytics reports.
+	// AnalyticsS3BucketEnv overrides the destination bucket for exported analytics reports.
 	AnalyticsS3BucketEnv = "ANALYTICS_S3_BUCKET"
+	// AnalyticsS3DefaultBucket is the frontend S3 bucket served by CloudFront.
+	AnalyticsS3DefaultBucket = "gishathfetch.com"
 	// AnalyticsS3KeyPrefixEnv is the object key prefix for exported analytics reports.
 	AnalyticsS3KeyPrefixEnv = "ANALYTICS_S3_KEY_PREFIX"
+	// AnalyticsS3DefaultKeyPrefix is the default object key prefix under the frontend bucket.
+	AnalyticsS3DefaultKeyPrefix = "analytics/top-search-keywords"
+	// AnalyticsLatestJSONCacheControl is applied to latest.json so CloudFront can cache it
+	// between daily exports without a separate invalidation.
+	AnalyticsLatestJSONCacheControl = "public, max-age=3600"
 	// AWSRegion is the AWS region used for DynamoDB and other managed services.
 	AWSRegion = "ap-southeast-1"
 )

--- a/api/store/analyticsreport/s3.go
+++ b/api/store/analyticsreport/s3.go
@@ -40,12 +40,12 @@ var loadAWSConfig = func(ctx context.Context) (aws.Config, error) {
 func NewS3Writer(ctx context.Context) (*S3Writer, error) {
 	bucket := strings.TrimSpace(os.Getenv(config.AnalyticsS3BucketEnv))
 	if bucket == "" {
-		return nil, fmt.Errorf("analyticsreport: %s is not set", config.AnalyticsS3BucketEnv)
+		bucket = config.AnalyticsS3DefaultBucket
 	}
 
 	prefix := strings.Trim(strings.TrimSpace(os.Getenv(config.AnalyticsS3KeyPrefixEnv)), "/")
 	if prefix == "" {
-		prefix = "analytics/top-search-keywords"
+		prefix = config.AnalyticsS3DefaultKeyPrefix
 	}
 
 	cfg, err := loadAWSConfig(ctx)
@@ -72,10 +72,11 @@ func (w *S3Writer) Write(ctx context.Context, report *analyticskeywords.Report) 
 
 	key := w.objectKey("latest.json")
 	_, err = w.client.PutObject(ctx, &s3.PutObjectInput{
-		Bucket:      aws.String(w.bucket),
-		Key:         aws.String(key),
-		Body:        bytes.NewReader(payload),
-		ContentType: aws.String("application/json"),
+		Bucket:       aws.String(w.bucket),
+		Key:          aws.String(key),
+		Body:         bytes.NewReader(payload),
+		ContentType:  aws.String("application/json"),
+		CacheControl: aws.String(config.AnalyticsLatestJSONCacheControl),
 	})
 	if err != nil {
 		return fmt.Errorf("analyticsreport: put s3://%s/%s: %w", w.bucket, key, err)

--- a/api/store/analyticsreport/s3_test.go
+++ b/api/store/analyticsreport/s3_test.go
@@ -7,34 +7,61 @@ import (
 	"testing"
 
 	"mtg-price-checker-sg/controller/analyticskeywords"
+	"mtg-price-checker-sg/pkg/config"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 )
 
+type mockS3Object struct {
+	body         []byte
+	contentType  string
+	cacheControl string
+}
+
 type mockS3Client struct {
-	objects map[string][]byte
+	objects map[string]mockS3Object
 }
 
 func (m *mockS3Client) PutObject(_ context.Context, input *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
 	if m.objects == nil {
-		m.objects = make(map[string][]byte)
+		m.objects = make(map[string]mockS3Object)
 	}
 
 	body, err := io.ReadAll(input.Body)
 	if err != nil {
 		return nil, err
 	}
-	m.objects[aws.ToString(input.Key)] = body
+	m.objects[aws.ToString(input.Key)] = mockS3Object{
+		body:         body,
+		contentType:  aws.ToString(input.ContentType),
+		cacheControl: aws.ToString(input.CacheControl),
+	}
 	return &s3.PutObjectOutput{}, nil
+}
+
+func TestNewS3WriterDefaultsToFrontendBucket(t *testing.T) {
+	t.Setenv(config.AnalyticsS3BucketEnv, "")
+	t.Setenv(config.AnalyticsS3KeyPrefixEnv, "")
+
+	writer, err := NewS3Writer(context.Background())
+	if err != nil {
+		t.Fatalf("new s3 writer: %v", err)
+	}
+	if writer.bucket != config.AnalyticsS3DefaultBucket {
+		t.Fatalf("expected bucket %q, got %q", config.AnalyticsS3DefaultBucket, writer.bucket)
+	}
+	if writer.prefix != config.AnalyticsS3DefaultKeyPrefix {
+		t.Fatalf("expected prefix %q, got %q", config.AnalyticsS3DefaultKeyPrefix, writer.prefix)
+	}
 }
 
 func TestS3Writer_WriteUploadsLatestObject(t *testing.T) {
 	mockClient := &mockS3Client{}
 	writer := &S3Writer{
 		client: mockClient,
-		bucket: "analytics-bucket",
-		prefix: "analytics/top-search-keywords",
+		bucket: config.AnalyticsS3DefaultBucket,
+		prefix: config.AnalyticsS3DefaultKeyPrefix,
 	}
 
 	report := &analyticskeywords.Report{
@@ -56,13 +83,20 @@ func TestS3Writer_WriteUploadsLatestObject(t *testing.T) {
 		t.Fatalf("expected 1 object, got %d", len(mockClient.objects))
 	}
 
-	latestKey := "analytics/top-search-keywords/latest.json"
-	if _, ok := mockClient.objects[latestKey]; !ok {
+	latestKey := config.AnalyticsS3DefaultKeyPrefix + "/latest.json"
+	object, ok := mockClient.objects[latestKey]
+	if !ok {
 		t.Fatalf("missing latest object")
+	}
+	if object.contentType != "application/json" {
+		t.Fatalf("expected application/json content type, got %q", object.contentType)
+	}
+	if object.cacheControl != config.AnalyticsLatestJSONCacheControl {
+		t.Fatalf("expected cache control %q, got %q", config.AnalyticsLatestJSONCacheControl, object.cacheControl)
 	}
 
 	var decoded analyticskeywords.Report
-	if err := json.Unmarshal(mockClient.objects[latestKey], &decoded); err != nil {
+	if err := json.Unmarshal(object.body, &decoded); err != nil {
 		t.Fatalf("decode report: %v", err)
 	}
 	if decoded.PropertyID != "123456789" {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The analytics keywords export now writes `latest.json` to the frontend S3 bucket (`gishathfetch.com`) by default, so the report can be fetched same-origin via CloudFront.

## Changes

- Default `ANALYTICS_S3_BUCKET` to `gishathfetch.com` when unset
- Set `Cache-Control: public, max-age=3600` on upload for edge caching between daily exports
- Add config constants for the default bucket, key prefix, and cache header
- Update README architecture/docs with the public URL and Lambda IAM note

## Public URL after deploy

`https://gishathfetch.com/analytics/top-search-keywords/latest.json`

## Post-merge AWS setup

If the Lambda still has `ANALYTICS_S3_BUCKET` pointing at a legacy analytics bucket, remove it or set it to `gishathfetch.com`, and ensure the Lambda role can `PutObject` on `arn:aws:s3:::gishathfetch.com/analytics/top-search-keywords/*`.

## Testing

- `go test -mod=vendor -failfast -timeout 5m ./store/analyticsreport/...`
- `make test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c38234e8-f2e2-47fb-b9f5-ab695d66b5c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c38234e8-f2e2-47fb-b9f5-ab695d66b5c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

