### PR TITLE
Use white/dark body background for cart action feedback bar

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -421,7 +421,7 @@ ins.adsbygoogle.adsbygoogle-noablate {
   width: 100%;
   padding: 0.375rem 1rem;
   border-top: 1px solid var(--bs-border-color-translucent);
-  background-color: var(--bs-secondary-bg);
+  background-color: var(--bs-body-bg);
   color: var(--bs-success);
   font-size: 0.875rem;
   font-weight: 600;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the cart action feedback bar background to use `var(--bs-body-bg)` instead of the grey secondary background:

- **Light mode:** white bar above the footer
- **Dark mode:** standard dark body surface for appropriate contrast

Green confirmation text and full-width layout are unchanged.

## Screenshots

### Desktop (light)

![White cart feedback bar on desktop light mode](https://cursor.com/artifacts/c/art-e4cdba3a-2454-4940-9c5e-5fa19598e316)

### Mobile (light)

![White cart feedback bar on mobile light mode](https://cursor.com/artifacts/c/art-988523f1-f35d-4a8b-859a-be1c97ba90ae)

### Desktop (dark)

![Dark mode cart feedback bar on desktop](https://cursor.com/artifacts/c/art-bd75e0bb-ee37-4af5-a097-e890f195c9fd)

## Test plan

- [x] `npm run lint`
- [x] Verified feedback bar is white in light mode and uses dark body background in dark mode (screenshots)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4e2fad74-a045-421e-8303-7626515fbf75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e2fad74-a045-421e-8303-7626515fbf75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

