### PR TITLE
Fix empty AdSense placeholders showing on page

### DIFF
--- a/frontend/src/components/AdComponent.jsx
+++ b/frontend/src/components/AdComponent.jsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useState } from "react";
 import { ADSENSE_CLIENT, ADSENSE_DISPLAY_AD_SLOT } from "../constants";
 
-const UNFILLED_COLLAPSE_MS = 2500;
-const LAZY_UNFILLED_COLLAPSE_MS = 5000;
+const UNFILLED_COLLAPSE_MS = 2000;
+const LAZY_UNFILLED_COLLAPSE_MS = 4000;
 const LAZY_LOAD_ROOT_MARGIN = "200px";
 const ADSENSE_SCRIPT_WAIT_MS = 10000;
 
@@ -70,9 +70,9 @@ const AdComponent = ({
   layoutKey,
 }) => {
   const containerRef = useRef(null);
-  const adInitialized = useRef(false);
   const insRef = useRef(null);
   const [collapsed, setCollapsed] = useState(false);
+  const [isFilled, setIsFilled] = useState(false);
   const [isNearViewport, setIsNearViewport] = useState(!lazyLoad);
   const isInFeedFormat = Boolean(layoutKey);
 
@@ -98,16 +98,22 @@ const AdComponent = ({
   }, [lazyLoad]);
 
   useEffect(() => {
-    if (!isNearViewport || adInitialized.current) return;
+    if (!isNearViewport) return;
 
     const insEl = insRef.current;
     if (!insEl) return;
 
-    adInitialized.current = true;
+    let cancelled = false;
 
-    return waitForAdSenseScript(() => {
+    const cleanupWait = waitForAdSenseScript(() => {
+      if (cancelled) return;
       pushAdSlot(insEl);
     });
+
+    return () => {
+      cancelled = true;
+      cleanupWait();
+    };
   }, [isNearViewport]);
 
   useEffect(() => {
@@ -123,12 +129,21 @@ const AdComponent = ({
 
     const maybeCollapse = () => {
       if (cancelled) return;
-      if (insEl.getAttribute("data-ad-status") === "unfilled") {
+
+      const adStatus = insEl.getAttribute("data-ad-status");
+      if (adStatus === "unfilled") {
         setCollapsed(true);
+        setIsFilled(false);
         return;
       }
-      if (hasFilledAd(insEl)) setCollapsed(false);
+
+      if (hasFilledAd(insEl)) {
+        setCollapsed(false);
+        setIsFilled(true);
+      }
     };
+
+    maybeCollapse();
 
     const timeoutId = window.setTimeout(() => {
       if (cancelled) return;
@@ -169,16 +184,21 @@ const AdComponent = ({
       className="ad-large text-center d-print-none d-block d-sm-block w-100"
       style={{ overflow: "hidden" }}
     >
-      <div className="text-center mb-2" style={{ fontSize: "11px" }}>
-        <a
-          href="https://www.patreon.com/GishathFetch"
-          target="_blank"
-          rel="noreferrer"
-        >
-          Follow / Support Gishath Fetch on Patreon
-        </a>
-      </div>
-      <div style={{ minHeight: "90px", overflow: "hidden" }}>
+      {isFilled && (
+        <div className="text-center mb-2" style={{ fontSize: "11px" }}>
+          <a
+            href="https://www.patreon.com/GishathFetch"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Follow / Support Gishath Fetch on Patreon
+          </a>
+        </div>
+      )}
+      <div
+        className={isFilled ? "ad-slot-filled" : "ad-slot-pending"}
+        style={{ overflow: "hidden" }}
+      >
         <ins
           ref={insRef}
           className="adsbygoogle"
@@ -190,9 +210,11 @@ const AdComponent = ({
           {...(isInFeedFormat ? { "data-ad-layout-key": layoutKey } : {})}
         ></ins>
       </div>
-      <div className="text-secondary" style={{ fontSize: "11px" }}>
-        Advertisement
-      </div>
+      {isFilled && (
+        <div className="text-secondary" style={{ fontSize: "11px" }}>
+          Advertisement
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/CartOffcanvas.jsx
+++ b/frontend/src/components/CartOffcanvas.jsx
@@ -108,7 +108,7 @@ const CartOffcanvas = ({
               ))}
 
             <div className="mt-4">
-              <AdComponent />
+              <AdComponent lazyLoad />
             </div>
 
             {cart.length >= 2 && (

--- a/frontend/src/components/SearchResults.jsx
+++ b/frontend/src/components/SearchResults.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import {
   ADSENSE_IN_FEED_AD_SLOT,
   ADSENSE_IN_FEED_LAYOUT_KEY,
@@ -86,9 +86,9 @@ const SearchResults = ({
     ? MAX_IN_FEED_ADS_DESKTOP
     : MAX_IN_FEED_ADS_MOBILE;
 
-  const inFeedAdSlotIndices = useMemo(() => {
+  const inFeedAdSlots = useMemo(() => {
     if (filteredResults.length <= adDisplayInterval) {
-      return new Set();
+      return [];
     }
 
     const slots = [];
@@ -101,10 +101,23 @@ const SearchResults = ({
         continue;
       }
       if (slots.length >= maxInFeedAds) break;
-      slots.push(i);
+      slots.push({ cardIndex: i, slotIndex: slots.length });
     }
-    return new Set(slots);
+    return slots;
   }, [filteredResults.length, adDisplayInterval, maxInFeedAds]);
+
+  const inFeedAdSlotIndices = useMemo(
+    () => new Set(inFeedAdSlots.map(({ cardIndex }) => cardIndex)),
+    [inFeedAdSlots],
+  );
+
+  const inFeedAdSlotIndexByCard = useMemo(() => {
+    const slotIndexByCard = new Map();
+    for (const { cardIndex, slotIndex } of inFeedAdSlots) {
+      slotIndexByCard.set(cardIndex, slotIndex);
+    }
+    return slotIndexByCard;
+  }, [inFeedAdSlots]);
 
   const resultsAnchorRef = useRef(null);
   const wasSearchingRef = useRef(false);
@@ -197,11 +210,11 @@ const SearchResults = ({
                 ) : (
                   <div id="result" className="mb-3 text-center">
                     <div className="row">
-                      {filteredResults.map((card, i) => (
-                        <React.Fragment
-                          key={`${card.src}-${card.url}-${card.price}-${card.quality}`}
-                        >
+                      {filteredResults.flatMap((card, i) => {
+                        const cardKey = `${card.src}-${card.url}-${card.price}-${card.quality}`;
+                        const items = [
                           <Card
+                            key={cardKey}
                             card={card}
                             index={i}
                             isCardInCart={isCardInCart}
@@ -210,18 +223,26 @@ const SearchResults = ({
                             removeFromCartByCard={removeFromCartByCard}
                             onSearchStore={onSearchStore}
                             baseUrl={baseUrl}
-                          />
-                          {inFeedAdSlotIndices.has(i) && (
-                            <div className="col-12 mb-4">
+                          />,
+                        ];
+
+                        if (inFeedAdSlotIndices.has(i)) {
+                          items.push(
+                            <div
+                              key={`in-feed-ad-${inFeedAdSlotIndexByCard.get(i)}`}
+                              className="col-12 mb-4"
+                            >
                               <AdComponent
                                 lazyLoad
                                 slot={ADSENSE_IN_FEED_AD_SLOT}
                                 layoutKey={ADSENSE_IN_FEED_LAYOUT_KEY}
                               />
-                            </div>
-                          )}
-                        </React.Fragment>
-                      ))}
+                            </div>,
+                          );
+                        }
+
+                        return items;
+                      })}
                     </div>
                   </div>
                 )}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -403,6 +403,19 @@ ins.adsbygoogle[data-ad-status="unfilled"] {
   display: none !important;
 }
 
+.ad-large:has(ins.adsbygoogle[data-ad-status="unfilled"]) {
+  /* biome-ignore lint/complexity/noImportantStyles: Collapse wrapper before React state catches up */
+  display: none !important;
+}
+
+.ad-slot-pending {
+  min-height: 0;
+}
+
+.ad-slot-filled {
+  min-height: 90px;
+}
+
 ins.adsbygoogle.adsbygoogle-noablate {
   margin-bottom: var(--footer-nav-height, 0px);
   /* biome-ignore lint/complexity/noImportantStyles: Cap Google anchor ad z-index below site footer */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reviewed the AdSense implementation and fixed several causes of visible empty ad slots.

### Root causes found

1. **Empty chrome stayed visible** — When AdSense marked a slot `unfilled`, CSS hid the `<ins>` element but the wrapper still showed a reserved 90px box plus the Patreon link and "Advertisement" label.
2. **React StrictMode init bug** — `adInitialized` was set before `adsbygoogle.push()`, so the effect cleanup/re-run in StrictMode could skip initialization entirely.
3. **In-feed ads remounted on sort/filter** — Ads lived inside card-keyed `React.Fragment`s, so changing sort or filters destroyed and recreated ad instances, causing repeat unfilled requests.
4. **Cart + footer slot competition** — Both placements use the same display ad unit; the cart ad now lazy-loads so it only requests when opened.

### Changes

- **`AdComponent`**: Remove brittle init guard; only show Patreon/Advertisement labels after fill; no min-height while pending; faster collapse (2s / 4s).
- **CSS**: Hide entire `.ad-large` wrapper instantly when `data-ad-status="unfilled"` via `:has()`.
- **`SearchResults`**: Use `flatMap` with stable `in-feed-ad-{0,1,2}` keys so ads survive sort/filter.
- **`CartOffcanvas`**: Lazy-load the display ad.

### Screenshots

**Desktop**

![Homepage desktop after AdSense empty-slot fixes](https://cursor.com/artifacts/c/art-8c89967b-795c-447c-a67e-85fe2af0bdf1)

**Mobile**

![Homepage mobile after AdSense empty-slot fixes](https://cursor.com/artifacts/c/art-aff913b5-4ddb-4066-a450-ee359eba0791)

## Test plan

- [x] `make test`
- [x] `cd frontend && npm run lint`
- [ ] Verify on production that unfilled slots collapse without leaving blank boxes
- [ ] Run a search with 8+ results, scroll through in-feed ads, then change sort/filter — ads should not flash empty placeholders
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8f44101-e655-4bed-8bc1-a816519eb0bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8f44101-e655-4bed-8bc1-a816519eb0bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

