### PR TITLE
Open popular searches by default on home when 24h data exists

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -176,6 +176,10 @@ export default function App() {
             isLoading={isLoadingTopSearchKeywords}
             collapsible
             collapseOnSearch={isSearching}
+            defaultExpanded={
+              searchQuery.trim() === "" &&
+              topSearchKeywordsByPeriod.last24Hours.length > 0
+            }
           />
         }
       />

--- a/frontend/src/components/SearchForm.jsx
+++ b/frontend/src/components/SearchForm.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { Loader, X } from "react-feather";
 import { MAX_SEARCH_LENGTH, MIN_SEARCH_LENGTH } from "../constants";
-import { hasStoredStoreSelection } from "../utils/searchUrl";
 import StoreSelector from "./StoreSelector";
 
 const TIP_DISMISSED_STORAGE_KEY = "search-form-tip-dismissed";
@@ -293,7 +292,7 @@ const SearchForm = ({
           onSelectNone={onSelectNone}
           collapsible
           collapseOnSearch={isSearching}
-          defaultExpanded={!hasStoredStoreSelection()}
+          defaultExpanded={false}
         />
 
         {showTip && (

--- a/frontend/src/components/StoreSelector.jsx
+++ b/frontend/src/components/StoreSelector.jsx
@@ -3,22 +3,8 @@ import { ChevronDown, MapPin } from "react-feather";
 
 const SECTION_CLASS_NAME = "store-selector-section google-anno-skip mb-3";
 
-function getSelectionSummary(selectedStores, totalCount) {
-  const selectedCount = selectedStores.length;
-
-  if (selectedCount === 0) {
-    return "No stores selected";
-  }
-
-  if (selectedCount === totalCount) {
-    return `All ${totalCount} stores`;
-  }
-
-  if (selectedCount <= 3) {
-    return selectedStores.join(", ");
-  }
-
-  return `${selectedCount} of ${totalCount} stores`;
+function getSelectionSummary(selectedCount, totalCount) {
+  return `${selectedCount} of ${totalCount} stores selected`;
 }
 
 const StoreSelector = memo(
@@ -48,8 +34,8 @@ const StoreSelector = memo(
     const showContent = !collapsible || isExpanded;
 
     const summaryText = useMemo(
-      () => getSelectionSummary(selectedStores, totalCount),
-      [selectedStores, totalCount],
+      () => getSelectionSummary(selectedCount, totalCount),
+      [selectedCount, totalCount],
     );
 
     const handleToggleSection = () => {
@@ -78,11 +64,6 @@ const StoreSelector = memo(
             <span className="store-selector-title">
               {isExpanded ? "Stores" : summaryText}
             </span>
-            {!isExpanded && !allSelected && !noneSelected && (
-              <span className="store-selector-badge" aria-hidden="true">
-                {selectedCount}
-              </span>
-            )}
             <ChevronDown
               size={16}
               aria-hidden="true"

--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -110,12 +110,21 @@ export default function TopSearchKeywords({
   isLoading,
   collapsible = false,
   collapseOnSearch = false,
+  defaultExpanded = false,
 }) {
   const [period, setPeriod] = useState("last24Hours");
-  const [isExpanded, setIsExpanded] = useState(!collapsible);
+  const [isExpanded, setIsExpanded] = useState(
+    () => !collapsible || defaultExpanded,
+  );
   const isDesktop = useMediaQuery(DESKTOP_MIN_WIDTH_MEDIA_QUERY);
   const displayLimit = getDisplayLimit(isDesktop);
   const panelId = useId();
+
+  useEffect(() => {
+    if (defaultExpanded) {
+      setIsExpanded(true);
+    }
+  }, [defaultExpanded]);
 
   useEffect(() => {
     if (collapseOnSearch) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When a visitor lands on the home page with an empty search box, the popular searches panel now opens automatically once `latest.json` loads and includes keywords for the last 24 hours.

The store selector now starts collapsed by default, including for first-time visitors who still have all stores selected. When collapsed, it shows a consistent summary such as `17 of 18 stores selected`.

## Changes

- Added a `defaultExpanded` prop to `TopSearchKeywords`, matching the existing `StoreSelector` pattern.
- Wired `App.jsx` to pass `defaultExpanded` when `searchQuery` is empty and `last24Hours` keywords are available from the analytics export.
- Set `StoreSelector` `defaultExpanded={false}` so the store picker stays collapsed on load even when every store is selected.
- Updated collapsed store summary text to always use `X of Y stores selected` (removed the old `All N stores`, store-name list, and numeric badge variants).
- The popular searches panel still collapses while a search is in progress (`collapseOnSearch`).

## Testing

- `make test`
- `cd frontend && npm run lint`
- Verified locally at `http://localhost:5173/` with the Vite `/analytics` proxy: popular searches expand on load when 24h data is present, and the collapsed store selector shows `18 of 18 stores selected`.

## Screenshots

### Desktop

![Popular searches expanded and collapsed store selector showing X of Y stores selected on desktop](https://cursor.com/artifacts/c/art-db29f630-fd5d-4a7d-8515-d5f2f4182aef)

### Mobile

![Popular searches expanded and collapsed store selector showing X of Y stores selected on mobile](https://cursor.com/artifacts/c/art-12af58d4-55aa-4b84-a589-b6095e87007d)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7546b48f-45fe-47d7-8bb7-7be4d514015f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7546b48f-45fe-47d7-8bb7-7be4d514015f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

