### PR TITLE
Enhance store search error logging for Cards & Collections and TCG Marketplace

### DIFF
--- a/api/gateway/cardsandcollection/search.go
+++ b/api/gateway/cardsandcollection/search.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -181,14 +180,16 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := gateway.ReadResponseBody(resp)
 	if err != nil {
 		return cards, err
 	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return cards, fmt.Errorf("%s", gateway.FormatUnexpectedHTTPStatus(s.Name, resp, body))
+	}
 
-	err = json.Unmarshal(body, &res)
-	if err != nil {
-		return cards, err
+	if err = json.Unmarshal(body, &res); err != nil {
+		return cards, gateway.WrapJSONDecodeError(err, resp, body)
 	}
 
 	if res.Hits.Total > 0 {

--- a/api/gateway/http_response.go
+++ b/api/gateway/http_response.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 	"unicode"
 )
 
@@ -83,6 +84,44 @@ func ResponseBodyPreview(body []byte, maxLen int) string {
 		return preview + "..."
 	}
 	return preview
+}
+
+// FormatHTTPRequestContext builds request metadata for transport-layer error messages.
+func FormatHTTPRequestContext(req *http.Request, extra ...string) string {
+	parts := make([]string, 0, 4+len(extra))
+	if req != nil {
+		parts = append(parts, "method="+req.Method)
+		if req.URL != nil {
+			parts = append(parts, "url="+req.URL.String())
+		}
+		if req.ContentLength >= 0 {
+			parts = append(parts, fmt.Sprintf("request_body_len=%d", req.ContentLength))
+		}
+		if deadline, ok := req.Context().Deadline(); ok {
+			parts = append(parts, "context_deadline="+deadline.UTC().Format(time.RFC3339))
+		}
+		if ctxErr := req.Context().Err(); ctxErr != nil {
+			parts = append(parts, "context_err="+ctxErr.Error())
+		}
+	}
+	parts = append(parts, extra...)
+	return strings.Join(parts, " ")
+}
+
+// WrapHTTPRequestError annotates an HTTP client/transport error with request context.
+func WrapHTTPRequestError(err error, req *http.Request, extra ...string) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("http request failed (%s): %w", FormatHTTPRequestContext(req, extra...), err)
+}
+
+// WrapResponseBodyReadError annotates a response body read error with HTTP context.
+func WrapResponseBodyReadError(err error, resp *http.Response) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("read response body failed (%s): %w", formatHTTPResponseContext(resp, nil), err)
 }
 
 func formatHTTPResponseContext(resp *http.Response, body []byte) string {

--- a/api/gateway/http_response.go
+++ b/api/gateway/http_response.go
@@ -7,7 +7,10 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"unicode"
 )
+
+const defaultResponseBodyPreviewLimit = 200
 
 // ReadResponseBody reads an HTTP response body, transparently decompressing gzip
 // when needed. Go's net/http does not auto-decompress when the request sets
@@ -49,4 +52,65 @@ func isGzipBody(body []byte, contentEncoding string) bool {
 		return true
 	}
 	return len(body) >= 2 && body[0] == 0x1f && body[1] == 0x8b
+}
+
+// ResponseBodyPreview returns a single-line, truncated preview of body for error messages.
+func ResponseBodyPreview(body []byte, maxLen int) string {
+	if len(body) == 0 {
+		return "(empty)"
+	}
+	if maxLen <= 0 {
+		maxLen = defaultResponseBodyPreviewLimit
+	}
+
+	var b strings.Builder
+	for _, r := range string(body) {
+		switch {
+		case r == '\n' || r == '\r' || r == '\t':
+			b.WriteByte(' ')
+		case unicode.IsPrint(r):
+			b.WriteRune(r)
+		default:
+			b.WriteByte('?')
+		}
+		if b.Len() >= maxLen {
+			break
+		}
+	}
+
+	preview := strings.TrimSpace(b.String())
+	if len(body) > len(preview) {
+		return preview + "..."
+	}
+	return preview
+}
+
+func formatHTTPResponseContext(resp *http.Response, body []byte) string {
+	parts := make([]string, 0, 4)
+	if resp != nil {
+		parts = append(parts, "status="+resp.Status)
+		if contentType := resp.Header.Get("Content-Type"); contentType != "" {
+			parts = append(parts, "content-type="+contentType)
+		}
+	}
+	parts = append(parts, fmt.Sprintf("body_len=%d", len(body)))
+	parts = append(parts, fmt.Sprintf("body_preview=%q", ResponseBodyPreview(body, defaultResponseBodyPreviewLimit)))
+	return strings.Join(parts, " ")
+}
+
+// FormatUnexpectedHTTPStatus builds an error message for a non-success HTTP response.
+func FormatUnexpectedHTTPStatus(storeName string, resp *http.Response, body []byte) string {
+	status := ""
+	if resp != nil {
+		status = resp.Status
+	}
+	return fmt.Sprintf("unexpected status for %s: %s (%s)", storeName, status, formatHTTPResponseContext(resp, body))
+}
+
+// WrapJSONDecodeError annotates a JSON decode error with HTTP response context.
+func WrapJSONDecodeError(err error, resp *http.Response, body []byte) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("json decode failed (%s): %w", formatHTTPResponseContext(resp, body), err)
 }

--- a/api/gateway/http_response_test.go
+++ b/api/gateway/http_response_test.go
@@ -3,12 +3,14 @@ package gateway
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestReadResponseBody_plainJSON(t *testing.T) {
@@ -145,5 +147,64 @@ func TestWrapJSONDecodeError_preservesCause(t *testing.T) {
 	err := WrapJSONDecodeError(cause, nil, []byte("{bad"))
 	if !errors.Is(err, cause) {
 		t.Fatalf("expected wrapped cause, got %v", err)
+	}
+}
+
+func TestFormatHTTPRequestContext(t *testing.T) {
+	ctx, cancel := context.WithDeadline(context.Background(), time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC))
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://thetcgmarketplace.com:3501/encoder/advancedsearch", bytes.NewReader([]byte(`{"name":"Opt"}`)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.ContentLength = 15
+
+	msg := FormatHTTPRequestContext(req, "access_token_configured=false")
+	for _, want := range []string{
+		"method=POST",
+		"url=https://thetcgmarketplace.com:3501/encoder/advancedsearch",
+		"request_body_len=15",
+		"context_deadline=2026-07-01T12:00:00Z",
+		"access_token_configured=false",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("context %q missing %q", msg, want)
+		}
+	}
+}
+
+func TestWrapHTTPRequestError(t *testing.T) {
+	req, err := http.NewRequest(http.MethodPost, "https://example.com/api", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cause := errors.New("EOF")
+	err = WrapHTTPRequestError(cause, req)
+	if !errors.Is(err, cause) {
+		t.Fatalf("expected wrapped cause, got %v", err)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "http request failed") {
+		t.Fatalf("unexpected error: %s", msg)
+	}
+	if !strings.Contains(msg, "method=POST") || !strings.Contains(msg, "url=https://example.com/api") {
+		t.Fatalf("missing request context: %s", msg)
+	}
+}
+
+func TestWrapResponseBodyReadError(t *testing.T) {
+	resp := &http.Response{
+		Status:     "200 OK",
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+	}
+	cause := errors.New("unexpected EOF")
+	err := WrapResponseBodyReadError(cause, resp)
+	if !errors.Is(err, cause) {
+		t.Fatalf("expected wrapped cause, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "read response body failed") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/api/gateway/http_response_test.go
+++ b/api/gateway/http_response_test.go
@@ -3,8 +3,11 @@ package gateway
 import (
 	"bytes"
 	"compress/gzip"
+	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -71,5 +74,76 @@ func TestReadResponseBody_gzipMagicWithoutHeader(t *testing.T) {
 	}
 	if string(got) != string(plain) {
 		t.Fatalf("got %q, want %q", got, plain)
+	}
+}
+
+func TestResponseBodyPreview(t *testing.T) {
+	if got := ResponseBodyPreview(nil, 0); got != "(empty)" {
+		t.Fatalf("empty body = %q", got)
+	}
+
+	html := []byte("<!DOCTYPE html>\n<html><title>Blocked</title></html>")
+	got := ResponseBodyPreview(html, 40)
+	if !strings.Contains(got, "<!DOCTYPE html>") {
+		t.Fatalf("preview = %q", got)
+	}
+	if !strings.HasSuffix(got, "...") {
+		t.Fatalf("expected truncated preview, got %q", got)
+	}
+}
+
+func TestWrapJSONDecodeError(t *testing.T) {
+	resp := &http.Response{
+		Status:     "403 Forbidden",
+		StatusCode: http.StatusForbidden,
+		Header: http.Header{
+			"Content-Type": []string{"text/html"},
+		},
+	}
+	body := []byte("<html>blocked</html>")
+	err := WrapJSONDecodeError(json.Unmarshal(body, &map[string]any{}), resp, body)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"json decode failed",
+		"status=403 Forbidden",
+		"content-type=text/html",
+		"body_len=20",
+		"body_preview=",
+		"invalid character",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error %q missing %q", msg, want)
+		}
+	}
+}
+
+func TestFormatUnexpectedHTTPStatus(t *testing.T) {
+	resp := &http.Response{
+		Status:     "503 Service Unavailable",
+		StatusCode: http.StatusServiceUnavailable,
+	}
+	msg := FormatUnexpectedHTTPStatus("Cards & Collections", resp, []byte("down"))
+	if !strings.Contains(msg, "unexpected status for Cards & Collections: 503 Service Unavailable") {
+		t.Fatalf("unexpected message: %s", msg)
+	}
+	if !strings.Contains(msg, "body_preview=\"down\"") {
+		t.Fatalf("missing body preview: %s", msg)
+	}
+}
+
+func TestWrapJSONDecodeError_nil(t *testing.T) {
+	if err := WrapJSONDecodeError(nil, nil, nil); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestWrapJSONDecodeError_preservesCause(t *testing.T) {
+	cause := errors.New("decode failed")
+	err := WrapJSONDecodeError(cause, nil, []byte("{bad"))
+	if !errors.Is(err, cause) {
+		t.Fatalf("expected wrapped cause, got %v", err)
 	}
 }

--- a/api/gateway/tcgmarketplace/search.go
+++ b/api/gateway/tcgmarketplace/search.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -87,7 +86,7 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 		return cards, err
 	}
 
-	res, err = getApiResponse(ctx, reqPayload)
+	res, err = getApiResponse(ctx, reqPayload, accessToken != "")
 	if err != nil {
 		return cards, err
 	}
@@ -159,7 +158,7 @@ func isSurgeFoil(extraInfo []string, name string) bool {
 	return false
 }
 
-func getApiResponse(ctx context.Context, payload []byte) (response, error) {
+func getApiResponse(ctx context.Context, payload []byte, accessTokenConfigured bool) (response, error) {
 	var res response
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cardLinkAPI, bytes.NewBuffer(payload))
@@ -167,20 +166,28 @@ func getApiResponse(ctx context.Context, payload []byte) (response, error) {
 		return res, err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.ContentLength = int64(len(payload))
+
+	var requestContext []string
+	if !accessTokenConfigured {
+		requestContext = append(requestContext, "access_token_configured=false")
+	}
+
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return res, err
+		return res, gateway.WrapHTTPRequestError(err, req, requestContext...)
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := gateway.ReadResponseBody(resp)
 	if err != nil {
-		return res, err
+		return res, gateway.WrapResponseBodyReadError(err, resp)
 	}
-
-	err = json.Unmarshal(body, &res)
-	if err != nil {
-		return res, err
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return res, fmt.Errorf("%s", gateway.FormatUnexpectedHTTPStatus(StoreName, resp, body))
+	}
+	if err = json.Unmarshal(body, &res); err != nil {
+		return res, gateway.WrapJSONDecodeError(err, resp, body)
 	}
 
 	return res, nil


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Store search failures were logging only bare Go errors, which made production logs and Discord alerts hard to diagnose. This PR enriches those messages with HTTP request/response context.

## Changes

### Shared gateway helpers (`api/gateway/http_response.go`)
- `ResponseBodyPreview` — single-line, truncated body snippet for logs
- `WrapJSONDecodeError` — annotates JSON decode failures with status, content-type, body length, and preview
- `FormatUnexpectedHTTPStatus` — same context for non-2xx responses
- `WrapHTTPRequestError` — annotates transport/client failures (e.g. EOF) with method, URL, body length, and context deadline
- `WrapResponseBodyReadError` — annotates body read failures with HTTP status context

### Cards & Collections
- Read bodies via `ReadResponseBody` (handles gzip)
- Fail fast on non-2xx before JSON decode
- Wrap JSON unmarshal errors with response context

### The TCG Marketplace
- Wrap `advancedsearch` transport failures (e.g. `EOF`) with request context
- Surface whether `TCG_MARKETPLACE_ACCESS_TOKEN` is configured (without logging the token)
- Apply the same JSON/status/body-preview handling for API responses

## Example log output

**Cards & Collections (HTML instead of JSON):**
```
Error encountered searching [Cards & Collections] for [Opt]: json decode failed (status=403 Forbidden content-type=text/html body_len=1234 body_preview="<!DOCTYPE html>..."): invalid character '<' looking for beginning of value
```

**The TCG Marketplace (connection closed):**
```
Error encountered searching [The TCG Marketplace] for [Mole Man, Moloid Master]: http request failed (method=POST url=https://thetcgmarketplace.com:3501/encoder/advancedsearch request_body_len=98 context_deadline=2026-07-01T12:00:05Z access_token_configured=true): Post "https://thetcgmarketplace.com:3501/encoder/advancedsearch": EOF
```

## Testing

- `go test -mod=vendor -failfast -timeout 5m ./gateway/... ./controller/...`
- Added unit tests for the new helpers in `gateway/http_response_test.go`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a01d8dd-97ee-4fce-9e3e-f9c104ac8f6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a01d8dd-97ee-4fce-9e3e-f9c104ac8f6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

