### PR TITLE
Frontpage UX and SEO improvements

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -23,13 +23,15 @@
   <meta name="keywords"
     content="MTG, Magic The Gathering, Singapore, LGS, online shop, card prices, price checker, local game store, TCG, trading card game, singles" />
 
-  <meta property="og:title" content="Gishath Fetch">
+  <meta property="og:title" content="Gishath Fetch: MTG Price Checker for Singapore's LGS & Online Shops">
   <meta property="og:site_name" content="Gishath Fetch">
   <meta property="og:url" content="https://gishathfetch.com/">
   <meta property="og:description"
     content="Compare MTG singles prices across 18 Singapore local game stores and online shops in one search. In-stock results sorted by price.">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://gishathfetch.com/img/og-image.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
 
   <!-- Preconnect to external domains for better performance -->
   <link rel="preconnect" href="https://api.scryfall.com">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -64,6 +64,14 @@
     "author": {
       "@type": "Person",
       "name": "Alvin Yeoh"
+    },
+    "potentialAction": {
+      "@type": "SearchAction",
+      "target": {
+        "@type": "EntryPoint",
+        "urlTemplate": "https://gishathfetch.com/?s={search_term_string}"
+      },
+      "query-input": "required name=search_term_string"
     }
   }
   </script>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -33,6 +33,12 @@
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
 
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Gishath Fetch: MTG Price Checker for Singapore's LGS & Online Shops">
+  <meta name="twitter:description"
+    content="Compare MTG singles prices across 18 Singapore local game stores and online shops in one search. In-stock results sorted by price.">
+  <meta name="twitter:image" content="https://gishathfetch.com/img/og-image.png">
+
   <!-- Preconnect to external domains for better performance -->
   <link rel="preconnect" href="https://api.scryfall.com">
   <link rel="preconnect" href="https://pagead2.googlesyndication.com">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -39,6 +39,8 @@
     content="Compare MTG singles prices across 18 Singapore local game stores and online shops in one search. In-stock results sorted by price.">
   <meta name="twitter:image" content="https://gishathfetch.com/img/og-image.png">
 
+  <link rel="canonical" href="https://gishathfetch.com/">
+
   <!-- Preconnect to external domains for better performance -->
   <link rel="preconnect" href="https://api.scryfall.com">
   <link rel="preconnect" href="https://pagead2.googlesyndication.com">

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -164,6 +164,14 @@ export default function App() {
         searchError={searchError}
         storesWarning={storesWarning}
         onCancelSearch={cancelSearch}
+        popularSearchesSlot={
+          !hasSearched ? (
+            <TopSearchKeywords
+              keywordsByPeriod={topSearchKeywordsByPeriod}
+              isLoading={isLoadingTopSearchKeywords}
+            />
+          ) : null
+        }
       />
 
       <SearchResults
@@ -184,10 +192,12 @@ export default function App() {
         baseUrl={BASE_URL}
       />
 
-      <TopSearchKeywords
-        keywordsByPeriod={topSearchKeywordsByPeriod}
-        isLoading={isLoadingTopSearchKeywords}
-      />
+      {hasSearched && (
+        <TopSearchKeywords
+          keywordsByPeriod={topSearchKeywordsByPeriod}
+          isLoading={isLoadingTopSearchKeywords}
+        />
+      )}
 
       <Footer
         cartCount={cart.length}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -165,13 +165,12 @@ export default function App() {
         storesWarning={storesWarning}
         onCancelSearch={cancelSearch}
         popularSearchesSlot={
-          !hasSearched ? (
-            <TopSearchKeywords
-              keywordsByPeriod={topSearchKeywordsByPeriod}
-              isLoading={isLoadingTopSearchKeywords}
-              collapsible
-            />
-          ) : null
+          <TopSearchKeywords
+            keywordsByPeriod={topSearchKeywordsByPeriod}
+            isLoading={isLoadingTopSearchKeywords}
+            collapsible
+            collapseOnSearch={isSearching}
+          />
         }
       />
 
@@ -192,13 +191,6 @@ export default function App() {
         cardKingdomPrice={cardKingdomPrice}
         baseUrl={BASE_URL}
       />
-
-      {hasSearched && (
-        <TopSearchKeywords
-          keywordsByPeriod={topSearchKeywordsByPeriod}
-          isLoading={isLoadingTopSearchKeywords}
-        />
-      )}
 
       <Footer
         cartCount={cart.length}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -169,6 +169,7 @@ export default function App() {
             <TopSearchKeywords
               keywordsByPeriod={topSearchKeywordsByPeriod}
               isLoading={isLoadingTopSearchKeywords}
+              collapsible
             />
           ) : null
         }

--- a/frontend/src/components/SearchForm.jsx
+++ b/frontend/src/components/SearchForm.jsx
@@ -23,6 +23,7 @@ const SearchForm = ({
   searchError,
   storesWarning,
   onCancelSearch,
+  popularSearchesSlot,
 }) => {
   const wrapperRef = useRef(null);
   const [selectedIndex, setSelectedIndex] = useState(-1);
@@ -179,6 +180,8 @@ const SearchForm = ({
             </div>
           )}
         </div>
+
+        {popularSearchesSlot}
 
         <StoreSelector
           options={lgsOptions}

--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -80,10 +80,16 @@ function getDisplayLimit(isDesktop) {
     : TOP_SEARCH_KEYWORDS_MOBILE_DISPLAY_LIMIT;
 }
 
-export default function TopSearchKeywords({ keywordsByPeriod, isLoading }) {
+export default function TopSearchKeywords({
+  keywordsByPeriod,
+  isLoading,
+  collapsible = false,
+}) {
   const [period, setPeriod] = useState("last24Hours");
+  const [isExpanded, setIsExpanded] = useState(!collapsible);
   const isDesktop = useMediaQuery(DESKTOP_MIN_WIDTH_MEDIA_QUERY);
   const displayLimit = getDisplayLimit(isDesktop);
+  const panelId = "popular-searches-panel";
 
   if (!isLoading && !hasAnyKeywords(keywordsByPeriod)) {
     return null;
@@ -93,9 +99,38 @@ export default function TopSearchKeywords({ keywordsByPeriod, isLoading }) {
   const selectedPeriodLabel =
     PERIOD_OPTIONS.find((option) => option.id === period)?.label ?? "";
 
+  if (collapsible && !isExpanded) {
+    return (
+      <div className={`${SECTION_CLASS_NAME} popular-searches-collapsed`}>
+        <button
+          type="button"
+          className="btn btn-link btn-sm p-0 text-decoration-none popular-searches-toggle"
+          aria-expanded="false"
+          aria-controls={panelId}
+          onClick={() => setIsExpanded(true)}
+        >
+          Show popular searches
+        </button>
+      </div>
+    );
+  }
+
   if (isLoading) {
     return (
-      <div className={SECTION_CLASS_NAME}>
+      <div className={SECTION_CLASS_NAME} id={panelId}>
+        {collapsible && (
+          <div className="mb-2">
+            <button
+              type="button"
+              className="btn btn-link btn-sm p-0 text-decoration-none popular-searches-toggle"
+              aria-expanded="true"
+              aria-controls={panelId}
+              onClick={() => setIsExpanded(false)}
+            >
+              Hide popular searches
+            </button>
+          </div>
+        )}
         <PopularSearchHeader
           period={period}
           onPeriodChange={setPeriod}
@@ -115,7 +150,20 @@ export default function TopSearchKeywords({ keywordsByPeriod, isLoading }) {
   }
 
   return (
-    <div className={SECTION_CLASS_NAME}>
+    <div className={SECTION_CLASS_NAME} id={panelId}>
+      {collapsible && (
+        <div className="mb-2">
+          <button
+            type="button"
+            className="btn btn-link btn-sm p-0 text-decoration-none popular-searches-toggle"
+            aria-expanded="true"
+            aria-controls={panelId}
+            onClick={() => setIsExpanded(false)}
+          >
+            Hide popular searches
+          </button>
+        </div>
+      )}
       <PopularSearchHeader period={period} onPeriodChange={setPeriod} />
       {keywords.length > 0 ? (
         <div className="d-flex flex-wrap justify-content-center gap-2">

--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   BASE_URL,
   DESKTOP_MIN_WIDTH_MEDIA_QUERY,
@@ -84,12 +84,19 @@ export default function TopSearchKeywords({
   keywordsByPeriod,
   isLoading,
   collapsible = false,
+  collapseOnSearch = false,
 }) {
   const [period, setPeriod] = useState("last24Hours");
   const [isExpanded, setIsExpanded] = useState(!collapsible);
   const isDesktop = useMediaQuery(DESKTOP_MIN_WIDTH_MEDIA_QUERY);
   const displayLimit = getDisplayLimit(isDesktop);
   const panelId = "popular-searches-panel";
+
+  useEffect(() => {
+    if (collapseOnSearch) {
+      setIsExpanded(false);
+    }
+  }, [collapseOnSearch]);
 
   if (!isLoading && !hasAnyKeywords(keywordsByPeriod)) {
     return null;

--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -28,7 +28,7 @@ const PERIOD_OPTIONS = [
 
 // Stable selector for AdSense "Excluded areas" and google-anno-skip for ad intents.
 const SECTION_CLASS_NAME =
-  "popular-searches-section google-anno-skip mb-3 text-center";
+  "popular-searches-section google-anno-skip mb-3";
 
 function hasAnyKeywords(keywordsByPeriod) {
   return PERIOD_OPTIONS.some(
@@ -60,7 +60,7 @@ function PeriodToggle({ period, onPeriodChange, disabled }) {
 function PopularSearchHeader({ period, onPeriodChange, disabled }) {
   return (
     <fieldset className="popular-search-header border-0 p-0 m-0 mb-2">
-      <div className="d-inline-flex align-items-center justify-content-center gap-2 flex-wrap">
+      <div className="d-flex align-items-center justify-content-start gap-2 flex-wrap">
         <legend className="popular-search-legend small mb-0">
           Popular searches:
         </legend>
@@ -136,7 +136,7 @@ export default function TopSearchKeywords({
           onPeriodChange={setPeriod}
           disabled
         />
-        <div className="d-flex flex-wrap justify-content-center gap-2">
+        <div className="d-flex flex-wrap justify-content-start gap-2">
           {LOADING_SKELETON_KEYS.slice(0, displayLimit).map((key) => (
             <span
               key={key}
@@ -166,7 +166,7 @@ export default function TopSearchKeywords({
       )}
       <PopularSearchHeader period={period} onPeriodChange={setPeriod} />
       {keywords.length > 0 ? (
-        <div className="d-flex flex-wrap justify-content-center gap-2">
+        <div className="d-flex flex-wrap justify-content-start gap-2">
           {keywords.map((keyword) => (
             <a
               key={keyword}

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -33,8 +33,6 @@ export const SITE_LOGO_SRC = "img/gishath-fetch-thor.png";
 // Keep in sync with meta/og descriptions in frontend/index.html.
 export const SITE_DESCRIPTION = `Compare MTG singles prices across ${LGS_OPTIONS.length} Singapore local game stores and online shops in one search. In-stock results sorted by price.`;
 
-export const SITE_OG_IMAGE_URL = "https://gishathfetch.com/img/og-image.png";
-
 export const LGS_MAP = [
   {
     id: "5-mana-map",

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -33,6 +33,8 @@ export const SITE_LOGO_SRC = "img/gishath-fetch-thor.png";
 // Keep in sync with meta/og descriptions in frontend/index.html.
 export const SITE_DESCRIPTION = `Compare MTG singles prices across ${LGS_OPTIONS.length} Singapore local game stores and online shops in one search. In-stock results sorted by price.`;
 
+export const SITE_OG_IMAGE_URL = "https://gishathfetch.com/img/og-image.png";
+
 export const LGS_MAP = [
   {
     id: "5-mana-map",

--- a/frontend/src/hooks/useSearch.js
+++ b/frontend/src/hooks/useSearch.js
@@ -15,6 +15,7 @@ import {
   isSearchHistoryState,
   persistSelectedStores,
 } from "../utils/searchUrl";
+import { applyHomeSeo, applySearchSeo } from "../utils/seo";
 
 const SEARCH_TOO_LONG_ERROR = `Card name is too long (maximum ${MAX_SEARCH_LENGTH} characters).`;
 const SEARCH_TOO_SHORT_ERROR = `Enter at least ${MIN_SEARCH_LENGTH} characters to search.`;
@@ -91,7 +92,11 @@ export default function useSearch() {
       : "replaceState";
 
     window.history[historyMethod](state, title, newUrl);
-    document.title = title;
+    if (snapshot.query) {
+      applySearchSeo(snapshot.query);
+    } else {
+      applyHomeSeo();
+    }
   }, []);
 
   const resolveStoresToSearch = useCallback((stores) => {
@@ -324,7 +329,7 @@ export default function useSearch() {
       setHasSearched(false);
       setIsSearching(false);
       setSearchProgress("Search");
-      document.title = PAGE_TITLE;
+      applyHomeSeo();
 
       if (
         query.length >= MIN_SEARCH_LENGTH &&
@@ -350,9 +355,11 @@ export default function useSearch() {
     setDismissedStoreErrorsKey(null);
     setIsSearching(false);
     setSearchProgress("Search");
-    document.title = state.query
-      ? `${state.query} @ Gishath Fetch`
-      : PAGE_TITLE;
+    if (state.query) {
+      applySearchSeo(state.query);
+    } else {
+      applyHomeSeo();
+    }
     restoringHistoryRef.current = false;
   }, []);
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -249,3 +249,7 @@ ins.adsbygoogle iframe {
   border-color: var(--bs-primary);
   color: var(--bs-primary);
 }
+
+.popular-searches-collapsed {
+  margin-bottom: 0.75rem;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -195,8 +195,12 @@ ins.adsbygoogle iframe {
   );
 }
 
+.popular-searches-section {
+  text-align: start;
+}
+
 .popular-search-header {
-  text-align: center;
+  text-align: start;
 }
 
 .popular-search-legend {
@@ -252,4 +256,8 @@ ins.adsbygoogle iframe {
 
 .popular-searches-collapsed {
   margin-bottom: 0.75rem;
+}
+
+.popular-searches-toggle {
+  text-align: start;
 }

--- a/frontend/src/utils/seo.js
+++ b/frontend/src/utils/seo.js
@@ -6,9 +6,7 @@ import {
 } from "../constants";
 
 function getOrCreateMeta(attrName, attrValue) {
-  let element = document.head.querySelector(
-    `meta[${attrName}="${attrValue}"]`,
-  );
+  let element = document.head.querySelector(`meta[${attrName}="${attrValue}"]`);
   if (!element) {
     element = document.createElement("meta");
     element.setAttribute(attrName, attrValue);
@@ -62,6 +60,7 @@ export function applySearchSeo(query) {
   setMetaContent("property", "og:url", url);
   setMetaContent("name", "twitter:title", title);
   setMetaContent("name", "twitter:description", description);
+  setCanonicalUrl(url);
 }
 
 export function applyHomeSeo() {
@@ -72,4 +71,5 @@ export function applyHomeSeo() {
   setMetaContent("property", "og:url", BASE_URL);
   setMetaContent("name", "twitter:title", PAGE_TITLE);
   setMetaContent("name", "twitter:description", SITE_DESCRIPTION);
+  setCanonicalUrl(BASE_URL);
 }

--- a/frontend/src/utils/seo.js
+++ b/frontend/src/utils/seo.js
@@ -21,6 +21,20 @@ function setMetaContent(attrName, attrValue, content) {
   getOrCreateMeta(attrName, attrValue).setAttribute("content", content);
 }
 
+function getOrCreateLink(rel) {
+  let element = document.head.querySelector(`link[rel="${rel}"]`);
+  if (!element) {
+    element = document.createElement("link");
+    element.setAttribute("rel", rel);
+    document.head.appendChild(element);
+  }
+  return element;
+}
+
+function setCanonicalUrl(url) {
+  getOrCreateLink("canonical").setAttribute("href", url);
+}
+
 export function buildSearchPageTitle(query) {
   return `${query} @ Gishath Fetch`;
 }

--- a/frontend/src/utils/seo.js
+++ b/frontend/src/utils/seo.js
@@ -1,0 +1,57 @@
+import {
+  BASE_URL,
+  LGS_OPTIONS,
+  PAGE_TITLE,
+  SITE_DESCRIPTION,
+} from "../constants";
+
+function getOrCreateMeta(attrName, attrValue) {
+  let element = document.head.querySelector(
+    `meta[${attrName}="${attrValue}"]`,
+  );
+  if (!element) {
+    element = document.createElement("meta");
+    element.setAttribute(attrName, attrValue);
+    document.head.appendChild(element);
+  }
+  return element;
+}
+
+function setMetaContent(attrName, attrValue, content) {
+  getOrCreateMeta(attrName, attrValue).setAttribute("content", content);
+}
+
+export function buildSearchPageTitle(query) {
+  return `${query} @ Gishath Fetch`;
+}
+
+export function buildSearchDescription(query) {
+  const storeCount = LGS_OPTIONS.length;
+  return `Compare ${query} prices across ${storeCount} Singapore MTG stores and online shops. In-stock results sorted by price.`;
+}
+
+export function buildSearchCanonicalUrl(query) {
+  const params = new URLSearchParams();
+  params.set("s", query);
+  return `${BASE_URL}?${params.toString()}`;
+}
+
+export function applySearchSeo(query) {
+  const title = buildSearchPageTitle(query);
+  const description = buildSearchDescription(query);
+  const url = buildSearchCanonicalUrl(query);
+
+  document.title = title;
+  setMetaContent("name", "description", description);
+  setMetaContent("property", "og:title", title);
+  setMetaContent("property", "og:description", description);
+  setMetaContent("property", "og:url", url);
+}
+
+export function applyHomeSeo() {
+  document.title = PAGE_TITLE;
+  setMetaContent("name", "description", SITE_DESCRIPTION);
+  setMetaContent("property", "og:title", PAGE_TITLE);
+  setMetaContent("property", "og:description", SITE_DESCRIPTION);
+  setMetaContent("property", "og:url", BASE_URL);
+}

--- a/frontend/src/utils/seo.js
+++ b/frontend/src/utils/seo.js
@@ -46,6 +46,8 @@ export function applySearchSeo(query) {
   setMetaContent("property", "og:title", title);
   setMetaContent("property", "og:description", description);
   setMetaContent("property", "og:url", url);
+  setMetaContent("name", "twitter:title", title);
+  setMetaContent("name", "twitter:description", description);
 }
 
 export function applyHomeSeo() {
@@ -54,4 +56,6 @@ export function applyHomeSeo() {
   setMetaContent("property", "og:title", PAGE_TITLE);
   setMetaContent("property", "og:description", SITE_DESCRIPTION);
   setMetaContent("property", "og:url", BASE_URL);
+  setMetaContent("name", "twitter:title", PAGE_TITLE);
+  setMetaContent("name", "twitter:description", SITE_DESCRIPTION);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the frontpage UX and SEO recommendations from the layout review:

1. **Popular searches under search bar** — always rendered between the card name input and store selector.
2. **Collapsible by default** — compact "Show popular searches" toggle on initial load.
3. **Collapse on search** — popular searches auto-collapse whenever a search starts.
4. **Left-aligned** — toggle, header, period filter, and keyword pills align to the start of the content column.
5. **Dynamic meta tags** — `seo.js` helper updates title, description, and Open Graph tags on search/history navigation.
6. **SearchAction JSON-LD**, **OG alignment**, **Twitter Cards**, and **canonical URLs**.

## UI screenshots

### Homepage — collapsed (default)

![Homepage collapsed mobile](https://cursor.com/artifacts/c/art-ed349ac1-353f-45fd-a93e-835cc7d7d47f)
![Homepage collapsed desktop](https://cursor.com/artifacts/c/art-f8ea6bde-124f-4663-9f0e-a8cdd90a1a39)

### Homepage — expanded popular searches

![Homepage expanded mobile](https://cursor.com/artifacts/c/art-63b89c13-0355-4ea9-a253-5e040391dfcb)
![Homepage expanded desktop](https://cursor.com/artifacts/c/art-d21ab86d-0f11-401b-95c6-7ec4ab384078)

## Testing

- `make test` — passed
- `cd frontend && npm run lint` — passed (pre-existing `noArguments` warning in `index.html` GA snippet)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b88a27d7-051f-486e-9685-9e6302c0bba4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b88a27d7-051f-486e-9685-9e6302c0bba4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

