### PR TITLE
Show fewer popular searches on mobile viewports

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -187,8 +187,6 @@ export default function App() {
       <TopSearchKeywords
         keywordsByPeriod={topSearchKeywordsByPeriod}
         isLoading={isLoadingTopSearchKeywords}
-        onKeywordClick={handleSuggestionClick}
-        disabled={isSearching}
       />
 
       <Footer

--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -1,4 +1,10 @@
 import { useState } from "react";
+import {
+  DESKTOP_MIN_WIDTH_MEDIA_QUERY,
+  TOP_SEARCH_KEYWORDS_DISPLAY_LIMIT,
+  TOP_SEARCH_KEYWORDS_MOBILE_DISPLAY_LIMIT,
+} from "../constants";
+import useMediaQuery from "../hooks/useMediaQuery";
 
 const LOADING_SKELETON_KEYS = [
   "top-search-keyword-skeleton-a",
@@ -6,6 +12,11 @@ const LOADING_SKELETON_KEYS = [
   "top-search-keyword-skeleton-c",
   "top-search-keyword-skeleton-d",
   "top-search-keyword-skeleton-e",
+  "top-search-keyword-skeleton-f",
+  "top-search-keyword-skeleton-g",
+  "top-search-keyword-skeleton-h",
+  "top-search-keyword-skeleton-i",
+  "top-search-keyword-skeleton-j",
 ];
 
 const PERIOD_OPTIONS = [
@@ -61,6 +72,12 @@ function PopularSearchHeader({ period, onPeriodChange, disabled }) {
   );
 }
 
+function getDisplayLimit(isDesktop) {
+  return isDesktop
+    ? TOP_SEARCH_KEYWORDS_DISPLAY_LIMIT
+    : TOP_SEARCH_KEYWORDS_MOBILE_DISPLAY_LIMIT;
+}
+
 export default function TopSearchKeywords({
   keywordsByPeriod,
   isLoading,
@@ -68,12 +85,14 @@ export default function TopSearchKeywords({
   disabled = false,
 }) {
   const [period, setPeriod] = useState("last24Hours");
+  const isDesktop = useMediaQuery(DESKTOP_MIN_WIDTH_MEDIA_QUERY);
+  const displayLimit = getDisplayLimit(isDesktop);
 
   if (!isLoading && !hasAnyKeywords(keywordsByPeriod)) {
     return null;
   }
 
-  const keywords = keywordsByPeriod?.[period] ?? [];
+  const keywords = (keywordsByPeriod?.[period] ?? []).slice(0, displayLimit);
   const selectedPeriodLabel =
     PERIOD_OPTIONS.find((option) => option.id === period)?.label ?? "";
 
@@ -86,7 +105,7 @@ export default function TopSearchKeywords({
           disabled
         />
         <div className="d-flex flex-wrap justify-content-center gap-2">
-          {LOADING_SKELETON_KEYS.map((key) => (
+          {LOADING_SKELETON_KEYS.slice(0, displayLimit).map((key) => (
             <span
               key={key}
               className="placeholder col-3 rounded-pill"

--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -1,10 +1,12 @@
 import { useState } from "react";
 import {
+  BASE_URL,
   DESKTOP_MIN_WIDTH_MEDIA_QUERY,
   TOP_SEARCH_KEYWORDS_DISPLAY_LIMIT,
   TOP_SEARCH_KEYWORDS_MOBILE_DISPLAY_LIMIT,
 } from "../constants";
 import useMediaQuery from "../hooks/useMediaQuery";
+import { buildSearchQueryUrl } from "../utils/searchUrl";
 
 const LOADING_SKELETON_KEYS = [
   "top-search-keyword-skeleton-a",
@@ -78,12 +80,7 @@ function getDisplayLimit(isDesktop) {
     : TOP_SEARCH_KEYWORDS_MOBILE_DISPLAY_LIMIT;
 }
 
-export default function TopSearchKeywords({
-  keywordsByPeriod,
-  isLoading,
-  onKeywordClick,
-  disabled = false,
-}) {
+export default function TopSearchKeywords({ keywordsByPeriod, isLoading }) {
   const [period, setPeriod] = useState("last24Hours");
   const isDesktop = useMediaQuery(DESKTOP_MIN_WIDTH_MEDIA_QUERY);
   const displayLimit = getDisplayLimit(isDesktop);
@@ -119,24 +116,18 @@ export default function TopSearchKeywords({
 
   return (
     <div className={SECTION_CLASS_NAME}>
-      <PopularSearchHeader
-        period={period}
-        onPeriodChange={setPeriod}
-        disabled={disabled}
-      />
+      <PopularSearchHeader period={period} onPeriodChange={setPeriod} />
       {keywords.length > 0 ? (
         <div className="d-flex flex-wrap justify-content-center gap-2">
           {keywords.map((keyword) => (
-            <button
+            <a
               key={keyword}
-              type="button"
-              className="btn btn-sm popular-search-pill"
-              disabled={disabled}
+              href={buildSearchQueryUrl(BASE_URL, keyword)}
+              className="btn btn-sm popular-search-pill text-decoration-none"
               aria-label={`Search for ${keyword}`}
-              onClick={() => onKeywordClick(keyword)}
             >
               {keyword}
-            </button>
+            </a>
           ))}
         </div>
       ) : (

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -179,3 +179,5 @@ export const TOP_SEARCH_KEYWORDS_URL =
   "/analytics/top-search-keywords/latest.json";
 
 export const TOP_SEARCH_KEYWORDS_DISPLAY_LIMIT = 20;
+export const TOP_SEARCH_KEYWORDS_MOBILE_DISPLAY_LIMIT = 10;
+export const DESKTOP_MIN_WIDTH_MEDIA_QUERY = "(min-width: 768px)";

--- a/frontend/src/hooks/useMediaQuery.js
+++ b/frontend/src/hooks/useMediaQuery.js
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+
+function getInitialMatch(query) {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  return window.matchMedia(query).matches;
+}
+
+export default function useMediaQuery(query) {
+  const [matches, setMatches] = useState(() => getInitialMatch(query));
+
+  useEffect(() => {
+    const media = window.matchMedia(query);
+    const onChange = () => setMatches(media.matches);
+
+    onChange();
+    media.addEventListener("change", onChange);
+
+    return () => media.removeEventListener("change", onChange);
+  }, [query]);
+
+  return matches;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -243,8 +243,8 @@ ins.adsbygoogle iframe {
   color: var(--bs-secondary-color);
 }
 
-.popular-search-pill:hover:not(:disabled),
-.popular-search-pill:focus-visible:not(:disabled) {
+.popular-search-pill:hover,
+.popular-search-pill:focus-visible {
   background-color: rgba(var(--bs-primary-rgb), 0.15);
   border-color: var(--bs-primary);
   color: var(--bs-primary);

--- a/frontend/src/utils/searchUrl.js
+++ b/frontend/src/utils/searchUrl.js
@@ -90,6 +90,17 @@ export function buildSearchUrl(baseUrl, query, stores) {
 }
 
 /**
+ * @param {string} baseUrl
+ * @param {string} query
+ * @returns {string}
+ */
+export function buildSearchQueryUrl(baseUrl, query) {
+  const params = new URLSearchParams();
+  params.set("s", query);
+  return `${baseUrl}?${params.toString()}`;
+}
+
+/**
  * @param {URLSearchParams} urlParams
  * @returns {string[] | null}
  */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Popular searches now show **10 items on mobile** (viewports below Bootstrap `md`, 768px) and **20 items on desktop**, and each keyword is a **link to gishathfetch with the `?s=` query param** (e.g. `https://gishathfetch.com/?s=Lightning+Bolt`).

## Changes

- Added `TOP_SEARCH_KEYWORDS_MOBILE_DISPLAY_LIMIT` (10) and `DESKTOP_MIN_WIDTH_MEDIA_QUERY` constants
- Added a small `useMediaQuery` hook to react to viewport width changes
- `TopSearchKeywords` slices the keyword list at render time based on viewport, and adjusts loading skeleton count accordingly
- Replaced keyword buttons with `<a>` links using `buildSearchQueryUrl` so searches are shareable deep links
- Removed `onKeywordClick` / `disabled` props from `TopSearchKeywords` (navigation is handled by the link)

## Notes

- No backend or API changes needed — the analytics export already provides up to 20 keywords; display limit is a frontend slice.
- The `?s=` param matches the existing search URL format used elsewhere in the app (e.g. card search links).
- Resizing the browser across the 768px breakpoint updates the visible count live.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e52110d0-ab3b-4a78-b7cf-7a105663e205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e52110d0-ab3b-4a78-b7cf-7a105663e205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

