### PR TITLE
Add temporary feedback for save/update/delete cart actions

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,8 +1,9 @@
 import { lazy, Suspense, useCallback, useEffect, useState } from "react";
 import "./index.css";
 
-import Footer from "./components/Footer";
 // --- Modular Components ---
+import CartActionFeedback from "./components/CartActionFeedback";
+import Footer from "./components/Footer";
 import Header from "./components/Header";
 import SearchForm from "./components/SearchForm";
 import SearchResults from "./components/SearchResults";
@@ -25,6 +26,7 @@ export default function App() {
     cart,
     showCart,
     setShowCart,
+    cartActionFeedback,
     addToCart,
     removeFromCart,
     removeFromCartByCard,
@@ -208,6 +210,8 @@ export default function App() {
         onShowMap={() => setModalType("MAP")}
         onShowFaq={() => setModalType("FAQ")}
       />
+
+      <CartActionFeedback message={cartActionFeedback} />
 
       <Suspense fallback={null}>
         <CartOffcanvas

--- a/frontend/src/components/CartActionFeedback.jsx
+++ b/frontend/src/components/CartActionFeedback.jsx
@@ -1,0 +1,17 @@
+const CartActionFeedback = ({ message }) => {
+  if (!message) {
+    return null;
+  }
+
+  return (
+    <output
+      className="cart-action-feedback"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      {message}
+    </output>
+  );
+};
+
+export default CartActionFeedback;

--- a/frontend/src/hooks/useCart.js
+++ b/frontend/src/hooks/useCart.js
@@ -1,5 +1,7 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { cardsExactMatch, dedupeCartItems } from "../utils/cardIdentity";
+
+const CART_FEEDBACK_DURATION_MS = 2500;
 
 const loadCartFromStorage = () => {
   const storedCart = localStorage.getItem("cart");
@@ -55,33 +57,75 @@ export { formatSavedAt };
 export default function useCart() {
   const [cart, setCart] = useState(loadCartFromStorage);
   const [showCart, setShowCart] = useState(false);
+  const [cartActionFeedback, setCartActionFeedback] = useState(null);
+  const feedbackTimeoutRef = useRef(null);
 
-  const addToCart = useCallback((card) => {
-    setCart((prev) => {
-      const withoutExactMatch = prev.filter(
-        (item) => !cardsExactMatch(item, card),
-      );
-      const newCart = [{ ...card, savedAt: Date.now() }, ...withoutExactMatch];
-      try {
-        localStorage.setItem("cart", JSON.stringify(newCart));
-      } catch (err) {
-        console.error("Failed to save cart to localStorage:", err);
-      }
-      return newCart;
-    });
+  const showCartActionFeedback = useCallback((message) => {
+    if (feedbackTimeoutRef.current) {
+      clearTimeout(feedbackTimeoutRef.current);
+    }
+
+    setCartActionFeedback(message);
+    feedbackTimeoutRef.current = setTimeout(() => {
+      setCartActionFeedback(null);
+      feedbackTimeoutRef.current = null;
+    }, CART_FEEDBACK_DURATION_MS);
   }, []);
 
-  const removeFromCart = useCallback((index) => {
-    setCart((prev) => {
-      const newCart = prev.filter((_, i) => i !== index);
-      try {
-        localStorage.setItem("cart", JSON.stringify(newCart));
-      } catch (err) {
-        console.error("Failed to save cart to localStorage:", err);
+  useEffect(() => {
+    return () => {
+      if (feedbackTimeoutRef.current) {
+        clearTimeout(feedbackTimeoutRef.current);
       }
-      return newCart;
-    });
+    };
   }, []);
+
+  const addToCart = useCallback(
+    (card) => {
+      let feedbackMessage = "Card saved";
+
+      setCart((prev) => {
+        const wasInCart = prev.some((item) => cardsExactMatch(item, card));
+        if (wasInCart) {
+          feedbackMessage = "Card updated";
+        }
+
+        const withoutExactMatch = prev.filter(
+          (item) => !cardsExactMatch(item, card),
+        );
+        const newCart = [
+          { ...card, savedAt: Date.now() },
+          ...withoutExactMatch,
+        ];
+        try {
+          localStorage.setItem("cart", JSON.stringify(newCart));
+        } catch (err) {
+          console.error("Failed to save cart to localStorage:", err);
+        }
+        return newCart;
+      });
+
+      showCartActionFeedback(feedbackMessage);
+    },
+    [showCartActionFeedback],
+  );
+
+  const removeFromCart = useCallback(
+    (index) => {
+      setCart((prev) => {
+        const newCart = prev.filter((_, i) => i !== index);
+        try {
+          localStorage.setItem("cart", JSON.stringify(newCart));
+        } catch (err) {
+          console.error("Failed to save cart to localStorage:", err);
+        }
+        return newCart;
+      });
+
+      showCartActionFeedback("Card removed");
+    },
+    [showCartActionFeedback],
+  );
 
   const clearCart = useCallback(() => {
     setCart([]);
@@ -90,21 +134,33 @@ export default function useCart() {
     } catch (err) {
       console.error("Failed to clear cart from localStorage:", err);
     }
-  }, []);
 
-  const removeFromCartByCard = useCallback((card) => {
-    setCart((prev) => {
-      const newCart = prev.filter((item) => !cardsExactMatch(item, card));
-      if (newCart.length === prev.length) return prev;
+    showCartActionFeedback("All saved cards removed");
+  }, [showCartActionFeedback]);
 
-      try {
-        localStorage.setItem("cart", JSON.stringify(newCart));
-      } catch (err) {
-        console.error("Failed to save cart to localStorage:", err);
+  const removeFromCartByCard = useCallback(
+    (card) => {
+      let removed = false;
+
+      setCart((prev) => {
+        const newCart = prev.filter((item) => !cardsExactMatch(item, card));
+        if (newCart.length === prev.length) return prev;
+
+        removed = true;
+        try {
+          localStorage.setItem("cart", JSON.stringify(newCart));
+        } catch (err) {
+          console.error("Failed to save cart to localStorage:", err);
+        }
+        return newCart;
+      });
+
+      if (removed) {
+        showCartActionFeedback("Card removed");
       }
-      return newCart;
-    });
-  }, []);
+    },
+    [showCartActionFeedback],
+  );
 
   const isCardInCart = useCallback(
     (card) => {
@@ -117,6 +173,7 @@ export default function useCart() {
     cart,
     showCart,
     setShowCart,
+    cartActionFeedback,
     addToCart,
     removeFromCart,
     removeFromCartByCard,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -412,6 +412,37 @@ ins.adsbygoogle.adsbygoogle-noablate {
   z-index: 1030;
 }
 
+.cart-action-feedback {
+  position: fixed;
+  left: 50%;
+  bottom: calc(var(--footer-nav-height, 3rem) + 0.75rem);
+  z-index: 1040;
+  transform: translateX(-50%);
+  max-width: calc(100% - 2rem);
+  padding: 0.5rem 1rem;
+  border-radius: var(--bs-border-radius-pill);
+  background-color: var(--bs-success);
+  color: var(--bs-white);
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.2);
+  animation: cart-feedback-in 0.2s ease-out;
+  pointer-events: none;
+}
+
+@keyframes cart-feedback-in {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(0.5rem);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
+}
+
 .site-footer-spacer {
   padding-bottom: calc(
     var(--footer-nav-height, 3rem) +

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -415,18 +415,14 @@ ins.adsbygoogle.adsbygoogle-noablate {
 .cart-action-feedback {
   position: fixed;
   left: 50%;
-  bottom: calc(var(--footer-nav-height, 3rem) + 0.75rem);
+  bottom: calc(var(--footer-nav-height, 3rem) + 0.5rem);
   z-index: 1040;
   transform: translateX(-50%);
   max-width: calc(100% - 2rem);
-  padding: 0.5rem 1rem;
-  border-radius: var(--bs-border-radius-pill);
-  background-color: var(--bs-success);
-  color: var(--bs-white);
+  color: var(--bs-success);
   font-size: 0.875rem;
   font-weight: 600;
   text-align: center;
-  box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.2);
   animation: cart-feedback-in 0.2s ease-out;
   pointer-events: none;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a brief confirmation message above the bottom navigation when users save, update, or remove cards from their saved list.

- **Card saved** — first-time save from search results
- **Card updated** — re-saving an already-saved card snapshot
- **Card removed** — removing a card from search results or the saved-cards panel
- **All saved cards removed** — clearing the entire saved list

The message auto-dismisses after 2.5 seconds and uses `aria-live="polite"` for screen readers. Styled as plain green text above the bottom nav.

## Screenshots

### Desktop

![Card saved feedback as green text on desktop](https://cursor.com/artifacts/c/art-e1b1e0ec-dcc3-453e-aacb-bb26615ec557)

### Mobile

![Card saved feedback as green text on mobile](https://cursor.com/artifacts/c/art-d7939fac-4391-4c62-8f6b-b751a272ce2b)

## Test plan

- [x] `npm run lint` (frontend)
- [x] `make test`
- [x] Manually verified save feedback appears as green text above bottom nav (desktop + mobile screenshots)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e2fad74-a045-421e-8303-7626515fbf75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e2fad74-a045-421e-8303-7626515fbf75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

