### PR TITLE
Add full-width grey background to cart action feedback bar

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -414,11 +414,14 @@ ins.adsbygoogle.adsbygoogle-noablate {
 
 .cart-action-feedback {
   position: fixed;
-  left: 50%;
-  bottom: calc(var(--footer-nav-height, 3rem) + 0.5rem);
+  left: 0;
+  right: 0;
+  bottom: var(--footer-nav-height, 3rem);
   z-index: 1040;
-  transform: translateX(-50%);
-  max-width: calc(100% - 2rem);
+  width: 100%;
+  padding: 0.375rem 1rem;
+  border-top: 1px solid var(--bs-border-color-translucent);
+  background-color: var(--bs-secondary-bg);
   color: var(--bs-success);
   font-size: 0.875rem;
   font-weight: 600;
@@ -430,12 +433,12 @@ ins.adsbygoogle.adsbygoogle-noablate {
 @keyframes cart-feedback-in {
   from {
     opacity: 0;
-    transform: translateX(-50%) translateY(0.5rem);
+    transform: translateY(0.5rem);
   }
 
   to {
     opacity: 1;
-    transform: translateX(-50%) translateY(0);
+    transform: translateY(0);
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Refines the cart action feedback bar (save / update / remove) with better contrast and layout:

- Full-width light grey background (`--bs-secondary-bg`) spanning the viewport
- Sits flush above the bottom navigation bar
- Green confirmation text remains centered in the bar

## Screenshots

### Desktop

![Full-width grey cart feedback bar on desktop](https://cursor.com/artifacts/c/art-ba12af11-b52b-4b9e-a80c-7f0229b2b118)

### Mobile

![Full-width grey cart feedback bar on mobile](https://cursor.com/artifacts/c/art-4da0d052-cd42-4ccd-9ae9-cafa944126c8)

## Test plan

- [x] `npm run lint`
- [x] Manually verified feedback bar is full width with grey background above footer (desktop + mobile screenshots)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e2fad74-a045-421e-8303-7626515fbf75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e2fad74-a045-421e-8303-7626515fbf75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

