### PR TITLE
Use muted colors for popular search pills with primary highlight

### DIFF
--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -111,7 +111,7 @@ export default function TopSearchKeywords({
             <button
               key={keyword}
               type="button"
-              className="btn btn-outline-secondary btn-sm rounded-pill"
+              className="btn btn-sm popular-search-pill"
               disabled={disabled}
               aria-label={`Search for ${keyword}`}
               onClick={() => onKeywordClick(keyword)}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -235,3 +235,17 @@ ins.adsbygoogle iframe {
   border-color: var(--bs-primary);
   color: var(--bs-primary);
 }
+
+.popular-search-pill {
+  border-radius: var(--bs-border-radius-pill);
+  border: 1px solid var(--bs-border-color);
+  background-color: var(--bs-tertiary-bg);
+  color: var(--bs-secondary-color);
+}
+
+.popular-search-pill:hover:not(:disabled),
+.popular-search-pill:focus-visible:not(:disabled) {
+  background-color: rgba(var(--bs-primary-rgb), 0.15);
+  border-color: var(--bs-primary);
+  color: var(--bs-primary);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Replaced `btn-outline-secondary` on popular search keyword pills with a dedicated `popular-search-pill` style.
- Default state uses muted Bootstrap theme tokens (`tertiary-bg`, `border-color`, `secondary-color`) so the pills sit more quietly below the period toggle.
- Hover and focus states switch to the primary color, matching the period toggle highlight treatment.

## Test plan

- [x] `make test`
- [x] `cd frontend && npm run lint`
- [x] Verified popular search pills render with muted styling in local dev
- [x] Verified hover/focus uses primary color

## Screenshots

### Desktop (default)

![Popular search pills on desktop with muted styling](https://cursor.com/artifacts/c/art-a0383ca0-3d3a-440e-bd2f-c1bbb94da98a)

### Desktop (hover)

![Popular search pill on desktop with primary highlight on hover](https://cursor.com/artifacts/c/art-4ed663e2-b198-4f6a-be0d-0b556251367a)

### Mobile (default)

![Popular search pills on mobile with muted styling](https://cursor.com/artifacts/c/art-698e3671-b555-4069-9bd4-cf88a707197a)

### Mobile (hover)

![Popular search pill on mobile with primary highlight on hover](https://cursor.com/artifacts/c/art-150de842-5f5a-4373-bb8d-6805ee323444)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e79a9986-33e1-442b-aaff-d5d7c35c55bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e79a9986-33e1-442b-aaff-d5d7c35c55bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

