### PR TITLE
Sort search results by name match tier, then price

### DIFF
--- a/frontend/src/hooks/useResultFilters.js
+++ b/frontend/src/hooks/useResultFilters.js
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { getNameMatchTier } from "../utils/nameMatch.js";
 
 const DEFAULT_SORT = "price-asc";
 
@@ -51,6 +52,13 @@ export default function useResultFilters(results, searchQuery) {
     }
 
     filtered.sort((a, b) => {
+      const tierDiff =
+        getNameMatchTier(a.name, searchQuery) -
+        getNameMatchTier(b.name, searchQuery);
+      if (tierDiff !== 0) {
+        return tierDiff;
+      }
+
       if (sortBy === "price-desc") {
         return b.price - a.price;
       }
@@ -58,7 +66,7 @@ export default function useResultFilters(results, searchQuery) {
     });
 
     return filtered;
-  }, [results, sortBy, qualityFilter, foilOnly, cheapestPerStore]);
+  }, [results, sortBy, qualityFilter, foilOnly, cheapestPerStore, searchQuery]);
 
   const hasActiveFilters =
     qualityFilter !== "all" || foilOnly || cheapestPerStore;

--- a/frontend/src/utils/nameMatch.js
+++ b/frontend/src/utils/nameMatch.js
@@ -1,0 +1,24 @@
+export const NAME_MATCH_TIER = {
+  EXACT: 0,
+  PREFIX: 1,
+  PARTIAL: 2,
+  NONE: 3,
+};
+
+export function getNameMatchTier(cardName, searchQuery) {
+  const lowerName = String(cardName ?? "").toLowerCase();
+  const lowerQuery = String(searchQuery ?? "")
+    .trim()
+    .toLowerCase();
+
+  if (!lowerQuery || !lowerName.includes(lowerQuery)) {
+    return NAME_MATCH_TIER.NONE;
+  }
+  if (lowerName === lowerQuery) {
+    return NAME_MATCH_TIER.EXACT;
+  }
+  if (lowerName.startsWith(lowerQuery)) {
+    return NAME_MATCH_TIER.PREFIX;
+  }
+  return NAME_MATCH_TIER.PARTIAL;
+}

--- a/frontend/src/utils/nameMatch.test.js
+++ b/frontend/src/utils/nameMatch.test.js
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { getNameMatchTier, NAME_MATCH_TIER } from "./nameMatch.js";
+
+assert.equal(
+  getNameMatchTier("Cosmic Cube", "Cosmic Cube"),
+  NAME_MATCH_TIER.EXACT,
+);
+assert.equal(
+  getNameMatchTier("Cosmic Cube", "cosmic cube"),
+  NAME_MATCH_TIER.EXACT,
+);
+assert.equal(
+  getNameMatchTier("Cosmic Cube Foil", "Cosmic Cube"),
+  NAME_MATCH_TIER.PREFIX,
+);
+assert.equal(
+  getNameMatchTier("Construct a Cosmic Cube", "Cosmic Cube"),
+  NAME_MATCH_TIER.PARTIAL,
+);
+assert.equal(
+  getNameMatchTier("Lightning Bolt", "Cosmic Cube"),
+  NAME_MATCH_TIER.NONE,
+);
+assert.equal(getNameMatchTier("Opt", ""), NAME_MATCH_TIER.NONE);
+
+console.log("nameMatch tests passed");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Search results were re-sorted on the frontend by price only, which mixed exact, prefix, and partial name matches together. For example, a cheaper listing for "Construct a Cosmic Cube" could appear above a "Cosmic Cube" listing when searching for `Cosmic Cube`.

This change keeps the existing price sort (low/high) **within** each relevance group, matching the backend's `filterAndSortCards` ordering:

1. Exact name matches (sorted by price)
2. Prefix matches (sorted by price)
3. Partial matches (sorted by price)

## Changes

- Add `getNameMatchTier()` utility mirroring backend exact/prefix/partial logic
- Update `useResultFilters` to sort by match tier first, then by the selected price order
- Add unit tests for the tier helper

## Testing

- `node frontend/src/utils/nameMatch.test.js`
- `cd frontend && npm run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-677bacf7-a895-4431-b7b3-04d3d3dc9724"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-677bacf7-a895-4431-b7b3-04d3d3dc9724"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

