### PR TITLE
Add 6-month and 1-year periods to top search keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,9 @@ Example report shape:
   "periods": {
     "last24Hours": { "start": "...", "end": "...", "keywords": [{"term": "Opt", "count": 4}] },
     "last7Days": { "startDate": "7daysAgo", "endDate": "today", "keywords": [] },
-    "last30Days": { "startDate": "30daysAgo", "endDate": "today", "keywords": [] }
+    "last30Days": { "startDate": "30daysAgo", "endDate": "today", "keywords": [] },
+    "last6Months": { "startDate": "6monthsAgo", "endDate": "today", "keywords": [] },
+    "last1Year": { "startDate": "365daysAgo", "endDate": "today", "keywords": [] }
   }
 }
 ```

--- a/api/controller/analyticskeywords/report.go
+++ b/api/controller/analyticskeywords/report.go
@@ -16,6 +16,8 @@ const (
 	periodLast24Hours = "last24Hours"
 	periodLast7Days   = "last7Days"
 	periodLast30Days  = "last30Days"
+	periodLast6Months = "last6Months"
+	periodLast1Year   = "last1Year"
 )
 
 // KeywordCount is one ranked search keyword.
@@ -47,7 +49,7 @@ var (
 	verifyCardNameFunc = scryfall.VerifyCardName
 )
 
-// BuildReport fetches top search keywords for the last 24 hours, 7 days, and 30 days.
+// BuildReport fetches top search keywords for the last 24 hours, 7 days, 30 days, 6 months, and 1 year.
 func BuildReport(ctx context.Context, reporter ga4.Reporter, propertyID string, limit int) (*Report, error) {
 	if reporter == nil {
 		return nil, fmt.Errorf("analyticskeywords: reporter is required")
@@ -61,7 +63,7 @@ func BuildReport(ctx context.Context, reporter ga4.Reporter, propertyID string, 
 		GeneratedAt: now.Format(time.RFC3339),
 		PropertyID:  propertyID,
 		EventName:   ga4.SearchEventName,
-		Periods:     make(map[string]PeriodReport, 3),
+		Periods:     make(map[string]PeriodReport, 5),
 	}
 
 	last24Hours, err := reporter.TopSearchTermsLast24Hours(ctx, now, ga4CandidateLimit)
@@ -106,6 +108,36 @@ func BuildReport(ctx context.Context, reporter ga4.Reporter, propertyID string, 
 		StartDate:    "30daysAgo",
 		EndDate:      "today",
 		Keywords:     validated30Days,
+		KeywordLimit: limit,
+	}
+
+	last6Months, err := reporter.TopSearchTerms(ctx, "6monthsAgo", "today", ga4CandidateLimit)
+	if err != nil {
+		return nil, fmt.Errorf("analyticskeywords: last 6 months: %w", err)
+	}
+	validated6Months, err := validateKeywords(ctx, last6Months, limit)
+	if err != nil {
+		return nil, fmt.Errorf("analyticskeywords: last 6 months: %w", err)
+	}
+	report.Periods[periodLast6Months] = PeriodReport{
+		StartDate:    "6monthsAgo",
+		EndDate:      "today",
+		Keywords:     validated6Months,
+		KeywordLimit: limit,
+	}
+
+	last1Year, err := reporter.TopSearchTerms(ctx, "365daysAgo", "today", ga4CandidateLimit)
+	if err != nil {
+		return nil, fmt.Errorf("analyticskeywords: last 1 year: %w", err)
+	}
+	validated1Year, err := validateKeywords(ctx, last1Year, limit)
+	if err != nil {
+		return nil, fmt.Errorf("analyticskeywords: last 1 year: %w", err)
+	}
+	report.Periods[periodLast1Year] = PeriodReport{
+		StartDate:    "365daysAgo",
+		EndDate:      "today",
+		Keywords:     validated1Year,
 		KeywordLimit: limit,
 	}
 

--- a/api/controller/analyticskeywords/report_test.go
+++ b/api/controller/analyticskeywords/report_test.go
@@ -13,6 +13,8 @@ type mockReporter struct {
 	last24Hours []ga4.SearchTermCount
 	last7Days   []ga4.SearchTermCount
 	last30Days  []ga4.SearchTermCount
+	last6Months []ga4.SearchTermCount
+	last1Year   []ga4.SearchTermCount
 }
 
 func (m *mockReporter) TopSearchTerms(_ context.Context, startDate, endDate string, limit int) ([]ga4.SearchTermCount, error) {
@@ -21,6 +23,10 @@ func (m *mockReporter) TopSearchTerms(_ context.Context, startDate, endDate stri
 		return trimTerms(m.last7Days, limit), nil
 	case startDate == "30daysAgo" && endDate == "today":
 		return trimTerms(m.last30Days, limit), nil
+	case startDate == "6monthsAgo" && endDate == "today":
+		return trimTerms(m.last6Months, limit), nil
+	case startDate == "365daysAgo" && endDate == "today":
+		return trimTerms(m.last1Year, limit), nil
 	default:
 		return nil, nil
 	}
@@ -61,6 +67,8 @@ func TestBuildReport(t *testing.T) {
 		last24Hours: []ga4.SearchTermCount{{Term: "Opt", Count: 4}},
 		last7Days:   []ga4.SearchTermCount{{Term: "Lightning Bolt", Count: 10}},
 		last30Days:  []ga4.SearchTermCount{{Term: "Sol Ring", Count: 20}},
+		last6Months: []ga4.SearchTermCount{{Term: "Opt", Count: 40}},
+		last1Year:   []ga4.SearchTermCount{{Term: "Lightning Bolt", Count: 100}},
 	}
 
 	report, err := BuildReport(context.Background(), reporter, "123456789", 20)
@@ -94,6 +102,22 @@ func TestBuildReport(t *testing.T) {
 	}
 	if len(last30Days.Keywords) != 1 || last30Days.Keywords[0].Term != "Sol Ring" {
 		t.Fatalf("unexpected 30d keywords: %+v", last30Days.Keywords)
+	}
+
+	last6Months := report.Periods[periodLast6Months]
+	if last6Months.StartDate != "6monthsAgo" || last6Months.EndDate != "today" {
+		t.Fatalf("unexpected 6mo window: %+v", last6Months)
+	}
+	if len(last6Months.Keywords) != 1 || last6Months.Keywords[0].Term != "Opt" {
+		t.Fatalf("unexpected 6mo keywords: %+v", last6Months.Keywords)
+	}
+
+	last1Year := report.Periods[periodLast1Year]
+	if last1Year.StartDate != "365daysAgo" || last1Year.EndDate != "today" {
+		t.Fatalf("unexpected 1yr window: %+v", last1Year)
+	}
+	if len(last1Year.Keywords) != 1 || last1Year.Keywords[0].Term != "Lightning Bolt" {
+		t.Fatalf("unexpected 1yr keywords: %+v", last1Year.Keywords)
 	}
 }
 

--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -25,6 +25,8 @@ const LOADING_SKELETON_KEYS = [
 const PERIOD_OPTIONS = [
   { id: "last24Hours", label: "24 hours" },
   { id: "last30Days", label: "30 days" },
+  { id: "last6Months", label: "6 months" },
+  { id: "last1Year", label: "1 year" },
 ];
 
 // Stable selector for AdSense "Excluded areas" and google-anno-skip for ad intents.

--- a/frontend/src/hooks/useTopSearchKeywords.js
+++ b/frontend/src/hooks/useTopSearchKeywords.js
@@ -19,12 +19,16 @@ function parseTopSearchKeywords(payload) {
   return {
     last24Hours: parseKeywordList(payload?.periods?.last24Hours?.keywords),
     last30Days: parseKeywordList(payload?.periods?.last30Days?.keywords),
+    last6Months: parseKeywordList(payload?.periods?.last6Months?.keywords),
+    last1Year: parseKeywordList(payload?.periods?.last1Year?.keywords),
   };
 }
 
 const EMPTY_KEYWORDS_BY_PERIOD = {
   last24Hours: [],
   last30Days: [],
+  last6Months: [],
+  last1Year: [],
 };
 
 export default function useTopSearchKeywords(enabled) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends the top search keywords analytics export and Popular searches UI with two additional time ranges: **6 months** and **1 year**.

## Changes

- **Backend (`api/controller/analyticskeywords/report.go`)**: Fetch and validate GA4 top search terms for `6monthsAgo` and `365daysAgo` windows, adding `last6Months` and `last1Year` to the S3 export JSON.
- **Frontend hook (`useTopSearchKeywords.js`)**: Parse the new period keys from `latest.json`.
- **Frontend UI (`TopSearchKeywords.jsx`)**: Add "6 months" and "1 year" toggle buttons alongside the existing 24 hours and 30 days options.
- **Docs (`README.md`)**: Document the new report period keys in the example JSON shape.

## Screenshots

### Desktop

![Popular searches with 24 hours, 30 days, 6 months, and 1 year toggles (desktop)](https://cursor.com/artifacts/c/art-92a98e61-d5c0-471d-8d6b-2b19f9117304)

### Mobile

![Popular searches with 24 hours, 30 days, 6 months, and 1 year toggles (mobile)](https://cursor.com/artifacts/c/art-d71a6286-4ec4-464a-980e-be7f6d6b399d)

## Testing

- `make test` (all backend tests pass)
- `go test ./controller/analyticskeywords/...` (new period coverage in `TestBuildReport`)

## Notes

The daily analytics export Lambda will need to run once after deploy for production `latest.json` to include the new periods. Until then, the UI gracefully shows empty results for 6 months / 1 year if those keys are missing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-214630ff-1c43-4ae7-901d-21c24c003e8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-214630ff-1c43-4ae7-901d-21c24c003e8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

