### PR TITLE
Add toggle between 24-hour and 30-day popular searches

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -61,8 +61,10 @@ export default function App() {
   } = useSearch();
 
   const showTopSearchKeywords = !hasSearched;
-  const { keywords: topSearchKeywords, isLoading: isLoadingTopSearchKeywords } =
-    useTopSearchKeywords(showTopSearchKeywords);
+  const {
+    keywordsByPeriod: topSearchKeywordsByPeriod,
+    isLoading: isLoadingTopSearchKeywords,
+  } = useTopSearchKeywords(showTopSearchKeywords);
 
   const [modalType, setModalType] = useState(null);
   const [theme, setTheme] = useState(() => {
@@ -167,7 +169,7 @@ export default function App() {
 
       {showTopSearchKeywords && (
         <TopSearchKeywords
-          keywords={topSearchKeywords}
+          keywordsByPeriod={topSearchKeywordsByPeriod}
           isLoading={isLoadingTopSearchKeywords}
           onKeywordClick={handleSuggestionClick}
           disabled={isSearching}

--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -21,14 +21,14 @@ function hasAnyKeywords(keywordsByPeriod) {
 
 function PeriodToggle({ period, onPeriodChange, disabled }) {
   return (
-    <fieldset className="btn-group btn-group-sm border-0 p-0 m-0">
+    <fieldset className="popular-search-period-toggle border-0 p-0 m-0">
       <legend className="visually-hidden">Popular search time range</legend>
       {PERIOD_OPTIONS.map((option) => (
         <button
           key={option.id}
           type="button"
-          className={`btn ${
-            period === option.id ? "btn-secondary" : "btn-outline-secondary"
+          className={`btn btn-sm popular-search-period-btn${
+            period === option.id ? " is-active" : ""
           }`}
           disabled={disabled}
           aria-pressed={period === option.id}

--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -21,8 +21,7 @@ function hasAnyKeywords(keywordsByPeriod) {
 
 function PeriodToggle({ period, onPeriodChange, disabled }) {
   return (
-    <fieldset className="popular-search-period-toggle border-0 p-0 m-0">
-      <legend className="visually-hidden">Popular search time range</legend>
+    <div className="popular-search-period-toggle">
       {PERIOD_OPTIONS.map((option) => (
         <button
           key={option.id}
@@ -37,6 +36,23 @@ function PeriodToggle({ period, onPeriodChange, disabled }) {
           {option.label}
         </button>
       ))}
+    </div>
+  );
+}
+
+function PopularSearchHeader({ period, onPeriodChange, disabled }) {
+  return (
+    <fieldset className="popular-search-header border-0 p-0 m-0 mb-2">
+      <div className="d-inline-flex align-items-center justify-content-center gap-2 flex-wrap">
+        <legend className="popular-search-legend small text-muted mb-0">
+          Popular searches:
+        </legend>
+        <PeriodToggle
+          period={period}
+          onPeriodChange={onPeriodChange}
+          disabled={disabled}
+        />
+      </div>
     </fieldset>
   );
 }
@@ -60,10 +76,11 @@ export default function TopSearchKeywords({
   if (isLoading) {
     return (
       <div className="mb-3 text-center">
-        <div className="small text-muted mb-2">Popular searches</div>
-        <div className="d-flex justify-content-center mb-2">
-          <PeriodToggle period={period} onPeriodChange={setPeriod} disabled />
-        </div>
+        <PopularSearchHeader
+          period={period}
+          onPeriodChange={setPeriod}
+          disabled
+        />
         <div className="d-flex flex-wrap justify-content-center gap-2">
           {LOADING_SKELETON_KEYS.map((key) => (
             <span
@@ -79,14 +96,11 @@ export default function TopSearchKeywords({
 
   return (
     <div className="mb-3 text-center">
-      <div className="small text-muted mb-2">Popular searches</div>
-      <div className="d-flex justify-content-center mb-2">
-        <PeriodToggle
-          period={period}
-          onPeriodChange={setPeriod}
-          disabled={disabled}
-        />
-      </div>
+      <PopularSearchHeader
+        period={period}
+        onPeriodChange={setPeriod}
+        disabled={disabled}
+      />
       {keywords.length > 0 ? (
         <div className="d-flex flex-wrap justify-content-center gap-2">
           {keywords.map((keyword) => (

--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+
 const LOADING_SKELETON_KEYS = [
   "top-search-keyword-skeleton-a",
   "top-search-keyword-skeleton-b",
@@ -6,17 +8,61 @@ const LOADING_SKELETON_KEYS = [
   "top-search-keyword-skeleton-e",
 ];
 
+const PERIOD_OPTIONS = [
+  { id: "last24Hours", label: "24 hours" },
+  { id: "last30Days", label: "30 days" },
+];
+
+function hasAnyKeywords(keywordsByPeriod) {
+  return PERIOD_OPTIONS.some(
+    (option) => (keywordsByPeriod?.[option.id]?.length ?? 0) > 0,
+  );
+}
+
+function PeriodToggle({ period, onPeriodChange, disabled }) {
+  return (
+    <fieldset className="btn-group btn-group-sm border-0 p-0 m-0">
+      <legend className="visually-hidden">Popular search time range</legend>
+      {PERIOD_OPTIONS.map((option) => (
+        <button
+          key={option.id}
+          type="button"
+          className={`btn ${
+            period === option.id ? "btn-secondary" : "btn-outline-secondary"
+          }`}
+          disabled={disabled}
+          aria-pressed={period === option.id}
+          onClick={() => onPeriodChange(option.id)}
+        >
+          {option.label}
+        </button>
+      ))}
+    </fieldset>
+  );
+}
+
 export default function TopSearchKeywords({
-  keywords,
+  keywordsByPeriod,
   isLoading,
   onKeywordClick,
   disabled = false,
 }) {
+  const [period, setPeriod] = useState("last24Hours");
+
+  if (!isLoading && !hasAnyKeywords(keywordsByPeriod)) {
+    return null;
+  }
+
+  const keywords = keywordsByPeriod?.[period] ?? [];
+  const selectedPeriodLabel =
+    PERIOD_OPTIONS.find((option) => option.id === period)?.label ?? "";
+
   if (isLoading) {
     return (
       <div className="mb-3 text-center">
-        <div className="small text-muted mb-2">
-          Popular searches (last 24 hours)
+        <div className="small text-muted mb-2">Popular searches</div>
+        <div className="d-flex justify-content-center mb-2">
+          <PeriodToggle period={period} onPeriodChange={setPeriod} disabled />
         </div>
         <div className="d-flex flex-wrap justify-content-center gap-2">
           {LOADING_SKELETON_KEYS.map((key) => (
@@ -31,29 +77,36 @@ export default function TopSearchKeywords({
     );
   }
 
-  if (keywords.length === 0) {
-    return null;
-  }
-
   return (
     <div className="mb-3 text-center">
-      <div className="small text-muted mb-2">
-        Popular searches (last 24 hours)
+      <div className="small text-muted mb-2">Popular searches</div>
+      <div className="d-flex justify-content-center mb-2">
+        <PeriodToggle
+          period={period}
+          onPeriodChange={setPeriod}
+          disabled={disabled}
+        />
       </div>
-      <div className="d-flex flex-wrap justify-content-center gap-2">
-        {keywords.map((keyword) => (
-          <button
-            key={keyword}
-            type="button"
-            className="btn btn-outline-secondary btn-sm rounded-pill"
-            disabled={disabled}
-            aria-label={`Search for ${keyword}`}
-            onClick={() => onKeywordClick(keyword)}
-          >
-            {keyword}
-          </button>
-        ))}
-      </div>
+      {keywords.length > 0 ? (
+        <div className="d-flex flex-wrap justify-content-center gap-2">
+          {keywords.map((keyword) => (
+            <button
+              key={keyword}
+              type="button"
+              className="btn btn-outline-secondary btn-sm rounded-pill"
+              disabled={disabled}
+              aria-label={`Search for ${keyword}`}
+              onClick={() => onKeywordClick(keyword)}
+            >
+              {keyword}
+            </button>
+          ))}
+        </div>
+      ) : (
+        <div className="small text-muted">
+          No popular searches in the last {selectedPeriodLabel}.
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -44,7 +44,7 @@ function PopularSearchHeader({ period, onPeriodChange, disabled }) {
   return (
     <fieldset className="popular-search-header border-0 p-0 m-0 mb-2">
       <div className="d-inline-flex align-items-center justify-content-center gap-2 flex-wrap">
-        <legend className="popular-search-legend small text-muted mb-0">
+        <legend className="popular-search-legend small mb-0">
           Popular searches:
         </legend>
         <PeriodToggle

--- a/frontend/src/hooks/useTopSearchKeywords.js
+++ b/frontend/src/hooks/useTopSearchKeywords.js
@@ -4,8 +4,7 @@ import {
   TOP_SEARCH_KEYWORDS_URL,
 } from "../constants";
 
-function parseTopSearchKeywords(payload) {
-  const keywords = payload?.periods?.last24Hours?.keywords;
+function parseKeywordList(keywords) {
   if (!Array.isArray(keywords)) {
     return [];
   }
@@ -16,8 +15,22 @@ function parseTopSearchKeywords(payload) {
     .slice(0, TOP_SEARCH_KEYWORDS_DISPLAY_LIMIT);
 }
 
+function parseTopSearchKeywords(payload) {
+  return {
+    last24Hours: parseKeywordList(payload?.periods?.last24Hours?.keywords),
+    last30Days: parseKeywordList(payload?.periods?.last30Days?.keywords),
+  };
+}
+
+const EMPTY_KEYWORDS_BY_PERIOD = {
+  last24Hours: [],
+  last30Days: [],
+};
+
 export default function useTopSearchKeywords(enabled) {
-  const [keywords, setKeywords] = useState([]);
+  const [keywordsByPeriod, setKeywordsByPeriod] = useState(
+    EMPTY_KEYWORDS_BY_PERIOD,
+  );
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
@@ -42,12 +55,12 @@ export default function useTopSearchKeywords(enabled) {
 
         const payload = await response.json();
         if (!cancelled) {
-          setKeywords(parseTopSearchKeywords(payload));
+          setKeywordsByPeriod(parseTopSearchKeywords(payload));
         }
       } catch (error) {
         if (!cancelled && error.name !== "AbortError") {
           console.error("Failed to load top search keywords:", error);
-          setKeywords([]);
+          setKeywordsByPeriod(EMPTY_KEYWORDS_BY_PERIOD);
         }
       } finally {
         if (!cancelled) {
@@ -64,5 +77,5 @@ export default function useTopSearchKeywords(enabled) {
     };
   }, [enabled]);
 
-  return { keywords, isLoading };
+  return { keywordsByPeriod, isLoading };
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -203,6 +203,8 @@ ins.adsbygoogle iframe {
   float: none;
   width: auto;
   padding: 0;
+  color: var(--bs-secondary-color);
+  opacity: 0.7;
 }
 
 .popular-search-period-toggle {
@@ -213,15 +215,20 @@ ins.adsbygoogle iframe {
 
 .popular-search-period-btn {
   border-radius: var(--bs-border-radius-pill);
-  border: 1px solid var(--bs-secondary);
+  border: 1px solid var(--bs-primary);
   background-color: transparent;
-  color: var(--bs-secondary);
+  color: var(--bs-primary);
 }
 
-.popular-search-period-btn.is-active,
-.popular-search-period-btn:hover:not(:disabled),
-.popular-search-period-btn:focus-visible:not(:disabled) {
-  background-color: var(--bs-secondary);
-  border-color: var(--bs-secondary);
+.popular-search-period-btn.is-active {
+  background-color: var(--bs-primary);
+  border-color: var(--bs-primary);
   color: var(--bs-white);
+}
+
+.popular-search-period-btn:hover:not(:disabled):not(.is-active),
+.popular-search-period-btn:focus-visible:not(:disabled):not(.is-active) {
+  background-color: rgba(var(--bs-primary-rgb), 0.15);
+  border-color: var(--bs-primary);
+  color: var(--bs-primary);
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -194,3 +194,24 @@ ins.adsbygoogle iframe {
     var(--bs-body-bg)
   );
 }
+
+.popular-search-period-toggle {
+  display: inline-flex;
+  gap: 0.375rem;
+  align-items: center;
+}
+
+.popular-search-period-btn {
+  border-radius: var(--bs-border-radius-pill);
+  border: 1px solid var(--bs-secondary);
+  background-color: transparent;
+  color: var(--bs-secondary);
+}
+
+.popular-search-period-btn.is-active,
+.popular-search-period-btn:hover:not(:disabled),
+.popular-search-period-btn:focus-visible:not(:disabled) {
+  background-color: var(--bs-secondary);
+  border-color: var(--bs-secondary);
+  color: var(--bs-white);
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -203,8 +203,11 @@ ins.adsbygoogle iframe {
   float: none;
   width: auto;
   padding: 0;
-  color: var(--bs-secondary-color);
-  opacity: 0.7;
+  color: #000;
+}
+
+[data-bs-theme="dark"] .popular-search-legend {
+  color: var(--bs-body-color);
 }
 
 .popular-search-period-toggle {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -195,6 +195,16 @@ ins.adsbygoogle iframe {
   );
 }
 
+.popular-search-header {
+  text-align: center;
+}
+
+.popular-search-legend {
+  float: none;
+  width: auto;
+  padding: 0;
+}
+
 .popular-search-period-toggle {
   display: inline-flex;
   gap: 0.375rem;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a segmented toggle on the home page popular searches section so users can switch between **last 24 hours** and **last 30 days**. The analytics API already returns both periods; this change only updates the frontend to expose that data.

## Changes

- **`useTopSearchKeywords`**: Parses and returns keywords for both `last24Hours` and `last30Days` from the existing analytics JSON payload.
- **`TopSearchKeywords`**: Adds a pill-style toggle (24 hours / 30 days) and displays keywords for the selected period. The label and toggle are inlined on one row (`Popular searches: 24 hours 30 days`).
- **`index.css`**: Active period uses primary blue (matching the Search button); inactive options use outline primary. The label is solid black in light mode.
- **`App.jsx`**: Wires the updated hook return shape into the component.

## Testing

- `npx biome check` on changed frontend files (passes)
- No backend changes required

## Screenshots

### Desktop header (1280×900)

**24 hours selected**

![Desktop popular searches header — 24 hours selected (20260628-v2)](https://cursor.com/artifacts/c/art-c93a8899-4122-4bc4-94e7-5a0ff65b34af)

**30 days selected**

![Desktop popular searches header — 30 days selected (20260628-v2)](https://cursor.com/artifacts/c/art-438d6e32-5eef-4649-8aa6-1bdc0b869bbe)

### Desktop full page (1280×900)

**24 hours**

![Desktop full page — 24 hours selected (20260628-v2)](https://cursor.com/artifacts/c/art-3860dff7-c73e-4da6-8d73-b506346645f3)

**30 days**

![Desktop full page — 30 days selected (20260628-v2)](https://cursor.com/artifacts/c/art-dfeaacb8-b9a5-4fd4-84d9-81302786576f)

### Mobile header (390×844)

**24 hours selected**

![Mobile popular searches header — 24 hours selected (20260628-v2)](https://cursor.com/artifacts/c/art-33496152-7a72-4abb-b277-afb98c53e7ce)

**30 days selected**

![Mobile popular searches header — 30 days selected (20260628-v2)](https://cursor.com/artifacts/c/art-ad42bca6-d4d4-4b7f-a622-a9146fccfae3)

### Mobile full page (390×844)

**24 hours**

![Mobile full page — 24 hours selected (20260628-v2)](https://cursor.com/artifacts/c/art-aa1bb55a-f81e-4d32-91c8-3e3b8a56819a)

**30 days**

![Mobile full page — 30 days selected (20260628-v2)](https://cursor.com/artifacts/c/art-1435c2a3-0367-4729-8617-2024842429e0)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e9089f9-4dd6-4ebf-b2db-ada813a80fd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e9089f9-4dd6-4ebf-b2db-ada813a80fd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

