### PR TITLE
Add mobile show more toggle for popular searches

### DIFF
--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -20,6 +20,16 @@ const LOADING_SKELETON_KEYS = [
   "top-search-keyword-skeleton-h",
   "top-search-keyword-skeleton-i",
   "top-search-keyword-skeleton-j",
+  "top-search-keyword-skeleton-k",
+  "top-search-keyword-skeleton-l",
+  "top-search-keyword-skeleton-m",
+  "top-search-keyword-skeleton-n",
+  "top-search-keyword-skeleton-o",
+  "top-search-keyword-skeleton-p",
+  "top-search-keyword-skeleton-q",
+  "top-search-keyword-skeleton-r",
+  "top-search-keyword-skeleton-s",
+  "top-search-keyword-skeleton-t",
 ];
 
 const PERIOD_OPTIONS = [
@@ -99,8 +109,12 @@ function PopularSearchesToggle({ isExpanded, collapsible, panelId, onToggle }) {
   );
 }
 
-function getDisplayLimit(isDesktop) {
-  return isDesktop
+function getDisplayLimit(isDesktop, showAllKeywords) {
+  if (isDesktop) {
+    return TOP_SEARCH_KEYWORDS_DISPLAY_LIMIT;
+  }
+
+  return showAllKeywords
     ? TOP_SEARCH_KEYWORDS_DISPLAY_LIMIT
     : TOP_SEARCH_KEYWORDS_MOBILE_DISPLAY_LIMIT;
 }
@@ -116,8 +130,9 @@ export default function TopSearchKeywords({
   const [isExpanded, setIsExpanded] = useState(
     () => !collapsible || defaultExpanded,
   );
+  const [showAllKeywords, setShowAllKeywords] = useState(false);
   const isDesktop = useMediaQuery(DESKTOP_MIN_WIDTH_MEDIA_QUERY);
-  const displayLimit = getDisplayLimit(isDesktop);
+  const displayLimit = getDisplayLimit(isDesktop, showAllKeywords);
   const panelId = useId();
 
   useEffect(() => {
@@ -132,11 +147,19 @@ export default function TopSearchKeywords({
     }
   }, [collapseOnSearch]);
 
+  const handlePeriodChange = (nextPeriod) => {
+    setPeriod(nextPeriod);
+    setShowAllKeywords(false);
+  };
+
   if (!isLoading && !hasAnyKeywords(keywordsByPeriod)) {
     return null;
   }
 
-  const keywords = (keywordsByPeriod?.[period] ?? []).slice(0, displayLimit);
+  const allKeywords = keywordsByPeriod?.[period] ?? [];
+  const keywords = allKeywords.slice(0, displayLimit);
+  const hasMoreKeywords =
+    !isDesktop && allKeywords.length > TOP_SEARCH_KEYWORDS_MOBILE_DISPLAY_LIMIT;
   const selectedPeriodLabel =
     PERIOD_OPTIONS.find((option) => option.id === period)?.label ?? "";
   const showContent = !collapsible || isExpanded;
@@ -172,7 +195,7 @@ export default function TopSearchKeywords({
           <div className="popular-searches-controls">
             <PeriodToggle
               period={period}
-              onPeriodChange={setPeriod}
+              onPeriodChange={handlePeriodChange}
               disabled={isLoading}
             />
           </div>
@@ -187,19 +210,31 @@ export default function TopSearchKeywords({
               ))}
             </div>
           ) : keywords.length > 0 ? (
-            <div className="popular-searches-pills">
-              {keywords.map((keyword) => (
-                <a
-                  key={keyword}
-                  href={buildPopularSearchUrl(BASE_URL, keyword, period)}
-                  className="btn btn-sm popular-search-pill text-decoration-none"
-                  aria-label={`Search for ${keyword}`}
-                  onClick={() => handlePopularSearchClick(keyword)}
+            <>
+              <div className="popular-searches-pills">
+                {keywords.map((keyword) => (
+                  <a
+                    key={keyword}
+                    href={buildPopularSearchUrl(BASE_URL, keyword, period)}
+                    className="btn btn-sm popular-search-pill text-decoration-none"
+                    aria-label={`Search for ${keyword}`}
+                    onClick={() => handlePopularSearchClick(keyword)}
+                  >
+                    {keyword}
+                  </a>
+                ))}
+              </div>
+              {hasMoreKeywords && (
+                <button
+                  type="button"
+                  className="popular-searches-show-more"
+                  aria-expanded={showAllKeywords}
+                  onClick={() => setShowAllKeywords((expanded) => !expanded)}
                 >
-                  {keyword}
-                </a>
-              ))}
-            </div>
+                  {showAllKeywords ? "Show less" : "Show more"}
+                </button>
+              )}
+            </>
           ) : (
             <p className="popular-searches-empty small text-muted mb-0">
               No popular searches in the last {selectedPeriodLabel}.

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -601,3 +601,27 @@ ins.adsbygoogle.adsbygoogle-noablate {
 .popular-searches-empty {
   padding-top: 0.125rem;
 }
+
+.popular-searches-show-more {
+  display: block;
+  margin-top: 0.5rem;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--bs-primary);
+  cursor: pointer;
+}
+
+.popular-searches-show-more:hover,
+.popular-searches-show-more:focus-visible {
+  text-decoration: underline;
+  color: var(--bs-primary);
+}
+
+.popular-searches-show-more:focus-visible {
+  outline: 0;
+  box-shadow: 0 0 0 0.2rem rgba(var(--bs-primary-rgb), 0.35);
+  border-radius: var(--bs-border-radius-sm);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On mobile, popular searches now show 10 pills by default with a **Show more** toggle to reveal the remaining 10. Desktop continues to show all 20 without a toggle.

## Changes

- Added `showAllKeywords` state in `TopSearchKeywords` to expand/collapse the mobile list
- Reset expanded state when changing the time period
- Added styling for the show more/less button

## Screenshots

### Mobile (collapsed — 10 pills + Show more)

![Popular searches on mobile with Show more toggle](https://cursor.com/artifacts/c/art-dcc0ed5c-65ce-4b08-beac-c16da90a9f19)

### Mobile (expanded — 20 pills + Show less)

![Popular searches on mobile expanded with Show less toggle](https://cursor.com/artifacts/c/art-e73f498c-2836-4eea-ac04-1b2e14e38a19)

### Desktop (all 20 pills, no toggle)

![Popular searches on desktop showing all 20 pills](https://cursor.com/artifacts/c/art-8de57cbd-c502-4cde-9b28-8fbad56f4363)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e09bef3f-79ad-4815-aeba-ac490b154181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e09bef3f-79ad-4815-aeba-ac490b154181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

