### PR TITLE
Use responsive AdSense format for all ad placements

### DIFF
--- a/frontend/src/components/AdComponent.jsx
+++ b/frontend/src/components/AdComponent.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
-const AdComponent = ({ variant = "leaderboard" }) => {
+const AdComponent = () => {
   const adInitialized = useRef(false);
   const insRef = useRef(null);
   const [collapsed, setCollapsed] = useState(false);
@@ -24,8 +24,6 @@ const AdComponent = ({ variant = "leaderboard" }) => {
       console.error("AdSense error:", e);
     }
   }, []);
-
-  const isResponsive = variant === "responsive";
 
   useEffect(() => {
     const insEl = insRef.current;
@@ -84,15 +82,11 @@ const AdComponent = ({ variant = "leaderboard" }) => {
         <ins
           ref={insRef}
           className="adsbygoogle"
-          style={
-            isResponsive
-              ? { display: "block", width: "100%", maxWidth: "100%" }
-              : { display: "inline-block", width: "728px", height: "90px" }
-          }
+          style={{ display: "block", width: "100%", maxWidth: "100%" }}
           data-ad-client="ca-pub-2393161407259792"
           data-ad-slot="6707964257"
-          data-ad-format={isResponsive ? "auto" : undefined}
-          data-full-width-responsive={isResponsive ? "true" : undefined}
+          data-ad-format="auto"
+          data-full-width-responsive="true"
         ></ins>
       </div>
       <div className="text-secondary" style={{ fontSize: "11px" }}>

--- a/frontend/src/components/CartOffcanvas.jsx
+++ b/frontend/src/components/CartOffcanvas.jsx
@@ -108,7 +108,7 @@ const CartOffcanvas = ({
               ))}
 
             <div className="mt-4">
-              <AdComponent variant="responsive" />
+              <AdComponent />
             </div>
 
             {cart.length >= 2 && (

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -1,53 +1,11 @@
-import React, { useEffect } from "react";
 import { ArrowUp, FolderPlus, HelpCircle, Map as MapIcon } from "react-feather";
+import AdComponent from "./AdComponent";
 
 const Footer = ({ cartCount, onShowCart, onShowMap, onShowFaq }) => {
-  const adInitialized = React.useRef(false);
-
-  useEffect(() => {
-    if (adInitialized.current) return;
-    adInitialized.current = true;
-
-    try {
-      // biome-ignore lint/suspicious/noAssignInExpressions: Legacy Google Ads code
-      (window.adsbygoogle = window.adsbygoogle || []).push({});
-
-      // Parity fix: use setTimeout to set z-index for footer ads, exactly as in legacy index.js
-      setTimeout(() => {
-        const ads = document.querySelectorAll("ins.adsbygoogle");
-        ads.forEach((ad) => {
-          ad.style.zIndex = "1000";
-        });
-      }, 1000);
-    } catch (e) {
-      console.error("Footer AdSense error:", e);
-    }
-  }, []);
   return (
     <>
-      {/* Footer / Ads */}
-      <div className="ad-large mt-4 pb-5 text-center d-print-none d-block d-sm-block">
-        <div className="text-center mb-2" style={{ fontSize: "11px" }}>
-          <a
-            href="https://www.patreon.com/GishathFetch"
-            target="_blank"
-            rel="noreferrer"
-          >
-            Follow / Support Gishath Fetch on Patreon
-          </a>
-        </div>
-        <div style={{ minHeight: "90px" }}>
-          {/* AdSense slot placeholder */}
-          <ins
-            className="adsbygoogle"
-            style={{ display: "inline-block", width: "728px", height: "90px" }}
-            data-ad-client="ca-pub-2393161407259792"
-            data-ad-slot="6707964257"
-          ></ins>
-        </div>
-        <div className="text-secondary" style={{ fontSize: "11px" }}>
-          Advertisement
-        </div>
+      <div className="mt-4 pb-5">
+        <AdComponent />
       </div>
 
       {/* Fixed Bottom Navigation */}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Standardizes all AdSense slots on the responsive configuration already used in the saved cards offcanvas
- Removes the fixed 728×90 leaderboard variant from `AdComponent`
- Refactors `Footer` to reuse `AdComponent` instead of duplicating ad markup and initialization logic

## Changes

| Location | Before | After |
|----------|--------|-------|
| `AdComponent` (search results, footer, cart) | Fixed 728×90 by default; responsive only via `variant="responsive"` | Always responsive (`data-ad-format="auto"`, `data-full-width-responsive="true"`) |
| `Footer` | Inline fixed-size `<ins>` with separate `adsbygoogle.push` | Reuses `AdComponent` |
| `CartOffcanvas` | `variant="responsive"` prop | Plain `<AdComponent />` (no prop needed) |

## Why

Fixed leaderboard units often have poor fill rates on mobile. Using the same responsive unit everywhere should improve ad fill and revenue across screen sizes.

## Test plan

- [x] `npm run lint` (frontend)
- [x] `make test` — one unrelated transient failure in `gateway/agora` live probe (timeout); no frontend or ad logic changes in backend

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0532cab4-7617-4c1e-a233-bcfa293a9944"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0532cab4-7617-4c1e-a233-bcfa293a9944"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

