### PR TITLE
Fix Google anchor ads appearing behind the bottom footer

### DIFF
--- a/frontend/src/components/AdComponent.jsx
+++ b/frontend/src/components/AdComponent.jsx
@@ -12,14 +12,6 @@ const AdComponent = () => {
     try {
       // biome-ignore lint/suspicious/noAssignInExpressions: Legacy Google Ads code
       (window.adsbygoogle = window.adsbygoogle || []).push({});
-
-      // Parity fix: use setTimeout to set z-index, exactly as in legacy index.js
-      setTimeout(() => {
-        const ads = document.querySelectorAll("ins.adsbygoogle");
-        ads.forEach((ad) => {
-          ad.style.zIndex = "1000";
-        });
-      }, 1000);
     } catch (e) {
       console.error("AdSense error:", e);
     }

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -1,15 +1,18 @@
 import { ArrowUp, FolderPlus, HelpCircle, Map as MapIcon } from "react-feather";
+import useAnchorAdOffset from "../hooks/useAnchorAdOffset";
 import AdComponent from "./AdComponent";
 
 const Footer = ({ cartCount, onShowCart, onShowMap, onShowFaq }) => {
+  useAnchorAdOffset();
+
   return (
     <>
-      <div className="mt-4 pb-5">
+      <div className="mt-4 site-footer-spacer">
         <AdComponent />
       </div>
 
       {/* Fixed Bottom Navigation */}
-      <div className="fixed-bottom bg-primary text-light text-center">
+      <div className="site-bottom-nav bg-primary text-light text-center">
         <div className="d-flex flex-row align-items-center justify-content-center">
           <button
             type="button"

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -1,9 +1,9 @@
 import { ArrowUp, FolderPlus, HelpCircle, Map as MapIcon } from "react-feather";
-import useAnchorAdOffset from "../hooks/useAnchorAdOffset";
+import useBottomChromeLayout from "../hooks/useBottomChromeLayout";
 import AdComponent from "./AdComponent";
 
 const Footer = ({ cartCount, onShowCart, onShowMap, onShowFaq }) => {
-  useAnchorAdOffset();
+  useBottomChromeLayout();
 
   return (
     <>

--- a/frontend/src/hooks/useAnchorAdOffset.js
+++ b/frontend/src/hooks/useAnchorAdOffset.js
@@ -1,0 +1,73 @@
+import { useEffect } from "react";
+
+const ANCHOR_AD_SELECTOR = "ins.adsbygoogle.adsbygoogle-noablate";
+const CSS_VAR = "--anchor-ad-offset";
+
+function measureAnchorAdOffset() {
+  const anchorAd = document.querySelector(ANCHOR_AD_SELECTOR);
+  if (!anchorAd || !anchorAd.isConnected) {
+    return 0;
+  }
+
+  const status = anchorAd.getAttribute("data-anchor-status");
+  if (status === "dismissed") {
+    return 0;
+  }
+
+  const rect = anchorAd.getBoundingClientRect();
+  if (rect.height <= 0 || rect.bottom < window.innerHeight - 2) {
+    return 0;
+  }
+
+  return Math.ceil(rect.height);
+}
+
+function syncAnchorAdOffset() {
+  const offset = measureAnchorAdOffset();
+  document.documentElement.style.setProperty(CSS_VAR, `${offset}px`);
+  return offset;
+}
+
+export default function useAnchorAdOffset() {
+  useEffect(() => {
+    let rafId = 0;
+
+    const scheduleSync = () => {
+      if (rafId) {
+        cancelAnimationFrame(rafId);
+      }
+      rafId = requestAnimationFrame(() => {
+        rafId = 0;
+        syncAnchorAdOffset();
+      });
+    };
+
+    scheduleSync();
+
+    const observer = new MutationObserver(scheduleSync);
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ["style", "class", "data-anchor-status"],
+    });
+
+    window.addEventListener("resize", scheduleSync);
+
+    const pollId = window.setInterval(scheduleSync, 2000);
+    const stopPollId = window.setTimeout(() => {
+      window.clearInterval(pollId);
+    }, 30000);
+
+    return () => {
+      if (rafId) {
+        cancelAnimationFrame(rafId);
+      }
+      observer.disconnect();
+      window.removeEventListener("resize", scheduleSync);
+      window.clearInterval(pollId);
+      window.clearTimeout(stopPollId);
+      document.documentElement.style.removeProperty(CSS_VAR);
+    };
+  }, []);
+}

--- a/frontend/src/hooks/useAnchorAdOffset.js
+++ b/frontend/src/hooks/useAnchorAdOffset.js
@@ -3,23 +3,41 @@ import { useEffect } from "react";
 const ANCHOR_AD_SELECTOR = "ins.adsbygoogle.adsbygoogle-noablate";
 const CSS_VAR = "--anchor-ad-offset";
 
+function parsePixelValue(value) {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
 function measureAnchorAdOffset() {
-  const anchorAd = document.querySelector(ANCHOR_AD_SELECTOR);
-  if (!anchorAd || !anchorAd.isConnected) {
-    return 0;
+  const anchorAds = document.querySelectorAll(ANCHOR_AD_SELECTOR);
+  let maxOffset = 0;
+
+  for (const anchorAd of anchorAds) {
+    if (!anchorAd.isConnected) continue;
+
+    const status = anchorAd.getAttribute("data-anchor-status");
+    if (status === "dismissed") continue;
+
+    const rect = anchorAd.getBoundingClientRect();
+    const computed = window.getComputedStyle(anchorAd);
+    const height = Math.max(
+      rect.height,
+      anchorAd.offsetHeight,
+      parsePixelValue(computed.height),
+    );
+    if (height <= 0) continue;
+
+    const isBottomAnchored =
+      computed.position === "fixed" &&
+      parsePixelValue(computed.bottom) <= 4 &&
+      rect.bottom >= window.innerHeight - 4;
+
+    if (!isBottomAnchored) continue;
+
+    maxOffset = Math.max(maxOffset, Math.ceil(height));
   }
 
-  const status = anchorAd.getAttribute("data-anchor-status");
-  if (status === "dismissed") {
-    return 0;
-  }
-
-  const rect = anchorAd.getBoundingClientRect();
-  if (rect.height <= 0 || rect.bottom < window.innerHeight - 2) {
-    return 0;
-  }
-
-  return Math.ceil(rect.height);
+  return maxOffset;
 }
 
 function syncAnchorAdOffset() {

--- a/frontend/src/hooks/useBottomChromeLayout.js
+++ b/frontend/src/hooks/useBottomChromeLayout.js
@@ -1,16 +1,27 @@
 import { useEffect } from "react";
 
+const FOOTER_NAV_SELECTOR = ".site-bottom-nav";
 const ANCHOR_AD_SELECTOR = "ins.adsbygoogle.adsbygoogle-noablate";
-const CSS_VAR = "--anchor-ad-offset";
+const FOOTER_NAV_HEIGHT_VAR = "--footer-nav-height";
+const ANCHOR_AD_HEIGHT_VAR = "--anchor-ad-height";
 
 function parsePixelValue(value) {
   const parsed = Number.parseFloat(value);
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
-function measureAnchorAdOffset() {
+function measureFooterNavHeight() {
+  const footerNav = document.querySelector(FOOTER_NAV_SELECTOR);
+  if (!footerNav) {
+    return 0;
+  }
+
+  return Math.ceil(footerNav.getBoundingClientRect().height);
+}
+
+function measureAnchorAdHeight() {
   const anchorAds = document.querySelectorAll(ANCHOR_AD_SELECTOR);
-  let maxOffset = 0;
+  let maxHeight = 0;
 
   for (const anchorAd of anchorAds) {
     if (!anchorAd.isConnected) continue;
@@ -27,26 +38,27 @@ function measureAnchorAdOffset() {
     );
     if (height <= 0) continue;
 
-    const isBottomAnchored =
-      computed.position === "fixed" &&
-      parsePixelValue(computed.bottom) <= 4 &&
-      rect.bottom >= window.innerHeight - 4;
-
-    if (!isBottomAnchored) continue;
-
-    maxOffset = Math.max(maxOffset, Math.ceil(height));
+    maxHeight = Math.max(maxHeight, Math.ceil(height));
   }
 
-  return maxOffset;
+  return maxHeight;
 }
 
-function syncAnchorAdOffset() {
-  const offset = measureAnchorAdOffset();
-  document.documentElement.style.setProperty(CSS_VAR, `${offset}px`);
-  return offset;
+function syncBottomChromeLayout() {
+  const footerNavHeight = measureFooterNavHeight();
+  const anchorAdHeight = measureAnchorAdHeight();
+
+  document.documentElement.style.setProperty(
+    FOOTER_NAV_HEIGHT_VAR,
+    `${footerNavHeight}px`,
+  );
+  document.documentElement.style.setProperty(
+    ANCHOR_AD_HEIGHT_VAR,
+    `${anchorAdHeight}px`,
+  );
 }
 
-export default function useAnchorAdOffset() {
+export default function useBottomChromeLayout() {
   useEffect(() => {
     let rafId = 0;
 
@@ -56,7 +68,7 @@ export default function useAnchorAdOffset() {
       }
       rafId = requestAnimationFrame(() => {
         rafId = 0;
-        syncAnchorAdOffset();
+        syncBottomChromeLayout();
       });
     };
 
@@ -85,7 +97,8 @@ export default function useAnchorAdOffset() {
       window.removeEventListener("resize", scheduleSync);
       window.clearInterval(pollId);
       window.clearTimeout(stopPollId);
-      document.documentElement.style.removeProperty(CSS_VAR);
+      document.documentElement.style.removeProperty(FOOTER_NAV_HEIGHT_VAR);
+      document.documentElement.style.removeProperty(ANCHOR_AD_HEIGHT_VAR);
     };
   }, []);
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -306,11 +306,6 @@ input#search:focus-visible {
   -webkit-box-shadow: 0 0 1px rgba(255, 255, 255, 0.5);
 }
 
-/* Parity fix: Google Ads z-index */
-ins.adsbygoogle {
-  z-index: 1000;
-}
-
 /* Prevent AdSense from causing horizontal scrolling in narrow containers (e.g. offcanvas) */
 .ad-large {
   max-width: 100%;
@@ -330,6 +325,19 @@ ins.adsbygoogle {
 
 ins.adsbygoogle iframe {
   display: block;
+}
+
+.site-bottom-nav {
+  position: fixed;
+  right: 0;
+  left: 0;
+  bottom: var(--anchor-ad-offset, 0px);
+  z-index: 1030;
+  transition: bottom 0.2s ease;
+}
+
+.site-footer-spacer {
+  padding-bottom: calc(3rem + var(--anchor-ad-offset, 0px));
 }
 
 .bottom-nav-icon {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -327,17 +327,24 @@ ins.adsbygoogle iframe {
   display: block;
 }
 
+ins.adsbygoogle.adsbygoogle-noablate {
+  /* biome-ignore lint/complexity/noImportantStyles: Keep anchor ads above the fixed footer nav */
+  bottom: var(--footer-nav-height, 0px) !important;
+}
+
 .site-bottom-nav {
   position: fixed;
   right: 0;
   left: 0;
-  bottom: var(--anchor-ad-offset, 0px);
+  bottom: 0;
   z-index: 1030;
-  transition: bottom 0.2s ease;
 }
 
 .site-footer-spacer {
-  padding-bottom: calc(3rem + var(--anchor-ad-offset, 0px));
+  padding-bottom: calc(
+    var(--footer-nav-height, 3rem) +
+    var(--anchor-ad-height, 0px)
+  );
 }
 
 .bottom-nav-icon {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Google's bottom slide-up anchor ads were rendering underneath the fixed site footer, making them hard to see and interact with.

**Root cause:** A legacy `z-index: 1000` rule (and a JS timeout that applied the same value) was applied to all `ins.adsbygoogle` elements. Bootstrap's fixed footer uses `z-index: 1030`, so anchor auto ads (`ins.adsbygoogle.adsbygoogle-noablate`) ended up behind the nav bar.

**Fix:**
- Remove the global AdSense z-index override.
- Keep the footer nav pinned to `bottom: 0`.
- Measure footer nav height and push anchor ads upward with `bottom: var(--footer-nav-height)` so the ad sits **above** the footer.
- Add matching bottom spacer padding so page content is not hidden behind the footer + ad stack.

## Screenshots

Desktop (mock anchor ad injected to demonstrate layering):

![Desktop: anchor ad above footer nav](https://cursor.com/artifacts/c/art-c0c51040-9055-40ad-9873-eaad82eb70ea)

Mobile:

![Mobile: anchor ad above footer nav](https://cursor.com/artifacts/c/art-f9c0289c-03d3-4a59-acd5-08f5cadadb69)

## Test plan

- [x] `npm run lint` passes
- [x] Verified with a mock `ins.adsbygoogle.adsbygoogle-noablate` element that anchor ads get `bottom: 40px` (footer height) while footer stays at `bottom: 0`
- [ ] Confirm on production that real Google anchor ads slide up above the footer nav without being obscured
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b67535ca-7b2e-4c1b-b528-23dc876d6bd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b67535ca-7b2e-4c1b-b528-23dc876d6bd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

