### PR TITLE
Align saved list and search result card button order and styles

### DIFF
--- a/frontend/src/components/Card.jsx
+++ b/frontend/src/components/Card.jsx
@@ -72,6 +72,13 @@ const Card = ({
         <div>
           {isCart ? (
             <div className="d-flex justify-content-center gap-1">
+              <a
+                href={`${baseUrl}?s=${encodeURIComponent(card.name)}&src=${encodeURIComponent(card.src)}`}
+                className="btn btn-primary btn-sm cartSearchBtn"
+                onClick={(e) => onSearchStore(e, card.name, card.src)}
+              >
+                <SearchIcon size={12} className="cartIcon" /> Search
+              </a>
               <button
                 type="button"
                 className="removeFromCartBtn btn btn-danger btn-sm"
@@ -79,19 +86,12 @@ const Card = ({
               >
                 <Trash2 size={12} className="cartIcon" /> Remove
               </button>
-              <a
-                href={`${baseUrl}?s=${encodeURIComponent(card.name)}&src=${encodeURIComponent(card.src)}`}
-                className="btn btn-primary btn-sm cartSearchBtn ms-1"
-                onClick={(e) => onSearchStore(e, card.name, card.src)}
-              >
-                <SearchIcon size={12} className="cartIcon" /> Search
-              </a>
             </div>
           ) : inCart ? (
             <div className="d-flex justify-content-center gap-1">
               <button
                 type="button"
-                className="btn btn-outline-success btn-sm addCartBtn"
+                className="btn btn-success btn-sm addCartBtn"
                 onClick={() => addToCart(card)}
                 aria-label="Update saved snapshot"
                 title="Update saved snapshot"
@@ -100,12 +100,12 @@ const Card = ({
               </button>
               <button
                 type="button"
-                className="btn btn-outline-danger btn-sm"
+                className="removeFromCartBtn btn btn-danger btn-sm"
                 onClick={() => removeFromCartByCard(card)}
                 aria-label="Remove from saved"
                 title="Remove from saved"
               >
-                <Trash2 size={12} className="cartIcon" />
+                <Trash2 size={12} className="cartIcon" /> Remove
               </button>
             </div>
           ) : (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns card action buttons between the saved list offcanvas and search results listing:

- **Saved list**: Search is now on the left, Remove on the right (matching search results layout).
- **Search results (saved cards)**: Update and Remove now use solid colored buttons (white text on colored background) instead of outline styles.
- **Search results**: Remove button now shows "Remove" text alongside the icon, not icon-only.

## Screenshots

### Search results (Update / Remove)

**Desktop**

![Search results card buttons on desktop](https://cursor.com/artifacts/c/art-4796f6c1-8555-42a4-978c-01c496de4845)

**Mobile**

![Search results card buttons on mobile](https://cursor.com/artifacts/c/art-5aaa5975-c5ba-4fe7-9cd3-e16548181bbd)

### Saved list (Search / Remove)

**Desktop**

![Saved list card buttons on desktop](https://cursor.com/artifacts/c/art-6d8c8e39-50e4-48f8-8710-7c46f917670d)

**Mobile**

![Saved list card buttons on mobile](https://cursor.com/artifacts/c/art-937a183e-62b8-42fc-96b7-c9be51196c4f)

## Test plan

- [x] Frontend lint passes (`npm run lint`)
- [x] Verified button order and styling in local dev with mocked search data
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da67353f-0ffa-4eed-a5ea-6ff510b2ef42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da67353f-0ffa-4eed-a5ea-6ff510b2ef42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

