### PR TITLE
Fix GA4 date ranges for 6-month and 1-year keyword export

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,8 @@ Example report shape:
     "last24Hours": { "start": "...", "end": "...", "keywords": [{"term": "Opt", "count": 4}] },
     "last7Days": { "startDate": "7daysAgo", "endDate": "today", "keywords": [] },
     "last30Days": { "startDate": "30daysAgo", "endDate": "today", "keywords": [] },
-    "last6Months": { "startDate": "6monthsAgo", "endDate": "today", "keywords": [] },
-    "last1Year": { "startDate": "365daysAgo", "endDate": "today", "keywords": [] }
+    "last6Months": { "startDate": "2025-12-28", "endDate": "today", "keywords": [] },
+    "last1Year": { "startDate": "2025-06-28", "endDate": "today", "keywords": [] }
   }
 }
 ```

--- a/api/controller/analyticskeywords/report.go
+++ b/api/controller/analyticskeywords/report.go
@@ -59,6 +59,8 @@ func BuildReport(ctx context.Context, reporter ga4.Reporter, propertyID string, 
 	}
 
 	now := nowFunc().UTC()
+	start6Months := ga4CalendarDate(now.AddDate(0, -6, 0))
+	start1Year := ga4CalendarDate(now.AddDate(-1, 0, 0))
 	report := &Report{
 		GeneratedAt: now.Format(time.RFC3339),
 		PropertyID:  propertyID,
@@ -111,7 +113,7 @@ func BuildReport(ctx context.Context, reporter ga4.Reporter, propertyID string, 
 		KeywordLimit: limit,
 	}
 
-	last6Months, err := reporter.TopSearchTerms(ctx, "6monthsAgo", "today", ga4CandidateLimit)
+	last6Months, err := reporter.TopSearchTerms(ctx, start6Months, "today", ga4CandidateLimit)
 	if err != nil {
 		return nil, fmt.Errorf("analyticskeywords: last 6 months: %w", err)
 	}
@@ -120,13 +122,13 @@ func BuildReport(ctx context.Context, reporter ga4.Reporter, propertyID string, 
 		return nil, fmt.Errorf("analyticskeywords: last 6 months: %w", err)
 	}
 	report.Periods[periodLast6Months] = PeriodReport{
-		StartDate:    "6monthsAgo",
+		StartDate:    start6Months,
 		EndDate:      "today",
 		Keywords:     validated6Months,
 		KeywordLimit: limit,
 	}
 
-	last1Year, err := reporter.TopSearchTerms(ctx, "365daysAgo", "today", ga4CandidateLimit)
+	last1Year, err := reporter.TopSearchTerms(ctx, start1Year, "today", ga4CandidateLimit)
 	if err != nil {
 		return nil, fmt.Errorf("analyticskeywords: last 1 year: %w", err)
 	}
@@ -135,13 +137,17 @@ func BuildReport(ctx context.Context, reporter ga4.Reporter, propertyID string, 
 		return nil, fmt.Errorf("analyticskeywords: last 1 year: %w", err)
 	}
 	report.Periods[periodLast1Year] = PeriodReport{
-		StartDate:    "365daysAgo",
+		StartDate:    start1Year,
 		EndDate:      "today",
 		Keywords:     validated1Year,
 		KeywordLimit: limit,
 	}
 
 	return report, nil
+}
+
+func ga4CalendarDate(t time.Time) string {
+	return t.UTC().Format("2006-01-02")
 }
 
 func validateKeywords(ctx context.Context, terms []ga4.SearchTermCount, limit int) ([]KeywordCount, error) {

--- a/api/controller/analyticskeywords/report_test.go
+++ b/api/controller/analyticskeywords/report_test.go
@@ -10,11 +10,13 @@ import (
 )
 
 type mockReporter struct {
-	last24Hours []ga4.SearchTermCount
-	last7Days   []ga4.SearchTermCount
-	last30Days  []ga4.SearchTermCount
-	last6Months []ga4.SearchTermCount
-	last1Year   []ga4.SearchTermCount
+	start6Months string
+	start1Year   string
+	last24Hours  []ga4.SearchTermCount
+	last7Days    []ga4.SearchTermCount
+	last30Days   []ga4.SearchTermCount
+	last6Months  []ga4.SearchTermCount
+	last1Year    []ga4.SearchTermCount
 }
 
 func (m *mockReporter) TopSearchTerms(_ context.Context, startDate, endDate string, limit int) ([]ga4.SearchTermCount, error) {
@@ -23,9 +25,9 @@ func (m *mockReporter) TopSearchTerms(_ context.Context, startDate, endDate stri
 		return trimTerms(m.last7Days, limit), nil
 	case startDate == "30daysAgo" && endDate == "today":
 		return trimTerms(m.last30Days, limit), nil
-	case startDate == "6monthsAgo" && endDate == "today":
+	case startDate == m.start6Months && endDate == "today":
 		return trimTerms(m.last6Months, limit), nil
-	case startDate == "365daysAgo" && endDate == "today":
+	case startDate == m.start1Year && endDate == "today":
 		return trimTerms(m.last1Year, limit), nil
 	default:
 		return nil, nil
@@ -64,7 +66,9 @@ func TestBuildReport(t *testing.T) {
 	}()
 
 	reporter := &mockReporter{
-		last24Hours: []ga4.SearchTermCount{{Term: "Opt", Count: 4}},
+		start6Months: ga4CalendarDate(fixedNow.AddDate(0, -6, 0)),
+		start1Year:   ga4CalendarDate(fixedNow.AddDate(-1, 0, 0)),
+		last24Hours:  []ga4.SearchTermCount{{Term: "Opt", Count: 4}},
 		last7Days:   []ga4.SearchTermCount{{Term: "Lightning Bolt", Count: 10}},
 		last30Days:  []ga4.SearchTermCount{{Term: "Sol Ring", Count: 20}},
 		last6Months: []ga4.SearchTermCount{{Term: "Opt", Count: 40}},
@@ -105,7 +109,7 @@ func TestBuildReport(t *testing.T) {
 	}
 
 	last6Months := report.Periods[periodLast6Months]
-	if last6Months.StartDate != "6monthsAgo" || last6Months.EndDate != "today" {
+	if last6Months.StartDate != "2025-12-28" || last6Months.EndDate != "today" {
 		t.Fatalf("unexpected 6mo window: %+v", last6Months)
 	}
 	if len(last6Months.Keywords) != 1 || last6Months.Keywords[0].Term != "Opt" {
@@ -113,7 +117,7 @@ func TestBuildReport(t *testing.T) {
 	}
 
 	last1Year := report.Periods[periodLast1Year]
-	if last1Year.StartDate != "365daysAgo" || last1Year.EndDate != "today" {
+	if last1Year.StartDate != "2025-06-28" || last1Year.EndDate != "today" {
 		t.Fatalf("unexpected 1yr window: %+v", last1Year)
 	}
 	if len(last1Year.Keywords) != 1 || last1Year.Keywords[0].Term != "Lightning Bolt" {

--- a/api/controller/analyticskeywords/report_test.go
+++ b/api/controller/analyticskeywords/report_test.go
@@ -125,6 +125,64 @@ func TestBuildReport(t *testing.T) {
 	}
 }
 
+func TestGA4CalendarDate(t *testing.T) {
+	got := ga4CalendarDate(time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC))
+	if got != "2026-06-28" {
+		t.Fatalf("unexpected calendar date: %q", got)
+	}
+}
+
+func TestBuildReport_LongRangePeriodsUseGA4CalendarDates(t *testing.T) {
+	fixedNow := time.Date(2026, 6, 28, 12, 0, 0, 0, time.UTC)
+	originalNowFunc := nowFunc
+	originalVerifyFunc := verifyCardNameFunc
+	nowFunc = func() time.Time { return fixedNow }
+	verifyCardNameFunc = mockVerifyCardName
+	defer func() {
+		nowFunc = originalNowFunc
+		verifyCardNameFunc = originalVerifyFunc
+	}()
+
+	reporter := &mockReporter{
+		start6Months: ga4CalendarDate(fixedNow.AddDate(0, -6, 0)),
+		start1Year:   ga4CalendarDate(fixedNow.AddDate(-1, 0, 0)),
+		last6Months:  []ga4.SearchTermCount{{Term: "Opt", Count: 1}},
+		last1Year:    []ga4.SearchTermCount{{Term: "Sol Ring", Count: 1}},
+	}
+
+	report, err := BuildReport(context.Background(), reporter, "123456789", 20)
+	if err != nil {
+		t.Fatalf("build report: %v", err)
+	}
+
+	last6Months := report.Periods[periodLast6Months]
+	if !isGA4CalendarDate(last6Months.StartDate) {
+		t.Fatalf("6-month startDate must be YYYY-MM-DD, got %q", last6Months.StartDate)
+	}
+	if last6Months.StartDate != ga4CalendarDate(fixedNow.AddDate(0, -6, 0)) {
+		t.Fatalf("unexpected 6-month start date: %q", last6Months.StartDate)
+	}
+	if last6Months.EndDate != "today" {
+		t.Fatalf("unexpected 6-month end date: %q", last6Months.EndDate)
+	}
+
+	last1Year := report.Periods[periodLast1Year]
+	if !isGA4CalendarDate(last1Year.StartDate) {
+		t.Fatalf("1-year startDate must be YYYY-MM-DD, got %q", last1Year.StartDate)
+	}
+	if last1Year.StartDate != ga4CalendarDate(fixedNow.AddDate(-1, 0, 0)) {
+		t.Fatalf("unexpected 1-year start date: %q", last1Year.StartDate)
+	}
+	if last1Year.EndDate != "today" {
+		t.Fatalf("unexpected 1-year end date: %q", last1Year.EndDate)
+	}
+}
+
+func isGA4CalendarDate(value string) bool {
+	_, err := time.Parse("2006-01-02", value)
+	return err == nil
+}
+
 func TestValidateKeywords_FiltersInvalidAndMergesCanonicalNames(t *testing.T) {
 	originalVerifyFunc := verifyCardNameFunc
 	verifyCardNameFunc = func(_ context.Context, query string) (string, error) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the analytics keywords Lambda failure when exporting 6-month and 1-year top search periods.

After #194, the export used `6monthsAgo` and `365daysAgo`. GA4 rejects `6monthsAgo` with:

```
Invalid startDate : 6monthsAgo. startDate must be YYYY-MM-DD, NdaysAgo, yesterday, or today.
```

This PR switches both long-range windows to computed calendar dates (`YYYY-MM-DD`) via `now.AddDate(0, -6, 0)` and `now.AddDate(-1, 0, 0)`.

## Changes

- **`api/controller/analyticskeywords/report.go`**: Use `ga4CalendarDate()` for 6-month and 1-year `startDate` values sent to GA4.
- **`api/controller/analyticskeywords/report_test.go`**: Update mocks and add tests asserting both long-range periods use valid `YYYY-MM-DD` dates.
- **`README.md`**: Update example export JSON to show calendar date format.

## Testing

- `make test`

## Post-deploy

Re-run the analytics keywords export Lambda, then invalidate CloudFront for `latest.json` if needed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-214630ff-1c43-4ae7-901d-21c24c003e8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-214630ff-1c43-4ae7-901d-21c24c003e8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

