### PR TITLE
Fix saved card dedup and allow updating saved snapshots from search

### DIFF
--- a/frontend/src/components/Card.jsx
+++ b/frontend/src/components/Card.jsx
@@ -88,13 +88,25 @@ const Card = ({
               </a>
             </div>
           ) : inCart ? (
-            <button
-              type="button"
-              className="btn btn-outline-success btn-sm addCartBtn"
-              onClick={() => removeFromCartByCard(card)}
-            >
-              <CheckSquare size={12} className="cartIcon" /> Saved
-            </button>
+            <div className="d-flex justify-content-center gap-1">
+              <button
+                type="button"
+                className="btn btn-outline-success btn-sm addCartBtn"
+                onClick={() => addToCart(card)}
+                title="Update saved snapshot"
+              >
+                <CheckSquare size={12} className="cartIcon" /> Saved
+              </button>
+              <button
+                type="button"
+                className="btn btn-outline-danger btn-sm"
+                onClick={() => removeFromCartByCard(card)}
+                aria-label="Remove from saved"
+                title="Remove from saved"
+              >
+                <Trash2 size={12} className="cartIcon" />
+              </button>
+            </div>
           ) : (
             <button
               type="button"

--- a/frontend/src/hooks/useCart.js
+++ b/frontend/src/hooks/useCart.js
@@ -1,9 +1,28 @@
 import { useCallback, useState } from "react";
+import { cardsExactMatch, dedupeCartItems } from "../utils/cardIdentity";
 
-const cardsExactMatch = (a, b) =>
-  a.src === b.src &&
-  a.name === b.name &&
-  (a.extraInfo ?? "") === (b.extraInfo ?? "");
+const loadCartFromStorage = () => {
+  const storedCart = localStorage.getItem("cart");
+  if (!storedCart) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(storedCart);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    const deduped = dedupeCartItems(parsed);
+    if (deduped.length !== parsed.length) {
+      localStorage.setItem("cart", JSON.stringify(deduped));
+    }
+    return deduped;
+  } catch (err) {
+    console.error("Failed to parse cart from localStorage:", err);
+    return [];
+  }
+};
 
 const formatSavedAt = (savedAt) => {
   if (!savedAt) return null;
@@ -34,18 +53,7 @@ const formatSavedAt = (savedAt) => {
 export { formatSavedAt };
 
 export default function useCart() {
-  const [cart, setCart] = useState(() => {
-    const storedCart = localStorage.getItem("cart");
-    if (storedCart) {
-      try {
-        return JSON.parse(storedCart);
-      } catch (err) {
-        console.error("Failed to parse cart from localStorage:", err);
-        return [];
-      }
-    }
-    return [];
-  });
+  const [cart, setCart] = useState(loadCartFromStorage);
   const [showCart, setShowCart] = useState(false);
 
   const addToCart = useCallback((card) => {

--- a/frontend/src/utils/cardIdentity.js
+++ b/frontend/src/utils/cardIdentity.js
@@ -1,0 +1,56 @@
+const normalizeText = (value) =>
+  String(value ?? "")
+    .trim()
+    .normalize("NFKC")
+    .replace(/[\u2018\u2019\u0060]/g, "'");
+
+export const normalizeExtraInfo = (extraInfo) => {
+  if (extraInfo == null) {
+    return "";
+  }
+
+  const text = Array.isArray(extraInfo)
+    ? extraInfo.join(" ")
+    : String(extraInfo);
+  const trimmed = normalizeText(text);
+  if (!trimmed) {
+    return "";
+  }
+
+  const bracketParts = [...trimmed.matchAll(/\[([^\]]+)\]/g)].map(
+    (match) => `[${match[1].trim()}]`,
+  );
+  if (bracketParts.length > 0) {
+    return [...new Set(bracketParts)].sort().join(" ");
+  }
+
+  return trimmed;
+};
+
+export const cardIdentityKey = (card) =>
+  JSON.stringify({
+    src: normalizeText(card.src),
+    name: normalizeText(card.name),
+    extraInfo: normalizeExtraInfo(card.extraInfo),
+    quality: normalizeText(card.quality),
+    isFoil: !!card.isFoil,
+  });
+
+export const cardsExactMatch = (a, b) =>
+  cardIdentityKey(a) === cardIdentityKey(b);
+
+export const dedupeCartItems = (items) => {
+  const seen = new Set();
+  const deduped = [];
+
+  for (const item of items) {
+    const key = cardIdentityKey(item);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(item);
+  }
+
+  return deduped;
+};

--- a/frontend/src/utils/cardIdentity.test.js
+++ b/frontend/src/utils/cardIdentity.test.js
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import {
+  cardIdentityKey,
+  cardsExactMatch,
+  dedupeCartItems,
+  normalizeExtraInfo,
+} from "./cardIdentity.js";
+
+const base = {
+  src: "The TCG Marketplace",
+  name: "Swordsman's Steel",
+  extraInfo: "[Marvel Super Heroes Commander]",
+};
+
+assert.equal(
+  normalizeExtraInfo(["[Marvel Super Heroes Commander]"]),
+  "[Marvel Super Heroes Commander]",
+);
+assert.equal(
+  normalizeExtraInfo("[Marvel Super Heroes Commander] "),
+  "[Marvel Super Heroes Commander]",
+);
+assert.equal(normalizeExtraInfo([]), "");
+assert.equal(normalizeExtraInfo(undefined), "");
+assert.equal(normalizeExtraInfo("[Set B] [Set A]"), "[Set A] [Set B]");
+
+assert.ok(
+  cardsExactMatch(base, {
+    ...base,
+    extraInfo: ["[Marvel Super Heroes Commander]"],
+  }),
+);
+assert.ok(
+  cardsExactMatch(base, {
+    ...base,
+    name: "Swordsman\u2019s Steel",
+  }),
+);
+assert.ok(
+  cardsExactMatch(base, {
+    ...base,
+    url: "https://example.com/a",
+    price: 20,
+  }),
+);
+assert.ok(
+  !cardsExactMatch(base, {
+    ...base,
+    isFoil: true,
+  }),
+);
+assert.ok(
+  !cardsExactMatch(base, {
+    ...base,
+    quality: "NM",
+  }),
+);
+
+const deduped = dedupeCartItems([
+  { ...base, savedAt: 2, url: "https://example.com/new" },
+  { ...base, savedAt: 1, url: "https://example.com/old" },
+  {
+    ...base,
+    name: "Other Card",
+    savedAt: 3,
+  },
+]);
+assert.equal(deduped.length, 2);
+assert.equal(deduped[0].url, "https://example.com/new");
+assert.equal(cardIdentityKey(base), cardIdentityKey({ ...base, savedAt: 99 }));
+
+console.log("cardIdentity tests passed");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

PR #207 switched saved-card matching to `src` + `name` + `extraInfo`, but the comparison still used strict equality. That fails on common variations between searches/saves:

- `extraInfo` as a string vs array (e.g. `"[Marvel Super Heroes Commander]"` vs `["[Marvel Super Heroes Commander]"]`)
- Trailing/leading whitespace
- Curly vs straight apostrophes in names (e.g. `Swordsman's Steel`)
- Reordered bracket tags in `extraInfo`

Re-saving the same listing (e.g. **Swordsman's Steel** from **The TCG Marketplace**) could therefore create duplicate saved cards instead of replacing the existing snapshot.

Additionally, when a card was already saved, search results showed a **Saved** button that only removed the entry (`removeFromCartByCard`). There was no way to refresh the saved snapshot (price/URL) without removing and saving again.

## Fix

- Add `cardIdentity.js` with normalized identity matching:
  - Normalize text (trim, NFKC, apostrophe variants)
  - Normalize `extraInfo` from string or array, preserving multi-word set names inside brackets
  - Include `quality` and `isFoil` in identity so different listings at the same store remain distinct
  - **Exclude `url` and `price`** — changes to those fields still match and replace the saved snapshot
- Use normalized matching in `useCart` for add/remove/in-cart checks
- Dedupe existing `localStorage` cart entries on load (keeps the newest entry per identity)
- **Saved button in search results now calls `addToCart`** to update the snapshot; a separate remove button preserves unsave from search

## Screenshots

### Desktop
![Saved card update button on desktop](https://cursor.com/artifacts/c/art-3275b240-d600-45ac-aae6-39aec8f2b307)

### Mobile
![Saved card update button on mobile](https://cursor.com/artifacts/c/art-8299e500-1953-4615-a3e3-e1e90b0e7761)

## Testing

- `node frontend/src/utils/cardIdentity.test.js`
- `cd frontend && npm run lint`
- `make test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d41f87e-1699-4ce8-95cf-540c25f87bae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d41f87e-1699-4ce8-95cf-540c25f87bae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

