### PR TITLE
Fix resizeObservers Set/Map type mismatch in useBottomChromeLayout

### DIFF
--- a/frontend/src/hooks/useBottomChromeLayout.js
+++ b/frontend/src/hooks/useBottomChromeLayout.js
@@ -104,7 +104,7 @@ function applyAnchorAdOffsets(footerNavHeight) {
 export default function useBottomChromeLayout() {
   useEffect(() => {
     let rafId = 0;
-    const resizeObservers = new Set();
+    const resizeObservers = new Map();
 
     const unobserveAnchorAd = (anchorAd) => {
       const observer = resizeObservers.get(anchorAd);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes repeated browser console errors: `Uncaught TypeError: s.set is not a function`.

In `useBottomChromeLayout`, the hook that keeps AdSense anchor ads above the bottom footer nav, `resizeObservers` was initialized as a `Set` but used with `Map` APIs (`.set`, `.get`, `.has`, `.delete`, `.keys`). That throws as soon as an anchor ad is observed.

## Fix

Change `new Set()` to `new Map()` so the collection type matches its usage.

## Testing

- `npm run lint` (frontend)
- `npm run build` (frontend)
- `make test` (full suite)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2538b54-7ebf-4d9f-a0cf-ebffd6ab75c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2538b54-7ebf-4d9f-a0cf-ebffd6ab75c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

