### PR TITLE
Fix collapsed anchor ad covering footer nav

### DIFF
--- a/frontend/src/hooks/useBottomChromeLayout.js
+++ b/frontend/src/hooks/useBottomChromeLayout.js
@@ -37,6 +37,7 @@ function measureAnchorAdHeight() {
       parsePixelValue(computed.height),
     );
     if (height <= 0) continue;
+    if (!isBottomAnchorAd(anchorAd)) continue;
 
     maxHeight = Math.max(maxHeight, Math.ceil(height));
   }
@@ -56,6 +57,48 @@ function syncBottomChromeLayout() {
     ANCHOR_AD_HEIGHT_VAR,
     `${anchorAdHeight}px`,
   );
+  applyAnchorAdOffsets(footerNavHeight);
+}
+
+function isBottomAnchorAd(anchorAd) {
+  const computed = window.getComputedStyle(anchorAd);
+  if (computed.position !== "fixed") {
+    return false;
+  }
+
+  const bottom = parsePixelValue(computed.bottom);
+  if (bottom > 0 && bottom <= 16) {
+    return true;
+  }
+
+  const rect = anchorAd.getBoundingClientRect();
+  return rect.height > 0 && rect.bottom >= window.innerHeight - 16;
+}
+
+function applyAnchorAdOffsets(footerNavHeight) {
+  const anchorAds = document.querySelectorAll(ANCHOR_AD_SELECTOR);
+
+  for (const anchorAd of anchorAds) {
+    if (!anchorAd.isConnected) continue;
+
+    const status = anchorAd.getAttribute("data-anchor-status");
+    if (status === "dismissed") {
+      anchorAd.style.removeProperty("margin-bottom");
+      anchorAd.style.removeProperty("z-index");
+      continue;
+    }
+
+    if (!isBottomAnchorAd(anchorAd)) {
+      continue;
+    }
+
+    anchorAd.style.setProperty(
+      "margin-bottom",
+      `${footerNavHeight}px`,
+      "important",
+    );
+    anchorAd.style.setProperty("z-index", "1020", "important");
+  }
 }
 
 export default function useBottomChromeLayout() {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -400,7 +400,8 @@ ins.adsbygoogle iframe {
 
 ins.adsbygoogle.adsbygoogle-noablate {
   margin-bottom: var(--footer-nav-height, 0px);
-  z-index: 1040;
+  /* biome-ignore lint/complexity/noImportantStyles: Cap Google anchor ad z-index below site footer */
+  z-index: 1020 !important;
 }
 
 .site-bottom-nav {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #195. After fixing the collapse toggle, collapsing the anchor ad caused it to cover the footer nav.

**Root cause:** When collapsed, Google can clear the `margin-bottom` offset and the anchor ad keeps a very high default `z-index`, so the collapsed tab renders on top of the footer (`z-index: 1030`).

**Fix:**
- Re-apply `margin-bottom` with `important` via JS on every layout sync (expanded and collapsed), so the anchor tab stays spatially above the footer.
- Cap anchor ad `z-index` to `1020` (below footer `1030`) so any transient overlap during collapse animation leaves the nav visible and clickable.
- Only apply offsets to bottom-anchored ads, not other auto ad formats.

## Test plan

- [x] `npm run lint` passes
- [ ] Confirm on production: expanded ad sits above footer, collapse toggle works, collapsed tab does not cover footer nav
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b67535ca-7b2e-4c1b-b528-23dc876d6bd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b67535ca-7b2e-4c1b-b528-23dc876d6bd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

