### PR TITLE
Fix mobile in-feed ads: avoid blanks, collapse unfilled slots

### DIFF
--- a/frontend/src/components/AdComponent.jsx
+++ b/frontend/src/components/AdComponent.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 
 const UNFILLED_COLLAPSE_MS = 2500;
+const LAZY_UNFILLED_COLLAPSE_MS = 5000;
 const LAZY_LOAD_ROOT_MARGIN = "200px";
 
 function hasFilledAd(insEl) {
@@ -58,11 +59,14 @@ const AdComponent = ({ lazyLoad = false, collapseWhenUnfilled = true }) => {
     if (!insEl) return;
 
     let cancelled = false;
+    const collapseMs = lazyLoad
+      ? LAZY_UNFILLED_COLLAPSE_MS
+      : UNFILLED_COLLAPSE_MS;
 
     const timeoutId = window.setTimeout(() => {
       if (cancelled) return;
       if (!hasFilledAd(insEl)) setCollapsed(true);
-    }, UNFILLED_COLLAPSE_MS);
+    }, collapseMs);
 
     const observer = new MutationObserver(() => {
       if (cancelled) return;
@@ -79,9 +83,20 @@ const AdComponent = ({ lazyLoad = false, collapseWhenUnfilled = true }) => {
       window.clearTimeout(timeoutId);
       observer.disconnect();
     };
-  }, [collapseWhenUnfilled, isNearViewport]);
+  }, [collapseWhenUnfilled, isNearViewport, lazyLoad]);
 
   if (collapsed) return null;
+
+  if (lazyLoad && !isNearViewport) {
+    return (
+      <div
+        ref={containerRef}
+        className="ad-large d-print-none w-100"
+        style={{ height: 1, overflow: "hidden" }}
+        aria-hidden="true"
+      />
+    );
+  }
 
   return (
     <div

--- a/frontend/src/components/AdComponent.jsx
+++ b/frontend/src/components/AdComponent.jsx
@@ -1,12 +1,46 @@
 import { useEffect, useRef, useState } from "react";
 
-const AdComponent = () => {
+const UNFILLED_COLLAPSE_MS = 2500;
+const LAZY_LOAD_ROOT_MARGIN = "200px";
+
+function hasFilledAd(insEl) {
+  if (!insEl?.isConnected) return false;
+  if (insEl.querySelector("iframe")) return true;
+  // Some fills won't use an iframe immediately; a non-trivial height is a good proxy.
+  return insEl.offsetHeight >= 50;
+}
+
+const AdComponent = ({ lazyLoad = false, collapseWhenUnfilled = true }) => {
+  const containerRef = useRef(null);
   const adInitialized = useRef(false);
   const insRef = useRef(null);
   const [collapsed, setCollapsed] = useState(false);
+  const [isNearViewport, setIsNearViewport] = useState(!lazyLoad);
 
   useEffect(() => {
-    if (adInitialized.current) return;
+    if (!lazyLoad) return;
+
+    const containerEl = containerRef.current;
+    if (!containerEl) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsNearViewport(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: LAZY_LOAD_ROOT_MARGIN },
+    );
+
+    observer.observe(containerEl);
+
+    return () => observer.disconnect();
+  }, [lazyLoad]);
+
+  useEffect(() => {
+    if (!isNearViewport || adInitialized.current) return;
+
     adInitialized.current = true;
 
     try {
@@ -15,31 +49,24 @@ const AdComponent = () => {
     } catch (e) {
       console.error("AdSense error:", e);
     }
-  }, []);
+  }, [isNearViewport]);
 
   useEffect(() => {
+    if (!collapseWhenUnfilled || !isNearViewport) return;
+
     const insEl = insRef.current;
     if (!insEl) return;
 
     let cancelled = false;
 
-    const hasFilledAd = () => {
-      if (!insEl.isConnected) return false;
-      if (insEl.querySelector("iframe")) return true;
-      // Some fills won't use an iframe immediately; a non-trivial height is a good proxy.
-      return insEl.offsetHeight >= 50;
-    };
-
-    // Give AdSense a moment to render; if it doesn't fill, collapse this block.
     const timeoutId = window.setTimeout(() => {
       if (cancelled) return;
-      if (!hasFilledAd()) setCollapsed(true);
-    }, 2500);
+      if (!hasFilledAd(insEl)) setCollapsed(true);
+    }, UNFILLED_COLLAPSE_MS);
 
-    // If it does fill later, un-collapse.
     const observer = new MutationObserver(() => {
       if (cancelled) return;
-      if (hasFilledAd()) setCollapsed(false);
+      if (hasFilledAd(insEl)) setCollapsed(false);
     });
     observer.observe(insEl, {
       childList: true,
@@ -52,12 +79,13 @@ const AdComponent = () => {
       window.clearTimeout(timeoutId);
       observer.disconnect();
     };
-  }, []);
+  }, [collapseWhenUnfilled, isNearViewport]);
 
   if (collapsed) return null;
 
   return (
     <div
+      ref={containerRef}
       className="ad-large text-center d-print-none d-block d-sm-block w-100"
       style={{ overflow: "hidden" }}
     >

--- a/frontend/src/components/SearchResults.jsx
+++ b/frontend/src/components/SearchResults.jsx
@@ -1,4 +1,6 @@
 import React, { useEffect, useRef } from "react";
+import { DESKTOP_MIN_WIDTH_MEDIA_QUERY } from "../constants";
+import useMediaQuery from "../hooks/useMediaQuery";
 import useResultFilters from "../hooks/useResultFilters";
 import AdComponent from "./AdComponent";
 import Card from "./Card";
@@ -7,8 +9,9 @@ import ResultFilters from "./ResultFilters";
 import SkeletonCard from "./SkeletonCard";
 import StoreErrorsBanner from "./StoreErrorsBanner";
 
-// Display ad after every N results
-const AD_DISPLAY_INTERVAL = 8;
+// Display ad after every N results (fewer on mobile where cards are 2-wide)
+const AD_DISPLAY_INTERVAL_DESKTOP = 8;
+const AD_DISPLAY_INTERVAL_MOBILE = 4;
 
 const EmptySearchState = () => (
   <div className="mb-3 text-center py-4 px-3">
@@ -68,6 +71,11 @@ const SearchResults = ({
     hasActiveFilters,
     clearFilters,
   } = useResultFilters(results, searchQuery);
+
+  const isDesktop = useMediaQuery(DESKTOP_MIN_WIDTH_MEDIA_QUERY);
+  const adDisplayInterval = isDesktop
+    ? AD_DISPLAY_INTERVAL_DESKTOP
+    : AD_DISPLAY_INTERVAL_MOBILE;
 
   const resultsAnchorRef = useRef(null);
   const wasSearchingRef = useRef(false);
@@ -162,8 +170,8 @@ const SearchResults = ({
                     <div className="row">
                       {filteredResults.map((card, i) => {
                         const showAd =
-                          filteredResults.length > AD_DISPLAY_INTERVAL &&
-                          (i + 1) % AD_DISPLAY_INTERVAL === 0 &&
+                          filteredResults.length > adDisplayInterval &&
+                          (i + 1) % adDisplayInterval === 0 &&
                           i + 1 !== filteredResults.length;
                         return (
                           <React.Fragment

--- a/frontend/src/components/SearchResults.jsx
+++ b/frontend/src/components/SearchResults.jsx
@@ -181,7 +181,10 @@ const SearchResults = ({
                             />
                             {showAd && (
                               <div className="col-12 mb-4">
-                                <AdComponent />
+                                <AdComponent
+                                  lazyLoad
+                                  collapseWhenUnfilled={false}
+                                />
                               </div>
                             )}
                           </React.Fragment>

--- a/frontend/src/components/SearchResults.jsx
+++ b/frontend/src/components/SearchResults.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 import { DESKTOP_MIN_WIDTH_MEDIA_QUERY } from "../constants";
 import useMediaQuery from "../hooks/useMediaQuery";
 import useResultFilters from "../hooks/useResultFilters";
@@ -12,6 +12,8 @@ import StoreErrorsBanner from "./StoreErrorsBanner";
 // Display ad after every N results (fewer on mobile where cards are 2-wide)
 const AD_DISPLAY_INTERVAL_DESKTOP = 8;
 const AD_DISPLAY_INTERVAL_MOBILE = 4;
+const MAX_IN_FEED_ADS_DESKTOP = 3;
+const MAX_IN_FEED_ADS_MOBILE = 2;
 
 const EmptySearchState = () => (
   <div className="mb-3 text-center py-4 px-3">
@@ -76,6 +78,29 @@ const SearchResults = ({
   const adDisplayInterval = isDesktop
     ? AD_DISPLAY_INTERVAL_DESKTOP
     : AD_DISPLAY_INTERVAL_MOBILE;
+  const maxInFeedAds = isDesktop
+    ? MAX_IN_FEED_ADS_DESKTOP
+    : MAX_IN_FEED_ADS_MOBILE;
+
+  const inFeedAdSlotIndices = useMemo(() => {
+    if (filteredResults.length <= adDisplayInterval) {
+      return new Set();
+    }
+
+    const slots = [];
+    for (let i = 0; i < filteredResults.length; i++) {
+      const position = i + 1;
+      if (
+        position % adDisplayInterval !== 0 ||
+        position === filteredResults.length
+      ) {
+        continue;
+      }
+      if (slots.length >= maxInFeedAds) break;
+      slots.push(i);
+    }
+    return new Set(slots);
+  }, [filteredResults.length, adDisplayInterval, maxInFeedAds]);
 
   const resultsAnchorRef = useRef(null);
   const wasSearchingRef = useRef(false);
@@ -168,36 +193,27 @@ const SearchResults = ({
                 ) : (
                   <div id="result" className="mb-3 text-center">
                     <div className="row">
-                      {filteredResults.map((card, i) => {
-                        const showAd =
-                          filteredResults.length > adDisplayInterval &&
-                          (i + 1) % adDisplayInterval === 0 &&
-                          i + 1 !== filteredResults.length;
-                        return (
-                          <React.Fragment
-                            key={`${card.src}-${card.url}-${card.price}-${card.quality}`}
-                          >
-                            <Card
-                              card={card}
-                              index={i}
-                              isCardInCart={isCardInCart}
-                              addToCart={addToCart}
-                              removeFromCart={removeFromCart}
-                              removeFromCartByCard={removeFromCartByCard}
-                              onSearchStore={onSearchStore}
-                              baseUrl={baseUrl}
-                            />
-                            {showAd && (
-                              <div className="col-12 mb-4">
-                                <AdComponent
-                                  lazyLoad
-                                  collapseWhenUnfilled={false}
-                                />
-                              </div>
-                            )}
-                          </React.Fragment>
-                        );
-                      })}
+                      {filteredResults.map((card, i) => (
+                        <React.Fragment
+                          key={`${card.src}-${card.url}-${card.price}-${card.quality}`}
+                        >
+                          <Card
+                            card={card}
+                            index={i}
+                            isCardInCart={isCardInCart}
+                            addToCart={addToCart}
+                            removeFromCart={removeFromCart}
+                            removeFromCartByCard={removeFromCartByCard}
+                            onSearchStore={onSearchStore}
+                            baseUrl={baseUrl}
+                          />
+                          {inFeedAdSlotIndices.has(i) && (
+                            <div className="col-12 mb-4">
+                              <AdComponent lazyLoad />
+                            </div>
+                          )}
+                        </React.Fragment>
+                      ))}
                     </div>
                   </div>
                 )}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On mobile, Google ads only appeared at the bottom of the page instead of between card search results. A follow-up fix disabled auto-collapse for in-feed slots, which left many blank "Advertisement" placeholders when AdSense did not fill every slot.

## Root cause

1. In-feed slots below the fold were collapsing too early (before AdSense could fill on mobile).
2. Disabling collapse entirely left empty placeholders visible — AdSense typically only fills a few display slots per page when reusing the same ad unit.
3. Showing an ad every 4 cards on mobile created more slots than AdSense would fill.

## Fix

- **Lazy-load in-feed slots:** defer the AdSense request until a slot is near the viewport.
- **Hide off-screen slots:** no visible placeholder until the user scrolls near the slot.
- **Collapse unfilled in-feed ads:** after a slot enters the viewport, give AdSense 5s to fill; remove the slot if it stays empty.
- **Cap in-feed ads:** at most **2 on mobile** and **3 on desktop**, still at every 4 / 8 cards respectively.
- **Footer / saved-cards ads:** unchanged — eager load with 2.5s collapse when unfilled.

## Testing

- `make test` (pass)
- `cd frontend && npm run lint` (pass; pre-existing `index.html` warning only)

## Notes

Actual ad fill still depends on AdSense inventory. This avoids blank gaps in the card grid while still allowing in-feed ads when Google serves them.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b988e80-0eb9-4046-8b56-9601d933bf8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b988e80-0eb9-4046-8b56-9601d933bf8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

