### PR TITLE
Show top search keywords on home page before first search

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import Footer from "./components/Footer";
 import Header from "./components/Header";
 import SearchForm from "./components/SearchForm";
 import SearchResults from "./components/SearchResults";
+import TopSearchKeywords from "./components/TopSearchKeywords";
 
 const CartOffcanvas = lazy(() => import("./components/CartOffcanvas"));
 const Modals = lazy(() => import("./components/Modals"));
@@ -15,6 +16,7 @@ import { BASE_URL, LGS_MAP, LGS_OPTIONS, MIN_SEARCH_LENGTH } from "./constants";
 // --- Hooks ---
 import useCart from "./hooks/useCart";
 import useSearch from "./hooks/useSearch";
+import useTopSearchKeywords from "./hooks/useTopSearchKeywords";
 
 const THEME_STORAGE_KEY = "gishathfetch-theme";
 
@@ -57,6 +59,10 @@ export default function App() {
     cancelSearch,
     retrySearch,
   } = useSearch();
+
+  const showTopSearchKeywords = !hasSearched;
+  const { keywords: topSearchKeywords, isLoading: isLoadingTopSearchKeywords } =
+    useTopSearchKeywords(showTopSearchKeywords);
 
   const [modalType, setModalType] = useState(null);
   const [theme, setTheme] = useState(() => {
@@ -158,6 +164,15 @@ export default function App() {
         storesWarning={storesWarning}
         onCancelSearch={cancelSearch}
       />
+
+      {showTopSearchKeywords && (
+        <TopSearchKeywords
+          keywords={topSearchKeywords}
+          isLoading={isLoadingTopSearchKeywords}
+          onKeywordClick={handleSuggestionClick}
+          disabled={isSearching}
+        />
+      )}
 
       <SearchResults
         results={searchResults}

--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -1,0 +1,59 @@
+const LOADING_SKELETON_KEYS = [
+  "top-search-keyword-skeleton-a",
+  "top-search-keyword-skeleton-b",
+  "top-search-keyword-skeleton-c",
+  "top-search-keyword-skeleton-d",
+  "top-search-keyword-skeleton-e",
+];
+
+export default function TopSearchKeywords({
+  keywords,
+  isLoading,
+  onKeywordClick,
+  disabled = false,
+}) {
+  if (isLoading) {
+    return (
+      <div className="mb-3 text-center">
+        <div className="small text-muted mb-2">
+          Popular searches (last 24 hours)
+        </div>
+        <div className="d-flex flex-wrap justify-content-center gap-2">
+          {LOADING_SKELETON_KEYS.map((key) => (
+            <span
+              key={key}
+              className="placeholder col-3 rounded-pill"
+              style={{ height: "31px" }}
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (keywords.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mb-3 text-center">
+      <div className="small text-muted mb-2">
+        Popular searches (last 24 hours)
+      </div>
+      <div className="d-flex flex-wrap justify-content-center gap-2">
+        {keywords.map((keyword) => (
+          <button
+            key={keyword}
+            type="button"
+            className="btn btn-outline-secondary btn-sm rounded-pill"
+            disabled={disabled}
+            aria-label={`Search for ${keyword}`}
+            onClick={() => onKeywordClick(keyword)}
+          >
+            {keyword}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -173,3 +173,9 @@ export const MAX_SEARCH_LENGTH = 150;
 export const API_BASE_URL = "https://api.gishathfetch.com/";
 
 export const BASE_URL = "https://gishathfetch.com/";
+
+// Same-origin on production (served from gishathfetch.com via CloudFront).
+export const TOP_SEARCH_KEYWORDS_URL =
+  "/analytics/top-search-keywords/latest.json";
+
+export const TOP_SEARCH_KEYWORDS_DISPLAY_LIMIT = 10;

--- a/frontend/src/hooks/useTopSearchKeywords.js
+++ b/frontend/src/hooks/useTopSearchKeywords.js
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+import {
+  TOP_SEARCH_KEYWORDS_DISPLAY_LIMIT,
+  TOP_SEARCH_KEYWORDS_URL,
+} from "../constants";
+
+function parseTopSearchKeywords(payload) {
+  const keywords = payload?.periods?.last24Hours?.keywords;
+  if (!Array.isArray(keywords)) {
+    return [];
+  }
+
+  return keywords
+    .map((item) => (typeof item?.term === "string" ? item.term.trim() : ""))
+    .filter(Boolean)
+    .slice(0, TOP_SEARCH_KEYWORDS_DISPLAY_LIMIT);
+}
+
+export default function useTopSearchKeywords(enabled) {
+  const [keywords, setKeywords] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const controller = new AbortController();
+    let cancelled = false;
+
+    const loadKeywords = async () => {
+      setIsLoading(true);
+      try {
+        const response = await fetch(TOP_SEARCH_KEYWORDS_URL, {
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          throw new Error(
+            `Failed to load top search keywords (${response.status})`,
+          );
+        }
+
+        const payload = await response.json();
+        if (!cancelled) {
+          setKeywords(parseTopSearchKeywords(payload));
+        }
+      } catch (error) {
+        if (!cancelled && error.name !== "AbortError") {
+          console.error("Failed to load top search keywords:", error);
+          setKeywords([]);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    loadKeywords();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [enabled]);
+
+  return { keywords, isLoading };
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -30,4 +30,12 @@ export default defineConfig({
     },
   ],
   base: "",
+  server: {
+    proxy: {
+      "/analytics": {
+        target: "https://gishathfetch.com",
+        changeOrigin: true,
+      },
+    },
+  },
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When a user lands on the home page without having searched yet, the app fetches `/analytics/top-search-keywords/latest.json` and shows the top 10 most-searched card names from the last 24 hours as clickable pills between the search form and the footer ad.

Clicking a keyword triggers the same search flow as autocomplete suggestions (`handleSuggestionClick` → `performSearch`).

## Changes

- **`TopSearchKeywords` component** — renders keyword pills with a loading skeleton
- **`useTopSearchKeywords` hook** — fetches and parses `periods.last24Hours.keywords`, limited to 10 terms
- **`App.jsx`** — shows the section only when `!hasSearched`
- **`constants.js`** — adds analytics URL and display limit
- **`vite.config.js`** — dev proxy for `/analytics` so the feature works on `localhost:5173`

## Screenshots

### Desktop (1280px)

![Top search keywords on desktop](https://cursor.com/artifacts/c/art-79736436-b328-41d4-bffc-840c6084287a)

### Mobile (390px)

![Top search keywords on mobile](https://cursor.com/artifacts/c/art-8175a42a-2837-4334-963f-2ebd2d479273)

## Testing

- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- `make test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc9c036e-38e5-4010-b4db-dcdb8571c438"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc9c036e-38e5-4010-b4db-dcdb8571c438"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

