### PR TITLE
Add AdSense exclusion class to popular searches section

### DIFF
--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -13,6 +13,10 @@ const PERIOD_OPTIONS = [
   { id: "last30Days", label: "30 days" },
 ];
 
+// Stable selector for AdSense "Excluded areas" and google-anno-skip for ad intents.
+const SECTION_CLASS_NAME =
+  "popular-searches-section google-anno-skip mb-3 text-center";
+
 function hasAnyKeywords(keywordsByPeriod) {
   return PERIOD_OPTIONS.some(
     (option) => (keywordsByPeriod?.[option.id]?.length ?? 0) > 0,
@@ -75,7 +79,7 @@ export default function TopSearchKeywords({
 
   if (isLoading) {
     return (
-      <div className="mb-3 text-center">
+      <div className={SECTION_CLASS_NAME}>
         <PopularSearchHeader
           period={period}
           onPeriodChange={setPeriod}
@@ -95,7 +99,7 @@ export default function TopSearchKeywords({
   }
 
   return (
-    <div className="mb-3 text-center">
+    <div className={SECTION_CLASS_NAME}>
       <PopularSearchHeader
         period={period}
         onPeriodChange={setPeriod}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds stable CSS classes to the Popular searches block so Google AdSense can be told not to inject Related Search chips (e.g. "MTG Card Search") into that area.

## Changes

- `popular-searches-section` — use this selector in AdSense **Ads → Edit site → Excluded areas**
- `google-anno-skip` — opt-out class for Ad intents links/chips per [Google's documentation](https://support.google.com/adsense/answer/13844047)

## AdSense setup (after deploy)

1. Sign in to AdSense → **Ads** → **Edit** next to `gishathfetch.com`
2. Open **Excluded areas**
3. Exclude the `.popular-searches-section` region (or click it in the preview)
4. Click **Apply to site**

Alternatively, disable **Related search** under **In-page formats** if you prefer to turn it off site-wide.

## Testing

- `cd frontend && npm run lint` — passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cd13e8a8-62df-4270-b01d-ecb37aec7865"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd13e8a8-62df-4270-b01d-ecb37aec7865"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

