### PR TITLE
Add UTM and GA4 tracking to popular search section

### DIFF
--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -7,7 +7,7 @@ import {
   TOP_SEARCH_KEYWORDS_MOBILE_DISPLAY_LIMIT,
 } from "../constants";
 import useMediaQuery from "../hooks/useMediaQuery";
-import { buildSearchQueryUrl } from "../utils/searchUrl";
+import { buildPopularSearchUrl } from "../utils/searchUrl";
 
 const LOADING_SKELETON_KEYS = [
   "top-search-keyword-skeleton-a",
@@ -145,6 +145,15 @@ export default function TopSearchKeywords({
     setIsExpanded((expanded) => !expanded);
   };
 
+  const handlePopularSearchClick = (keyword) => {
+    if (window.gtag) {
+      window.gtag("event", "popular_search_click", {
+        search_term: keyword,
+        popular_search_period: period,
+      });
+    }
+  };
+
   return (
     <div
       className={`${SECTION_CLASS_NAME}${
@@ -182,9 +191,10 @@ export default function TopSearchKeywords({
               {keywords.map((keyword) => (
                 <a
                   key={keyword}
-                  href={buildSearchQueryUrl(BASE_URL, keyword)}
+                  href={buildPopularSearchUrl(BASE_URL, keyword, period)}
                   className="btn btn-sm popular-search-pill text-decoration-none"
                   aria-label={`Search for ${keyword}`}
+                  onClick={() => handlePopularSearchClick(keyword)}
                 >
                   {keyword}
                 </a>

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -181,3 +181,8 @@ export const TOP_SEARCH_KEYWORDS_URL =
 export const TOP_SEARCH_KEYWORDS_DISPLAY_LIMIT = 20;
 export const TOP_SEARCH_KEYWORDS_MOBILE_DISPLAY_LIMIT = 10;
 export const DESKTOP_MIN_WIDTH_MEDIA_QUERY = "(min-width: 768px)";
+
+// UTM params for popular search pill links (GA4 session attribution).
+export const POPULAR_SEARCH_UTM_SOURCE = "popular_searches";
+export const POPULAR_SEARCH_UTM_MEDIUM = "internal";
+export const POPULAR_SEARCH_UTM_CAMPAIGN = "popular_searches";

--- a/frontend/src/utils/searchUrl.js
+++ b/frontend/src/utils/searchUrl.js
@@ -1,4 +1,9 @@
-import { LGS_OPTIONS } from "../constants";
+import {
+  LGS_OPTIONS,
+  POPULAR_SEARCH_UTM_CAMPAIGN,
+  POPULAR_SEARCH_UTM_MEDIUM,
+  POPULAR_SEARCH_UTM_SOURCE,
+} from "../constants";
 
 /**
  * @typedef {{
@@ -99,6 +104,24 @@ export function buildSearchUrl(baseUrl, query, stores) {
 export function buildSearchQueryUrl(baseUrl, query) {
   const params = new URLSearchParams();
   params.set("s", query);
+  return `${baseUrl}?${params.toString()}`;
+}
+
+/**
+ * @param {string} baseUrl
+ * @param {string} query
+ * @param {string} [period]
+ * @returns {string}
+ */
+export function buildPopularSearchUrl(baseUrl, query, period) {
+  const params = new URLSearchParams();
+  params.set("s", query);
+  params.set("utm_source", POPULAR_SEARCH_UTM_SOURCE);
+  params.set("utm_medium", POPULAR_SEARCH_UTM_MEDIUM);
+  params.set("utm_campaign", POPULAR_SEARCH_UTM_CAMPAIGN);
+  if (period) {
+    params.set("utm_content", period);
+  }
   return `${baseUrl}?${params.toString()}`;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds engagement tracking to the popular searches section so clicks can be measured in GA4.

- Popular search pill links now include UTM parameters:
  - `utm_source=popular_searches`
  - `utm_medium=internal`
  - `utm_campaign=popular_searches`
  - `utm_content={period}` (e.g. `last24Hours`, `last30Days`)
- Fires a `popular_search_click` GA4 event on pill click with `search_term` and `popular_search_period` for direct engagement reporting.

## How to measure in GA4

- **Session attribution:** filter or segment by `Session source = popular_searches` (from UTM params on landing URLs).
- **Click engagement:** use the `popular_search_click` event; break down by `search_term` or `popular_search_period`.

## Testing

- `cd frontend && npm run lint` — passed
- `make test` — failed on unrelated live gateway probe (`gateway/fivemana` returned 503 from upstream); no backend/frontend code changes in that area
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d145fe52-e589-4f82-b490-0637ab0ce24d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d145fe52-e589-4f82-b490-0637ab0ce24d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

