### PR TITLE
Rename in-list save button from Saved to Update

### DIFF
--- a/frontend/src/components/Card.jsx
+++ b/frontend/src/components/Card.jsx
@@ -93,9 +93,10 @@ const Card = ({
                 type="button"
                 className="btn btn-outline-success btn-sm addCartBtn"
                 onClick={() => addToCart(card)}
+                aria-label="Update saved snapshot"
                 title="Update saved snapshot"
               >
-                <CheckSquare size={12} className="cartIcon" /> Saved
+                <CheckSquare size={12} className="cartIcon" /> Update
               </button>
               <button
                 type="button"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cards already in the saved list refresh their snapshot when clicked again. The previous **Saved** label read like a static status, not an action.

This change renames the button to **Update** and adds an `aria-label` so the intent is clear in both visible text and assistive tech. It pairs cleanly with **Save** for cards not yet in the list.

## Changes

- `frontend/src/components/Card.jsx`: button label `Saved` → `Update`; added `aria-label="Update saved snapshot"` (tooltip unchanged)

## Screenshots

### Desktop

![Search results showing Update button for a card already in the saved list (desktop)](https://cursor.com/artifacts/c/art-c8e78422-be8f-4b00-8636-7e4e96fc9ea4)

### Mobile

![Search results showing Update button for a card already in the saved list (mobile)](https://cursor.com/artifacts/c/art-52931f5a-e4a3-4068-bc21-26bbdf88c29f)

## Testing

- `cd frontend && npm run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-108d6d95-5cf3-4c80-bd4d-fb42d8da61a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-108d6d95-5cf3-4c80-bd4d-fb42d8da61a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

