### PR TITLE
Handle TCG Marketplace API error payloads in advancedsearch responses

### DIFF
--- a/api/gateway/tcgmarketplace/response_test.go
+++ b/api/gateway/tcgmarketplace/response_test.go
@@ -1,0 +1,73 @@
+package tcgmarketplace
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseResponseBody_success(t *testing.T) {
+	body := []byte(`{
+		"status": 200,
+		"data": {
+			"message": "",
+			"data": [{
+				"name": " [DOM] Teferi, Hero of Dominaria",
+				"setcode": "DOM",
+				"setname": "Dominaria",
+				"image": "https://thetcgmarketplace.com:3500/uploads/example.webp",
+				"language": "en",
+				"crd_foil_type": null,
+				"rarity": "Mythic",
+				"available": 4,
+				"from": "7.49",
+				"non_foil_reference_price": "SGD 8.00",
+				"foil_reference_price": "USD 16.29",
+				"url": "https://thetcgmarketplace.com/product/B/example/0"
+			}]
+		},
+		"meta": {"total": 1}
+	}`)
+
+	items, err := parseResponseBody(body)
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	require.Equal(t, " [DOM] Teferi, Hero of Dominaria", items[0].Name)
+	require.Equal(t, "Dominaria", items[0].Setname)
+}
+
+func TestParseResponseBody_unauthorized(t *testing.T) {
+	body := []byte(`{"status":500,"data":{"message":"Unathorised","data":""},"meta":{"total":0}}`)
+
+	_, err := parseResponseBody(body)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "API error (status=500)")
+	require.Contains(t, err.Error(), "Unathorised")
+}
+
+func TestParseResponseBody_databaseError(t *testing.T) {
+	body := []byte(`{"status":500,"data":{"message":"","data":{"errno":-111,"code":"ECONNREFUSED","syscall":"connect","address":"::1","port":3306,"fatal":true}},"meta":{}}`)
+
+	_, err := parseResponseBody(body)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "API error (status=500)")
+	require.Contains(t, err.Error(), "ECONNREFUSED")
+	require.Contains(t, err.Error(), "::1:3306")
+}
+
+func TestParseResponseBody_emptyResults(t *testing.T) {
+	body := []byte(`{"status":200,"data":{"message":"","data":[]},"meta":{"total":0}}`)
+
+	items, err := parseResponseBody(body)
+	require.NoError(t, err)
+	require.Empty(t, items)
+}
+
+func TestParseResponseBody_unexpectedDataShape(t *testing.T) {
+	body := []byte(`{"status":200,"data":{"message":"","data":{"unexpected":"value"}},"meta":{}}`)
+
+	_, err := parseResponseBody(body)
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "unexpected data payload"))
+}

--- a/api/gateway/tcgmarketplace/search.go
+++ b/api/gateway/tcgmarketplace/search.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -23,28 +24,30 @@ const cardLinkAPI = "https://thetcgmarketplace.com:3501/encoder/advancedsearch"
 const mtgCategoryNo = 3
 const accessTokenKey = "TCG_MARKETPLACE_ACCESS_TOKEN"
 
-type response struct {
+type apiEnvelope struct {
 	Status int `json:"status"`
 	Data   struct {
-		Message string `json:"message"`
-		Data    []struct {
-			Name                  string      `json:"name"`
-			Setcode               string      `json:"setcode"`
-			Setname               string      `json:"setname"`
-			Image                 string      `json:"image"`
-			Language              string      `json:"language"`
-			CrdFoilType           interface{} `json:"crd_foil_type"`
-			Rarity                string      `json:"rarity"`
-			Available             interface{} `json:"available"`
-			From                  interface{} `json:"from"`
-			NonFoilReferencePrice interface{} `json:"non_foil_reference_price"`
-			FoilReferencePrice    interface{} `json:"foil_reference_price"`
-			URL                   string      `json:"url"`
-		} `json:"data"`
+		Message string          `json:"message"`
+		Data    json.RawMessage `json:"data"`
 	} `json:"data"`
 	Meta struct {
 		Total int `json:"total"`
 	} `json:"meta"`
+}
+
+type cardItem struct {
+	Name                  string      `json:"name"`
+	Setcode               string      `json:"setcode"`
+	Setname               string      `json:"setname"`
+	Image                 string      `json:"image"`
+	Language              string      `json:"language"`
+	CrdFoilType           interface{} `json:"crd_foil_type"`
+	Rarity                string      `json:"rarity"`
+	Available             interface{} `json:"available"`
+	From                  interface{} `json:"from"`
+	NonFoilReferencePrice interface{} `json:"non_foil_reference_price"`
+	FoilReferencePrice    interface{} `json:"foil_reference_price"`
+	URL                   string      `json:"url"`
 }
 
 type Store struct {
@@ -69,7 +72,6 @@ func NewLGS() gateway.LGS {
 
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
 	var (
-		res         response
 		cards       []gateway.Card
 		accessToken string
 	)
@@ -86,13 +88,13 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 		return cards, err
 	}
 
-	res, err = getApiResponse(ctx, reqPayload, accessToken != "")
+	items, err := getApiResponse(ctx, reqPayload, accessToken != "")
 	if err != nil {
 		return cards, err
 	}
 
-	if len(res.Data.Data) > 0 {
-		for _, card := range res.Data.Data {
+	if len(items) > 0 {
+		for _, card := range items {
 			stock, err := strconv.ParseInt(fmt.Sprint(card.Available), 10, 64)
 			if err != nil {
 				continue
@@ -158,12 +160,82 @@ func isSurgeFoil(extraInfo []string, name string) bool {
 	return false
 }
 
-func getApiResponse(ctx context.Context, payload []byte, accessTokenConfigured bool) (response, error) {
-	var res response
+func parseResponseBody(body []byte) ([]cardItem, error) {
+	var envelope apiEnvelope
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil, err
+	}
 
+	if envelope.Status != http.StatusOK {
+		return nil, apiError(envelope.Status, envelope.Data.Message, envelope.Data.Data)
+	}
+
+	return parseCardItems(envelope.Data.Data)
+}
+
+func parseCardItems(raw json.RawMessage) ([]cardItem, error) {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed == `""` || trimmed == "null" {
+		return nil, nil
+	}
+	if !strings.HasPrefix(trimmed, "[") {
+		return nil, fmt.Errorf("%s API returned unexpected data payload: %s", StoreName, trimmed)
+	}
+
+	var cards []cardItem
+	if err := json.Unmarshal(raw, &cards); err != nil {
+		return nil, err
+	}
+	return cards, nil
+}
+
+func apiError(status int, message string, raw json.RawMessage) error {
+	detail := strings.TrimSpace(message)
+	if detail == "" {
+		detail = describeErrorPayload(raw)
+	}
+	if detail == "" {
+		detail = "unknown error"
+	}
+	return fmt.Errorf("%s API error (status=%d): %s", StoreName, status, detail)
+}
+
+func describeErrorPayload(raw json.RawMessage) string {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed == `""` || trimmed == "null" {
+		return ""
+	}
+	if !strings.HasPrefix(trimmed, "{") {
+		return trimmed
+	}
+
+	var errData struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+		Syscall string `json:"syscall"`
+		Address string `json:"address"`
+		Port    int    `json:"port"`
+	}
+	if err := json.Unmarshal(raw, &errData); err != nil {
+		return trimmed
+	}
+
+	switch {
+	case errData.Code != "" && errData.Address != "":
+		return fmt.Sprintf("%s (%s:%d)", errData.Code, errData.Address, errData.Port)
+	case errData.Code != "":
+		return errData.Code
+	case errData.Message != "":
+		return errData.Message
+	default:
+		return trimmed
+	}
+}
+
+func getApiResponse(ctx context.Context, payload []byte, accessTokenConfigured bool) ([]cardItem, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cardLinkAPI, bytes.NewBuffer(payload))
 	if err != nil {
-		return res, err
+		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.ContentLength = int64(len(payload))
@@ -175,20 +247,26 @@ func getApiResponse(ctx context.Context, payload []byte, accessTokenConfigured b
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return res, gateway.WrapHTTPRequestError(err, req, requestContext...)
+		return nil, gateway.WrapHTTPRequestError(err, req, requestContext...)
 	}
 	defer resp.Body.Close()
 
 	body, err := gateway.ReadResponseBody(resp)
 	if err != nil {
-		return res, gateway.WrapResponseBodyReadError(err, resp)
+		return nil, gateway.WrapResponseBodyReadError(err, resp)
 	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return res, fmt.Errorf("%s", gateway.FormatUnexpectedHTTPStatus(StoreName, resp, body))
-	}
-	if err = json.Unmarshal(body, &res); err != nil {
-		return res, gateway.WrapJSONDecodeError(err, resp, body)
+		return nil, fmt.Errorf("%s", gateway.FormatUnexpectedHTTPStatus(StoreName, resp, body))
 	}
 
-	return res, nil
+	items, err := parseResponseBody(body)
+	if err != nil {
+		var syntaxErr *json.SyntaxError
+		if errors.As(err, &syntaxErr) {
+			return nil, gateway.WrapJSONDecodeError(err, resp, body)
+		}
+		return nil, err
+	}
+
+	return items, nil
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Investigated the `[The TCG Marketplace] json decode failed` error when searching for cards like "Teferi, Hero of Dominaria".

**Finding:** The advancedsearch API payload for successful searches is unchanged. With a valid access token, searches return the expected card array. The failure occurs when the API responds with HTTP 200 but an application-level `status: 500`, where `data.data` is not a card array — it can be an empty string (unauthorised) or a backend error object (e.g. MySQL `ECONNREFUSED` on `::1:3306`).

## Changes

- Parse the API envelope with `json.RawMessage` for the polymorphic `data.data` field
- Return clear API errors for non-200 application status (e.g. `API error (status=500): Unathorised` or `ECONNREFUSED (::1:3306)`)
- Only wrap true JSON syntax errors with the shared decode helper
- Add unit tests covering success, unauthorised, database error, empty results, and unexpected data shapes

## Verification

- `go test ./gateway/tcgmarketplace/...` (unit + live search with token)
- `make test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3fb20fb-9821-4741-b32e-6dcd4a469895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3fb20fb-9821-4741-b32e-6dcd4a469895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

