### PR TITLE
Keep popular searches visible above footer ad

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -60,11 +60,10 @@ export default function App() {
     retrySearch,
   } = useSearch();
 
-  const showTopSearchKeywords = !hasSearched;
   const {
     keywordsByPeriod: topSearchKeywordsByPeriod,
     isLoading: isLoadingTopSearchKeywords,
-  } = useTopSearchKeywords(showTopSearchKeywords);
+  } = useTopSearchKeywords(true);
 
   const [modalType, setModalType] = useState(null);
   const [theme, setTheme] = useState(() => {
@@ -167,15 +166,6 @@ export default function App() {
         onCancelSearch={cancelSearch}
       />
 
-      {showTopSearchKeywords && (
-        <TopSearchKeywords
-          keywordsByPeriod={topSearchKeywordsByPeriod}
-          isLoading={isLoadingTopSearchKeywords}
-          onKeywordClick={handleSuggestionClick}
-          disabled={isSearching}
-        />
-      )}
-
       <SearchResults
         results={searchResults}
         searchQuery={searchQuery}
@@ -192,6 +182,13 @@ export default function App() {
         onSearchStore={handleCardSearch}
         cardKingdomPrice={cardKingdomPrice}
         baseUrl={BASE_URL}
+      />
+
+      <TopSearchKeywords
+        keywordsByPeriod={topSearchKeywordsByPeriod}
+        isLoading={isLoadingTopSearchKeywords}
+        onKeywordClick={handleSuggestionClick}
+        disabled={isSearching}
       />
 
       <Footer


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Move the popular searches section below search results and directly above the footer ad slot.
- Always render the section (and fetch keywords on load), instead of hiding it after the first search.
- Rebased onto latest `master`, preserving the 24-hour / 30-day period toggle from #178.

## Test plan

- [x] `cd frontend && npm run lint`
- [ ] Load the homepage and confirm popular searches appear below search results before any search.
- [ ] Run a search and confirm popular searches remain visible above the footer ad.
- [ ] Toggle between 24-hour and 30-day periods and confirm keywords update.
- [ ] Click a popular search keyword and confirm it triggers a search.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ecc835f9-fc81-4042-9d16-d417b89d6b4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ecc835f9-fc81-4042-9d16-d417b89d6b4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

