### PR TITLE
Improve keyword search input UX

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -54,7 +54,6 @@ export default function App() {
     handleQueryChange,
     handleClearQuery,
     handleSuggestionClick,
-    handlePopularSearchClick,
     handleSearchSubmit,
     toggleStore,
     selectAllStores,
@@ -177,7 +176,6 @@ export default function App() {
             isLoading={isLoadingTopSearchKeywords}
             collapsible
             collapseOnSearch={isSearching}
-            onKeywordClick={handlePopularSearchClick}
           />
         }
       />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -47,10 +47,14 @@ export default function App() {
     suggestions,
     showSuggestions,
     setShowSuggestions,
+    isLoadingSuggestions,
+    showEmptySuggestions,
     selectedStores,
     setSelectedStores,
     handleQueryChange,
+    handleClearQuery,
     handleSuggestionClick,
+    handlePopularSearchClick,
     handleSearchSubmit,
     toggleStore,
     selectAllStores,
@@ -146,9 +150,12 @@ export default function App() {
       <SearchForm
         searchQuery={searchQuery}
         onQueryChange={handleQueryChange}
+        onClearQuery={handleClearQuery}
         onSearchSubmit={handleSearchSubmit}
         suggestions={suggestions}
         showSuggestions={showSuggestions}
+        showEmptySuggestions={showEmptySuggestions}
+        isLoadingSuggestions={isLoadingSuggestions}
         onSuggestionClick={handleSuggestionClick}
         onFocus={() =>
           searchQuery.length > MIN_SEARCH_LENGTH - 1 && setShowSuggestions(true)
@@ -170,6 +177,7 @@ export default function App() {
             isLoading={isLoadingTopSearchKeywords}
             collapsible
             collapseOnSearch={isSearching}
+            onKeywordClick={handlePopularSearchClick}
           />
         }
       />

--- a/frontend/src/components/SearchForm.jsx
+++ b/frontend/src/components/SearchForm.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { Loader, X } from "react-feather";
 import { MAX_SEARCH_LENGTH, MIN_SEARCH_LENGTH } from "../constants";
 import StoreSelector from "./StoreSelector";
 
@@ -7,9 +8,12 @@ const TIP_DISMISSED_STORAGE_KEY = "search-form-tip-dismissed";
 const SearchForm = ({
   searchQuery,
   onQueryChange,
+  onClearQuery,
   onSearchSubmit,
   suggestions,
   showSuggestions,
+  showEmptySuggestions,
+  isLoadingSuggestions,
   onSuggestionClick,
   onFocus,
   isSearching,
@@ -26,6 +30,7 @@ const SearchForm = ({
   popularSearchesSlot,
 }) => {
   const wrapperRef = useRef(null);
+  const inputRef = useRef(null);
   const [selectedIndex, setSelectedIndex] = useState(-1);
   const [showTip, setShowTip] = useState(() => {
     if (typeof window === "undefined") {
@@ -52,11 +57,54 @@ const SearchForm = ({
     };
   }, [onCloseSuggestions]);
 
+  useEffect(() => {
+    if (selectedIndex < 0) {
+      return;
+    }
+
+    document
+      .getElementById(`suggestion-${selectedIndex}`)
+      ?.scrollIntoView({ block: "nearest" });
+  }, [selectedIndex]);
+
+  useEffect(() => {
+    const handleGlobalKeyDown = (event) => {
+      if (event.key !== "/" || event.ctrlKey || event.metaKey || event.altKey) {
+        return;
+      }
+
+      const target = event.target;
+      if (target instanceof HTMLElement) {
+        const tag = target.tagName;
+        if (
+          tag === "INPUT" ||
+          tag === "TEXTAREA" ||
+          tag === "SELECT" ||
+          target.isContentEditable
+        ) {
+          return;
+        }
+      }
+
+      event.preventDefault();
+      inputRef.current?.focus();
+    };
+
+    document.addEventListener("keydown", handleGlobalKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleGlobalKeyDown);
+    };
+  }, []);
+
+  const handleInputChange = (event) => {
+    setSelectedIndex(-1);
+    onQueryChange(event);
+  };
+
   const handleKeyDown = (e) => {
     if (!showSuggestions || suggestions.length === 0) {
-      // Reset index when suggestions are not shown
-      if (selectedIndex !== -1) {
-        setSelectedIndex(-1);
+      if (e.key === "Escape") {
+        onCloseSuggestions?.();
       }
       return;
     }
@@ -101,82 +149,135 @@ const SearchForm = ({
 
   const queryTooShort =
     searchQuery.length > 0 && searchQuery.length < MIN_SEARCH_LENGTH;
+  const showSuggestionDropdown =
+    (showSuggestions && suggestions.length > 0) ||
+    isLoadingSuggestions ||
+    showEmptySuggestions;
+  const showClearButton = searchQuery.length > 0 && !isSearching;
 
   return (
     <div ref={wrapperRef}>
       <form id="searchForm" onSubmit={onSearchSubmit}>
         <div className="mb-3 position-relative">
-          <div className="form-floating">
+          <div className="form-floating search-input-wrapper">
             <input
-              type="search"
-              className="form-control"
+              ref={inputRef}
+              type="text"
+              inputMode="search"
+              enterKeyHint="search"
+              className="form-control search-input"
               id="search"
               role="combobox"
               placeholder="lightning bolt"
               value={searchQuery}
-              onChange={onQueryChange}
+              onChange={handleInputChange}
               onKeyDown={handleKeyDown}
               autoComplete="off"
               onFocus={onFocus}
               maxLength={MAX_SEARCH_LENGTH}
               aria-autocomplete="list"
               aria-controls="suggestions"
-              aria-expanded={showSuggestions && suggestions.length > 0}
+              aria-expanded={showSuggestionDropdown}
               aria-activedescendant={
                 selectedIndex >= 0 ? `suggestion-${selectedIndex}` : undefined
               }
+              aria-describedby={
+                queryTooShort || searchError ? "search-error" : undefined
+              }
             />
             <label htmlFor="search">Card Name</label>
+            <div className="search-input-actions">
+              {isLoadingSuggestions && (
+                <Loader
+                  size={16}
+                  className="search-input-spinner"
+                  aria-hidden="true"
+                />
+              )}
+              {showClearButton && (
+                <button
+                  type="button"
+                  className="search-input-clear"
+                  onClick={() => {
+                    onClearQuery();
+                    inputRef.current?.focus();
+                  }}
+                  aria-label="Clear search"
+                >
+                  <X size={16} aria-hidden="true" />
+                </button>
+              )}
+            </div>
           </div>
 
           {(queryTooShort || searchError) && (
-            <div className="form-text text-danger" role="alert">
+            <div
+              className="form-text text-danger"
+              id="search-error"
+              role="alert"
+            >
               {searchError ||
                 `Enter at least ${MIN_SEARCH_LENGTH} characters to search.`}
             </div>
           )}
 
-          {showSuggestions && suggestions.length > 0 && (
+          {showSuggestionDropdown && (
             <div
               id="suggestions"
               className="suggestions d-block"
               role="listbox"
               aria-label="Card name suggestions"
             >
-              {suggestions.map((s, suggestionIndex) => {
-                // Escape query for regex and split suggestion into parts
-                const escapedQuery = searchQuery.replace(
-                  /[.*+?^${}()|[\]\\]/g,
-                  "\\$&",
-                );
-                const parts = s.split(new RegExp(`(${escapedQuery})`, "gi"));
+              {isLoadingSuggestions && (
+                <output className="suggestion-status">
+                  <Loader size={14} className="search-input-spinner me-2" />
+                  Loading suggestions…
+                </output>
+              )}
 
-                return (
-                  // biome-ignore lint/a11y/useFocusableInteractive: Focus is managed by input
-                  // biome-ignore lint/a11y/useKeyWithClickEvents: Keyboard navigation is handled by input
-                  <div
-                    key={s}
-                    id={`suggestion-${suggestionIndex}`}
-                    className={`suggestion-item${selectedIndex === suggestionIndex ? " selected" : ""}`}
-                    onClick={() => {
-                      onSuggestionClick(s);
-                      setSelectedIndex(-1);
-                    }}
-                    role="option"
-                    aria-selected={selectedIndex === suggestionIndex}
-                  >
-                    {parts.map((part, index) =>
-                      part.toLowerCase() === searchQuery.toLowerCase() ? (
-                        // biome-ignore lint/suspicious/noArrayIndexKey: Order of regex parts is stable
-                        <b key={`${suggestionIndex}-${index}`}>{part}</b>
-                      ) : (
-                        // biome-ignore lint/suspicious/noArrayIndexKey: Order of regex parts is stable
-                        <span key={`${suggestionIndex}-${index}`}>{part}</span>
-                      ),
-                    )}
-                  </div>
-                );
-              })}
+              {!isLoadingSuggestions && showEmptySuggestions && (
+                <output className="suggestion-status">
+                  No matching cards found.
+                </output>
+              )}
+
+              {!isLoadingSuggestions &&
+                showSuggestions &&
+                suggestions.map((s, suggestionIndex) => {
+                  const escapedQuery = searchQuery.replace(
+                    /[.*+?^${}()|[\]\\]/g,
+                    "\\$&",
+                  );
+                  const parts = s.split(new RegExp(`(${escapedQuery})`, "gi"));
+
+                  return (
+                    // biome-ignore lint/a11y/useFocusableInteractive: Focus is managed by input
+                    // biome-ignore lint/a11y/useKeyWithClickEvents: Keyboard navigation is handled by input
+                    <div
+                      key={s}
+                      id={`suggestion-${suggestionIndex}`}
+                      className={`suggestion-item${selectedIndex === suggestionIndex ? " selected" : ""}`}
+                      onClick={() => {
+                        onSuggestionClick(s);
+                        setSelectedIndex(-1);
+                      }}
+                      role="option"
+                      aria-selected={selectedIndex === suggestionIndex}
+                    >
+                      {parts.map((part, index) =>
+                        part.toLowerCase() === searchQuery.toLowerCase() ? (
+                          // biome-ignore lint/suspicious/noArrayIndexKey: Order of regex parts is stable
+                          <b key={`${suggestionIndex}-${index}`}>{part}</b>
+                        ) : (
+                          // biome-ignore lint/suspicious/noArrayIndexKey: Order of regex parts is stable
+                          <span key={`${suggestionIndex}-${index}`}>
+                            {part}
+                          </span>
+                        ),
+                      )}
+                    </div>
+                  );
+                })}
             </div>
           )}
         </div>

--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -108,6 +108,7 @@ export default function TopSearchKeywords({
   isLoading,
   collapsible = false,
   collapseOnSearch = false,
+  onKeywordClick,
 }) {
   const [period, setPeriod] = useState("last24Hours");
   const [isExpanded, setIsExpanded] = useState(!collapsible);
@@ -168,16 +169,28 @@ export default function TopSearchKeywords({
             </div>
           ) : keywords.length > 0 ? (
             <div className="popular-searches-pills">
-              {keywords.map((keyword) => (
-                <a
-                  key={keyword}
-                  href={buildSearchQueryUrl(BASE_URL, keyword)}
-                  className="btn btn-sm popular-search-pill text-decoration-none"
-                  aria-label={`Search for ${keyword}`}
-                >
-                  {keyword}
-                </a>
-              ))}
+              {keywords.map((keyword) =>
+                onKeywordClick ? (
+                  <button
+                    key={keyword}
+                    type="button"
+                    className="btn btn-sm popular-search-pill"
+                    aria-label={`Search for ${keyword}`}
+                    onClick={() => onKeywordClick(keyword)}
+                  >
+                    {keyword}
+                  </button>
+                ) : (
+                  <a
+                    key={keyword}
+                    href={buildSearchQueryUrl(BASE_URL, keyword)}
+                    className="btn btn-sm popular-search-pill text-decoration-none"
+                    aria-label={`Search for ${keyword}`}
+                  >
+                    {keyword}
+                  </a>
+                ),
+              )}
             </div>
           ) : (
             <p className="popular-searches-empty small text-muted mb-0">

--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -108,7 +108,6 @@ export default function TopSearchKeywords({
   isLoading,
   collapsible = false,
   collapseOnSearch = false,
-  onKeywordClick,
 }) {
   const [period, setPeriod] = useState("last24Hours");
   const [isExpanded, setIsExpanded] = useState(!collapsible);
@@ -169,28 +168,16 @@ export default function TopSearchKeywords({
             </div>
           ) : keywords.length > 0 ? (
             <div className="popular-searches-pills">
-              {keywords.map((keyword) =>
-                onKeywordClick ? (
-                  <button
-                    key={keyword}
-                    type="button"
-                    className="btn btn-sm popular-search-pill"
-                    aria-label={`Search for ${keyword}`}
-                    onClick={() => onKeywordClick(keyword)}
-                  >
-                    {keyword}
-                  </button>
-                ) : (
-                  <a
-                    key={keyword}
-                    href={buildSearchQueryUrl(BASE_URL, keyword)}
-                    className="btn btn-sm popular-search-pill text-decoration-none"
-                    aria-label={`Search for ${keyword}`}
-                  >
-                    {keyword}
-                  </a>
-                ),
-              )}
+              {keywords.map((keyword) => (
+                <a
+                  key={keyword}
+                  href={buildSearchQueryUrl(BASE_URL, keyword)}
+                  className="btn btn-sm popular-search-pill text-decoration-none"
+                  aria-label={`Search for ${keyword}`}
+                >
+                  {keyword}
+                </a>
+              ))}
             </div>
           ) : (
             <p className="popular-searches-empty small text-muted mb-0">

--- a/frontend/src/hooks/useSearch.js
+++ b/frontend/src/hooks/useSearch.js
@@ -48,6 +48,8 @@ export default function useSearch() {
   const [searchProgress, setSearchProgress] = useState("Search");
   const [suggestions, setSuggestions] = useState([]);
   const [showSuggestions, setShowSuggestions] = useState(false);
+  const [isLoadingSuggestions, setIsLoadingSuggestions] = useState(false);
+  const [autocompleteSettled, setAutocompleteSettled] = useState(false);
   const [searchError, setSearchError] = useState(null);
   const [searchStoreErrors, setSearchStoreErrors] = useState([]);
   const [cardKingdomPrice, setCardKingdomPrice] = useState(null);
@@ -411,10 +413,26 @@ export default function useSearch() {
   // --- Handlers ---
   const handleQueryChange = (e) => {
     setSearchQuery(e.target.value);
+    setAutocompleteSettled(false);
     if (searchError === SEARCH_TOO_SHORT_ERROR) {
       setSearchError(null);
     }
   };
+
+  const handleClearQuery = useCallback(() => {
+    setSearchQuery("");
+    setSuggestions([]);
+    setShowSuggestions(false);
+    setAutocompleteSettled(false);
+    setIsLoadingSuggestions(false);
+    if (searchError === SEARCH_TOO_SHORT_ERROR) {
+      setSearchError(null);
+    }
+    if (autocompleteAbortControllerRef.current) {
+      autocompleteAbortControllerRef.current.abort();
+      autocompleteAbortControllerRef.current = null;
+    }
+  }, [searchError]);
 
   useEffect(() => {
     if (skipSuggestionsRef.current) {
@@ -434,6 +452,8 @@ export default function useSearch() {
         }
         const autocompleteAbortController = new AbortController();
         autocompleteAbortControllerRef.current = autocompleteAbortController;
+        setIsLoadingSuggestions(true);
+        setAutocompleteSettled(false);
 
         fetch(
           `https://api.scryfall.com/cards/autocomplete?q=${encodeURIComponent(searchQuery.toLowerCase())}`,
@@ -473,6 +493,8 @@ export default function useSearch() {
               autocompleteAbortController
             ) {
               autocompleteAbortControllerRef.current = null;
+              setIsLoadingSuggestions(false);
+              setAutocompleteSettled(true);
             }
           });
       }, AUTOCOMPLETE_DEBOUNCE_MS);
@@ -483,6 +505,8 @@ export default function useSearch() {
       autocompleteAbortControllerRef.current.abort();
       autocompleteAbortControllerRef.current = null;
     }
+    setIsLoadingSuggestions(false);
+    setAutocompleteSettled(false);
     setSuggestions([]);
     setShowSuggestions(false);
   }, [searchQuery]);
@@ -508,9 +532,21 @@ export default function useSearch() {
     skipSuggestionsRef.current = true;
     setSearchQuery(suggestion);
     setShowSuggestions(false);
+    setAutocompleteSettled(false);
 
     performSearch(suggestion, resolveStoresToSearch(selectedStores));
   };
+
+  const handlePopularSearchClick = useCallback(
+    (keyword) => {
+      skipSuggestionsRef.current = true;
+      setSearchQuery(keyword);
+      setShowSuggestions(false);
+      setAutocompleteSettled(false);
+      performSearch(keyword, resolveStoresToSearch(selectedStores));
+    },
+    [performSearch, resolveStoresToSearch, selectedStores],
+  );
 
   const handleSearchSubmit = (e) => {
     if (e) e.preventDefault();
@@ -575,10 +611,18 @@ export default function useSearch() {
     suggestions,
     showSuggestions,
     setShowSuggestions,
+    isLoadingSuggestions,
+    showEmptySuggestions:
+      autocompleteSettled &&
+      searchQuery.length > MIN_SEARCH_LENGTH - 1 &&
+      searchQuery.length <= MAX_SEARCH_LENGTH &&
+      suggestions.length === 0,
     selectedStores,
     setSelectedStores,
     handleQueryChange,
+    handleClearQuery,
     handleSuggestionClick,
+    handlePopularSearchClick,
     handleSearchSubmit,
     toggleStore,
     selectAllStores,

--- a/frontend/src/hooks/useSearch.js
+++ b/frontend/src/hooks/useSearch.js
@@ -537,17 +537,6 @@ export default function useSearch() {
     performSearch(suggestion, resolveStoresToSearch(selectedStores));
   };
 
-  const handlePopularSearchClick = useCallback(
-    (keyword) => {
-      skipSuggestionsRef.current = true;
-      setSearchQuery(keyword);
-      setShowSuggestions(false);
-      setAutocompleteSettled(false);
-      performSearch(keyword, resolveStoresToSearch(selectedStores));
-    },
-    [performSearch, resolveStoresToSearch, selectedStores],
-  );
-
   const handleSearchSubmit = (e) => {
     if (e) e.preventDefault();
     setShowSuggestions(false);
@@ -622,7 +611,6 @@ export default function useSearch() {
     handleQueryChange,
     handleClearQuery,
     handleSuggestionClick,
-    handlePopularSearchClick,
     handleSearchSubmit,
     toggleStore,
     selectAllStores,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -284,6 +284,77 @@ body {
   color: var(--bs-white);
 }
 
+.search-input-wrapper {
+  position: relative;
+}
+
+.search-input-wrapper .search-input {
+  padding-right: 2.75rem;
+}
+
+.search-input-actions {
+  position: absolute;
+  right: 0.75rem;
+  bottom: 0.625rem;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  z-index: 3;
+  pointer-events: none;
+}
+
+.search-input-clear {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--bs-secondary-color);
+  cursor: pointer;
+  pointer-events: auto;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.search-input-clear:hover {
+  background-color: rgba(var(--bs-primary-rgb), 0.12);
+  color: var(--bs-body-color);
+}
+
+.search-input-clear:focus-visible {
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem rgba(var(--bs-primary-rgb), 0.35);
+}
+
+.search-input-spinner {
+  animation: spin 0.8s linear infinite;
+  color: var(--bs-secondary-color);
+  flex-shrink: 0;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+#suggestions .suggestion-status {
+  padding: 0.625rem 0.75rem;
+  color: var(--bs-secondary-color);
+  font-size: 0.875rem;
+  display: flex;
+  align-items: center;
+}
+
 input#search:focus-visible {
   border-color: var(--bs-primary);
   box-shadow: 0 0 0 0.25rem rgba(var(--bs-primary-rgb), 0.25);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Polishes the card name search input with clearer feedback and faster keyboard workflows. Popular search pills remain as `<a href>` links for SEO crawlability.

## Changes

- **Clear button** — visible × control inside the input (replaces inconsistent native `type="search"` clear behavior)
- **Autocomplete feedback** — spinner while Scryfall suggestions load; "No matching cards found" when the query returns nothing
- **Keyboard navigation** — arrow-key selection now scrolls into view within the dropdown
- **`/` shortcut** — press `/` from anywhere on the page to focus the search field (skipped when already typing in an input)
- **Popular searches unchanged** — pills still use crawlable `href` links with `?s=` query params for SEO

## Screenshots

### Desktop — autocomplete with clear button

![Desktop search input with autocomplete suggestions and clear button](https://cursor.com/artifacts/c/art-e9704d45-7e1d-4646-baf2-53b11996d029)

### Desktop — filled query showing clear button

![Desktop search input with query text and clear button](https://cursor.com/artifacts/c/art-3e67c801-36f0-4766-a1ca-6e6b1a205c0f)

### Mobile — autocomplete

![Mobile search input with autocomplete suggestions](https://cursor.com/artifacts/c/art-e9716882-ccc5-4297-a6b5-7189eaa9961e)

## Test plan

- [x] `cd frontend && npm run lint`
- [x] Manual: type 2+ characters → loading spinner → suggestions appear
- [x] Manual: clear button resets query and refocuses input
- [x] Manual: `/` focuses search from page body
- [x] Popular search pills remain `<a href="/?s=...">` links for crawlers

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e09358f-9e56-4edb-b4eb-c26303ef9fd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e09358f-9e56-4edb-b4eb-c26303ef9fd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

