### PR TITLE
Fix CK price for double-faced cards with face-only names

### DIFF
--- a/api/controller/ckprice/ckprice.go
+++ b/api/controller/ckprice/ckprice.go
@@ -3,7 +3,6 @@ package ckprice
 import (
 	"context"
 	"log"
-	"strings"
 	"time"
 
 	"mtg-price-checker-sg/gateway/cardkingdom"
@@ -28,14 +27,21 @@ func GetLatestPrice(ctx context.Context, store ckprices.Store, query string) (*c
 		return nil, nil
 	}
 
-	listing, err := store.GetByNameKey(ctx, strings.ToLower(strings.TrimSpace(verifiedName)))
-	if err != nil || listing == nil {
-		return nil, err
+	now := nowFunc()
+	var best *cardkingdom.Listing
+	for _, nameKey := range cardkingdom.NameLookupKeys(verifiedName) {
+		listing, err := store.GetByNameKey(ctx, nameKey)
+		if err != nil {
+			return nil, err
+		}
+		if listing == nil || !listingIsFresh(listing, now) {
+			continue
+		}
+		if best == nil || listing.PriceUsd < best.PriceUsd {
+			best = listing
+		}
 	}
-	if !listingIsFresh(listing, nowFunc()) {
-		return nil, nil
-	}
-	return listing, nil
+	return best, nil
 }
 
 func listingIsFresh(listing *cardkingdom.Listing, now time.Time) bool {

--- a/api/controller/ckprice/ckprice_test.go
+++ b/api/controller/ckprice/ckprice_test.go
@@ -11,12 +11,16 @@ import (
 )
 
 type mockStore struct {
-	listing *cardkingdom.Listing
-	getKey  string
+	listing  *cardkingdom.Listing
+	listings map[string]*cardkingdom.Listing
+	getKeys  []string
 }
 
 func (m *mockStore) GetByNameKey(_ context.Context, nameKey string) (*cardkingdom.Listing, error) {
-	m.getKey = nameKey
+	m.getKeys = append(m.getKeys, nameKey)
+	if m.listings != nil {
+		return m.listings[nameKey], nil
+	}
 	return m.listing, nil
 }
 
@@ -42,7 +46,7 @@ func TestGetLatestPrice_UsesVerifiedName(t *testing.T) {
 
 	listing, err := GetLatestPrice(context.Background(), store, "lightning bolt")
 	require.NoError(t, err)
-	require.Equal(t, "lightning bolt", store.getKey)
+	require.Equal(t, []string{"lightning bolt"}, store.getKeys)
 	require.Equal(t, 1.49, listing.PriceUsd)
 }
 
@@ -78,6 +82,40 @@ func TestGetLatestPrice_StaleListing(t *testing.T) {
 	listing, err := GetLatestPrice(context.Background(), store, "Lightning Bolt")
 	require.NoError(t, err)
 	require.Nil(t, listing)
+}
+
+func TestGetLatestPrice_PrefersCheapestDoubleFacedAlias(t *testing.T) {
+	originalVerify := verifyCardNameFunc
+	defer func() { verifyCardNameFunc = originalVerify }()
+
+	verifyCardNameFunc = func(_ context.Context, _ string) (string, error) {
+		return "Jennifer Walters // The Sensational She-Hulk", nil
+	}
+
+	store := &mockStore{
+		listings: map[string]*cardkingdom.Listing{
+			"jennifer walters // the sensational she-hulk": {
+				CardName:  "Jennifer Walters // The Sensational She-Hulk",
+				PriceUsd:  69.99,
+				UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+			},
+			"jennifer walters": {
+				CardName:  "Jennifer Walters",
+				PriceUsd:  10.99,
+				UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+			},
+		},
+	}
+
+	listing, err := GetLatestPrice(context.Background(), store, "Jennifer Walters")
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"jennifer walters // the sensational she-hulk",
+		"jennifer walters",
+		"the sensational she-hulk",
+	}, store.getKeys)
+	require.Equal(t, 10.99, listing.PriceUsd)
+	require.Equal(t, "Jennifer Walters", listing.CardName)
 }
 
 func TestListingIsFresh(t *testing.T) {

--- a/api/gateway/cardkingdom/index.go
+++ b/api/gateway/cardkingdom/index.go
@@ -13,18 +13,13 @@ func BuildCheapestByName(products []Product, updatedAt time.Time) map[string]Lis
 	updatedAtValue := updatedAt.UTC().Format(time.RFC3339)
 
 	for _, product := range products {
-		nameKey := strings.TrimSpace(strings.ToLower(product.Name))
-		if nameKey == "" {
-			continue
-		}
-
 		priceUsd, err := product.PriceRetail.Float64()
 		if err != nil || priceUsd <= 0 {
 			continue
 		}
 
 		quantity64, _ := product.QtyRetail.Int64()
-		listing := Listing{
+		considerCheapestListing(cheapestByName, Listing{
 			CardName:  product.Name,
 			Edition:   product.Edition,
 			PriceUsd:  priceUsd,
@@ -32,12 +27,7 @@ func BuildCheapestByName(products []Product, updatedAt time.Time) map[string]Lis
 			Quantity:  int(quantity64),
 			IsFoil:    strings.EqualFold(strings.TrimSpace(product.IsFoil), "true"),
 			UpdatedAt: updatedAtValue,
-		}
-
-		existing, ok := cheapestByName[nameKey]
-		if !ok || priceUsd < existing.PriceUsd {
-			cheapestByName[nameKey] = listing
-		}
+		})
 	}
 
 	return cheapestByName

--- a/api/gateway/cardkingdom/index_test.go
+++ b/api/gateway/cardkingdom/index_test.go
@@ -56,3 +56,30 @@ func TestBuildCheapestByName(t *testing.T) {
 	require.Equal(t, "https://www.cardkingdom.com/mtg/fourth-edition/lightning-bolt", listing.URL)
 	require.Equal(t, updatedAt.Format(time.RFC3339), listing.UpdatedAt)
 }
+
+func TestBuildCheapestByName_DoubleFacedCardIndexesFaceNames(t *testing.T) {
+	updatedAt := time.Date(2026, 7, 2, 12, 0, 0, 0, time.UTC)
+	products := []Product{
+		{
+			Name:        "Jennifer Walters",
+			Edition:     "Marvel Super Heroes",
+			PriceRetail: "10.99",
+			QtyRetail:   "8",
+			URL:         "mtg/marvel-super-heroes/jennifer-walters",
+			IsFoil:      "false",
+		},
+		{
+			Name:        "Jennifer Walters",
+			Edition:     "Marvel Super Heroes Variants",
+			PriceRetail: "24.99",
+			QtyRetail:   "3",
+			URL:         "mtg/marvel-super-heroes-variants/jennifer-walters-0328-borderless",
+			IsFoil:      "false",
+		},
+	}
+
+	cheapest := BuildCheapestByName(products, updatedAt)
+
+	require.InDelta(t, 10.99, cheapest["jennifer walters"].PriceUsd, 0.001)
+	require.Equal(t, "Marvel Super Heroes", cheapest["jennifer walters"].Edition)
+}

--- a/api/gateway/cardkingdom/mtgjson_fetch.go
+++ b/api/gateway/cardkingdom/mtgjson_fetch.go
@@ -34,7 +34,9 @@ type ckUUIDPrice struct {
 type mtgjsonCard struct {
 	UUID         string `json:"uuid"`
 	Name         string `json:"name"`
+	FaceName     string `json:"faceName"`
 	Number       string `json:"number"`
+	Side         string `json:"side"`
 	PurchaseUrls struct {
 		CardKingdom     string `json:"cardKingdom"`
 		CardKingdomFoil string `json:"cardKingdomFoil"`
@@ -44,9 +46,11 @@ type mtgjsonCard struct {
 type printingKey struct {
 	number string
 	name   string
+	isDFC  bool
 }
 
 type printingAggregate struct {
+	cardName        string
 	cardKingdom     string
 	cardKingdomFoil string
 	price           ckUUIDPrice
@@ -280,8 +284,8 @@ func decodeSetCatalog(
 		for _, card := range set.Cards {
 			mergePrintingAggregate(aggregates, card, pricesByUUID)
 		}
-		for key, aggregate := range aggregates {
-			applyPrintingAggregate(cheapest, key.name, set.Name, aggregate, updatedAt)
+		for _, aggregate := range aggregates {
+			applyPrintingAggregate(cheapest, aggregate.cardName, set.Name, aggregate, updatedAt)
 		}
 	}
 
@@ -299,11 +303,9 @@ func mergePrintingAggregate(
 		return
 	}
 
-	key := printingKey{
-		number: strings.TrimSpace(card.Number),
-		name:   name,
-	}
+	key := printingKeyFor(card)
 	aggregate := aggregates[key]
+	aggregate.cardName = preferCardName(aggregate.cardName, name)
 
 	if card.PurchaseUrls.CardKingdom != "" {
 		aggregate.cardKingdom = card.PurchaseUrls.CardKingdom
@@ -321,6 +323,33 @@ func mergePrintingAggregate(
 	}
 
 	aggregates[key] = aggregate
+}
+
+func printingKeyFor(card mtgjsonCard) printingKey {
+	number := strings.TrimSpace(card.Number)
+	side := strings.TrimSpace(card.Side)
+	if side == "a" || side == "b" {
+		return printingKey{number: number, isDFC: true}
+	}
+	return printingKey{number: number, name: strings.TrimSpace(card.Name)}
+}
+
+func preferCardName(current string, candidate string) string {
+	current = strings.TrimSpace(current)
+	candidate = strings.TrimSpace(candidate)
+	if candidate == "" {
+		return current
+	}
+	if current == "" {
+		return candidate
+	}
+	if strings.Contains(candidate, doubleFacedNameSeparator) {
+		return candidate
+	}
+	if strings.Contains(current, doubleFacedNameSeparator) {
+		return current
+	}
+	return candidate
 }
 
 func applyPrintingAggregate(
@@ -367,13 +396,15 @@ func applyPrintingAggregate(
 }
 
 func considerCheapestListing(cheapest map[string]Listing, listing Listing) {
-	nameKey := strings.ToLower(strings.TrimSpace(listing.CardName))
-	if nameKey == "" || listing.PriceUsd <= 0 {
+	if listing.PriceUsd <= 0 {
 		return
 	}
-	existing, ok := cheapest[nameKey]
-	if !ok || listing.PriceUsd < existing.PriceUsd {
-		cheapest[nameKey] = listing
+
+	for _, nameKey := range NameLookupKeys(listing.CardName) {
+		existing, ok := cheapest[nameKey]
+		if !ok || listing.PriceUsd < existing.PriceUsd {
+			cheapest[nameKey] = listing
+		}
 	}
 }
 

--- a/api/gateway/cardkingdom/mtgjson_fetch_test.go
+++ b/api/gateway/cardkingdom/mtgjson_fetch_test.go
@@ -109,6 +109,7 @@ const sampleAllPrintingsSplitUUID = `{
           "uuid": "uuid-tony-80-url",
           "name": "Tony Stark // The Invincible Iron Man",
           "number": "80",
+          "side": "a",
           "purchaseUrls": {
             "cardKingdom": "https://www.cardkingdom.com/mtg/marvel-super-heroes/tony-stark",
             "cardKingdomFoil": "https://www.cardkingdom.com/mtg/marvel-super-heroes/tony-stark-foil"
@@ -118,12 +119,14 @@ const sampleAllPrintingsSplitUUID = `{
           "uuid": "uuid-tony-80-price",
           "name": "Tony Stark // The Invincible Iron Man",
           "number": "80",
+          "side": "b",
           "purchaseUrls": {}
         },
         {
           "uuid": "uuid-tony-363-url",
           "name": "Tony Stark // The Invincible Iron Man",
           "number": "363",
+          "side": "a",
           "purchaseUrls": {
             "cardKingdom": "https://www.cardkingdom.com/mtg/marvel-super-heroes-variants/tony-stark-0363-borderless",
             "cardKingdomFoil": "https://www.cardkingdom.com/mtg/marvel-super-heroes-variants/tony-stark-0363-borderless-foil"
@@ -133,6 +136,36 @@ const sampleAllPrintingsSplitUUID = `{
           "uuid": "uuid-tony-363-price",
           "name": "Tony Stark // The Invincible Iron Man",
           "number": "363",
+          "side": "b",
+          "purchaseUrls": {}
+        }
+      ]
+    }
+  }
+}`
+
+const sampleAllPrintingsJenniferWalters = `{
+  "meta": {"date": "2026-07-02"},
+  "data": {
+    "MSH": {
+      "name": "Marvel Super Heroes",
+      "cards": [
+        {
+          "uuid": "uuid-jw-18-url",
+          "name": "Jennifer Walters // The Sensational She-Hulk",
+          "faceName": "Jennifer Walters",
+          "number": "18",
+          "side": "a",
+          "purchaseUrls": {
+            "cardKingdom": "https://www.cardkingdom.com/mtg/marvel-super-heroes/jennifer-walters"
+          }
+        },
+        {
+          "uuid": "uuid-jw-18-price",
+          "name": "Jennifer Walters // The Sensational She-Hulk",
+          "faceName": "The Sensational She-Hulk",
+          "number": "18",
+          "side": "b",
           "purchaseUrls": {}
         }
       ]
@@ -163,7 +196,6 @@ func TestDecodeAllPrintingsSets(t *testing.T) {
 		updatedAt,
 	)
 	require.NoError(t, err)
-	require.Len(t, cheapest, 1)
 
 	listing := cheapest["lightning bolt"]
 	require.Equal(t, "Lightning Bolt", listing.CardName)
@@ -187,7 +219,6 @@ func TestDecodeAllPrintingsSets_MergesSplitUUIDPrintings(t *testing.T) {
 		updatedAt,
 	)
 	require.NoError(t, err)
-	require.Len(t, cheapest, 1)
 
 	listing := cheapest["tony stark // the invincible iron man"]
 	require.Equal(t, "Tony Stark // The Invincible Iron Man", listing.CardName)
@@ -195,6 +226,31 @@ func TestDecodeAllPrintingsSets_MergesSplitUUIDPrintings(t *testing.T) {
 	require.InDelta(t, 7.49, listing.PriceUsd, 0.001)
 	require.False(t, listing.IsFoil)
 	require.Equal(t, "https://www.cardkingdom.com/mtg/marvel-super-heroes/tony-stark", listing.URL)
+
+	faceListing := cheapest["tony stark"]
+	require.InDelta(t, 7.49, faceListing.PriceUsd, 0.001)
+}
+
+func TestDecodeAllPrintingsSets_MergesDoubleFacedFacesByNumber(t *testing.T) {
+	prices := map[string]ckUUIDPrice{
+		"uuid-jw-18-price": {normal: 10.99},
+	}
+	updatedAt := time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC)
+
+	cheapest, err := decodeAllPrintingsSets(
+		json.NewDecoder(strings.NewReader(sampleAllPrintingsJenniferWalters)),
+		prices,
+		updatedAt,
+	)
+	require.NoError(t, err)
+
+	listing := cheapest["jennifer walters // the sensational she-hulk"]
+	require.Equal(t, "Jennifer Walters // The Sensational She-Hulk", listing.CardName)
+	require.InDelta(t, 10.99, listing.PriceUsd, 0.001)
+	require.Equal(t, "https://www.cardkingdom.com/mtg/marvel-super-heroes/jennifer-walters", listing.URL)
+
+	faceListing := cheapest["jennifer walters"]
+	require.InDelta(t, 10.99, faceListing.PriceUsd, 0.001)
 }
 
 func TestFetchCheapestFromMTGJSON_FromTestServers(t *testing.T) {

--- a/api/gateway/cardkingdom/names.go
+++ b/api/gateway/cardkingdom/names.go
@@ -1,0 +1,47 @@
+package cardkingdom
+
+import "strings"
+
+const doubleFacedNameSeparator = " // "
+
+// NormalizeNameKey lowercases and trims a card name for DynamoDB lookup.
+func NormalizeNameKey(name string) string {
+	return strings.ToLower(strings.TrimSpace(name))
+}
+
+// NameLookupKeys returns normalized lookup keys for a card name, including each
+// face of a double-faced card split on " // ".
+func NameLookupKeys(cardName string) []string {
+	trimmed := strings.TrimSpace(cardName)
+	if trimmed == "" {
+		return nil
+	}
+
+	keys := []string{NormalizeNameKey(trimmed)}
+	if before, after, ok := strings.Cut(trimmed, doubleFacedNameSeparator); ok {
+		if front := NormalizeNameKey(before); front != "" {
+			keys = append(keys, front)
+		}
+		if back := NormalizeNameKey(after); back != "" {
+			keys = append(keys, back)
+		}
+	}
+
+	return uniqueNameKeys(keys)
+}
+
+func uniqueNameKeys(keys []string) []string {
+	seen := make(map[string]struct{}, len(keys))
+	unique := make([]string, 0, len(keys))
+	for _, key := range keys {
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		unique = append(unique, key)
+	}
+	return unique
+}

--- a/api/gateway/cardkingdom/names_test.go
+++ b/api/gateway/cardkingdom/names_test.go
@@ -1,0 +1,25 @@
+package cardkingdom
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNameLookupKeys_DoubleFacedCard(t *testing.T) {
+	keys := NameLookupKeys("Jennifer Walters // The Sensational She-Hulk")
+	require.Equal(t, []string{
+		"jennifer walters // the sensational she-hulk",
+		"jennifer walters",
+		"the sensational she-hulk",
+	}, keys)
+}
+
+func TestNameLookupKeys_SingleFacedCard(t *testing.T) {
+	keys := NameLookupKeys("Lightning Bolt")
+	require.Equal(t, []string{"lightning bolt"}, keys)
+}
+
+func TestNameLookupKeys_Empty(t *testing.T) {
+	require.Nil(t, NameLookupKeys(""))
+}

--- a/api/gateway/cardkingdom/pricelist.go
+++ b/api/gateway/cardkingdom/pricelist.go
@@ -8,11 +8,18 @@ import (
 const mtgjsonErrorPrefix = "ck price mtgjson"
 
 // FetchCheapestByName downloads Card Kingdom retail prices from MTGJSON and
-// indexes the cheapest listing per card name.
+// indexes the cheapest listing per card name. When available, Card Kingdom's
+// pricelist is merged in as well so face-only names (for example "Jennifer
+// Walters") supplement MTGJSON's full double-faced names.
 func FetchCheapestByName(ctx context.Context) (map[string]Listing, error) {
 	listings, err := fetchCheapestFromMTGJSON(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", mtgjsonErrorPrefix, err)
 	}
+
+	if ckListings, ckErr := fetchCheapestFromCKPricelist(ctx); ckErr == nil {
+		mergeCheapestListings(listings, ckListings)
+	}
+
 	return listings, nil
 }

--- a/api/gateway/cardkingdom/pricelist_fetch.go
+++ b/api/gateway/cardkingdom/pricelist_fetch.go
@@ -1,0 +1,102 @@
+package cardkingdom
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"mtg-price-checker-sg/gateway"
+)
+
+const (
+	pricelistURL     = "https://api.cardkingdom.com/api/v2/pricelist"
+	pricelistTimeout = 3 * time.Minute
+)
+
+var fetchPricelistBody = func(ctx context.Context) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, pricelistTimeout)
+	defer cancel()
+
+	requestURL, err := url.Parse(pricelistURL)
+	if err != nil {
+		return nil, err
+	}
+	if err := gateway.WaitForDomainRequestSlot(ctx, requestURL); err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, pricelistURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	storeBase, err := url.Parse(listingBaseURL)
+	if err != nil {
+		return nil, err
+	}
+	if err := gateway.PrepareOutboundRequest(ctx, req, gateway.OutboundRequestOptions{
+		Style:          gateway.OutboundStyleJSON,
+		StoreBase:      storeBase,
+		SkipWebBotAuth: true,
+	}); err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{Timeout: pricelistTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %d", resp.StatusCode)
+	}
+	if looksLikeCloudflareChallenge(body) {
+		return nil, fmt.Errorf("cloudflare challenge")
+	}
+	return body, nil
+}
+
+func fetchCheapestFromCKPricelist(ctx context.Context) (map[string]Listing, error) {
+	body, err := fetchPricelistBody(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var products []Product
+	if err := json.Unmarshal(body, &products); err == nil {
+		return BuildCheapestByName(products, time.Now().UTC()), nil
+	}
+
+	var payload struct {
+		Data []Product `json:"data"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, err
+	}
+	return BuildCheapestByName(payload.Data, time.Now().UTC()), nil
+}
+
+func mergeCheapestListings(primary map[string]Listing, supplemental map[string]Listing) {
+	for _, listing := range supplemental {
+		considerCheapestListing(primary, listing)
+	}
+}
+
+func looksLikeCloudflareChallenge(body []byte) bool {
+	prefix := string(body)
+	if len(prefix) > 512 {
+		prefix = prefix[:512]
+	}
+	lower := strings.ToLower(prefix)
+	return strings.Contains(lower, "just a moment") || strings.Contains(lower, "cloudflare")
+}

--- a/api/gateway/cardkingdom/pricelist_fetch_test.go
+++ b/api/gateway/cardkingdom/pricelist_fetch_test.go
@@ -1,0 +1,78 @@
+package cardkingdom
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchCheapestFromCKPricelist_FromTestServer(t *testing.T) {
+	originalFetch := fetchPricelistBody
+	defer func() { fetchPricelistBody = originalFetch }()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"meta":{"created_at":"2026-07-02 12:10:11"},
+			"data":[
+				{
+					"name":"Jennifer Walters",
+					"edition":"Marvel Super Heroes",
+					"price_retail":10.99,
+					"qty_retail":8,
+					"url":"mtg/marvel-super-heroes/jennifer-walters",
+					"is_foil":"false"
+				}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	fetchPricelistBody = func(ctx context.Context) ([]byte, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, nil)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		defer resp.Body.Close()
+		return io.ReadAll(resp.Body)
+	}
+
+	cheapest, err := fetchCheapestFromCKPricelist(context.Background())
+	require.NoError(t, err)
+	require.InDelta(t, 10.99, cheapest["jennifer walters"].PriceUsd, 0.001)
+}
+
+func TestMergeCheapestListings_PrefersCheaperFaceNameListing(t *testing.T) {
+	updatedAt := time.Now().UTC().Format(time.RFC3339)
+	listings := make(map[string]Listing)
+	considerCheapestListing(listings, Listing{
+		CardName:  "Jennifer Walters // The Sensational She-Hulk",
+		Edition:   "Marvel Super Heroes Variants",
+		PriceUsd:  69.99,
+		URL:       "https://www.cardkingdom.com/mtg/marvel-super-heroes-variants/jennifer-walters-0355-borderless-foil",
+		IsFoil:    true,
+		UpdatedAt: updatedAt,
+	})
+
+	mergeCheapestListings(listings, map[string]Listing{
+		"jennifer walters": {
+			CardName:  "Jennifer Walters",
+			Edition:   "Marvel Super Heroes",
+			PriceUsd:  10.99,
+			URL:       "https://www.cardkingdom.com/mtg/marvel-super-heroes/jennifer-walters",
+			UpdatedAt: updatedAt,
+		},
+	})
+
+	require.InDelta(t, 10.99, listings["jennifer walters"].PriceUsd, 0.001)
+	require.InDelta(t, 69.99, listings["jennifer walters // the sensational she-hulk"].PriceUsd, 0.001)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Double-faced cards like **Jennifer Walters // The Sensational She-Hulk** were not returning the cheapest Card Kingdom price. Two naming mismatches were involved:

1. **Lookup mismatch** — Scryfall returns the full combined name (`Jennifer Walters // The Sensational She-Hulk`), but Card Kingdom's pricelist indexes the card under the front face name only (`Jennifer Walters`).
2. **MTGJSON split faces** — MTGJSON stores purchase URLs on the front-face UUID and retail prices on the back-face UUID for the same printing. Without merging by card number, some printings were skipped or only expensive variants (e.g. borderless foil) were indexed.

For Jennifer Walters specifically, CK sells the regular printing at **$10.99** under `Jennifer Walters`, while MTGJSON currently only had foil variant prices (~$69.99) indexed under the full name.

## Solution

- **Name aliases** — Index and look up listings under the full name plus each face name split on ` // `.
- **DFC face merge** — When MTGJSON provides `side: "a"` / `"b"`, merge purchase URLs and prices by card number before choosing the cheapest listing.
- **CK pricelist supplement** — After MTGJSON refresh, best-effort merge of CK's pricelist so face-only names (e.g. `Jennifer Walters` at $10.99) are available even when MTGJSON price data is incomplete for new sets.
- **Cheapest lookup** — `GetLatestPrice` now checks all name aliases and returns the lowest fresh price.

## Testing

- `make test` (full suite)
- New unit tests for Jennifer Walters / Tony Stark DFC scenarios in `cardkingdom` and `ckprice` packages

## Notes

- CK pricelist fetch is best-effort; if Cloudflare blocks it, MTGJSON data is still used.
- A CK price refresh run is needed after merge for DynamoDB to pick up the new face-name index entries.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1beefedd-e03b-4f59-9f43-17ee5c077da6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1beefedd-e03b-4f59-9f43-17ee5c077da6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

