### PR TITLE
Fix CK lowest price for Jennifer Walters DFC (10.99 vs 69.99 foil)

### DIFF
--- a/api/controller/ckprice/ckprice.go
+++ b/api/controller/ckprice/ckprice.go
@@ -28,8 +28,28 @@ func GetLatestPrice(ctx context.Context, store ckprices.Store, query string) (*c
 	}
 
 	now := nowFunc()
+	lookupKeys := cardkingdom.PriceLookupKeys(verifiedName)
+	best, err := cheapestFreshListing(ctx, store, lookupKeys, now)
+	if err != nil {
+		return nil, err
+	}
+	if best == nil && len(lookupKeys) < len(cardkingdom.NameLookupKeys(verifiedName)) {
+		best, err = cheapestFreshListing(ctx, store, []string{cardkingdom.NormalizeNameKey(verifiedName)}, now)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return best, nil
+}
+
+func cheapestFreshListing(
+	ctx context.Context,
+	store ckprices.Store,
+	nameKeys []string,
+	now time.Time,
+) (*cardkingdom.Listing, error) {
 	var best *cardkingdom.Listing
-	for _, nameKey := range cardkingdom.NameLookupKeys(verifiedName) {
+	for _, nameKey := range nameKeys {
 		listing, err := store.GetByNameKey(ctx, nameKey)
 		if err != nil {
 			return nil, err

--- a/api/controller/ckprice/ckprice.go
+++ b/api/controller/ckprice/ckprice.go
@@ -28,18 +28,7 @@ func GetLatestPrice(ctx context.Context, store ckprices.Store, query string) (*c
 	}
 
 	now := nowFunc()
-	lookupKeys := cardkingdom.PriceLookupKeys(verifiedName)
-	best, err := cheapestFreshListing(ctx, store, lookupKeys, now)
-	if err != nil {
-		return nil, err
-	}
-	if best == nil && len(lookupKeys) < len(cardkingdom.NameLookupKeys(verifiedName)) {
-		best, err = cheapestFreshListing(ctx, store, []string{cardkingdom.NormalizeNameKey(verifiedName)}, now)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return best, nil
+	return cheapestFreshListing(ctx, store, cardkingdom.PriceLookupKeys(verifiedName), now)
 }
 
 func cheapestFreshListing(

--- a/api/controller/ckprice/ckprice.go
+++ b/api/controller/ckprice/ckprice.go
@@ -18,6 +18,8 @@ var (
 )
 
 // GetLatestPrice verifies the query against Scryfall and returns the cheapest CK listing.
+// For double-faced cards it always checks the combined name, front face, and back
+// face together and returns the lowest fresh price across all three.
 func GetLatestPrice(ctx context.Context, store ckprices.Store, query string) (*cardkingdom.Listing, error) {
 	verifiedName, err := verifyCardNameFunc(ctx, query)
 	if err != nil {

--- a/api/controller/ckprice/ckprice_test.go
+++ b/api/controller/ckprice/ckprice_test.go
@@ -158,7 +158,7 @@ func TestGetLatestPrice_DoubleFacedChecksCombinedAndFaceNames(t *testing.T) {
 	require.Equal(t, "Jennifer Walters", listing.CardName)
 }
 
-func TestGetLatestPrice_DoubleFacedUsesCombinedNameWhenFacesMissing(t *testing.T) {
+func TestGetLatestPrice_DoubleFacedAlwaysChecksCombinedFrontAndBack(t *testing.T) {
 	originalVerify := verifyCardNameFunc
 	defer func() { verifyCardNameFunc = originalVerify }()
 
@@ -184,6 +184,45 @@ func TestGetLatestPrice_DoubleFacedUsesCombinedNameWhenFacesMissing(t *testing.T
 		"the invincible iron man",
 	}, store.getKeys)
 	require.Equal(t, 7.49, listing.PriceUsd)
+}
+
+func TestGetLatestPrice_DoubleFacedPicksCheapestIncludingCombinedName(t *testing.T) {
+	originalVerify := verifyCardNameFunc
+	defer func() { verifyCardNameFunc = originalVerify }()
+
+	verifyCardNameFunc = func(_ context.Context, _ string) (string, error) {
+		return "Jennifer Walters // The Sensational She-Hulk", nil
+	}
+
+	store := &mockStore{
+		listings: map[string]*cardkingdom.Listing{
+			"jennifer walters // the sensational she-hulk": {
+				CardName:  "Jennifer Walters // The Sensational She-Hulk",
+				PriceUsd:  5.99,
+				UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+			},
+			"jennifer walters": {
+				CardName:  "Jennifer Walters",
+				PriceUsd:  10.99,
+				UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+			},
+			"the sensational she-hulk": {
+				CardName:  "The Sensational She-Hulk",
+				PriceUsd:  14.99,
+				UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+			},
+		},
+	}
+
+	listing, err := GetLatestPrice(context.Background(), store, "Jennifer Walters // The Sensational She-Hulk")
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"jennifer walters // the sensational she-hulk",
+		"jennifer walters",
+		"the sensational she-hulk",
+	}, store.getKeys)
+	require.Equal(t, 5.99, listing.PriceUsd)
+	require.Equal(t, "Jennifer Walters // The Sensational She-Hulk", listing.CardName)
 }
 
 func TestListingIsFresh(t *testing.T) {

--- a/api/controller/ckprice/ckprice_test.go
+++ b/api/controller/ckprice/ckprice_test.go
@@ -110,6 +110,7 @@ func TestGetLatestPrice_PrefersCheapestDoubleFacedAlias(t *testing.T) {
 	listing, err := GetLatestPrice(context.Background(), store, "Jennifer Walters")
 	require.NoError(t, err)
 	require.Equal(t, []string{
+		"jennifer walters // the sensational she-hulk",
 		"jennifer walters",
 		"the sensational she-hulk",
 	}, store.getKeys)
@@ -117,7 +118,7 @@ func TestGetLatestPrice_PrefersCheapestDoubleFacedAlias(t *testing.T) {
 	require.Equal(t, "Jennifer Walters", listing.CardName)
 }
 
-func TestGetLatestPrice_DoubleFacedSkipsFullNameFoilVariant(t *testing.T) {
+func TestGetLatestPrice_DoubleFacedChecksCombinedAndFaceNames(t *testing.T) {
 	originalVerify := verifyCardNameFunc
 	defer func() { verifyCardNameFunc = originalVerify }()
 
@@ -149,6 +150,7 @@ func TestGetLatestPrice_DoubleFacedSkipsFullNameFoilVariant(t *testing.T) {
 	listing, err := GetLatestPrice(context.Background(), store, "Jennifer Walters // The Sensational She-Hulk")
 	require.NoError(t, err)
 	require.Equal(t, []string{
+		"jennifer walters // the sensational she-hulk",
 		"jennifer walters",
 		"the sensational she-hulk",
 	}, store.getKeys)
@@ -156,7 +158,7 @@ func TestGetLatestPrice_DoubleFacedSkipsFullNameFoilVariant(t *testing.T) {
 	require.Equal(t, "Jennifer Walters", listing.CardName)
 }
 
-func TestGetLatestPrice_DoubleFacedFallsBackToFullName(t *testing.T) {
+func TestGetLatestPrice_DoubleFacedUsesCombinedNameWhenFacesMissing(t *testing.T) {
 	originalVerify := verifyCardNameFunc
 	defer func() { verifyCardNameFunc = originalVerify }()
 
@@ -177,9 +179,9 @@ func TestGetLatestPrice_DoubleFacedFallsBackToFullName(t *testing.T) {
 	listing, err := GetLatestPrice(context.Background(), store, "Tony Stark")
 	require.NoError(t, err)
 	require.Equal(t, []string{
+		"tony stark // the invincible iron man",
 		"tony stark",
 		"the invincible iron man",
-		"tony stark // the invincible iron man",
 	}, store.getKeys)
 	require.Equal(t, 7.49, listing.PriceUsd)
 }

--- a/api/controller/ckprice/ckprice_test.go
+++ b/api/controller/ckprice/ckprice_test.go
@@ -110,12 +110,78 @@ func TestGetLatestPrice_PrefersCheapestDoubleFacedAlias(t *testing.T) {
 	listing, err := GetLatestPrice(context.Background(), store, "Jennifer Walters")
 	require.NoError(t, err)
 	require.Equal(t, []string{
-		"jennifer walters // the sensational she-hulk",
 		"jennifer walters",
 		"the sensational she-hulk",
 	}, store.getKeys)
 	require.Equal(t, 10.99, listing.PriceUsd)
 	require.Equal(t, "Jennifer Walters", listing.CardName)
+}
+
+func TestGetLatestPrice_DoubleFacedSkipsFullNameFoilVariant(t *testing.T) {
+	originalVerify := verifyCardNameFunc
+	defer func() { verifyCardNameFunc = originalVerify }()
+
+	verifyCardNameFunc = func(_ context.Context, _ string) (string, error) {
+		return "Jennifer Walters // The Sensational She-Hulk", nil
+	}
+
+	store := &mockStore{
+		listings: map[string]*cardkingdom.Listing{
+			"jennifer walters // the sensational she-hulk": {
+				CardName:  "Jennifer Walters // The Sensational She-Hulk",
+				PriceUsd:  69.99,
+				IsFoil:    true,
+				UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+			},
+			"jennifer walters": {
+				CardName:  "Jennifer Walters",
+				PriceUsd:  10.99,
+				UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+			},
+			"the sensational she-hulk": {
+				CardName:  "The Sensational She-Hulk",
+				PriceUsd:  14.99,
+				UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+			},
+		},
+	}
+
+	listing, err := GetLatestPrice(context.Background(), store, "Jennifer Walters // The Sensational She-Hulk")
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"jennifer walters",
+		"the sensational she-hulk",
+	}, store.getKeys)
+	require.Equal(t, 10.99, listing.PriceUsd)
+	require.Equal(t, "Jennifer Walters", listing.CardName)
+}
+
+func TestGetLatestPrice_DoubleFacedFallsBackToFullName(t *testing.T) {
+	originalVerify := verifyCardNameFunc
+	defer func() { verifyCardNameFunc = originalVerify }()
+
+	verifyCardNameFunc = func(_ context.Context, _ string) (string, error) {
+		return "Tony Stark // The Invincible Iron Man", nil
+	}
+
+	store := &mockStore{
+		listings: map[string]*cardkingdom.Listing{
+			"tony stark // the invincible iron man": {
+				CardName:  "Tony Stark // The Invincible Iron Man",
+				PriceUsd:  7.49,
+				UpdatedAt: time.Now().UTC().Format(time.RFC3339),
+			},
+		},
+	}
+
+	listing, err := GetLatestPrice(context.Background(), store, "Tony Stark")
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"tony stark",
+		"the invincible iron man",
+		"tony stark // the invincible iron man",
+	}, store.getKeys)
+	require.Equal(t, 7.49, listing.PriceUsd)
 }
 
 func TestListingIsFresh(t *testing.T) {

--- a/api/gateway/cardkingdom/mtgjson_fetch.go
+++ b/api/gateway/cardkingdom/mtgjson_fetch.go
@@ -400,7 +400,7 @@ func considerCheapestListing(cheapest map[string]Listing, listing Listing) {
 		return
 	}
 
-	for _, nameKey := range NameLookupKeys(listing.CardName) {
+	for _, nameKey := range ListingNameKeys(listing) {
 		existing, ok := cheapest[nameKey]
 		if !ok || listing.PriceUsd < existing.PriceUsd {
 			cheapest[nameKey] = listing

--- a/api/gateway/cardkingdom/mtgjson_fetch.go
+++ b/api/gateway/cardkingdom/mtgjson_fetch.go
@@ -314,10 +314,10 @@ func mergePrintingAggregate(
 		aggregate.cardKingdomFoil = card.PurchaseUrls.CardKingdomFoil
 	}
 	if price, ok := pricesByUUID[card.UUID]; ok {
-		if price.normal > aggregate.price.normal {
+		if price.normal > 0 && (aggregate.price.normal <= 0 || price.normal < aggregate.price.normal) {
 			aggregate.price.normal = price.normal
 		}
-		if price.foil > aggregate.price.foil {
+		if price.foil > 0 && (aggregate.price.foil <= 0 || price.foil < aggregate.price.foil) {
 			aggregate.price.foil = price.foil
 		}
 	}

--- a/api/gateway/cardkingdom/mtgjson_fetch_test.go
+++ b/api/gateway/cardkingdom/mtgjson_fetch_test.go
@@ -253,6 +253,54 @@ func TestDecodeAllPrintingsSets_MergesDoubleFacedFacesByNumber(t *testing.T) {
 	require.InDelta(t, 10.99, faceListing.PriceUsd, 0.001)
 }
 
+func TestDecodeAllPrintingsSets_MergesDoubleFacedFacesUsingCheapestSidePrice(t *testing.T) {
+	prices := map[string]ckUUIDPrice{
+		"uuid-jw-18-url":   {normal: 14.99},
+		"uuid-jw-18-price": {normal: 10.99},
+	}
+	updatedAt := time.Date(2026, 7, 3, 0, 0, 0, 0, time.UTC)
+
+	const sample = `{
+  "meta": {"date": "2026-07-03"},
+  "data": {
+    "MSH": {
+      "name": "Marvel Super Heroes",
+      "cards": [
+        {
+          "uuid": "uuid-jw-18-url",
+          "name": "Jennifer Walters // The Sensational She-Hulk",
+          "faceName": "Jennifer Walters",
+          "number": "18",
+          "side": "a",
+          "purchaseUrls": {
+            "cardKingdom": "https://www.cardkingdom.com/mtg/marvel-super-heroes/jennifer-walters"
+          }
+        },
+        {
+          "uuid": "uuid-jw-18-price",
+          "name": "Jennifer Walters // The Sensational She-Hulk",
+          "faceName": "The Sensational She-Hulk",
+          "number": "18",
+          "side": "b",
+          "purchaseUrls": {}
+        }
+      ]
+    }
+  }
+}`
+
+	cheapest, err := decodeAllPrintingsSets(
+		json.NewDecoder(strings.NewReader(sample)),
+		prices,
+		updatedAt,
+	)
+	require.NoError(t, err)
+
+	listing := cheapest["jennifer walters // the sensational she-hulk"]
+	require.InDelta(t, 10.99, listing.PriceUsd, 0.001)
+	require.False(t, listing.IsFoil)
+}
+
 func TestFetchCheapestFromMTGJSON_FromTestServers(t *testing.T) {
 	pricesServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/octet-stream")

--- a/api/gateway/cardkingdom/names.go
+++ b/api/gateway/cardkingdom/names.go
@@ -44,10 +44,22 @@ func DoubleFacedFaceNames(cardName string) (front string, back string, ok bool) 
 }
 
 // PriceLookupKeys returns the lookup keys used when resolving CK search prices.
-// Double-faced cards check the combined name plus both face names; the cheapest
-// fresh listing across all aliases wins.
+// For double-faced cards the combined name, front face, and back face are always
+// checked together in a single pass; the cheapest fresh listing wins. The
+// combined name is not a fallback.
 func PriceLookupKeys(cardName string) []string {
-	return NameLookupKeys(cardName)
+	trimmed := strings.TrimSpace(cardName)
+	if trimmed == "" {
+		return nil
+	}
+
+	combined := NormalizeNameKey(trimmed)
+	front, back, ok := DoubleFacedFaceNames(trimmed)
+	if !ok {
+		return []string{combined}
+	}
+
+	return uniqueNameKeys([]string{combined, front, back})
 }
 
 // ListingNameKeys returns the lookup keys that should receive a listing when it is

--- a/api/gateway/cardkingdom/names.go
+++ b/api/gateway/cardkingdom/names.go
@@ -44,14 +44,10 @@ func DoubleFacedFaceNames(cardName string) (front string, back string, ok bool) 
 }
 
 // PriceLookupKeys returns the lookup keys used when resolving CK search prices.
-// Double-faced cards use the main (front) and back face names so the cheapest
-// physical card price wins instead of a foil variant indexed under the full name.
+// Double-faced cards check the combined name plus both face names; the cheapest
+// fresh listing across all aliases wins.
 func PriceLookupKeys(cardName string) []string {
-	front, back, ok := DoubleFacedFaceNames(cardName)
-	if !ok {
-		return []string{NormalizeNameKey(cardName)}
-	}
-	return uniqueNameKeys([]string{front, back})
+	return NameLookupKeys(cardName)
 }
 
 // ListingNameKeys returns the lookup keys that should receive a listing when it is

--- a/api/gateway/cardkingdom/names.go
+++ b/api/gateway/cardkingdom/names.go
@@ -30,6 +30,17 @@ func NameLookupKeys(cardName string) []string {
 	return uniqueNameKeys(keys)
 }
 
+// ListingNameKeys returns the lookup keys that should receive a listing when it is
+// indexed. Foil double-faced listings are stored only under the full combined
+// name so a variant foil price does not overwrite cheaper face-only names.
+func ListingNameKeys(listing Listing) []string {
+	keys := NameLookupKeys(listing.CardName)
+	if !listing.IsFoil || len(keys) <= 1 {
+		return keys
+	}
+	return keys[:1]
+}
+
 func uniqueNameKeys(keys []string) []string {
 	seen := make(map[string]struct{}, len(keys))
 	unique := make([]string, 0, len(keys))

--- a/api/gateway/cardkingdom/names.go
+++ b/api/gateway/cardkingdom/names.go
@@ -30,6 +30,30 @@ func NameLookupKeys(cardName string) []string {
 	return uniqueNameKeys(keys)
 }
 
+// DoubleFacedFaceNames returns normalized front and back face keys for a
+// double-faced card name split on " // ".
+func DoubleFacedFaceNames(cardName string) (front string, back string, ok bool) {
+	trimmed := strings.TrimSpace(cardName)
+	before, after, found := strings.Cut(trimmed, doubleFacedNameSeparator)
+	if !found {
+		return "", "", false
+	}
+	front = NormalizeNameKey(before)
+	back = NormalizeNameKey(after)
+	return front, back, front != "" && back != ""
+}
+
+// PriceLookupKeys returns the lookup keys used when resolving CK search prices.
+// Double-faced cards use the main (front) and back face names so the cheapest
+// physical card price wins instead of a foil variant indexed under the full name.
+func PriceLookupKeys(cardName string) []string {
+	front, back, ok := DoubleFacedFaceNames(cardName)
+	if !ok {
+		return []string{NormalizeNameKey(cardName)}
+	}
+	return uniqueNameKeys([]string{front, back})
+}
+
 // ListingNameKeys returns the lookup keys that should receive a listing when it is
 // indexed. Foil double-faced listings are stored only under the full combined
 // name so a variant foil price does not overwrite cheaper face-only names.

--- a/api/gateway/cardkingdom/names_test.go
+++ b/api/gateway/cardkingdom/names_test.go
@@ -51,3 +51,22 @@ func TestListingNameKeys_SingleFacedFoilUsesNameKey(t *testing.T) {
 	})
 	require.Equal(t, []string{"lightning bolt"}, keys)
 }
+
+func TestDoubleFacedFaceNames(t *testing.T) {
+	front, back, ok := DoubleFacedFaceNames("Jennifer Walters // The Sensational She-Hulk")
+	require.True(t, ok)
+	require.Equal(t, "jennifer walters", front)
+	require.Equal(t, "the sensational she-hulk", back)
+}
+
+func TestPriceLookupKeys_DoubleFacedCardUsesFaceNames(t *testing.T) {
+	keys := PriceLookupKeys("Jennifer Walters // The Sensational She-Hulk")
+	require.Equal(t, []string{
+		"jennifer walters",
+		"the sensational she-hulk",
+	}, keys)
+}
+
+func TestPriceLookupKeys_SingleFacedCard(t *testing.T) {
+	require.Equal(t, []string{"lightning bolt"}, PriceLookupKeys("Lightning Bolt"))
+}

--- a/api/gateway/cardkingdom/names_test.go
+++ b/api/gateway/cardkingdom/names_test.go
@@ -23,3 +23,31 @@ func TestNameLookupKeys_SingleFacedCard(t *testing.T) {
 func TestNameLookupKeys_Empty(t *testing.T) {
 	require.Nil(t, NameLookupKeys(""))
 }
+
+func TestListingNameKeys_FoilDoubleFacedCardOnlyUsesFullName(t *testing.T) {
+	keys := ListingNameKeys(Listing{
+		CardName: "Jennifer Walters // The Sensational She-Hulk",
+		IsFoil:   true,
+	})
+	require.Equal(t, []string{"jennifer walters // the sensational she-hulk"}, keys)
+}
+
+func TestListingNameKeys_NonFoilDoubleFacedCardUsesAllAliases(t *testing.T) {
+	keys := ListingNameKeys(Listing{
+		CardName: "Jennifer Walters // The Sensational She-Hulk",
+		IsFoil:   false,
+	})
+	require.Equal(t, []string{
+		"jennifer walters // the sensational she-hulk",
+		"jennifer walters",
+		"the sensational she-hulk",
+	}, keys)
+}
+
+func TestListingNameKeys_SingleFacedFoilUsesNameKey(t *testing.T) {
+	keys := ListingNameKeys(Listing{
+		CardName: "Lightning Bolt",
+		IsFoil:   true,
+	})
+	require.Equal(t, []string{"lightning bolt"}, keys)
+}

--- a/api/gateway/cardkingdom/names_test.go
+++ b/api/gateway/cardkingdom/names_test.go
@@ -59,9 +59,10 @@ func TestDoubleFacedFaceNames(t *testing.T) {
 	require.Equal(t, "the sensational she-hulk", back)
 }
 
-func TestPriceLookupKeys_DoubleFacedCardUsesFaceNames(t *testing.T) {
+func TestPriceLookupKeys_DoubleFacedCardUsesAllAliases(t *testing.T) {
 	keys := PriceLookupKeys("Jennifer Walters // The Sensational She-Hulk")
 	require.Equal(t, []string{
+		"jennifer walters // the sensational she-hulk",
 		"jennifer walters",
 		"the sensational she-hulk",
 	}, keys)

--- a/api/gateway/cardkingdom/pricelist.go
+++ b/api/gateway/cardkingdom/pricelist.go
@@ -3,6 +3,7 @@ package cardkingdom
 import (
 	"context"
 	"fmt"
+	"log"
 )
 
 const mtgjsonErrorPrefix = "ck price mtgjson"
@@ -19,6 +20,8 @@ func FetchCheapestByName(ctx context.Context) (map[string]Listing, error) {
 
 	if ckListings, ckErr := fetchCheapestFromCKPricelist(ctx); ckErr == nil {
 		mergeCheapestListings(listings, ckListings)
+	} else {
+		log.Printf("ck price refresh: card kingdom pricelist supplement skipped: %v", ckErr)
 	}
 
 	return listings, nil

--- a/api/gateway/cardkingdom/pricelist_fetch.go
+++ b/api/gateway/cardkingdom/pricelist_fetch.go
@@ -14,8 +14,9 @@ import (
 )
 
 const (
-	pricelistURL     = "https://api.cardkingdom.com/api/v2/pricelist"
-	pricelistTimeout = 3 * time.Minute
+	pricelistURL        = "https://api.cardkingdom.com/api/v2/pricelist"
+	pricelistTimeout    = 3 * time.Minute
+	ckPricelistAttempts = 3
 )
 
 var fetchPricelistBody = func(ctx context.Context) ([]byte, error) {
@@ -67,6 +68,21 @@ var fetchPricelistBody = func(ctx context.Context) ([]byte, error) {
 }
 
 func fetchCheapestFromCKPricelist(ctx context.Context) (map[string]Listing, error) {
+	var lastErr error
+	for attempt := 1; attempt <= ckPricelistAttempts; attempt++ {
+		listings, err := fetchCheapestFromCKPricelistOnce(ctx)
+		if err == nil {
+			return listings, nil
+		}
+		lastErr = err
+		if attempt < ckPricelistAttempts {
+			time.Sleep(time.Duration(attempt) * time.Second)
+		}
+	}
+	return nil, lastErr
+}
+
+func fetchCheapestFromCKPricelistOnce(ctx context.Context) (map[string]Listing, error) {
 	body, err := fetchPricelistBody(ctx)
 	if err != nil {
 		return nil, err

--- a/api/gateway/cardkingdom/pricelist_fetch_test.go
+++ b/api/gateway/cardkingdom/pricelist_fetch_test.go
@@ -75,4 +75,25 @@ func TestMergeCheapestListings_PrefersCheaperFaceNameListing(t *testing.T) {
 
 	require.InDelta(t, 10.99, listings["jennifer walters"].PriceUsd, 0.001)
 	require.InDelta(t, 69.99, listings["jennifer walters // the sensational she-hulk"].PriceUsd, 0.001)
+	_, hasBackFace := listings["the sensational she-hulk"]
+	require.False(t, hasBackFace)
+}
+
+func TestConsiderCheapestListing_FoilDoubleFacedDoesNotPolluteFaceAlias(t *testing.T) {
+	updatedAt := time.Now().UTC().Format(time.RFC3339)
+	listings := make(map[string]Listing)
+	considerCheapestListing(listings, Listing{
+		CardName:  "Jennifer Walters // The Sensational She-Hulk",
+		Edition:   "Marvel Super Heroes",
+		PriceUsd:  69.99,
+		URL:       "https://mtgjson.com/links/d8187fd1eef32412",
+		IsFoil:    true,
+		UpdatedAt: updatedAt,
+	})
+
+	require.InDelta(t, 69.99, listings["jennifer walters // the sensational she-hulk"].PriceUsd, 0.001)
+	_, hasFrontFace := listings["jennifer walters"]
+	require.False(t, hasFrontFace)
+	_, hasBackFace := listings["the sensational she-hulk"]
+	require.False(t, hasBackFace)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Searching for **Jennifer Walters // The Sensational She-Hulk** shows a Card Kingdom reference price of **$69.99 (foil)** instead of the expected **$10.99** non-foil listing.

## Root cause

1. **MTGJSON often lacks a normal retail price** on the front-face UUID for DFCs like MSH #18. Card Kingdom indexes the card under the **main (front) face name** (`Jennifer Walters`) at $10.99.
2. **Foil variant prices** (e.g. borderless foil at $69.99) were indexed under every face alias, polluting the front-face key.
3. **Lookup did not consistently compare all name aliases**, so a foil variant indexed under the combined name could win even when a cheaper face-only listing existed.
4. CK pricelist fetch failures during refresh were **silent**.

## Fix

### Indexing (refresh)
- **Foil DFC listings** are indexed only under the full combined name, not individual face aliases.
- **MTGJSON face merges** keep the **lower** retail price when UUIDs split across sides.
- **CK pricelist fetch** retries up to 3 times and logs when the supplement is skipped.

### Lookup (search)
- **Double-faced cards** always check all three name aliases in a **single pass**: combined name, front face, and back face.
- The **cheapest fresh listing** across all three wins. The combined name is **not** a fallback — it is always one of the three keys checked.

For Jennifer Walters this means comparing:
- `jennifer walters // the sensational she-hulk` (combined) → may carry $69.99 foil variant
- `jennifer walters` (front, CK pricelist) → **$10.99**
- `the sensational she-hulk` (back face, when indexed)
→ **$10.99 wins** because it is the lowest across all three.

## Testing

- `make test`
- `cd api && go test -mod=vendor -failfast -timeout 5m ./gateway/... ./controller/...`

## Deployment note

Production DynamoDB was last synced with old indexing. **A CK price refresh must run after deploy** for search results to show $10.99.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90e97cc0-eb7e-4367-bd23-e2a79814946e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90e97cc0-eb7e-4367-bd23-e2a79814946e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

