### PR TITLE
Add robots.txt and update it from analytics keywords export

### DIFF
--- a/api/controller/analyticskeywords/robots.go
+++ b/api/controller/analyticskeywords/robots.go
@@ -1,0 +1,81 @@
+package analyticskeywords
+
+import (
+	"net/url"
+	"sort"
+	"strings"
+)
+
+const RobotsTxtObjectKey = "robots.txt"
+
+// RobotsTxtBase is the static robots.txt body written before keyword URLs are appended.
+const RobotsTxtBase = `User-agent: *
+Allow: /
+
+Disallow: /analytics/
+`
+
+// CollectUniqueSearchTerms returns deduplicated card search terms from every report period.
+func CollectUniqueSearchTerms(report *Report) []string {
+	if report == nil || len(report.Periods) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	terms := make([]string, 0)
+	for _, period := range report.Periods {
+		for _, keyword := range period.Keywords {
+			term := strings.TrimSpace(keyword.Term)
+			if term == "" {
+				continue
+			}
+			if _, ok := seen[term]; ok {
+				continue
+			}
+			seen[term] = struct{}{}
+			terms = append(terms, term)
+		}
+	}
+
+	sort.Strings(terms)
+	return terms
+}
+
+// BuildSearchPagePath returns the canonical search page path for robots.txt Allow lines.
+func BuildSearchPagePath(term string) string {
+	query := url.Values{}
+	query.Set("s", term)
+	return "/?" + query.Encode()
+}
+
+// BuildSearchPageURL returns the canonical search page URL for a card name.
+func BuildSearchPageURL(baseURL, term string) string {
+	baseURL = strings.TrimSpace(baseURL)
+	if baseURL == "" {
+		baseURL = "https://gishathfetch.com/"
+	}
+	if !strings.HasSuffix(baseURL, "/") {
+		baseURL += "/"
+	}
+
+	return baseURL + strings.TrimPrefix(BuildSearchPagePath(term), "/")
+}
+
+// BuildRobotsTxt renders robots.txt with Allow entries for each unique search page URL.
+func BuildRobotsTxt(report *Report, baseURL string) string {
+	terms := CollectUniqueSearchTerms(report)
+	if len(terms) == 0 {
+		return RobotsTxtBase
+	}
+
+	var builder strings.Builder
+	builder.WriteString(RobotsTxtBase)
+	builder.WriteString("\n# Popular MTG card search pages (updated daily)\n")
+	for _, term := range terms {
+		builder.WriteString("Allow: ")
+		builder.WriteString(BuildSearchPageURL(baseURL, term))
+		builder.WriteByte('\n')
+	}
+
+	return builder.String()
+}

--- a/api/controller/analyticskeywords/robots_test.go
+++ b/api/controller/analyticskeywords/robots_test.go
@@ -1,0 +1,78 @@
+package analyticskeywords
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCollectUniqueSearchTerms_DeduplicatesAcrossPeriods(t *testing.T) {
+	report := &Report{
+		Periods: map[string]PeriodReport{
+			periodLast24Hours: {
+				Keywords: []KeywordCount{{Term: "Opt", Count: 4}},
+			},
+			periodLast7Days: {
+				Keywords: []KeywordCount{
+					{Term: "Opt", Count: 10},
+					{Term: "Lightning Bolt", Count: 8},
+				},
+			},
+			periodLast30Days: {
+				Keywords: []KeywordCount{{Term: "Sol Ring", Count: 20}},
+			},
+		},
+	}
+
+	terms := CollectUniqueSearchTerms(report)
+	if len(terms) != 3 {
+		t.Fatalf("expected 3 unique terms, got %d: %v", len(terms), terms)
+	}
+	if terms[0] != "Lightning Bolt" || terms[1] != "Opt" || terms[2] != "Sol Ring" {
+		t.Fatalf("unexpected sorted terms: %v", terms)
+	}
+}
+
+func TestBuildSearchPageURL_EncodesQuery(t *testing.T) {
+	got := BuildSearchPageURL("https://gishathfetch.com/", "Lightning Bolt")
+	want := "https://gishathfetch.com/?s=Lightning+Bolt"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestBuildRobotsTxt_IncludesUniqueKeywordURLs(t *testing.T) {
+	report := &Report{
+		Periods: map[string]PeriodReport{
+			periodLast24Hours: {
+				Keywords: []KeywordCount{{Term: "Opt", Count: 4}},
+			},
+			periodLast7Days: {
+				Keywords: []KeywordCount{
+					{Term: "Opt", Count: 10},
+					{Term: "Lightning Bolt", Count: 8},
+				},
+			},
+		},
+	}
+
+	robotsTxt := BuildRobotsTxt(report, "https://gishathfetch.com/")
+	if !strings.HasPrefix(robotsTxt, RobotsTxtBase) {
+		t.Fatalf("expected robots.txt to start with base policy")
+	}
+	if strings.Count(robotsTxt, "Allow: https://gishathfetch.com/?s=") != 2 {
+		t.Fatalf("expected 2 keyword allow URLs, got:\n%s", robotsTxt)
+	}
+	if !strings.Contains(robotsTxt, "Allow: https://gishathfetch.com/?s=Lightning+Bolt\n") {
+		t.Fatalf("missing Lightning Bolt URL in:\n%s", robotsTxt)
+	}
+	if !strings.Contains(robotsTxt, "Allow: https://gishathfetch.com/?s=Opt\n") {
+		t.Fatalf("missing Opt URL in:\n%s", robotsTxt)
+	}
+}
+
+func TestBuildRobotsTxt_ReturnsBaseWhenNoKeywords(t *testing.T) {
+	robotsTxt := BuildRobotsTxt(&Report{}, "https://gishathfetch.com/")
+	if robotsTxt != RobotsTxtBase {
+		t.Fatalf("expected base robots.txt only, got:\n%s", robotsTxt)
+	}
+}

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -65,6 +65,10 @@ const (
 	// AnalyticsLatestJSONCacheControl is applied to latest.json so CloudFront can cache it
 	// between daily exports without a separate invalidation.
 	AnalyticsLatestJSONCacheControl = "public, max-age=3600"
+	// RobotsTxtCacheControl is applied to robots.txt so CloudFront can cache it between daily exports.
+	RobotsTxtCacheControl = "public, max-age=3600"
+	// SiteBaseURL is the public frontend origin used when generating robots.txt search URLs.
+	SiteBaseURL = "https://gishathfetch.com/"
 	// AWSRegion is the AWS region used for DynamoDB and other managed services.
 	AWSRegion = "ap-southeast-1"
 )

--- a/api/store/analyticsreport/s3.go
+++ b/api/store/analyticsreport/s3.go
@@ -82,6 +82,18 @@ func (w *S3Writer) Write(ctx context.Context, report *analyticskeywords.Report) 
 		return fmt.Errorf("analyticsreport: put s3://%s/%s: %w", w.bucket, key, err)
 	}
 
+	robotsTxt := analyticskeywords.BuildRobotsTxt(report, config.SiteBaseURL)
+	_, err = w.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:       aws.String(w.bucket),
+		Key:          aws.String(analyticskeywords.RobotsTxtObjectKey),
+		Body:         bytes.NewReader([]byte(robotsTxt)),
+		ContentType:  aws.String("text/plain; charset=utf-8"),
+		CacheControl: aws.String(config.RobotsTxtCacheControl),
+	})
+	if err != nil {
+		return fmt.Errorf("analyticsreport: put s3://%s/%s: %w", w.bucket, analyticskeywords.RobotsTxtObjectKey, err)
+	}
+
 	return nil
 }
 

--- a/api/store/analyticsreport/s3_test.go
+++ b/api/store/analyticsreport/s3_test.go
@@ -79,8 +79,8 @@ func TestS3Writer_WriteUploadsLatestObject(t *testing.T) {
 		t.Fatalf("write report: %v", err)
 	}
 
-	if len(mockClient.objects) != 1 {
-		t.Fatalf("expected 1 object, got %d", len(mockClient.objects))
+	if len(mockClient.objects) != 2 {
+		t.Fatalf("expected 2 objects, got %d", len(mockClient.objects))
 	}
 
 	latestKey := config.AnalyticsS3DefaultKeyPrefix + "/latest.json"
@@ -101,5 +101,20 @@ func TestS3Writer_WriteUploadsLatestObject(t *testing.T) {
 	}
 	if decoded.PropertyID != "123456789" {
 		t.Fatalf("unexpected decoded report: %+v", decoded)
+	}
+
+	robotsObject, ok := mockClient.objects[analyticskeywords.RobotsTxtObjectKey]
+	if !ok {
+		t.Fatalf("missing robots.txt object")
+	}
+	if robotsObject.contentType != "text/plain; charset=utf-8" {
+		t.Fatalf("expected text/plain content type, got %q", robotsObject.contentType)
+	}
+	if robotsObject.cacheControl != config.RobotsTxtCacheControl {
+		t.Fatalf("expected cache control %q, got %q", config.RobotsTxtCacheControl, robotsObject.cacheControl)
+	}
+	expectedRobotsTxt := analyticskeywords.BuildRobotsTxt(report, config.SiteBaseURL)
+	if string(robotsObject.body) != expectedRobotsTxt {
+		t.Fatalf("unexpected robots.txt:\n%s", robotsObject.body)
 	}
 }

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Disallow: /analytics/


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds a baseline `robots.txt` to the frontend static assets that allows crawling the site while blocking the internal analytics JSON export path (`/analytics/`).
- Extends the daily `mtg-analytics-keywords-export` Lambda so it also uploads `robots.txt` to the frontend S3 bucket alongside `latest.json`.
- Each export deduplicates top search keywords across the 24-hour, 7-day, and 30-day periods and appends canonical `Allow` entries for their search page URLs (e.g. `https://gishathfetch.com/?s=Lightning+Bolt`).

## Implementation

- `frontend/public/robots.txt` — static baseline served before the first daily export runs.
- `api/controller/analyticskeywords/robots.go` — builds robots.txt content from the analytics report.
- `api/store/analyticsreport/s3.go` — uploads `robots.txt` to the bucket root on each export.

## Testing

- `make test`
- `cd api && go test -mod=vendor -failfast -timeout 5m ./controller/analyticskeywords/... ./store/analyticsreport/... ./handler/...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4793a83d-541b-4c71-a973-ce7f4fae608d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4793a83d-541b-4c71-a973-ce7f4fae608d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

