### PR TITLE
Fix anchor ad collapse toggle after footer layering change

### DIFF
--- a/frontend/src/hooks/useBottomChromeLayout.js
+++ b/frontend/src/hooks/useBottomChromeLayout.js
@@ -61,6 +61,34 @@ function syncBottomChromeLayout() {
 export default function useBottomChromeLayout() {
   useEffect(() => {
     let rafId = 0;
+    const resizeObservers = new Set();
+
+    const unobserveAnchorAd = (anchorAd) => {
+      const observer = resizeObservers.get(anchorAd);
+      if (!observer) return;
+      observer.disconnect();
+      resizeObservers.delete(anchorAd);
+    };
+
+    const observeAnchorAd = (anchorAd) => {
+      if (resizeObservers.has(anchorAd)) return;
+
+      const resizeObserver = new ResizeObserver(scheduleSync);
+      resizeObserver.observe(anchorAd);
+      resizeObservers.set(anchorAd, resizeObserver);
+    };
+
+    const syncAnchorObservers = () => {
+      const anchorAds = document.querySelectorAll(ANCHOR_AD_SELECTOR);
+      for (const anchorAd of anchorAds) {
+        observeAnchorAd(anchorAd);
+      }
+      for (const anchorAd of resizeObservers.keys()) {
+        if (!anchorAd.isConnected) {
+          unobserveAnchorAd(anchorAd);
+        }
+      }
+    };
 
     const scheduleSync = () => {
       if (rafId) {
@@ -68,6 +96,7 @@ export default function useBottomChromeLayout() {
       }
       rafId = requestAnimationFrame(() => {
         rafId = 0;
+        syncAnchorObservers();
         syncBottomChromeLayout();
       });
     };
@@ -79,7 +108,7 @@ export default function useBottomChromeLayout() {
       childList: true,
       subtree: true,
       attributes: true,
-      attributeFilter: ["style", "class", "data-anchor-status"],
+      attributeFilter: ["class", "data-anchor-status"],
     });
 
     window.addEventListener("resize", scheduleSync);
@@ -97,6 +126,9 @@ export default function useBottomChromeLayout() {
       window.removeEventListener("resize", scheduleSync);
       window.clearInterval(pollId);
       window.clearTimeout(stopPollId);
+      for (const anchorAd of [...resizeObservers.keys()]) {
+        unobserveAnchorAd(anchorAd);
+      }
       document.documentElement.style.removeProperty(FOOTER_NAV_HEIGHT_VAR);
       document.documentElement.style.removeProperty(ANCHOR_AD_HEIGHT_VAR);
     };

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -399,8 +399,8 @@ ins.adsbygoogle iframe {
 }
 
 ins.adsbygoogle.adsbygoogle-noablate {
-  /* biome-ignore lint/complexity/noImportantStyles: Keep anchor ads above the fixed footer nav */
-  bottom: var(--footer-nav-height, 0px) !important;
+  margin-bottom: var(--footer-nav-height, 0px);
+  z-index: 1040;
 }
 
 .site-bottom-nav {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After #191, anchor ads correctly sit above the footer nav, but the AdSense collapse/hide toggle stopped working.

**Root cause:** The anchor ad rule used `bottom: var(--footer-nav-height) !important`, which overrode Google's inline `bottom` positioning during collapse/expand animations.

**Fix:**
- Replace `bottom: !important` with `margin-bottom: var(--footer-nav-height)` so Google keeps control of `bottom` while the ad still sits above the footer.
- Set `z-index: 1040` on anchor ads so the ad layer stays above the footer (`1030`).
- Stop observing `style` attribute mutations (which fire during toggle interactions) and use `ResizeObserver` for height changes instead.

## Test plan

- [x] `npm run lint` passes
- [x] Verified `margin-bottom` offsets fixed bottom anchor ads above the footer without blocking `bottom` style changes during collapse
- [ ] Confirm on production that the anchor ad hide/collapse chevron works again
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b67535ca-7b2e-4c1b-b528-23dc876d6bd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b67535ca-7b2e-4c1b-b528-23dc876d6bd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

