### PR TITLE
Add Amazon affiliate links admin dashboard and public API

### DIFF
--- a/api/controller/affiliatelinks/affiliatelinks.go
+++ b/api/controller/affiliatelinks/affiliatelinks.go
@@ -1,0 +1,228 @@
+package affiliatelinks
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	store "mtg-price-checker-sg/store/affiliatelinks"
+)
+
+var nowFunc = time.Now
+
+// Service coordinates affiliate link persistence and image uploads.
+type Service struct {
+	store  store.Store
+	images *store.ImageUploader
+	now    func() time.Time
+	newID  func() string
+}
+
+func NewService(linkStore store.Store, imageUploader *store.ImageUploader) *Service {
+	return &Service{
+		store:  linkStore,
+		images: imageUploader,
+		now:    nowFunc,
+		newID:  newLinkID,
+	}
+}
+
+// CreateInput is the payload for creating a new affiliate link.
+type CreateInput struct {
+	Title            string `json:"title"`
+	ImageURL         string `json:"imageUrl"`
+	ImageData        string `json:"imageData"`
+	ImageContentType string `json:"imageContentType"`
+	Price            string `json:"price"`
+	Link             string `json:"link"`
+	ExpiryDate       string `json:"expiryDate"`
+	Status           string `json:"status"`
+}
+
+// UpdateInput is the payload for updating an existing affiliate link.
+type UpdateInput struct {
+	Title            string `json:"title"`
+	ImageURL         string `json:"imageUrl"`
+	ImageData        string `json:"imageData"`
+	ImageContentType string `json:"imageContentType"`
+	Price            string `json:"price"`
+	Link             string `json:"link"`
+	ExpiryDate       string `json:"expiryDate"`
+	Status           string `json:"status"`
+}
+
+func (s *Service) ListAll(ctx context.Context) ([]store.Link, error) {
+	return s.store.ListAll(ctx)
+}
+
+func (s *Service) ListActive(ctx context.Context) ([]store.Link, error) {
+	links, err := s.store.ListAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	now := s.now().UTC()
+	active := make([]store.Link, 0, len(links))
+	for _, link := range links {
+		if link.IsActive(now) {
+			active = append(active, link)
+		}
+	}
+	return active, nil
+}
+
+func (s *Service) Create(ctx context.Context, input CreateInput) (store.Link, error) {
+	imageURL, err := s.resolveImageURL(ctx, strings.TrimSpace(input.ImageURL), input.ImageData, input.ImageContentType)
+	if err != nil {
+		return store.Link{}, err
+	}
+
+	link, err := s.buildLink("", input.Title, imageURL, input.Price, input.Link, input.ExpiryDate, input.Status, "", "")
+	if err != nil {
+		return store.Link{}, err
+	}
+
+	if err := s.store.Put(ctx, link); err != nil {
+		return store.Link{}, err
+	}
+	return link, nil
+}
+
+func (s *Service) Update(ctx context.Context, id string, input UpdateInput) (store.Link, error) {
+	existing, err := s.store.GetByID(ctx, id)
+	if err != nil {
+		return store.Link{}, err
+	}
+	if existing == nil {
+		return store.Link{}, fmt.Errorf("affiliate link not found")
+	}
+
+	imageURL := strings.TrimSpace(input.ImageURL)
+	if input.ImageData != "" {
+		imageURL, err = s.resolveImageURL(ctx, "", input.ImageData, input.ImageContentType)
+		if err != nil {
+			return store.Link{}, err
+		}
+	} else if imageURL == "" {
+		imageURL = existing.ImageURL
+	}
+
+	link, err := s.buildLink(id, input.Title, imageURL, input.Price, input.Link, input.ExpiryDate, input.Status, existing.CreatedAt, existing.UpdatedAt)
+	if err != nil {
+		return store.Link{}, err
+	}
+
+	if err := s.store.Put(ctx, link); err != nil {
+		return store.Link{}, err
+	}
+	return link, nil
+}
+
+func (s *Service) Delete(ctx context.Context, id string) error {
+	existing, err := s.store.GetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	if existing == nil {
+		return fmt.Errorf("affiliate link not found")
+	}
+	return s.store.Delete(ctx, id)
+}
+
+func (s *Service) buildLink(id, title, imageURL, price, linkURL, expiryDate, status, createdAt, updatedAt string) (store.Link, error) {
+	title = strings.TrimSpace(title)
+	imageURL = strings.TrimSpace(imageURL)
+	price = strings.TrimSpace(price)
+	linkURL = strings.TrimSpace(linkURL)
+	expiryDate = strings.TrimSpace(expiryDate)
+	status = normalizeStatus(status)
+
+	if imageURL == "" {
+		return store.Link{}, fmt.Errorf("image is required")
+	}
+	if price == "" {
+		return store.Link{}, fmt.Errorf("price is required")
+	}
+	if linkURL == "" {
+		return store.Link{}, fmt.Errorf("link is required")
+	}
+	if err := validateExpiryDate(expiryDate); err != nil {
+		return store.Link{}, err
+	}
+
+	now := s.now().UTC().Format(time.RFC3339)
+	if id == "" {
+		id = s.newID()
+		createdAt = now
+	}
+	if createdAt == "" {
+		createdAt = now
+	}
+
+	return store.Link{
+		ID:         id,
+		Title:      title,
+		ImageURL:   imageURL,
+		Price:      price,
+		Link:       linkURL,
+		ExpiryDate: expiryDate,
+		Status:     status,
+		CreatedAt:  createdAt,
+		UpdatedAt:  now,
+	}, nil
+}
+
+func (s *Service) resolveImageURL(ctx context.Context, imageURL, imageData, contentType string) (string, error) {
+	imageURL = strings.TrimSpace(imageURL)
+	imageData = strings.TrimSpace(imageData)
+	contentType = strings.TrimSpace(contentType)
+
+	if imageData != "" {
+		if s.images == nil {
+			return "", fmt.Errorf("image upload is not configured")
+		}
+		raw, err := base64.StdEncoding.DecodeString(imageData)
+		if err != nil {
+			return "", fmt.Errorf("invalid image data")
+		}
+		return s.images.Upload(ctx, raw, contentType)
+	}
+	if imageURL == "" {
+		return "", fmt.Errorf("image is required")
+	}
+	return imageURL, nil
+}
+
+func normalizeStatus(status string) string {
+	status = strings.ToLower(strings.TrimSpace(status))
+	if status == "" {
+		return store.StatusActive
+	}
+	if status != store.StatusActive && status != store.StatusInactive {
+		return store.StatusActive
+	}
+	return status
+}
+
+func validateExpiryDate(expiryDate string) error {
+	if expiryDate == "" {
+		return nil
+	}
+	_, err := time.Parse("2006-01-02", expiryDate)
+	if err != nil {
+		return fmt.Errorf("expiry date must use YYYY-MM-DD format")
+	}
+	return nil
+}
+
+func newLinkID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("link-%d", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(b[:])
+}

--- a/api/controller/affiliatelinks/affiliatelinks_test.go
+++ b/api/controller/affiliatelinks/affiliatelinks_test.go
@@ -1,0 +1,81 @@
+package affiliatelinks
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	store "mtg-price-checker-sg/store/affiliatelinks"
+
+	"github.com/stretchr/testify/require"
+)
+
+type memoryStore struct {
+	links map[string]store.Link
+}
+
+func (m *memoryStore) ListAll(ctx context.Context) ([]store.Link, error) {
+	links := make([]store.Link, 0, len(m.links))
+	for _, link := range m.links {
+		links = append(links, link)
+	}
+	return links, nil
+}
+
+func (m *memoryStore) GetByID(ctx context.Context, id string) (*store.Link, error) {
+	link, ok := m.links[id]
+	if !ok {
+		return nil, nil
+	}
+	return &link, nil
+}
+
+func (m *memoryStore) Put(ctx context.Context, link store.Link) error {
+	m.links[link.ID] = link
+	return nil
+}
+
+func (m *memoryStore) Delete(ctx context.Context, id string) error {
+	delete(m.links, id)
+	return nil
+}
+
+func TestServiceListActiveFiltersExpiredAndInactive(t *testing.T) {
+	fixedNow := time.Date(2026, 6, 29, 12, 0, 0, 0, time.UTC)
+	service := NewService(&memoryStore{
+		links: map[string]store.Link{
+			"1": {ID: "1", Status: store.StatusActive, ExpiryDate: "2099-01-01", ImageURL: "img", Price: "1", Link: "link"},
+			"2": {ID: "2", Status: store.StatusInactive, ExpiryDate: "2099-01-01", ImageURL: "img", Price: "1", Link: "link"},
+			"3": {ID: "3", Status: store.StatusActive, ExpiryDate: "2026-06-28", ImageURL: "img", Price: "1", Link: "link"},
+		},
+	}, nil)
+	service.now = func() time.Time { return fixedNow }
+
+	links, err := service.ListActive(context.Background())
+	require.NoError(t, err)
+	require.Len(t, links, 1)
+	require.Equal(t, "1", links[0].ID)
+}
+
+func TestServiceCreateRequiresFields(t *testing.T) {
+	service := NewService(&memoryStore{links: map[string]store.Link{}}, nil)
+	service.now = func() time.Time { return time.Date(2026, 6, 29, 0, 0, 0, 0, time.UTC) }
+	service.newID = func() string { return "abc123" }
+
+	_, err := service.Create(context.Background(), CreateInput{
+		Price: "S$10",
+		Link:  "https://amazon.sg/example",
+	})
+	require.Error(t, err)
+
+	link, err := service.Create(context.Background(), CreateInput{
+		ImageURL: "https://example.com/image.jpg",
+		Price:    "S$10",
+		Link:     "https://amazon.sg/example?tag=test-20",
+		Title:    "Deck Box",
+		Status:   store.StatusActive,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "abc123", link.ID)
+	require.Equal(t, "Deck Box", link.Title)
+}

--- a/api/handler/admin_auth.go
+++ b/api/handler/admin_auth.go
@@ -1,0 +1,43 @@
+package handler
+
+import (
+	"os"
+	"strings"
+
+	"mtg-price-checker-sg/pkg/config"
+)
+
+func isAffiliateAdminAuthorized(headers map[string]string) bool {
+	expected := strings.TrimSpace(os.Getenv(config.AffiliateAdminAPIKeyEnv))
+	if expected == "" {
+		return false
+	}
+
+	if token := bearerToken(headers); token != "" && token == expected {
+		return true
+	}
+
+	for _, key := range []string{"x-admin-api-key", "X-Admin-Api-Key"} {
+		if headers[key] == expected {
+			return true
+		}
+	}
+
+	return false
+}
+
+func bearerToken(headers map[string]string) string {
+	authHeader := strings.TrimSpace(headers["authorization"])
+	if authHeader == "" {
+		authHeader = strings.TrimSpace(headers["Authorization"])
+	}
+	if authHeader == "" {
+		return ""
+	}
+
+	const prefix = "Bearer "
+	if !strings.HasPrefix(authHeader, prefix) {
+		return ""
+	}
+	return strings.TrimSpace(strings.TrimPrefix(authHeader, prefix))
+}

--- a/api/handler/affiliate_links.go
+++ b/api/handler/affiliate_links.go
@@ -1,0 +1,177 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	affiliatecontroller "mtg-price-checker-sg/controller/affiliatelinks"
+	"mtg-price-checker-sg/store/affiliatelinks"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+const (
+	affiliateLinksPublicPath = "/affiliate-links"
+	affiliateLinksAdminPath  = "/admin/affiliate-links"
+	affiliateAdminCORSMethods = "GET, POST, PUT, DELETE, OPTIONS"
+)
+
+type affiliateLinksResponse struct {
+	Data []affiliatelinks.Link `json:"data"`
+}
+
+var newAffiliateService = func(ctx context.Context) (*affiliatecontroller.Service, error) {
+	store, err := affiliatelinks.NewDynamoDBStore(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	uploader, err := affiliatelinks.NewImageUploader(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return affiliatecontroller.NewService(store, uploader), nil
+}
+
+func AffiliateLinks(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	var apiRes events.APIGatewayProxyResponse
+	origin := request.Headers["origin"]
+
+	if request.HTTPMethod == "OPTIONS" {
+		return optionsResponseWithMethods(origin, "GET, OPTIONS")
+	}
+
+	if request.HTTPMethod != http.MethodGet {
+		return errorResponse(apiRes, origin, "method not allowed", http.StatusMethodNotAllowed)
+	}
+
+	service, err := newAffiliateService(ctx)
+	if err != nil {
+		return errorResponse(apiRes, origin, "affiliate links are not configured", http.StatusServiceUnavailable)
+	}
+
+	links, err := service.ListActive(ctx)
+	if err != nil {
+		return errorResponse(apiRes, origin, "failed to load affiliate links", http.StatusInternalServerError)
+	}
+	if links == nil {
+		links = []affiliatelinks.Link{}
+	}
+
+	return jsonResponse(apiRes, origin, http.StatusOK, affiliateLinksResponse{Data: links})
+}
+
+func AdminAffiliateLinks(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	var apiRes events.APIGatewayProxyResponse
+	origin := request.Headers["origin"]
+	path := normalizeAPIPath(request.Path)
+
+	if request.HTTPMethod == "OPTIONS" {
+		return optionsResponseWithMethods(origin, affiliateAdminCORSMethods)
+	}
+
+	if !isAffiliateAdminAuthorized(request.Headers) {
+		return errorResponseWithMethods(apiRes, origin, "unauthorized", http.StatusUnauthorized, affiliateAdminCORSMethods)
+	}
+
+	service, err := newAffiliateService(ctx)
+	if err != nil {
+		return errorResponseWithMethods(apiRes, origin, "affiliate links are not configured", http.StatusServiceUnavailable, affiliateAdminCORSMethods)
+	}
+
+	switch request.HTTPMethod {
+	case http.MethodGet:
+		links, listErr := service.ListAll(ctx)
+		if listErr != nil {
+			return errorResponseWithMethods(apiRes, origin, "failed to load affiliate links", http.StatusInternalServerError, affiliateAdminCORSMethods)
+		}
+		if links == nil {
+			links = []affiliatelinks.Link{}
+		}
+		return jsonResponseWithMethods(apiRes, origin, http.StatusOK, affiliateLinksResponse{Data: links}, affiliateAdminCORSMethods)
+
+	case http.MethodPost:
+		var input affiliatecontroller.CreateInput
+		if err := json.Unmarshal([]byte(request.Body), &input); err != nil {
+			return errorResponseWithMethods(apiRes, origin, "invalid request body", http.StatusBadRequest, affiliateAdminCORSMethods)
+		}
+		link, createErr := service.Create(ctx, input)
+		if createErr != nil {
+			return errorResponseWithMethods(apiRes, origin, createErr.Error(), http.StatusBadRequest, affiliateAdminCORSMethods)
+		}
+		return jsonResponseWithMethods(apiRes, origin, http.StatusCreated, link, affiliateAdminCORSMethods)
+
+	case http.MethodPut:
+		id := affiliateLinkIDFromPath(path)
+		if id == "" {
+			return errorResponseWithMethods(apiRes, origin, "link id is required", http.StatusBadRequest, affiliateAdminCORSMethods)
+		}
+		var input affiliatecontroller.UpdateInput
+		if err := json.Unmarshal([]byte(request.Body), &input); err != nil {
+			return errorResponseWithMethods(apiRes, origin, "invalid request body", http.StatusBadRequest, affiliateAdminCORSMethods)
+		}
+		link, updateErr := service.Update(ctx, id, input)
+		if updateErr != nil {
+			if updateErr.Error() == "affiliate link not found" {
+				return errorResponseWithMethods(apiRes, origin, updateErr.Error(), http.StatusNotFound, affiliateAdminCORSMethods)
+			}
+			return errorResponseWithMethods(apiRes, origin, updateErr.Error(), http.StatusBadRequest, affiliateAdminCORSMethods)
+		}
+		return jsonResponseWithMethods(apiRes, origin, http.StatusOK, link, affiliateAdminCORSMethods)
+
+	case http.MethodDelete:
+		id := affiliateLinkIDFromPath(path)
+		if id == "" {
+			return errorResponseWithMethods(apiRes, origin, "link id is required", http.StatusBadRequest, affiliateAdminCORSMethods)
+		}
+		if deleteErr := service.Delete(ctx, id); deleteErr != nil {
+			if deleteErr.Error() == "affiliate link not found" {
+				return errorResponseWithMethods(apiRes, origin, deleteErr.Error(), http.StatusNotFound, affiliateAdminCORSMethods)
+			}
+			return errorResponseWithMethods(apiRes, origin, "failed to delete affiliate link", http.StatusInternalServerError, affiliateAdminCORSMethods)
+		}
+		return jsonResponseWithMethods(apiRes, origin, http.StatusNoContent, map[string]string{}, affiliateAdminCORSMethods)
+
+	default:
+		return errorResponseWithMethods(apiRes, origin, "method not allowed", http.StatusMethodNotAllowed, affiliateAdminCORSMethods)
+	}
+}
+
+func routeAffiliateRequest(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	path := normalizeAPIPath(request.Path)
+	switch {
+	case path == affiliateLinksPublicPath:
+		return AffiliateLinks(ctx, request)
+	case path == affiliateLinksAdminPath || strings.HasPrefix(path, affiliateLinksAdminPath+"/"):
+		return AdminAffiliateLinks(ctx, request)
+	default:
+		var apiRes events.APIGatewayProxyResponse
+		return errorResponse(apiRes, request.Headers["origin"], "not found", http.StatusNotFound)
+	}
+}
+
+func normalizeAPIPath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "/"
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	if idx := strings.Index(path, "/admin/"); idx >= 0 {
+		return strings.TrimSuffix(path[idx:], "/")
+	}
+	if idx := strings.Index(path, "/affiliate-links"); idx >= 0 {
+		return strings.TrimSuffix(path[idx:], "/")
+	}
+	return strings.TrimSuffix(path, "/")
+}
+
+func affiliateLinkIDFromPath(path string) string {
+	path = strings.TrimPrefix(path, affiliateLinksAdminPath)
+	path = strings.TrimPrefix(path, "/")
+	return strings.TrimSpace(path)
+}

--- a/api/handler/affiliate_links_test.go
+++ b/api/handler/affiliate_links_test.go
@@ -1,0 +1,165 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"os"
+	"testing"
+
+	affiliatecontroller "mtg-price-checker-sg/controller/affiliatelinks"
+	"mtg-price-checker-sg/pkg/config"
+	"mtg-price-checker-sg/store/affiliatelinks"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/stretchr/testify/require"
+)
+
+type stubAffiliateService struct {
+	active []affiliatelinks.Link
+	all    []affiliatelinks.Link
+}
+
+func (s *stubAffiliateService) ListActive(ctx context.Context) ([]affiliatelinks.Link, error) {
+	return s.active, nil
+}
+
+func (s *stubAffiliateService) ListAll(ctx context.Context) ([]affiliatelinks.Link, error) {
+	return s.all, nil
+}
+
+func (s *stubAffiliateService) Create(ctx context.Context, input affiliatecontroller.CreateInput) (affiliatelinks.Link, error) {
+	return affiliatelinks.Link{ID: "new", Title: input.Title}, nil
+}
+
+func (s *stubAffiliateService) Update(ctx context.Context, id string, input affiliatecontroller.UpdateInput) (affiliatelinks.Link, error) {
+	return affiliatelinks.Link{ID: id, Title: input.Title}, nil
+}
+
+func (s *stubAffiliateService) Delete(ctx context.Context, id string) error {
+	return nil
+}
+
+func TestNormalizeAPIPath(t *testing.T) {
+	require.Equal(t, "/affiliate-links", normalizeAPIPath("/prod/affiliate-links"))
+	require.Equal(t, "/admin/affiliate-links", normalizeAPIPath("/prod/admin/affiliate-links"))
+	require.Equal(t, "/admin/affiliate-links/abc", normalizeAPIPath("/admin/affiliate-links/abc"))
+}
+
+func TestIsAffiliateAdminAuthorized(t *testing.T) {
+	t.Setenv(config.AffiliateAdminAPIKeyEnv, "secret-key")
+
+	require.True(t, isAffiliateAdminAuthorized(map[string]string{
+		"authorization": "Bearer secret-key",
+	}))
+	require.True(t, isAffiliateAdminAuthorized(map[string]string{
+		"x-admin-api-key": "secret-key",
+	}))
+	require.False(t, isAffiliateAdminAuthorized(map[string]string{
+		"authorization": "Bearer wrong",
+	}))
+}
+
+func TestAffiliateLinksPublicGET(t *testing.T) {
+	original := newAffiliateService
+	defer func() { newAffiliateService = original }()
+
+	newAffiliateService = func(ctx context.Context) (*affiliatecontroller.Service, error) {
+		return affiliatecontroller.NewService(&memoryAffiliateStore{
+			links: []affiliatelinks.Link{
+				{ID: "1", Status: affiliatelinks.StatusActive, ImageURL: "img", Price: "1", Link: "link"},
+			},
+		}, nil), nil
+	}
+
+	resp, err := AffiliateLinks(context.Background(), events.APIGatewayProxyRequest{
+		HTTPMethod: http.MethodGet,
+		Path:       "/affiliate-links",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var payload affiliateLinksResponse
+	require.NoError(t, json.Unmarshal([]byte(resp.Body), &payload))
+	require.Len(t, payload.Data, 1)
+}
+
+func TestAdminAffiliateLinksUnauthorized(t *testing.T) {
+	t.Setenv(config.AffiliateAdminAPIKeyEnv, "secret-key")
+
+	resp, err := AdminAffiliateLinks(context.Background(), events.APIGatewayProxyRequest{
+		HTTPMethod: http.MethodGet,
+		Path:       "/admin/affiliate-links",
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestAdminAffiliateLinksAuthorizedGET(t *testing.T) {
+	t.Setenv(config.AffiliateAdminAPIKeyEnv, "secret-key")
+
+	original := newAffiliateService
+	defer func() { newAffiliateService = original }()
+
+	newAffiliateService = func(ctx context.Context) (*affiliatecontroller.Service, error) {
+		return affiliatecontroller.NewService(&memoryAffiliateStore{
+			links: []affiliatelinks.Link{
+				{ID: "1", Title: "Deck Box", Status: affiliatelinks.StatusActive, ImageURL: "img", Price: "1", Link: "link"},
+			},
+		}, nil), nil
+	}
+
+	resp, err := AdminAffiliateLinks(context.Background(), events.APIGatewayProxyRequest{
+		HTTPMethod: http.MethodGet,
+		Path:       "/admin/affiliate-links",
+		Headers: map[string]string{
+			"x-admin-api-key": "secret-key",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+type memoryAffiliateStore struct {
+	links []affiliatelinks.Link
+}
+
+func (m *memoryAffiliateStore) ListAll(ctx context.Context) ([]affiliatelinks.Link, error) {
+	return m.links, nil
+}
+
+func (m *memoryAffiliateStore) GetByID(ctx context.Context, id string) (*affiliatelinks.Link, error) {
+	for _, link := range m.links {
+		if link.ID == id {
+			copy := link
+			return &copy, nil
+		}
+	}
+	return nil, nil
+}
+
+func (m *memoryAffiliateStore) Put(ctx context.Context, link affiliatelinks.Link) error {
+	for i, existing := range m.links {
+		if existing.ID == link.ID {
+			m.links[i] = link
+			return nil
+		}
+	}
+	m.links = append(m.links, link)
+	return nil
+}
+
+func (m *memoryAffiliateStore) Delete(ctx context.Context, id string) error {
+	filtered := m.links[:0]
+	for _, link := range m.links {
+		if link.ID != id {
+			filtered = append(filtered, link)
+		}
+	}
+	m.links = filtered
+	return nil
+}
+
+func TestMain(m *testing.M) {
+	os.Exit(m.Run())
+}

--- a/api/handler/cors.go
+++ b/api/handler/cors.go
@@ -12,13 +12,17 @@ import (
 )
 
 func applyCORSHeaders(apiResponse *events.APIGatewayProxyResponse, origin string) {
+	applyCORSHeadersWithMethods(apiResponse, origin, "GET, OPTIONS")
+}
+
+func applyCORSHeadersWithMethods(apiResponse *events.APIGatewayProxyResponse, origin string, methods string) {
 	if !slices.Contains(config.GetAllowedOrigins(), origin) {
 		return
 	}
 	apiResponse.Headers = map[string]string{
 		"Access-Control-Allow-Origin":  origin,
-		"Access-Control-Allow-Methods": "GET, OPTIONS",
-		"Access-Control-Allow-Headers": "Content-Type",
+		"Access-Control-Allow-Methods": methods,
+		"Access-Control-Allow-Headers": "Content-Type, Authorization, X-Admin-Api-Key",
 		"Vary":                         "Origin",
 	}
 }
@@ -29,14 +33,24 @@ func jsonResponse(
 	statusCode int,
 	payload any,
 ) (events.APIGatewayProxyResponse, error) {
+	return jsonResponseWithMethods(apiResponse, origin, statusCode, payload, "GET, OPTIONS")
+}
+
+func jsonResponseWithMethods(
+	apiResponse events.APIGatewayProxyResponse,
+	origin string,
+	statusCode int,
+	payload any,
+	methods string,
+) (events.APIGatewayProxyResponse, error) {
 	apiResponse.StatusCode = statusCode
-	applyCORSHeaders(&apiResponse, origin)
+	applyCORSHeadersWithMethods(&apiResponse, origin, methods)
 
 	var buf bytes.Buffer
 	encoder := json.NewEncoder(&buf)
 	encoder.SetEscapeHTML(false)
 	if err := encoder.Encode(payload); err != nil {
-		return errorResponse(apiResponse, origin, "err marshalling response", http.StatusInternalServerError)
+		return errorResponseWithMethods(apiResponse, origin, "err marshalling response", http.StatusInternalServerError, methods)
 	}
 
 	apiResponse.Body = buf.String()
@@ -49,8 +63,18 @@ func errorResponse(
 	message string,
 	statusCode int,
 ) (events.APIGatewayProxyResponse, error) {
+	return errorResponseWithMethods(apiResponse, origin, message, statusCode, "GET, OPTIONS")
+}
+
+func errorResponseWithMethods(
+	apiResponse events.APIGatewayProxyResponse,
+	origin string,
+	message string,
+	statusCode int,
+	methods string,
+) (events.APIGatewayProxyResponse, error) {
 	apiResponse.StatusCode = statusCode
-	applyCORSHeaders(&apiResponse, origin)
+	applyCORSHeadersWithMethods(&apiResponse, origin, methods)
 
 	var buf bytes.Buffer
 	encoder := json.NewEncoder(&buf)
@@ -69,7 +93,11 @@ func errorResponse(
 }
 
 func optionsResponse(origin string) (events.APIGatewayProxyResponse, error) {
+	return optionsResponseWithMethods(origin, "GET, OPTIONS")
+}
+
+func optionsResponseWithMethods(origin string, methods string) (events.APIGatewayProxyResponse, error) {
 	apiResponse := events.APIGatewayProxyResponse{StatusCode: http.StatusNoContent}
-	applyCORSHeaders(&apiResponse, origin)
+	applyCORSHeadersWithMethods(&apiResponse, origin, methods)
 	return apiResponse, nil
 }

--- a/api/handler/router.go
+++ b/api/handler/router.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"strings"
 
 	"github.com/aws/aws-lambda-go/events"
 )
@@ -24,6 +25,11 @@ func Handle(ctx context.Context, event json.RawMessage) (any, error) {
 	var apiRequest events.APIGatewayProxyRequest
 	if err := json.Unmarshal(event, &apiRequest); err != nil {
 		return events.APIGatewayProxyResponse{}, err
+	}
+
+	path := normalizeAPIPath(apiRequest.Path)
+	if path == affiliateLinksPublicPath || strings.HasPrefix(path, affiliateLinksAdminPath) {
+		return routeAffiliateRequest(ctx, apiRequest)
 	}
 
 	return Search(ctx, apiRequest)

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -71,6 +71,18 @@ const (
 	SiteBaseURL = "https://gishathfetch.com/"
 	// AWSRegion is the AWS region used for DynamoDB and other managed services.
 	AWSRegion = "ap-southeast-1"
+	// AffiliateLinksDynamoDBTableEnv is the DynamoDB table for Amazon affiliate links.
+	AffiliateLinksDynamoDBTableEnv = "AFFILIATE_LINKS_DYNAMODB_TABLE"
+	// AffiliateAdminAPIKeyEnv protects admin affiliate-link write endpoints.
+	AffiliateAdminAPIKeyEnv = "AFFILIATE_ADMIN_API_KEY"
+	// AffiliateImagesS3BucketEnv is the bucket used for uploaded affiliate images.
+	AffiliateImagesS3BucketEnv = "AFFILIATE_IMAGES_S3_BUCKET"
+	// AffiliateImagesS3DefaultBucket is the default bucket for affiliate images.
+	AffiliateImagesS3DefaultBucket = "gishathfetch.com"
+	// AffiliateImagesS3PrefixEnv is the object key prefix for affiliate images.
+	AffiliateImagesS3PrefixEnv = "AFFILIATE_IMAGES_S3_PREFIX"
+	// AffiliateImagesS3DefaultPrefix is the default object key prefix for affiliate images.
+	AffiliateImagesS3DefaultPrefix = "affiliate/images"
 )
 
 // UseLeasedDedicatedProxy enables exclusive per-request leases from the dedicated proxy pool.

--- a/api/store/affiliatelinks/dynamodb.go
+++ b/api/store/affiliatelinks/dynamodb.go
@@ -1,0 +1,110 @@
+package affiliatelinks
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"mtg-price-checker-sg/pkg/config"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+type DynamoDBStore struct {
+	client    *dynamodb.Client
+	tableName string
+}
+
+func NewDynamoDBStore(ctx context.Context) (*DynamoDBStore, error) {
+	tableName := strings.TrimSpace(os.Getenv(config.AffiliateLinksDynamoDBTableEnv))
+	if tableName == "" {
+		return nil, fmt.Errorf("affiliatelinks: %s is not set", config.AffiliateLinksDynamoDBTableEnv)
+	}
+
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(config.AWSRegion))
+	if err != nil {
+		return nil, err
+	}
+
+	return &DynamoDBStore{
+		client:    dynamodb.NewFromConfig(cfg),
+		tableName: tableName,
+	}, nil
+}
+
+func (s *DynamoDBStore) ListAll(ctx context.Context) ([]Link, error) {
+	var links []Link
+	var lastEvaluatedKey map[string]types.AttributeValue
+
+	for {
+		output, err := s.client.Scan(ctx, &dynamodb.ScanInput{
+			TableName:         aws.String(s.tableName),
+			ExclusiveStartKey: lastEvaluatedKey,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		var page []Link
+		if err := attributevalue.UnmarshalListOfMaps(output.Items, &page); err != nil {
+			return nil, err
+		}
+		links = append(links, page...)
+
+		if len(output.LastEvaluatedKey) == 0 {
+			break
+		}
+		lastEvaluatedKey = output.LastEvaluatedKey
+	}
+
+	return links, nil
+}
+
+func (s *DynamoDBStore) GetByID(ctx context.Context, id string) (*Link, error) {
+	output, err := s.client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName: aws.String(s.tableName),
+		Key: map[string]types.AttributeValue{
+			"id": &types.AttributeValueMemberS{Value: id},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(output.Item) == 0 {
+		return nil, nil
+	}
+
+	var link Link
+	if err := attributevalue.UnmarshalMap(output.Item, &link); err != nil {
+		return nil, err
+	}
+	return &link, nil
+}
+
+func (s *DynamoDBStore) Put(ctx context.Context, link Link) error {
+	item, err := attributevalue.MarshalMap(link)
+	if err != nil {
+		return err
+	}
+
+	_, err = s.client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String(s.tableName),
+		Item:      item,
+	})
+	return err
+}
+
+func (s *DynamoDBStore) Delete(ctx context.Context, id string) error {
+	_, err := s.client.DeleteItem(ctx, &dynamodb.DeleteItemInput{
+		TableName: aws.String(s.tableName),
+		Key: map[string]types.AttributeValue{
+			"id": &types.AttributeValueMemberS{Value: id},
+		},
+	})
+	return err
+}

--- a/api/store/affiliatelinks/id.go
+++ b/api/store/affiliatelinks/id.go
@@ -1,0 +1,15 @@
+package affiliatelinks
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+)
+
+func newImageObjectID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return fmt.Sprintf("%d", b[0])
+	}
+	return hex.EncodeToString(b[:])
+}

--- a/api/store/affiliatelinks/images.go
+++ b/api/store/affiliatelinks/images.go
@@ -1,0 +1,89 @@
+package affiliatelinks
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"mtg-price-checker-sg/pkg/config"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+const maxImageBytes = 2 * 1024 * 1024
+
+var allowedImageContentTypes = map[string]string{
+	"image/jpeg": ".jpg",
+	"image/png":  ".png",
+	"image/webp": ".webp",
+	"image/gif":  ".gif",
+}
+
+type ImageUploader struct {
+	client objectWriter
+	bucket string
+	prefix string
+}
+
+type objectWriter interface {
+	PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error)
+}
+
+var loadAWSConfig = func(ctx context.Context) (aws.Config, error) {
+	return awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(config.AWSRegion))
+}
+
+func NewImageUploader(ctx context.Context) (*ImageUploader, error) {
+	bucket := strings.TrimSpace(os.Getenv(config.AffiliateImagesS3BucketEnv))
+	if bucket == "" {
+		bucket = config.AffiliateImagesS3DefaultBucket
+	}
+
+	prefix := strings.Trim(strings.TrimSpace(os.Getenv(config.AffiliateImagesS3PrefixEnv)), "/")
+	if prefix == "" {
+		prefix = config.AffiliateImagesS3DefaultPrefix
+	}
+
+	cfg, err := loadAWSConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ImageUploader{
+		client: s3.NewFromConfig(cfg),
+		bucket: bucket,
+		prefix: prefix,
+	}, nil
+}
+
+func (u *ImageUploader) Upload(ctx context.Context, data []byte, contentType string) (string, error) {
+	if len(data) == 0 {
+		return "", fmt.Errorf("affiliatelinks: image data is required")
+	}
+	if len(data) > maxImageBytes {
+		return "", fmt.Errorf("affiliatelinks: image exceeds %d byte limit", maxImageBytes)
+	}
+
+	ext, ok := allowedImageContentTypes[strings.ToLower(strings.TrimSpace(contentType))]
+	if !ok {
+		return "", fmt.Errorf("affiliatelinks: unsupported image content type %q", contentType)
+	}
+
+	key := path.Join(u.prefix, newImageObjectID()+ext)
+	_, err := u.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:      aws.String(u.bucket),
+		Key:         aws.String(key),
+		Body:        bytes.NewReader(data),
+		ContentType: aws.String(contentType),
+	})
+	if err != nil {
+		return "", fmt.Errorf("affiliatelinks: upload image: %w", err)
+	}
+
+	return fmt.Sprintf("https://%s/%s", u.bucket, key), nil
+}

--- a/api/store/affiliatelinks/link.go
+++ b/api/store/affiliatelinks/link.go
@@ -1,0 +1,37 @@
+package affiliatelinks
+
+import "time"
+
+const (
+	StatusActive   = "active"
+	StatusInactive = "inactive"
+)
+
+// Link is a curated Amazon affiliate product entry.
+type Link struct {
+	ID         string `json:"id" dynamodbav:"id"`
+	Title      string `json:"title,omitempty" dynamodbav:"title,omitempty"`
+	ImageURL   string `json:"imageUrl" dynamodbav:"imageUrl"`
+	Price      string `json:"price" dynamodbav:"price"`
+	Link       string `json:"link" dynamodbav:"link"`
+	ExpiryDate string `json:"expiryDate,omitempty" dynamodbav:"expiryDate,omitempty"`
+	Status     string `json:"status" dynamodbav:"status"`
+	CreatedAt  string `json:"createdAt" dynamodbav:"createdAt"`
+	UpdatedAt  string `json:"updatedAt" dynamodbav:"updatedAt"`
+}
+
+// IsActive reports whether the link should be shown on the public site.
+func (l Link) IsActive(now time.Time) bool {
+	if l.Status != StatusActive {
+		return false
+	}
+	if l.ExpiryDate == "" {
+		return true
+	}
+	expiry, err := time.Parse("2006-01-02", l.ExpiryDate)
+	if err != nil {
+		return false
+	}
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	return !expiry.Before(today)
+}

--- a/api/store/affiliatelinks/link_test.go
+++ b/api/store/affiliatelinks/link_test.go
@@ -1,0 +1,32 @@
+package affiliatelinks
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLinkIsActive(t *testing.T) {
+	now := time.Date(2026, 6, 29, 12, 0, 0, 0, time.UTC)
+
+	t.Run("active with no expiry", func(t *testing.T) {
+		link := Link{Status: StatusActive}
+		require.True(t, link.IsActive(now))
+	})
+
+	t.Run("inactive status", func(t *testing.T) {
+		link := Link{Status: StatusInactive, ExpiryDate: "2099-01-01"}
+		require.False(t, link.IsActive(now))
+	})
+
+	t.Run("expired link", func(t *testing.T) {
+		link := Link{Status: StatusActive, ExpiryDate: "2026-06-28"}
+		require.False(t, link.IsActive(now))
+	})
+
+	t.Run("expires today", func(t *testing.T) {
+		link := Link{Status: StatusActive, ExpiryDate: "2026-06-29"}
+		require.True(t, link.IsActive(now))
+	})
+}

--- a/api/store/affiliatelinks/store.go
+++ b/api/store/affiliatelinks/store.go
@@ -1,0 +1,11 @@
+package affiliatelinks
+
+import "context"
+
+// Store persists Amazon affiliate link entries.
+type Store interface {
+	ListAll(ctx context.Context) ([]Link, error)
+	GetByID(ctx context.Context, id string) (*Link, error)
+	Put(ctx context.Context, link Link) error
+	Delete(ctx context.Context, id string) error
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,14 +12,15 @@
         "react": "^19.2.0",
         "react-bootstrap": "^2.10.10",
         "react-dom": "^19.2.0",
-        "react-feather": "^2.0.10"
+        "react-feather": "^2.0.10",
+        "react-router-dom": "^7.18.1"
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.2",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.1",
-        "vite": "^7.3.2"
+        "vite": "^7.3.6"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1626,6 +1627,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -2038,6 +2052,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.18.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
@@ -2114,6 +2166,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,8 @@
     "react": "^19.2.0",
     "react-bootstrap": "^2.10.10",
     "react-dom": "^19.2.0",
-    "react-feather": "^2.0.10"
+    "react-feather": "^2.0.10",
+    "react-router-dom": "^7.18.1"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.2",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, useCallback, useEffect, useState } from "react";
 import "./index.css";
 
+import AmazonAffiliateLinks from "./components/AmazonAffiliateLinks";
 import Footer from "./components/Footer";
 // --- Modular Components ---
 import Header from "./components/Header";
@@ -183,6 +184,8 @@ export default function App() {
           />
         }
       />
+
+      <AmazonAffiliateLinks />
 
       <SearchResults
         results={searchResults}

--- a/frontend/src/RootRouter.jsx
+++ b/frontend/src/RootRouter.jsx
@@ -1,0 +1,18 @@
+import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
+import App from "./App.jsx";
+import AdminAffiliateDashboard from "./pages/AdminAffiliateDashboard.jsx";
+
+export default function RootRouter() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<App />} />
+        <Route
+          path="/admin/affiliate-links"
+          element={<AdminAffiliateDashboard />}
+        />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}

--- a/frontend/src/components/AmazonAffiliateLinks.jsx
+++ b/frontend/src/components/AmazonAffiliateLinks.jsx
@@ -1,0 +1,47 @@
+import useAffiliateLinks from "../hooks/useAffiliateLinks";
+
+export default function AmazonAffiliateLinks() {
+  const { links, isLoading, error } = useAffiliateLinks(true);
+
+  if (isLoading || links.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="my-4" aria-label="Featured Amazon products">
+      <div className="d-flex align-items-center justify-content-between mb-2">
+        <h2 className="h5 mb-0">Featured Products</h2>
+        <span className="text-secondary small">Amazon affiliate links</span>
+      </div>
+      {error ? (
+        <div className="alert alert-warning py-2 mb-0">{error}</div>
+      ) : (
+        <div className="row g-3">
+          {links.map((item) => (
+            <div key={item.id} className="col-12 col-sm-6 col-lg-4">
+              <a
+                href={item.link}
+                target="_blank"
+                rel="noopener noreferrer sponsored"
+                className="card h-100 text-decoration-none text-reset affiliate-link-card"
+              >
+                <img
+                  src={item.imageUrl}
+                  alt={item.title || "Amazon product"}
+                  className="card-img-top affiliate-link-image"
+                  loading="lazy"
+                />
+                <div className="card-body">
+                  <div className="fw-semibold">
+                    {item.title || "View on Amazon"}
+                  </div>
+                  <div className="text-primary mt-1">{item.price}</div>
+                </div>
+              </a>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -172,6 +172,15 @@ export const MAX_SEARCH_LENGTH = 150;
 
 export const API_BASE_URL = "https://api.gishathfetch.com/";
 
+export function getApiBaseUrl() {
+  if (import.meta.env.DEV) {
+    return "/";
+  }
+  return API_BASE_URL;
+}
+
+export const AFFILIATE_LINKS_URL = `${getApiBaseUrl()}affiliate-links`;
+
 export const BASE_URL = "https://gishathfetch.com/";
 
 // Same-origin on production (served from gishathfetch.com via CloudFront).

--- a/frontend/src/hooks/useAffiliateLinks.js
+++ b/frontend/src/hooks/useAffiliateLinks.js
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useState } from "react";
+import { AFFILIATE_LINKS_URL } from "../constants";
+
+const EMPTY_LINKS = [];
+
+function parseAffiliateLinks(payload) {
+  if (!Array.isArray(payload?.data)) {
+    return EMPTY_LINKS;
+  }
+  return payload.data.filter(
+    (item) =>
+      typeof item?.link === "string" &&
+      typeof item?.imageUrl === "string" &&
+      typeof item?.price === "string",
+  );
+}
+
+export default function useAffiliateLinks(enabled = true) {
+  const [links, setLinks] = useState(EMPTY_LINKS);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const reload = useCallback(async (signal) => {
+    setIsLoading(true);
+    setError("");
+    try {
+      const response = await fetch(AFFILIATE_LINKS_URL, { signal });
+      if (!response.ok) {
+        throw new Error(`Failed to load affiliate links (${response.status})`);
+      }
+      const payload = await response.json();
+      setLinks(parseAffiliateLinks(payload));
+    } catch (err) {
+      if (err.name !== "AbortError") {
+        console.error("Failed to load affiliate links:", err);
+        setLinks(EMPTY_LINKS);
+        setError("Could not load featured products.");
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) {
+      return undefined;
+    }
+
+    const controller = new AbortController();
+    reload(controller.signal);
+    return () => controller.abort();
+  }, [enabled, reload]);
+
+  return { links, isLoading, error };
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -571,3 +571,36 @@ ins.adsbygoogle.adsbygoogle-noablate {
 .popular-searches-empty {
   padding-top: 0.125rem;
 }
+
+.affiliate-link-card {
+  transition:
+    transform 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.affiliate-link-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.08);
+}
+
+.affiliate-link-image {
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+  background-color: var(--bs-secondary-bg);
+}
+
+.affiliate-admin-thumb {
+  width: 56px;
+  height: 56px;
+  object-fit: cover;
+  border-radius: 0.375rem;
+  background-color: var(--bs-secondary-bg);
+}
+
+.affiliate-admin-preview {
+  max-width: 180px;
+  max-height: 180px;
+  object-fit: cover;
+  border-radius: 0.5rem;
+  border: 1px solid var(--bs-border-color);
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,10 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
-import App from "./App.jsx";
+import RootRouter from "./RootRouter.jsx";
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
-    <App />
+    <RootRouter />
   </StrictMode>,
 );

--- a/frontend/src/pages/AdminAffiliateDashboard.jsx
+++ b/frontend/src/pages/AdminAffiliateDashboard.jsx
@@ -1,0 +1,514 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { getApiBaseUrl } from "../constants";
+import {
+  clearStoredAdminApiKey,
+  createAffiliateLink,
+  deleteAffiliateLink,
+  fetchAdminAffiliateLinks,
+  fileToImagePayload,
+  loadStoredAdminApiKey,
+  storeAdminApiKey,
+  updateAffiliateLink,
+} from "../utils/affiliateAdminApi";
+
+const EMPTY_FORM = {
+  title: "",
+  price: "",
+  link: "",
+  expiryDate: "",
+  status: "active",
+  imageFile: null,
+  imageUrl: "",
+};
+
+function formatDate(value) {
+  if (!value) {
+    return "No expiry";
+  }
+  return value;
+}
+
+function LinkFormModal({
+  show,
+  initialValues,
+  onClose,
+  onSubmit,
+  isSaving,
+  error,
+}) {
+  const [form, setForm] = useState(EMPTY_FORM);
+
+  useEffect(() => {
+    if (!show) {
+      return;
+    }
+    setForm({
+      title: initialValues?.title || "",
+      price: initialValues?.price || "",
+      link: initialValues?.link || "",
+      expiryDate: initialValues?.expiryDate || "",
+      status: initialValues?.status || "active",
+      imageFile: null,
+      imageUrl: initialValues?.imageUrl || "",
+    });
+  }, [show, initialValues]);
+
+  if (!show) {
+    return null;
+  }
+
+  const handleChange = (event) => {
+    const { name, value, files } = event.target;
+    if (name === "imageFile") {
+      setForm((current) => ({ ...current, imageFile: files?.[0] || null }));
+      return;
+    }
+    setForm((current) => ({ ...current, [name]: value }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    await onSubmit(form);
+  };
+
+  return (
+    <div className="modal show d-block" tabIndex="-1" role="dialog">
+      <div className="modal-dialog modal-lg modal-dialog-scrollable">
+        <form className="modal-content" onSubmit={handleSubmit}>
+          <div className="modal-header">
+            <h2 className="modal-title h5">
+              {initialValues?.id ? "Edit Affiliate Link" : "Add Affiliate Link"}
+            </h2>
+            <button type="button" className="btn-close" onClick={onClose} />
+          </div>
+          <div className="modal-body">
+            {error ? <div className="alert alert-danger">{error}</div> : null}
+            <div className="row g-3">
+              <div className="col-md-6">
+                <label className="form-label" htmlFor="affiliate-title">
+                  Title
+                </label>
+                <input
+                  id="affiliate-title"
+                  name="title"
+                  className="form-control"
+                  value={form.title}
+                  onChange={handleChange}
+                  placeholder="Deck box, sleeves, etc."
+                />
+              </div>
+              <div className="col-md-6">
+                <label className="form-label" htmlFor="affiliate-price">
+                  Price
+                </label>
+                <input
+                  id="affiliate-price"
+                  name="price"
+                  className="form-control"
+                  value={form.price}
+                  onChange={handleChange}
+                  placeholder="S$24.90"
+                  required
+                />
+              </div>
+              <div className="col-12">
+                <label className="form-label" htmlFor="affiliate-link">
+                  Amazon link
+                </label>
+                <input
+                  id="affiliate-link"
+                  name="link"
+                  type="url"
+                  className="form-control"
+                  value={form.link}
+                  onChange={handleChange}
+                  placeholder="https://www.amazon.sg/..."
+                  required
+                />
+              </div>
+              <div className="col-md-6">
+                <label className="form-label" htmlFor="affiliate-expiry">
+                  Expiry date
+                </label>
+                <input
+                  id="affiliate-expiry"
+                  name="expiryDate"
+                  type="date"
+                  className="form-control"
+                  value={form.expiryDate}
+                  onChange={handleChange}
+                />
+              </div>
+              <div className="col-md-6">
+                <label className="form-label" htmlFor="affiliate-status">
+                  Status
+                </label>
+                <select
+                  id="affiliate-status"
+                  name="status"
+                  className="form-select"
+                  value={form.status}
+                  onChange={handleChange}
+                >
+                  <option value="active">Active</option>
+                  <option value="inactive">Inactive</option>
+                </select>
+              </div>
+              <div className="col-md-6">
+                <label className="form-label" htmlFor="affiliate-image-file">
+                  Upload image
+                </label>
+                <input
+                  id="affiliate-image-file"
+                  name="imageFile"
+                  type="file"
+                  accept="image/jpeg,image/png,image/webp,image/gif"
+                  className="form-control"
+                  onChange={handleChange}
+                />
+              </div>
+              <div className="col-md-6">
+                <label className="form-label" htmlFor="affiliate-image-url">
+                  Or image URL
+                </label>
+                <input
+                  id="affiliate-image-url"
+                  name="imageUrl"
+                  type="url"
+                  className="form-control"
+                  value={form.imageUrl}
+                  onChange={handleChange}
+                  placeholder="https://..."
+                />
+              </div>
+              {form.imageUrl ? (
+                <div className="col-12">
+                  <img
+                    src={form.imageUrl}
+                    alt="Current product"
+                    className="affiliate-admin-preview"
+                  />
+                </div>
+              ) : null}
+            </div>
+          </div>
+          <div className="modal-footer">
+            <button
+              type="button"
+              className="btn btn-outline-secondary"
+              onClick={onClose}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="btn btn-primary"
+              disabled={isSaving}
+            >
+              {isSaving ? "Saving..." : "Save"}
+            </button>
+          </div>
+        </form>
+      </div>
+      <div className="modal-backdrop show" />
+    </div>
+  );
+}
+
+export default function AdminAffiliateDashboard() {
+  const [apiKey, setApiKey] = useState(loadStoredAdminApiKey);
+  const [apiKeyInput, setApiKeyInput] = useState("");
+  const [links, setLinks] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState("");
+  const [formError, setFormError] = useState("");
+  const [editingLink, setEditingLink] = useState(null);
+  const [showForm, setShowForm] = useState(false);
+
+  const isAuthenticated = useMemo(() => apiKey.trim().length > 0, [apiKey]);
+
+  const loadLinks = useCallback(async () => {
+    if (!apiKey.trim()) {
+      return;
+    }
+    setIsLoading(true);
+    setError("");
+    try {
+      const data = await fetchAdminAffiliateLinks(getApiBaseUrl(), apiKey);
+      setLinks(data);
+    } catch (err) {
+      setError(err.message || "Failed to load affiliate links.");
+      if (
+        String(err.message || "")
+          .toLowerCase()
+          .includes("unauthorized")
+      ) {
+        clearStoredAdminApiKey();
+        setApiKey("");
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [apiKey]);
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      loadLinks();
+    }
+  }, [isAuthenticated, loadLinks]);
+
+  const handleLogin = (event) => {
+    event.preventDefault();
+    const trimmed = apiKeyInput.trim();
+    if (!trimmed) {
+      setError("API key is required.");
+      return;
+    }
+    storeAdminApiKey(trimmed);
+    setApiKey(trimmed);
+    setApiKeyInput("");
+    setError("");
+  };
+
+  const handleLogout = () => {
+    clearStoredAdminApiKey();
+    setApiKey("");
+    setLinks([]);
+  };
+
+  const buildPayload = async (form) => {
+    const payload = {
+      title: form.title.trim(),
+      price: form.price.trim(),
+      link: form.link.trim(),
+      expiryDate: form.expiryDate,
+      status: form.status,
+    };
+
+    if (form.imageFile) {
+      Object.assign(payload, await fileToImagePayload(form.imageFile));
+    } else if (form.imageUrl.trim()) {
+      payload.imageUrl = form.imageUrl.trim();
+    } else if (!editingLink) {
+      throw new Error("Image is required.");
+    }
+
+    return payload;
+  };
+
+  const handleCreate = async (form) => {
+    setIsSaving(true);
+    setFormError("");
+    try {
+      const payload = await buildPayload(form);
+      await createAffiliateLink(getApiBaseUrl(), apiKey, payload);
+      setShowForm(false);
+      await loadLinks();
+    } catch (err) {
+      setFormError(err.message || "Failed to create affiliate link.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleUpdate = async (form) => {
+    setIsSaving(true);
+    setFormError("");
+    try {
+      const payload = await buildPayload(form);
+      if (!payload.imageUrl && !payload.imageData && editingLink?.imageUrl) {
+        payload.imageUrl = editingLink.imageUrl;
+      }
+      await updateAffiliateLink(
+        getApiBaseUrl(),
+        apiKey,
+        editingLink.id,
+        payload,
+      );
+      setEditingLink(null);
+      setShowForm(false);
+      await loadLinks();
+    } catch (err) {
+      setFormError(err.message || "Failed to update affiliate link.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDelete = async (link) => {
+    if (!window.confirm(`Delete "${link.title || link.id}"?`)) {
+      return;
+    }
+    setError("");
+    try {
+      await deleteAffiliateLink(getApiBaseUrl(), apiKey, link.id);
+      await loadLinks();
+    } catch (err) {
+      setError(err.message || "Failed to delete affiliate link.");
+    }
+  };
+
+  if (!isAuthenticated) {
+    return (
+      <div className="container py-5" style={{ maxWidth: "480px" }}>
+        <h1 className="h3 mb-3">Affiliate Links Admin</h1>
+        <p className="text-secondary">
+          Enter the admin API key configured in the Lambda environment.
+        </p>
+        {error ? <div className="alert alert-danger">{error}</div> : null}
+        <form onSubmit={handleLogin} className="card card-body shadow-sm">
+          <label className="form-label" htmlFor="admin-api-key">
+            API key
+          </label>
+          <input
+            id="admin-api-key"
+            type="password"
+            className="form-control mb-3"
+            value={apiKeyInput}
+            onChange={(event) => setApiKeyInput(event.target.value)}
+            autoComplete="current-password"
+          />
+          <button type="submit" className="btn btn-primary">
+            Sign in
+          </button>
+        </form>
+        <div className="mt-3">
+          <Link to="/">Back to search</Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container-xl py-4">
+      <div className="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-4">
+        <div>
+          <h1 className="h3 mb-1">Affiliate Links Admin</h1>
+          <p className="text-secondary mb-0">
+            Manage Amazon affiliate products shown on the homepage.
+          </p>
+        </div>
+        <div className="d-flex gap-2">
+          <Link to="/" className="btn btn-outline-secondary">
+            Back to search
+          </Link>
+          <button
+            type="button"
+            className="btn btn-outline-danger"
+            onClick={handleLogout}
+          >
+            Sign out
+          </button>
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={() => {
+              setEditingLink(null);
+              setFormError("");
+              setShowForm(true);
+            }}
+          >
+            Add link
+          </button>
+        </div>
+      </div>
+
+      {error ? <div className="alert alert-danger">{error}</div> : null}
+
+      <div className="table-responsive card shadow-sm">
+        <table className="table table-striped mb-0 align-middle">
+          <thead>
+            <tr>
+              <th>Image</th>
+              <th>Title</th>
+              <th>Price</th>
+              <th>Status</th>
+              <th>Expiry</th>
+              <th>Link</th>
+              <th className="text-end">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {isLoading ? (
+              <tr>
+                <td colSpan={7} className="text-center py-4">
+                  Loading...
+                </td>
+              </tr>
+            ) : links.length === 0 ? (
+              <tr>
+                <td colSpan={7} className="text-center py-4 text-secondary">
+                  No affiliate links yet.
+                </td>
+              </tr>
+            ) : (
+              links.map((link) => (
+                <tr key={link.id}>
+                  <td>
+                    <img
+                      src={link.imageUrl}
+                      alt={link.title || "Product"}
+                      className="affiliate-admin-thumb"
+                    />
+                  </td>
+                  <td>{link.title || "—"}</td>
+                  <td>{link.price}</td>
+                  <td>
+                    <span
+                      className={`badge ${link.status === "active" ? "text-bg-success" : "text-bg-secondary"}`}
+                    >
+                      {link.status}
+                    </span>
+                  </td>
+                  <td>{formatDate(link.expiryDate)}</td>
+                  <td className="text-truncate" style={{ maxWidth: "220px" }}>
+                    <a href={link.link} target="_blank" rel="noreferrer">
+                      {link.link}
+                    </a>
+                  </td>
+                  <td className="text-end">
+                    <div className="btn-group btn-group-sm">
+                      <button
+                        type="button"
+                        className="btn btn-outline-primary"
+                        onClick={() => {
+                          setEditingLink(link);
+                          setFormError("");
+                          setShowForm(true);
+                        }}
+                      >
+                        Edit
+                      </button>
+                      <button
+                        type="button"
+                        className="btn btn-outline-danger"
+                        onClick={() => handleDelete(link)}
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <LinkFormModal
+        show={showForm}
+        initialValues={editingLink}
+        onClose={() => {
+          setShowForm(false);
+          setEditingLink(null);
+          setFormError("");
+        }}
+        onSubmit={editingLink ? handleUpdate : handleCreate}
+        isSaving={isSaving}
+        error={formError}
+      />
+    </div>
+  );
+}

--- a/frontend/src/utils/affiliateAdminApi.js
+++ b/frontend/src/utils/affiliateAdminApi.js
@@ -1,0 +1,115 @@
+const ADMIN_API_KEY_STORAGE_KEY = "gishathfetch-affiliate-admin-api-key";
+
+function getHeaders(apiKey) {
+  return {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${apiKey}`,
+  };
+}
+
+async function parseError(response) {
+  try {
+    const payload = await response.json();
+    if (typeof payload?.error === "string" && payload.error.trim()) {
+      return payload.error;
+    }
+  } catch {
+    // Ignore JSON parse failures and fall back to status text.
+  }
+  return `Request failed (${response.status})`;
+}
+
+export function loadStoredAdminApiKey() {
+  try {
+    return sessionStorage.getItem(ADMIN_API_KEY_STORAGE_KEY) || "";
+  } catch {
+    return "";
+  }
+}
+
+export function storeAdminApiKey(apiKey) {
+  try {
+    sessionStorage.setItem(ADMIN_API_KEY_STORAGE_KEY, apiKey);
+  } catch {
+    // Ignore storage failures; caller can keep the key in memory only.
+  }
+}
+
+export function clearStoredAdminApiKey() {
+  try {
+    sessionStorage.removeItem(ADMIN_API_KEY_STORAGE_KEY);
+  } catch {
+    // Ignore storage failures.
+  }
+}
+
+export async function fetchAdminAffiliateLinks(apiBaseUrl, apiKey) {
+  const response = await fetch(`${apiBaseUrl}admin/affiliate-links`, {
+    headers: getHeaders(apiKey),
+  });
+  if (!response.ok) {
+    throw new Error(await parseError(response));
+  }
+  const payload = await response.json();
+  return Array.isArray(payload?.data) ? payload.data : [];
+}
+
+export async function createAffiliateLink(apiBaseUrl, apiKey, body) {
+  const response = await fetch(`${apiBaseUrl}admin/affiliate-links`, {
+    method: "POST",
+    headers: getHeaders(apiKey),
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(await parseError(response));
+  }
+  return response.json();
+}
+
+export async function updateAffiliateLink(apiBaseUrl, apiKey, id, body) {
+  const response = await fetch(`${apiBaseUrl}admin/affiliate-links/${id}`, {
+    method: "PUT",
+    headers: getHeaders(apiKey),
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(await parseError(response));
+  }
+  return response.json();
+}
+
+export async function deleteAffiliateLink(apiBaseUrl, apiKey, id) {
+  const response = await fetch(`${apiBaseUrl}admin/affiliate-links/${id}`, {
+    method: "DELETE",
+    headers: getHeaders(apiKey),
+  });
+  if (!response.ok) {
+    throw new Error(await parseError(response));
+  }
+}
+
+export async function fileToImagePayload(file) {
+  if (!file) {
+    return {};
+  }
+
+  const allowedTypes = ["image/jpeg", "image/png", "image/webp", "image/gif"];
+  if (!allowedTypes.includes(file.type)) {
+    throw new Error("Image must be JPEG, PNG, WebP, or GIF.");
+  }
+  if (file.size > 2 * 1024 * 1024) {
+    throw new Error("Image must be 2 MB or smaller.");
+  }
+
+  const buffer = await file.arrayBuffer();
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+
+  return {
+    imageData: btoa(binary),
+    imageContentType: file.type,
+  };
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -36,6 +36,16 @@ export default defineConfig({
         target: "https://gishathfetch.com",
         changeOrigin: true,
       },
+      "/affiliate-links": {
+        target: "https://api.gishathfetch.com",
+        changeOrigin: true,
+        rewrite: (path) => path,
+      },
+      "/admin/affiliate-links": {
+        target: "https://api.gishathfetch.com",
+        changeOrigin: true,
+        rewrite: (path) => path,
+      },
     },
   },
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a full affiliate link management flow for Amazon products:

- **Admin dashboard** at `/admin/affiliate-links` for creating, updating, and deleting links
- **Public API** at `GET /affiliate-links` returning only active, non-expired links
- **Homepage section** that displays featured Amazon affiliate products
- **DynamoDB storage** for link metadata and **S3** for uploaded images

## Backend

New DynamoDB-backed store (`api/store/affiliatelinks/`) with fields:

| Field | Description |
|-------|-------------|
| `id` | Partition key (UUID) |
| `title` | Optional display name |
| `imageUrl` | Product image URL (uploaded to S3 or external URL) |
| `price` | Display price (e.g. `S$24.90`) |
| `link` | Amazon affiliate URL |
| `expiryDate` | Optional `YYYY-MM-DD` expiry |
| `status` | `active` or `inactive` |

### API endpoints

| Method | Path | Auth | Description |
|--------|------|------|-------------|
| `GET` | `/affiliate-links` | Public | Active links only |
| `GET` | `/admin/affiliate-links` | API key | All links |
| `POST` | `/admin/affiliate-links` | API key | Create link |
| `PUT` | `/admin/affiliate-links/{id}` | API key | Update link |
| `DELETE` | `/admin/affiliate-links/{id}` | API key | Delete link |

Admin auth accepts `Authorization: Bearer <key>` or `X-Admin-Api-Key` header.

Image upload: send base64 `imageData` + `imageContentType` in the JSON body; the API uploads to S3 and stores the public URL.

## Deployment setup required

1. **DynamoDB table** with partition key `id` (String)
2. **Lambda env vars** on `mtg-price-scrapper`:
   - `AFFILIATE_LINKS_DYNAMODB_TABLE` — table name
   - `AFFILIATE_ADMIN_API_KEY` — secret for admin writes
   - `AFFILIATE_IMAGES_S3_BUCKET` — optional, defaults to `gishathfetch.com`
   - `AFFILIATE_IMAGES_S3_PREFIX` — optional, defaults to `affiliate/images`
3. **API Gateway routes** (same Lambda):
   - `GET /affiliate-links`
   - `GET, POST, OPTIONS /admin/affiliate-links`
   - `PUT, DELETE, OPTIONS /admin/affiliate-links/{id}`
4. **IAM**: Lambda role needs DynamoDB read/write on the new table and S3 `PutObject` on the images prefix
5. **CloudFront**: ensure `/admin/*` serves `index.html` for SPA routing

## Frontend

- Admin dashboard: sign in with the API key, manage links in a table, upload images or paste URLs
- Homepage: "Featured Products" card grid below the search form (hidden when no active links)

## Screenshots

### Admin dashboard (desktop)

![Affiliate admin dashboard desktop](https://cursor.com/artifacts/c/art-8d47df10-22d7-477a-9671-1d5a29679352)

### Admin dashboard (mobile)

![Affiliate admin dashboard mobile](https://cursor.com/artifacts/c/art-904daf6b-9837-4b6e-a5a1-2b8f1e766feb)

## Testing

- `make test` — all tests pass
- `cd frontend && npm run lint` — passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65fa05f3-a4cc-487a-abee-036b98af53d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65fa05f3-a4cc-487a-abee-036b98af53d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

