### PR TITLE
Improve in-feed AdSense fill rate and initialization

### DIFF
--- a/frontend/src/components/AdComponent.jsx
+++ b/frontend/src/components/AdComponent.jsx
@@ -1,9 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import {
-  ADSENSE_CLIENT,
-  ADSENSE_DISPLAY_AD_SLOT,
-  ADSENSE_IN_FEED_LAYOUT_KEY,
-} from "../constants";
+import { ADSENSE_CLIENT, ADSENSE_DISPLAY_AD_SLOT } from "../constants";
 
 const UNFILLED_COLLAPSE_MS = 2500;
 const LAZY_UNFILLED_COLLAPSE_MS = 5000;
@@ -71,7 +67,7 @@ const AdComponent = ({
   lazyLoad = false,
   collapseWhenUnfilled = true,
   slot = ADSENSE_DISPLAY_AD_SLOT,
-  layoutKey = ADSENSE_IN_FEED_LAYOUT_KEY,
+  layoutKey,
 }) => {
   const containerRef = useRef(null);
   const adInitialized = useRef(false);

--- a/frontend/src/components/AdComponent.jsx
+++ b/frontend/src/components/AdComponent.jsx
@@ -1,22 +1,84 @@
 import { useEffect, useRef, useState } from "react";
+import {
+  ADSENSE_CLIENT,
+  ADSENSE_DISPLAY_AD_SLOT,
+  ADSENSE_IN_FEED_LAYOUT_KEY,
+} from "../constants";
 
 const UNFILLED_COLLAPSE_MS = 2500;
 const LAZY_UNFILLED_COLLAPSE_MS = 5000;
 const LAZY_LOAD_ROOT_MARGIN = "200px";
+const ADSENSE_SCRIPT_WAIT_MS = 10000;
 
 function hasFilledAd(insEl) {
   if (!insEl?.isConnected) return false;
+
+  const adStatus = insEl.getAttribute("data-ad-status");
+  if (adStatus === "filled") return true;
+  if (adStatus === "unfilled") return false;
+
   if (insEl.querySelector("iframe")) return true;
   // Some fills won't use an iframe immediately; a non-trivial height is a good proxy.
   return insEl.offsetHeight >= 50;
 }
 
-const AdComponent = ({ lazyLoad = false, collapseWhenUnfilled = true }) => {
+function isAdSenseProcessed(insEl) {
+  return insEl?.getAttribute("data-adsbygoogle-status") === "done";
+}
+
+function pushAdSlot(insEl) {
+  if (!insEl || isAdSenseProcessed(insEl)) return;
+
+  try {
+    // biome-ignore lint/suspicious/noAssignInExpressions: Legacy Google Ads code
+    (window.adsbygoogle = window.adsbygoogle || []).push({});
+  } catch (e) {
+    console.error("AdSense error:", e);
+  }
+}
+
+function waitForAdSenseScript(callback) {
+  if (window.adsbygoogle?.loaded || window.adsbygoogle?.push) {
+    callback();
+    return () => {};
+  }
+
+  let cancelled = false;
+  const startedAt = Date.now();
+
+  const intervalId = window.setInterval(() => {
+    if (cancelled) return;
+
+    if (window.adsbygoogle?.loaded || window.adsbygoogle?.push) {
+      window.clearInterval(intervalId);
+      callback();
+      return;
+    }
+
+    if (Date.now() - startedAt >= ADSENSE_SCRIPT_WAIT_MS) {
+      window.clearInterval(intervalId);
+      callback();
+    }
+  }, 100);
+
+  return () => {
+    cancelled = true;
+    window.clearInterval(intervalId);
+  };
+}
+
+const AdComponent = ({
+  lazyLoad = false,
+  collapseWhenUnfilled = true,
+  slot = ADSENSE_DISPLAY_AD_SLOT,
+  layoutKey = ADSENSE_IN_FEED_LAYOUT_KEY,
+}) => {
   const containerRef = useRef(null);
   const adInitialized = useRef(false);
   const insRef = useRef(null);
   const [collapsed, setCollapsed] = useState(false);
   const [isNearViewport, setIsNearViewport] = useState(!lazyLoad);
+  const isInFeedFormat = Boolean(layoutKey);
 
   useEffect(() => {
     if (!lazyLoad) return;
@@ -42,14 +104,14 @@ const AdComponent = ({ lazyLoad = false, collapseWhenUnfilled = true }) => {
   useEffect(() => {
     if (!isNearViewport || adInitialized.current) return;
 
+    const insEl = insRef.current;
+    if (!insEl) return;
+
     adInitialized.current = true;
 
-    try {
-      // biome-ignore lint/suspicious/noAssignInExpressions: Legacy Google Ads code
-      (window.adsbygoogle = window.adsbygoogle || []).push({});
-    } catch (e) {
-      console.error("AdSense error:", e);
-    }
+    return waitForAdSenseScript(() => {
+      pushAdSlot(insEl);
+    });
   }, [isNearViewport]);
 
   useEffect(() => {
@@ -63,19 +125,26 @@ const AdComponent = ({ lazyLoad = false, collapseWhenUnfilled = true }) => {
       ? LAZY_UNFILLED_COLLAPSE_MS
       : UNFILLED_COLLAPSE_MS;
 
+    const maybeCollapse = () => {
+      if (cancelled) return;
+      if (insEl.getAttribute("data-ad-status") === "unfilled") {
+        setCollapsed(true);
+        return;
+      }
+      if (hasFilledAd(insEl)) setCollapsed(false);
+    };
+
     const timeoutId = window.setTimeout(() => {
       if (cancelled) return;
       if (!hasFilledAd(insEl)) setCollapsed(true);
     }, collapseMs);
 
-    const observer = new MutationObserver(() => {
-      if (cancelled) return;
-      if (hasFilledAd(insEl)) setCollapsed(false);
-    });
+    const observer = new MutationObserver(maybeCollapse);
     observer.observe(insEl, {
       childList: true,
       subtree: true,
       attributes: true,
+      attributeFilter: ["data-ad-status", "data-adsbygoogle-status"],
     });
 
     return () => {
@@ -118,10 +187,11 @@ const AdComponent = ({ lazyLoad = false, collapseWhenUnfilled = true }) => {
           ref={insRef}
           className="adsbygoogle"
           style={{ display: "block", width: "100%", maxWidth: "100%" }}
-          data-ad-client="ca-pub-2393161407259792"
-          data-ad-slot="6707964257"
-          data-ad-format="auto"
-          data-full-width-responsive="true"
+          data-ad-client={ADSENSE_CLIENT}
+          data-ad-slot={slot}
+          data-ad-format={isInFeedFormat ? "fluid" : "auto"}
+          data-full-width-responsive={isInFeedFormat ? undefined : "true"}
+          {...(isInFeedFormat ? { "data-ad-layout-key": layoutKey } : {})}
         ></ins>
       </div>
       <div className="text-secondary" style={{ fontSize: "11px" }}>

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -12,7 +12,7 @@ const Footer = ({ cartCount, onShowCart, onShowMap, onShowFaq }) => {
   return (
     <>
       <div className="mt-4 site-footer-spacer">
-        <AdComponent lazyLoad />
+        <AdComponent />
       </div>
 
       {/* Fixed Bottom Navigation */}

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -12,7 +12,7 @@ const Footer = ({ cartCount, onShowCart, onShowMap, onShowFaq }) => {
   return (
     <>
       <div className="mt-4 site-footer-spacer">
-        <AdComponent />
+        <AdComponent lazyLoad />
       </div>
 
       {/* Fixed Bottom Navigation */}

--- a/frontend/src/components/SearchResults.jsx
+++ b/frontend/src/components/SearchResults.jsx
@@ -1,5 +1,9 @@
 import React, { useEffect, useMemo, useRef } from "react";
-import { DESKTOP_MIN_WIDTH_MEDIA_QUERY } from "../constants";
+import {
+  ADSENSE_IN_FEED_AD_SLOT,
+  ADSENSE_IN_FEED_LAYOUT_KEY,
+  DESKTOP_MIN_WIDTH_MEDIA_QUERY,
+} from "../constants";
 import useMediaQuery from "../hooks/useMediaQuery";
 import useResultFilters from "../hooks/useResultFilters";
 import AdComponent from "./AdComponent";
@@ -209,7 +213,11 @@ const SearchResults = ({
                           />
                           {inFeedAdSlotIndices.has(i) && (
                             <div className="col-12 mb-4">
-                              <AdComponent lazyLoad />
+                              <AdComponent
+                                lazyLoad
+                                slot={ADSENSE_IN_FEED_AD_SLOT}
+                                layoutKey={ADSENSE_IN_FEED_LAYOUT_KEY}
+                              />
                             </div>
                           )}
                         </React.Fragment>

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -187,13 +187,8 @@ export const POPULAR_SEARCH_UTM_SOURCE = "popular_searches";
 export const POPULAR_SEARCH_UTM_MEDIUM = "internal";
 export const POPULAR_SEARCH_UTM_CAMPAIGN = "popular_searches";
 
-// Google AdSense — use a separate ad unit per placement. Reusing the same slot
-// across footer + in-feed means AdSense only fills one instance per page (usually
-// the footer, which loads first). Create an In-feed ad unit in AdSense and set
-// ADSENSE_IN_FEED_AD_SLOT (and optional layout key) to the generated values.
+// Google AdSense — use a separate ad unit per placement.
 export const ADSENSE_CLIENT = "ca-pub-2393161407259792";
 export const ADSENSE_DISPLAY_AD_SLOT = "6707964257";
-/** @type {string} Dedicated in-feed slot — replace after creating an In-feed ad unit in AdSense. */
-export const ADSENSE_IN_FEED_AD_SLOT = "6707964257";
-/** @type {string | undefined} From AdSense In-feed ad code (`data-ad-layout-key`). */
-export const ADSENSE_IN_FEED_LAYOUT_KEY = undefined;
+export const ADSENSE_IN_FEED_AD_SLOT = "7667010672";
+export const ADSENSE_IN_FEED_LAYOUT_KEY = "-6t+ed+2i-1n-4w";

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -186,3 +186,14 @@ export const DESKTOP_MIN_WIDTH_MEDIA_QUERY = "(min-width: 768px)";
 export const POPULAR_SEARCH_UTM_SOURCE = "popular_searches";
 export const POPULAR_SEARCH_UTM_MEDIUM = "internal";
 export const POPULAR_SEARCH_UTM_CAMPAIGN = "popular_searches";
+
+// Google AdSense — use a separate ad unit per placement. Reusing the same slot
+// across footer + in-feed means AdSense only fills one instance per page (usually
+// the footer, which loads first). Create an In-feed ad unit in AdSense and set
+// ADSENSE_IN_FEED_AD_SLOT (and optional layout key) to the generated values.
+export const ADSENSE_CLIENT = "ca-pub-2393161407259792";
+export const ADSENSE_DISPLAY_AD_SLOT = "6707964257";
+/** @type {string} Dedicated in-feed slot — replace after creating an In-feed ad unit in AdSense. */
+export const ADSENSE_IN_FEED_AD_SLOT = "6707964257";
+/** @type {string | undefined} From AdSense In-feed ad code (`data-ad-layout-key`). */
+export const ADSENSE_IN_FEED_LAYOUT_KEY = undefined;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -398,6 +398,11 @@ ins.adsbygoogle iframe {
   display: block;
 }
 
+ins.adsbygoogle[data-ad-status="unfilled"] {
+  /* biome-ignore lint/complexity/noImportantStyles: Hide empty AdSense placeholders */
+  display: none !important;
+}
+
 ins.adsbygoogle.adsbygoogle-noablate {
   margin-bottom: var(--footer-nav-height, 0px);
   /* biome-ignore lint/complexity/noImportantStyles: Cap Google anchor ad z-index below site footer */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

In-feed ads between search result cards were staying empty because the same AdSense slot ID was reused for footer, cart, and in-feed placements. AdSense typically fills only one instance of a given ad unit per page.

This PR wires up the dedicated **In-feed ad unit** and improves ad initialization.

## Changes

- **Dedicated in-feed unit**: slot `7667010672`, fluid format with layout key `-6t+ed+2i-1n-4w`
- **Display unit unchanged**: footer/cart keep slot `6707964257` (`auto` format)
- **Safer AdSense push**: wait for `adsbygoogle.js`, skip double-init, detect `data-ad-status="unfilled"`
- **Footer eager load restored**: safe again because footer and in-feed no longer share a slot
- **CSS** to hide unfilled `ins.adsbygoogle` placeholders

## Testing

- `make test` (pass)
- `cd frontend && npm run lint` (pass)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11559433-cb40-44c1-88a7-a15893f33049"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11559433-cb40-44c1-88a7-a15893f33049"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

