### PR TITLE
Fix in-feed ads not showing between cards on mobile

### DIFF
--- a/frontend/src/components/AdComponent.jsx
+++ b/frontend/src/components/AdComponent.jsx
@@ -1,12 +1,46 @@
 import { useEffect, useRef, useState } from "react";
 
-const AdComponent = () => {
+const UNFILLED_COLLAPSE_MS = 2500;
+const LAZY_LOAD_ROOT_MARGIN = "200px";
+
+function hasFilledAd(insEl) {
+  if (!insEl?.isConnected) return false;
+  if (insEl.querySelector("iframe")) return true;
+  // Some fills won't use an iframe immediately; a non-trivial height is a good proxy.
+  return insEl.offsetHeight >= 50;
+}
+
+const AdComponent = ({ lazyLoad = false, collapseWhenUnfilled = true }) => {
+  const containerRef = useRef(null);
   const adInitialized = useRef(false);
   const insRef = useRef(null);
   const [collapsed, setCollapsed] = useState(false);
+  const [isNearViewport, setIsNearViewport] = useState(!lazyLoad);
 
   useEffect(() => {
-    if (adInitialized.current) return;
+    if (!lazyLoad) return;
+
+    const containerEl = containerRef.current;
+    if (!containerEl) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsNearViewport(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: LAZY_LOAD_ROOT_MARGIN },
+    );
+
+    observer.observe(containerEl);
+
+    return () => observer.disconnect();
+  }, [lazyLoad]);
+
+  useEffect(() => {
+    if (!isNearViewport || adInitialized.current) return;
+
     adInitialized.current = true;
 
     try {
@@ -15,31 +49,24 @@ const AdComponent = () => {
     } catch (e) {
       console.error("AdSense error:", e);
     }
-  }, []);
+  }, [isNearViewport]);
 
   useEffect(() => {
+    if (!collapseWhenUnfilled || !isNearViewport) return;
+
     const insEl = insRef.current;
     if (!insEl) return;
 
     let cancelled = false;
 
-    const hasFilledAd = () => {
-      if (!insEl.isConnected) return false;
-      if (insEl.querySelector("iframe")) return true;
-      // Some fills won't use an iframe immediately; a non-trivial height is a good proxy.
-      return insEl.offsetHeight >= 50;
-    };
-
-    // Give AdSense a moment to render; if it doesn't fill, collapse this block.
     const timeoutId = window.setTimeout(() => {
       if (cancelled) return;
-      if (!hasFilledAd()) setCollapsed(true);
-    }, 2500);
+      if (!hasFilledAd(insEl)) setCollapsed(true);
+    }, UNFILLED_COLLAPSE_MS);
 
-    // If it does fill later, un-collapse.
     const observer = new MutationObserver(() => {
       if (cancelled) return;
-      if (hasFilledAd()) setCollapsed(false);
+      if (hasFilledAd(insEl)) setCollapsed(false);
     });
     observer.observe(insEl, {
       childList: true,
@@ -52,12 +79,13 @@ const AdComponent = () => {
       window.clearTimeout(timeoutId);
       observer.disconnect();
     };
-  }, []);
+  }, [collapseWhenUnfilled, isNearViewport]);
 
   if (collapsed) return null;
 
   return (
     <div
+      ref={containerRef}
       className="ad-large text-center d-print-none d-block d-sm-block w-100"
       style={{ overflow: "hidden" }}
     >

--- a/frontend/src/components/SearchResults.jsx
+++ b/frontend/src/components/SearchResults.jsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useRef } from "react";
+import { DESKTOP_MIN_WIDTH_MEDIA_QUERY } from "../constants";
+import useMediaQuery from "../hooks/useMediaQuery";
 import useResultFilters from "../hooks/useResultFilters";
 import AdComponent from "./AdComponent";
 import Card from "./Card";
@@ -7,8 +9,9 @@ import ResultFilters from "./ResultFilters";
 import SkeletonCard from "./SkeletonCard";
 import StoreErrorsBanner from "./StoreErrorsBanner";
 
-// Display ad after every N results
-const AD_DISPLAY_INTERVAL = 8;
+// Display ad after every N results (fewer on mobile where cards are 2-wide)
+const AD_DISPLAY_INTERVAL_DESKTOP = 8;
+const AD_DISPLAY_INTERVAL_MOBILE = 4;
 
 const EmptySearchState = () => (
   <div className="mb-3 text-center py-4 px-3">
@@ -68,6 +71,11 @@ const SearchResults = ({
     hasActiveFilters,
     clearFilters,
   } = useResultFilters(results, searchQuery);
+
+  const isDesktop = useMediaQuery(DESKTOP_MIN_WIDTH_MEDIA_QUERY);
+  const adDisplayInterval = isDesktop
+    ? AD_DISPLAY_INTERVAL_DESKTOP
+    : AD_DISPLAY_INTERVAL_MOBILE;
 
   const resultsAnchorRef = useRef(null);
   const wasSearchingRef = useRef(false);
@@ -162,8 +170,8 @@ const SearchResults = ({
                     <div className="row">
                       {filteredResults.map((card, i) => {
                         const showAd =
-                          filteredResults.length > AD_DISPLAY_INTERVAL &&
-                          (i + 1) % AD_DISPLAY_INTERVAL === 0 &&
+                          filteredResults.length > adDisplayInterval &&
+                          (i + 1) % adDisplayInterval === 0 &&
                           i + 1 !== filteredResults.length;
                         return (
                           <React.Fragment

--- a/frontend/src/components/SearchResults.jsx
+++ b/frontend/src/components/SearchResults.jsx
@@ -181,7 +181,10 @@ const SearchResults = ({
                             />
                             {showAd && (
                               <div className="col-12 mb-4">
-                                <AdComponent />
+                                <AdComponent
+                                  lazyLoad
+                                  collapseWhenUnfilled={false}
+                                />
                               </div>
                             )}
                           </React.Fragment>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On mobile, Google ads only appeared at the bottom of the page (footer slot / anchor ads) instead of between card search results.

## Root cause

`AdComponent` collapses and unmounts any ad slot that AdSense has not filled within 2.5 seconds. In-feed slots between search results are typically below the fold on mobile, so AdSense often has not rendered them in time. The footer ad is visible sooner and survives the collapse check.

## Fix

- **In-feed ads (search results):** disable auto-collapse so slots stay in the DOM until AdSense can fill them as the user scrolls.
- **Lazy initialization:** defer the `adsbygoogle.push()` call until an in-feed slot is near the viewport (200px margin), which matches AdSense guidance for below-the-fold placements.
- **Responsive ad frequency:** show in-feed ads every **4 cards on mobile** (<768px) and every **8 cards on desktop**, matching the narrower two-column mobile grid.
- **Footer / saved-cards ads:** unchanged — still collapse when unfilled to avoid empty placeholders.

## Testing

- `make test` (pass)
- `cd frontend && npm run lint` (pass; pre-existing `index.html` warning only)

## Notes

Actual ad fill still depends on AdSense inventory and policy limits (e.g. max display ads per page). This change ensures in-feed slots are not removed prematurely on mobile.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b988e80-0eb9-4046-8b56-9601d933bf8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b988e80-0eb9-4046-8b56-9601d933bf8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

