### PR TITLE
Replace saved cards on exact store/name/extraInfo match

### DIFF
--- a/frontend/src/hooks/useCart.js
+++ b/frontend/src/hooks/useCart.js
@@ -1,12 +1,9 @@
 import { useCallback, useState } from "react";
 
-const stripSavedAt = (item) => {
-  const { savedAt: _savedAt, ...card } = item;
-  return card;
-};
-
-const cardsMatch = (a, b) =>
-  JSON.stringify(stripSavedAt(a)) === JSON.stringify(stripSavedAt(b));
+const cardsExactMatch = (a, b) =>
+  a.src === b.src &&
+  a.name === b.name &&
+  (a.extraInfo ?? "") === (b.extraInfo ?? "");
 
 const formatSavedAt = (savedAt) => {
   if (!savedAt) return null;
@@ -53,11 +50,10 @@ export default function useCart() {
 
   const addToCart = useCallback((card) => {
     setCart((prev) => {
-      const exists = prev.some((item) => cardsMatch(item, card));
-
-      if (exists) return prev;
-
-      const newCart = [{ ...card, savedAt: Date.now() }, ...prev];
+      const withoutExactMatch = prev.filter(
+        (item) => !cardsExactMatch(item, card),
+      );
+      const newCart = [{ ...card, savedAt: Date.now() }, ...withoutExactMatch];
       try {
         localStorage.setItem("cart", JSON.stringify(newCart));
       } catch (err) {
@@ -90,7 +86,7 @@ export default function useCart() {
 
   const removeFromCartByCard = useCallback((card) => {
     setCart((prev) => {
-      const newCart = prev.filter((item) => !cardsMatch(item, card));
+      const newCart = prev.filter((item) => !cardsExactMatch(item, card));
       if (newCart.length === prev.length) return prev;
 
       try {
@@ -104,7 +100,7 @@ export default function useCart() {
 
   const isCardInCart = useCallback(
     (card) => {
-      return cart.some((item) => cardsMatch(item, card));
+      return cart.some((item) => cardsExactMatch(item, card));
     },
     [cart],
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When saving a card, the app now treats **store** (`src`), **name**, and **extra info** as the identity for an exact match. If a saved entry with the same combination already exists, the old entry is removed and replaced with the new snapshot (updated price, URL, stock, etc.).

Previously, saving compared the full card object and silently skipped duplicates. Cards with the same identity but different price or other fields could end up as separate saved entries.

## Changes

- Added `cardsExactMatch` in `frontend/src/hooks/useCart.js` comparing `src`, `name`, and `extraInfo`
- Updated `addToCart` to filter out exact matches before prepending the new saved card
- Aligned `isCardInCart` and `removeFromCartByCard` with the same exact-match logic so the Saved button and remove behavior stay consistent

## Testing

- `make test` (full suite)
- `npx biome check src/hooks/useCart.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5cc0021-8d66-4b73-aca7-602232213761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5cc0021-8d66-4b73-aca7-602232213761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

