### PR TITLE
Fix bottom nav Top button triggering page reload

### DIFF
--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -2,6 +2,10 @@ import { ArrowUp, FolderPlus, HelpCircle, Map as MapIcon } from "react-feather";
 import useBottomChromeLayout from "../hooks/useBottomChromeLayout";
 import AdComponent from "./AdComponent";
 
+const scrollToTop = () => {
+  window.scrollTo({ top: 0, behavior: "smooth" });
+};
+
 const Footer = ({ cartCount, onShowCart, onShowMap, onShowFaq }) => {
   useBottomChromeLayout();
 
@@ -53,10 +57,11 @@ const Footer = ({ cartCount, onShowCart, onShowMap, onShowFaq }) => {
               <span>FAQs</span>
             </div>
           </button>
-          <a
-            href="#top"
+          <button
+            type="button"
             aria-label="Scroll to top of page"
-            className="py-1 link-light link-offset-2 link-underline-opacity-0"
+            className="btn btn-link py-1 link-light link-offset-2 link-underline-opacity-0 text-decoration-none border-0"
+            onClick={scrollToTop}
           >
             <div className="px-2 py-1 d-inline-flex align-items-center">
               <span className="bottom-nav-icon">
@@ -64,7 +69,7 @@ const Footer = ({ cartCount, onShowCart, onShowMap, onShowFaq }) => {
               </span>
               <span>Top</span>
             </div>
-          </a>
+          </button>
         </div>
       </div>
     </>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The **Top** button in the fixed bottom navigation used `<a href="#top">`. That hash navigation can conflict with the search history API (`pushState`), causing a full page reload (and re-running the search from URL params) instead of scrolling to the top of the page.

## Fix

Replace the anchor with a `<button>` that calls `window.scrollTo({ top: 0, behavior: "smooth" })`, matching the pattern used by the other bottom-nav actions (Saved, Map, FAQs).

## Testing

- Manual: scroll down on a search results page, tap **Top** — page should scroll smoothly to the top without reloading or re-fetching search results.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e6ecb28c-2c02-424d-b3f0-9d91f4044223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6ecb28c-2c02-424d-b3f0-9d91f4044223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

