### PR TITLE
Fix CK refresh picking wrong variant when MTGJSON splits URLs and prices

### DIFF
--- a/api/gateway/cardkingdom/mtgjson_fetch.go
+++ b/api/gateway/cardkingdom/mtgjson_fetch.go
@@ -34,10 +34,22 @@ type ckUUIDPrice struct {
 type mtgjsonCard struct {
 	UUID         string `json:"uuid"`
 	Name         string `json:"name"`
+	Number       string `json:"number"`
 	PurchaseUrls struct {
 		CardKingdom     string `json:"cardKingdom"`
 		CardKingdomFoil string `json:"cardKingdomFoil"`
 	} `json:"purchaseUrls"`
+}
+
+type printingKey struct {
+	number string
+	name   string
+}
+
+type printingAggregate struct {
+	cardKingdom     string
+	cardKingdomFoil string
+	price           ckUUIDPrice
 }
 
 func fetchCheapestFromMTGJSON(ctx context.Context) (map[string]Listing, error) {
@@ -264,8 +276,12 @@ func decodeSetCatalog(
 			return err
 		}
 
+		aggregates := make(map[printingKey]printingAggregate)
 		for _, card := range set.Cards {
-			applyMTGJSONCardPrices(cheapest, card, set.Name, pricesByUUID, updatedAt)
+			mergePrintingAggregate(aggregates, card, pricesByUUID)
+		}
+		for key, aggregate := range aggregates {
+			applyPrintingAggregate(cheapest, key.name, set.Name, aggregate, updatedAt)
 		}
 	}
 
@@ -273,47 +289,76 @@ func decodeSetCatalog(
 	return err
 }
 
-func applyMTGJSONCardPrices(
-	cheapest map[string]Listing,
+func mergePrintingAggregate(
+	aggregates map[printingKey]printingAggregate,
 	card mtgjsonCard,
-	setName string,
 	pricesByUUID map[string]ckUUIDPrice,
-	updatedAt time.Time,
 ) {
-	price, ok := pricesByUUID[card.UUID]
-	if !ok {
+	name := strings.TrimSpace(card.Name)
+	if name == "" {
 		return
 	}
 
+	key := printingKey{
+		number: strings.TrimSpace(card.Number),
+		name:   name,
+	}
+	aggregate := aggregates[key]
+
+	if card.PurchaseUrls.CardKingdom != "" {
+		aggregate.cardKingdom = card.PurchaseUrls.CardKingdom
+	}
+	if card.PurchaseUrls.CardKingdomFoil != "" {
+		aggregate.cardKingdomFoil = card.PurchaseUrls.CardKingdomFoil
+	}
+	if price, ok := pricesByUUID[card.UUID]; ok {
+		if price.normal > aggregate.price.normal {
+			aggregate.price.normal = price.normal
+		}
+		if price.foil > aggregate.price.foil {
+			aggregate.price.foil = price.foil
+		}
+	}
+
+	aggregates[key] = aggregate
+}
+
+func applyPrintingAggregate(
+	cheapest map[string]Listing,
+	cardName string,
+	setName string,
+	aggregate printingAggregate,
+	updatedAt time.Time,
+) {
 	updatedAtValue := updatedAt.Format(time.RFC3339)
-	if price.normal > 0 && card.PurchaseUrls.CardKingdom != "" {
+	if aggregate.price.normal > 0 && aggregate.cardKingdom != "" {
 		considerCheapestListing(cheapest, Listing{
-			CardName:  card.Name,
+			CardName:  cardName,
 			Edition:   setName,
-			PriceUsd:  price.normal,
-			URL:       card.PurchaseUrls.CardKingdom,
+			PriceUsd:  aggregate.price.normal,
+			URL:       aggregate.cardKingdom,
 			Quantity:  0,
 			IsFoil:    false,
 			UpdatedAt: updatedAtValue,
 		})
 	}
 
-	if price.foil <= 0 {
+	if aggregate.price.foil <= 0 {
 		return
 	}
 
-	foilURL := card.PurchaseUrls.CardKingdomFoil
+	foilURL := aggregate.cardKingdomFoil
 	if foilURL == "" {
-		foilURL = card.PurchaseUrls.CardKingdom
+		foilURL = aggregate.cardKingdom
 	}
 	if foilURL == "" {
 		return
 	}
 
 	considerCheapestListing(cheapest, Listing{
-		CardName:  card.Name,
+		CardName:  cardName,
 		Edition:   setName,
-		PriceUsd:  price.foil,
+		PriceUsd:  aggregate.price.foil,
 		URL:       foilURL,
 		Quantity:  0,
 		IsFoil:    true,

--- a/api/gateway/cardkingdom/mtgjson_fetch_test.go
+++ b/api/gateway/cardkingdom/mtgjson_fetch_test.go
@@ -35,6 +35,25 @@ const sampleAllPricesToday = `{
         }
       }
     },
+    "uuid-tony-80-price": {
+      "paper": {
+        "cardkingdom": {
+          "retail": {
+            "normal": {"2026-06-28": 7.49},
+            "foil": {"2026-06-28": 8.99}
+          }
+        }
+      }
+    },
+    "uuid-tony-363-price": {
+      "paper": {
+        "cardkingdom": {
+          "retail": {
+            "foil": {"2026-06-28": 44.99}
+          }
+        }
+      }
+    },
     "uuid-no-ck": {
       "paper": {
         "tcgplayer": {
@@ -56,6 +75,7 @@ const sampleAllPrintings = `{
         {
           "uuid": "uuid-bolt-4ed",
           "name": "Lightning Bolt",
+          "number": "162",
           "purchaseUrls": {
             "cardKingdom": "https://www.cardkingdom.com/mtg/fourth-edition/lightning-bolt"
           }
@@ -68,10 +88,52 @@ const sampleAllPrintings = `{
         {
           "uuid": "uuid-bolt-mm-foil",
           "name": "Lightning Bolt",
+          "number": "141",
           "purchaseUrls": {
             "cardKingdom": "https://www.cardkingdom.com/mtg/modern-masters-2015/lightning-bolt",
             "cardKingdomFoil": "https://www.cardkingdom.com/mtg/modern-masters-2015/lightning-bolt-foil"
           }
+        }
+      ]
+    }
+  }
+}`
+
+const sampleAllPrintingsSplitUUID = `{
+  "meta": {"date": "2026-06-28"},
+  "data": {
+    "MSH": {
+      "name": "Marvel Super Heroes",
+      "cards": [
+        {
+          "uuid": "uuid-tony-80-url",
+          "name": "Tony Stark // The Invincible Iron Man",
+          "number": "80",
+          "purchaseUrls": {
+            "cardKingdom": "https://www.cardkingdom.com/mtg/marvel-super-heroes/tony-stark",
+            "cardKingdomFoil": "https://www.cardkingdom.com/mtg/marvel-super-heroes/tony-stark-foil"
+          }
+        },
+        {
+          "uuid": "uuid-tony-80-price",
+          "name": "Tony Stark // The Invincible Iron Man",
+          "number": "80",
+          "purchaseUrls": {}
+        },
+        {
+          "uuid": "uuid-tony-363-url",
+          "name": "Tony Stark // The Invincible Iron Man",
+          "number": "363",
+          "purchaseUrls": {
+            "cardKingdom": "https://www.cardkingdom.com/mtg/marvel-super-heroes-variants/tony-stark-0363-borderless",
+            "cardKingdomFoil": "https://www.cardkingdom.com/mtg/marvel-super-heroes-variants/tony-stark-0363-borderless-foil"
+          }
+        },
+        {
+          "uuid": "uuid-tony-363-price",
+          "name": "Tony Stark // The Invincible Iron Man",
+          "number": "363",
+          "purchaseUrls": {}
         }
       ]
     }
@@ -110,6 +172,29 @@ func TestDecodeAllPrintingsSets(t *testing.T) {
 	require.False(t, listing.IsFoil)
 	require.Equal(t, "https://www.cardkingdom.com/mtg/fourth-edition/lightning-bolt", listing.URL)
 	require.Equal(t, updatedAt.Format(time.RFC3339), listing.UpdatedAt)
+}
+
+func TestDecodeAllPrintingsSets_MergesSplitUUIDPrintings(t *testing.T) {
+	prices := map[string]ckUUIDPrice{
+		"uuid-tony-80-price":  {normal: 7.49, foil: 8.99},
+		"uuid-tony-363-price": {foil: 44.99},
+	}
+	updatedAt := time.Date(2026, 6, 28, 0, 0, 0, 0, time.UTC)
+
+	cheapest, err := decodeAllPrintingsSets(
+		json.NewDecoder(strings.NewReader(sampleAllPrintingsSplitUUID)),
+		prices,
+		updatedAt,
+	)
+	require.NoError(t, err)
+	require.Len(t, cheapest, 1)
+
+	listing := cheapest["tony stark // the invincible iron man"]
+	require.Equal(t, "Tony Stark // The Invincible Iron Man", listing.CardName)
+	require.Equal(t, "Marvel Super Heroes", listing.Edition)
+	require.InDelta(t, 7.49, listing.PriceUsd, 0.001)
+	require.False(t, listing.IsFoil)
+	require.Equal(t, "https://www.cardkingdom.com/mtg/marvel-super-heroes/tony-stark", listing.URL)
 }
 
 func TestFetchCheapestFromMTGJSON_FromTestServers(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The CK price refresh was not reliably selecting the cheapest Card Kingdom listing for cards where MTGJSON stores purchase URLs and retail prices on separate UUIDs for the same printing.

**Example:** searching for Tony Stark should resolve to Marvel Super Heroes #80 (~$7.49), but the refresh could surface the borderless #363 foil variant (~$44.99) instead.

## Root cause

MTGJSON can emit duplicate entries for the same set printing (`number` + `name`):
- one UUID has Card Kingdom `purchaseUrls`
- a sibling UUID has `AllPricesToday` retail prices

The refresh previously required both fields on the same UUID, so many printings were skipped during indexing. That left stale DynamoDB entries and/or caused cheaper printings to be missed when comparing variants.

## Fix

When streaming `AllPrintings`, merge Card Kingdom URLs and retail prices per printing (`set` + `number` + `name`) before choosing the cheapest listing per card name.

## Testing

- Added `TestDecodeAllPrintingsSets_MergesSplitUUIDPrintings` using a Tony Stark MSH fixture (split UUIDs for #80 and #363)
- `make test`
- `cd api && go test -mod=vendor -failfast -timeout 5m ./gateway/... ./controller/...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9871b1b3-e995-4c96-b33f-7ae38520db74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9871b1b3-e995-4c96-b33f-7ae38520db74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

