### PR TITLE
Collapse store selector on landing when selection is stored

### DIFF
--- a/frontend/src/components/SearchForm.jsx
+++ b/frontend/src/components/SearchForm.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { MAX_SEARCH_LENGTH, MIN_SEARCH_LENGTH } from "../constants";
+import { hasStoredStoreSelection } from "../utils/searchUrl";
 import StoreSelector from "./StoreSelector";
 
 const TIP_DISMISSED_STORAGE_KEY = "search-form-tip-dismissed";
@@ -191,6 +192,7 @@ const SearchForm = ({
           onSelectNone={onSelectNone}
           collapsible
           collapseOnSearch={isSearching}
+          defaultExpanded={!hasStoredStoreSelection()}
         />
 
         {showTip && (

--- a/frontend/src/components/StoreSelector.jsx
+++ b/frontend/src/components/StoreSelector.jsx
@@ -30,8 +30,9 @@ const StoreSelector = memo(
     onSelectNone,
     collapsible = true,
     collapseOnSearch = false,
+    defaultExpanded = true,
   }) => {
-    const [isExpanded, setIsExpanded] = useState(true);
+    const [isExpanded, setIsExpanded] = useState(defaultExpanded);
     const panelId = useId();
 
     useEffect(() => {

--- a/frontend/src/utils/searchUrl.js
+++ b/frontend/src/utils/searchUrl.js
@@ -123,6 +123,17 @@ export function getStoresFromUrl(urlParams) {
 }
 
 /**
+ * @returns {boolean}
+ */
+export function hasStoredStoreSelection() {
+  try {
+    return localStorage.getItem("lgsSelected") !== null;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * @param {string[]} stores
  */
 export function persistSelectedStores(stores) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When a user has a saved store selection in `localStorage` (`lgsSelected`), the store selector now loads minimized on the landing page, showing the compact summary bar instead of the full pill list.

First-time visitors (no stored selection) still see the expanded selector so they can discover and configure stores.

## Changes

- Added `hasStoredStoreSelection()` helper in `searchUrl.js` to detect persisted store preferences.
- Added `defaultExpanded` prop to `StoreSelector` so the initial collapsed/expanded state can be controlled by the parent.
- `SearchForm` passes `defaultExpanded={!hasStoredStoreSelection()}` so returning users land with a minimized selector.

Users can still expand the selector manually via the header toggle, and it continues to auto-collapse when a search starts.

## Screenshots

### Returning user — stored selection (desktop)

![Store selector collapsed on desktop with stored selection](https://cursor.com/artifacts/c/art-29b6bf63-eb5b-4db6-8f4e-d16bf325ed41)

### Returning user — stored selection (mobile)

![Store selector collapsed on mobile with stored selection](https://cursor.com/artifacts/c/art-d9c39624-eea4-4d13-a99a-1b4b980a4f7a)

### First-time visitor — no stored selection (desktop, unchanged)

![Store selector expanded on desktop for first-time visitor](https://cursor.com/artifacts/c/art-c992884f-789c-47d1-bfc3-59c0aa8ddfb1)

## Test plan

- [x] Frontend lint passes (`npm run lint`)
- [x] Verified collapsed state when `lgsSelected` is present in localStorage
- [x] Verified expanded state when no stored selection exists
- [x] Manual toggle still expands/collapses the selector
- [x] Auto-collapse on search still works via `collapseOnSearch`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-925f1004-0cb5-4700-894b-11bf2ef209a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-925f1004-0cb5-4700-894b-11bf2ef209a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

