### PR TITLE
Preserve UTM params when syncing search URL to history

### DIFF
--- a/frontend/src/hooks/useSearch.js
+++ b/frontend/src/hooks/useSearch.js
@@ -84,7 +84,13 @@ export default function useSearch() {
       return;
     }
 
-    const newUrl = buildSearchUrl(BASE_URL, snapshot.query, snapshot.stores);
+    const existingParams = new URLSearchParams(window.location.search);
+    const newUrl = buildSearchUrl(
+      BASE_URL,
+      snapshot.query,
+      snapshot.stores,
+      existingParams,
+    );
     const title = snapshot.query
       ? `${snapshot.query} @ Gishath Fetch`
       : PAGE_TITLE;

--- a/frontend/src/utils/searchUrl.js
+++ b/frontend/src/utils/searchUrl.js
@@ -65,11 +65,34 @@ export function parseStoresFromUrlParam(lgsParam) {
 }
 
 /**
+ * @param {string} key
+ * @returns {boolean}
+ */
+export function isTrackingParam(key) {
+  return key.toLowerCase().startsWith("utm_");
+}
+
+/**
+ * Copy utm_* params from source into target without overwriting keys already set.
+ *
+ * @param {URLSearchParams} sourceParams
+ * @param {URLSearchParams} targetParams
+ */
+export function mergeTrackingParams(sourceParams, targetParams) {
+  for (const [key, value] of sourceParams.entries()) {
+    if (isTrackingParam(key) && !targetParams.has(key)) {
+      targetParams.set(key, value);
+    }
+  }
+}
+
+/**
  * @param {string} query
  * @param {string[]} stores
+ * @param {URLSearchParams} [existingParams]
  * @returns {URLSearchParams}
  */
-export function buildSearchUrlParams(query, stores) {
+export function buildSearchUrlParams(query, stores, existingParams) {
   const params = new URLSearchParams();
   params.set("s", query);
 
@@ -82,6 +105,10 @@ export function buildSearchUrlParams(query, stores) {
     params.set("lgs", validStores.join(","));
   }
 
+  if (existingParams) {
+    mergeTrackingParams(existingParams, params);
+  }
+
   return params;
 }
 
@@ -89,10 +116,11 @@ export function buildSearchUrlParams(query, stores) {
  * @param {string} baseUrl
  * @param {string} query
  * @param {string[]} stores
+ * @param {URLSearchParams} [existingParams]
  * @returns {string}
  */
-export function buildSearchUrl(baseUrl, query, stores) {
-  const params = buildSearchUrlParams(query, stores);
+export function buildSearchUrl(baseUrl, query, stores, existingParams) {
+  const params = buildSearchUrlParams(query, stores, existingParams);
   return `${baseUrl}?${params.toString()}`;
 }
 

--- a/frontend/src/utils/searchUrl.test.js
+++ b/frontend/src/utils/searchUrl.test.js
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import {
+  buildSearchUrl,
+  buildSearchUrlParams,
+  isTrackingParam,
+  mergeTrackingParams,
+} from "./searchUrl.js";
+
+assert.equal(isTrackingParam("utm_source"), true);
+assert.equal(isTrackingParam("UTM_CAMPAIGN"), true);
+assert.equal(isTrackingParam("s"), false);
+assert.equal(isTrackingParam("lgs"), false);
+assert.equal(isTrackingParam("faq"), false);
+
+const existing = new URLSearchParams(
+  "s=Old&utm_source=popular_searches&utm_medium=internal&utm_campaign=popular_searches&utm_content=last24Hours&faq=1",
+);
+const params = buildSearchUrlParams("Loki, Lord of Misrule", [], existing);
+
+assert.equal(params.get("s"), "Loki, Lord of Misrule");
+assert.equal(params.get("utm_source"), "popular_searches");
+assert.equal(params.get("utm_medium"), "internal");
+assert.equal(params.get("utm_campaign"), "popular_searches");
+assert.equal(params.get("utm_content"), "last24Hours");
+assert.equal(params.has("faq"), false);
+
+const withStores = buildSearchUrlParams(
+  "Lightning Bolt",
+  ["Hideout"],
+  existing,
+);
+assert.equal(withStores.get("lgs"), "Hideout");
+assert.equal(withStores.get("utm_source"), "popular_searches");
+
+const target = new URLSearchParams("s=test&utm_campaign=override");
+mergeTrackingParams(
+  new URLSearchParams("utm_source=email&utm_campaign=newsletter"),
+  target,
+);
+assert.equal(target.get("utm_source"), "email");
+assert.equal(target.get("utm_campaign"), "override");
+
+const url = buildSearchUrl(
+  "https://gishathfetch.com/",
+  "Loki, Lord of Misrule",
+  [],
+  existing,
+);
+assert.ok(url.includes("utm_source=popular_searches"));
+assert.ok(url.includes("utm_content=last24Hours"));
+assert.ok(url.includes("s=Loki%2C+Lord+of+Misrule"));
+
+console.log("searchUrl tests passed");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Popular search links include `utm_*` query parameters for GA4 session attribution. After a search completed, `syncSearchHistory` rewrote the browser URL with only `s` and `lgs`, stripping UTMs before `gtag.js` could reliably read them.

This change merges existing `utm_*` params from the current URL when building history URLs via `history.replaceState` / `pushState`.

## Changes

- Add `isTrackingParam` and `mergeTrackingParams` helpers in `searchUrl.js`
- Extend `buildSearchUrlParams` / `buildSearchUrl` to accept optional existing URL params
- Pass current `window.location.search` from `syncSearchHistory` in `useSearch.js`
- Add unit tests for UTM preservation

## Example

**Before:** landing on  
`/?s=Loki,+Lord+of+Misrule&utm_source=popular_searches&utm_medium=internal&utm_campaign=popular_searches&utm_content=last24Hours`  
→ after search completes → `/?s=Loki%2C+Lord+of+Misrule` (UTMs lost)

**After:** same landing URL → after search completes → `/?s=Loki%2C+Lord+of+Misrule&utm_source=popular_searches&utm_medium=internal&utm_campaign=popular_searches&utm_content=last24Hours`

Non-tracking params (e.g. `faq=1`) are not preserved; only `utm_*` keys are merged.

## Testing

- `npx tsx src/utils/searchUrl.test.js` (frontend unit tests)
- `npm run lint` (frontend)
- `make test` (backend)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aefa8e48-10f4-4072-bd69-80780e736211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aefa8e48-10f4-4072-bd69-80780e736211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

