### PR TITLE
Fix Card Kingdom reference price disappearing from search results

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ data), not the Card Kingdom API. The refresh Lambda streams
 `AllPricesToday.json.bz2` and `AllPrintings.json.bz2`, picks the cheapest CK
 retail listing per card name, and batch-writes the index. Search verifies the
 query against Scryfall before looking up DynamoDB and omits stale entries older
-than 24 hours.
+than 48 hours.
 
 ```mermaid
 sequenceDiagram

--- a/api/controller/ckprice/ckprice.go
+++ b/api/controller/ckprice/ckprice.go
@@ -43,9 +43,7 @@ func listingIsFresh(listing *cardkingdom.Listing, now time.Time) bool {
 		return false
 	}
 
-	// Prefer DynamoDB sync time over MTGJSON's calendar price date. MTGJSON
-	// meta.date is midnight UTC, so a 24h window against it hides prices for
-	// most of the day after the first daily refresh.
+	// Prefer DynamoDB sync time over MTGJSON's calendar price date.
 	freshnessSource := listing.SyncedAt
 	if freshnessSource == "" {
 		freshnessSource = listing.UpdatedAt

--- a/api/controller/ckprice/ckprice.go
+++ b/api/controller/ckprice/ckprice.go
@@ -39,14 +39,26 @@ func GetLatestPrice(ctx context.Context, store ckprices.Store, query string) (*c
 }
 
 func listingIsFresh(listing *cardkingdom.Listing, now time.Time) bool {
-	if listing == nil || listing.UpdatedAt == "" {
+	if listing == nil {
 		return false
 	}
-	updatedAt, err := time.Parse(time.RFC3339, listing.UpdatedAt)
+
+	// Prefer DynamoDB sync time over MTGJSON's calendar price date. MTGJSON
+	// meta.date is midnight UTC, so a 24h window against it hides prices for
+	// most of the day after the first daily refresh.
+	freshnessSource := listing.SyncedAt
+	if freshnessSource == "" {
+		freshnessSource = listing.UpdatedAt
+	}
+	if freshnessSource == "" {
+		return false
+	}
+
+	freshnessTime, err := time.Parse(time.RFC3339, freshnessSource)
 	if err != nil {
 		return false
 	}
-	return !now.After(updatedAt.Add(config.CKPriceMaxAge))
+	return !now.After(freshnessTime.Add(config.CKPriceMaxAge))
 }
 
 // RefreshPrices downloads Card Kingdom retail prices from MTGJSON and upserts the DynamoDB index.

--- a/api/controller/ckprice/ckprice_test.go
+++ b/api/controller/ckprice/ckprice_test.go
@@ -71,7 +71,7 @@ func TestGetLatestPrice_StaleListing(t *testing.T) {
 		listing: &cardkingdom.Listing{
 			CardName:  "Lightning Bolt",
 			PriceUsd:  1.49,
-			UpdatedAt: time.Now().UTC().Add(-25 * time.Hour).Format(time.RFC3339),
+			UpdatedAt: time.Now().UTC().Add(-49 * time.Hour).Format(time.RFC3339),
 		},
 	}
 
@@ -87,7 +87,7 @@ func TestListingIsFresh(t *testing.T) {
 		UpdatedAt: "2026-06-26T00:00:00Z",
 	}, now))
 	require.False(t, listingIsFresh(&cardkingdom.Listing{
-		UpdatedAt: "2026-06-25T11:59:59Z",
+		UpdatedAt: "2026-06-24T11:59:59Z",
 	}, now))
 	require.False(t, listingIsFresh(&cardkingdom.Listing{}, now))
 }

--- a/api/controller/ckprice/ckprice_test.go
+++ b/api/controller/ckprice/ckprice_test.go
@@ -91,3 +91,16 @@ func TestListingIsFresh(t *testing.T) {
 	}, now))
 	require.False(t, listingIsFresh(&cardkingdom.Listing{}, now))
 }
+
+func TestListingIsFresh_PrefersSyncedAt(t *testing.T) {
+	now := time.Date(2026, 6, 29, 12, 0, 0, 0, time.UTC)
+
+	require.True(t, listingIsFresh(&cardkingdom.Listing{
+		UpdatedAt: "2026-06-27T00:00:00Z",
+		SyncedAt:  "2026-06-29T03:00:00Z",
+	}, now))
+	require.False(t, listingIsFresh(&cardkingdom.Listing{
+		UpdatedAt: "2026-06-29T03:00:00Z",
+		SyncedAt:  "2026-06-27T03:00:00Z",
+	}, now))
+}

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -109,7 +109,7 @@ func WebBotAuthTTL() time.Duration {
 func CKPriceLookupEnabled() bool {
 	rawValue := strings.TrimSpace(os.Getenv(CKPriceLookupEnabledEnv))
 	if rawValue == "" {
-		return false
+		return strings.TrimSpace(os.Getenv(CKDynamoDBTableEnv)) != ""
 	}
 
 	enabled, err := strconv.ParseBool(rawValue)

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -45,7 +45,7 @@ const (
 	// CKPriceLookupEnabledEnv toggles Card Kingdom price lookup on search responses.
 	CKPriceLookupEnabledEnv = "CK_PRICE_LOOKUP_ENABLED"
 	// CKPriceMaxAge is how old a DynamoDB CK listing may be before search omits it.
-	CKPriceMaxAge = 24 * time.Hour
+	CKPriceMaxAge = 48 * time.Hour
 	// MTGJSONAllPricesTodayURLEnv overrides the MTGJSON AllPricesToday download URL.
 	MTGJSONAllPricesTodayURLEnv = "MTGJSON_ALL_PRICES_TODAY_URL"
 	// MTGJSONAllPrintingsURLEnv overrides the MTGJSON AllPrintings download URL.

--- a/api/pkg/config/config_test.go
+++ b/api/pkg/config/config_test.go
@@ -35,8 +35,17 @@ func TestUseDynamicProxy(t *testing.T) {
 }
 
 func TestCKPriceLookupEnabled(t *testing.T) {
+	t.Run("defaults to enabled when dynamodb table is configured", func(t *testing.T) {
+		t.Setenv(CKPriceLookupEnabledEnv, "")
+		t.Setenv(CKDynamoDBTableEnv, "mtg-ck-prices")
+		if !CKPriceLookupEnabled() {
+			t.Fatalf("expected ck price lookup to be enabled when table is configured")
+		}
+	})
+
 	t.Run("defaults to disabled when unset", func(t *testing.T) {
 		t.Setenv(CKPriceLookupEnabledEnv, "")
+		t.Setenv(CKDynamoDBTableEnv, "")
 		if CKPriceLookupEnabled() {
 			t.Fatalf("expected ck price lookup to be disabled by default")
 		}

--- a/frontend/src/hooks/useSearch.js
+++ b/frontend/src/hooks/useSearch.js
@@ -221,6 +221,7 @@ export default function useSearch() {
                 storeErrors,
                 hasSearched: true,
                 searchError: null,
+                cardKingdomPrice: result.cardKingdomPrice ?? null,
               });
             }
             skipHistorySyncRef.current = false;
@@ -282,6 +283,7 @@ export default function useSearch() {
               storeErrors: [],
               hasSearched: true,
               searchError: nextSearchError,
+              cardKingdomPrice: null,
             });
           }
           skipHistorySyncRef.current = false;
@@ -327,6 +329,7 @@ export default function useSearch() {
       setSearchResults([]);
       setSearchStoreErrors([]);
       setSearchError(null);
+      setCardKingdomPrice(null);
       setDismissedStoreErrorsKey(null);
       setHasSearched(false);
       setIsSearching(false);
@@ -354,6 +357,7 @@ export default function useSearch() {
     setSearchStoreErrors(state.storeErrors || []);
     setHasSearched(!!state.hasSearched);
     setSearchError(state.searchError || null);
+    setCardKingdomPrice(state.cardKingdomPrice ?? null);
     setDismissedStoreErrorsKey(null);
     setIsSearching(false);
     setSearchProgress("Search");

--- a/frontend/src/utils/searchUrl.js
+++ b/frontend/src/utils/searchUrl.js
@@ -8,6 +8,7 @@ import { LGS_OPTIONS } from "../constants";
  *   storeErrors: object[],
  *   hasSearched: boolean,
  *   searchError: string | null,
+ *   cardKingdomPrice: object | null,
  * }} SearchHistoryState
  */
 
@@ -23,6 +24,7 @@ export function buildSearchHistoryState(snapshot) {
     storeErrors: snapshot.storeErrors,
     hasSearched: snapshot.hasSearched,
     searchError: snapshot.searchError,
+    cardKingdomPrice: snapshot.cardKingdomPrice ?? null,
   };
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Card Kingdom reference price banner was missing because the live API was not returning `cardKingdomPrice`.

Root cause: freshness was checked against MTGJSON's calendar `meta.date` (stored as midnight UTC in `updatedAt`). With a 24-hour max age, listings became stale for most of the day after the first daily refresh — even when DynamoDB had just been synced.

## Changes

- **Backend freshness:** Prefer DynamoDB `syncedAt` over MTGJSON `updatedAt` when deciding whether a CK listing is fresh enough to show.
- **Staleness window:** Increase `CKPriceMaxAge` from 24 to 48 hours.
- **Lookup default:** Enable CK price lookup by default when `CK_DYNAMODB_TABLE` is configured (explicit `CK_PRICE_LOOKUP_ENABLED=false` still disables it).
- **Frontend history:** Persist `cardKingdomPrice` in browser history state so back/forward navigation keeps the banner visible.

## Screenshots

### Desktop

![Card Kingdom reference price banner on desktop search results](https://cursor.com/artifacts/c/art-4fefbfbd-2c01-4e30-be43-ad10e027fb60)

### Mobile

![Card Kingdom reference price banner on mobile search results](https://cursor.com/artifacts/c/art-75c059e1-b960-42dd-92d7-cc38bb7b23d6)

## Testing

- `make test`
- `cd api && go test -mod=vendor -failfast -timeout 5m ./controller/ckprice/... ./pkg/config/... ./handler/...`
- `cd frontend && npm run lint`

## Notes

After deploy, search responses should again include `cardKingdomPrice` for cards present in the CK DynamoDB index, as long as the daily refresh Lambda has run within the last 48 hours.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-794896d9-24b1-4c78-9bf7-be5090bef2a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-794896d9-24b1-4c78-9bf7-be5090bef2a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

