### PR TITLE
Eager-load the first in-feed ad for better viewability

### DIFF
--- a/frontend/src/components/SearchResults.jsx
+++ b/frontend/src/components/SearchResults.jsx
@@ -227,13 +227,15 @@ const SearchResults = ({
                         ];
 
                         if (inFeedAdSlotIndices.has(i)) {
+                          const inFeedSlotIndex =
+                            inFeedAdSlotIndexByCard.get(i);
                           items.push(
                             <div
-                              key={`in-feed-ad-${inFeedAdSlotIndexByCard.get(i)}`}
+                              key={`in-feed-ad-${inFeedSlotIndex}`}
                               className="col-12 mb-4"
                             >
                               <AdComponent
-                                lazyLoad
+                                lazyLoad={inFeedSlotIndex !== 0}
                                 slot={ADSENSE_IN_FEED_AD_SLOT}
                                 layoutKey={ADSENSE_IN_FEED_LAYOUT_KEY}
                               />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Eager-load only the first in-feed AdSense slot after search results render. Subsequent in-feed slots (2nd and 3rd on desktop, 2nd on mobile) remain lazy-loaded via IntersectionObserver.

## Why

The first in-feed ad appears after card 8 on desktop / card 4 on mobile. Lazy-loading it delayed AdSense initialization until the user scrolled near that position, reducing viewability and fill opportunity for the highest-value in-feed placement.

## Change

- `SearchResults.jsx`: pass `lazyLoad={inFeedSlotIndex !== 0}` to `AdComponent` for in-feed placements.

## Testing

- `cd frontend && npm run lint` (passes; pre-existing `index.html` gtag warning unchanged)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-98a5a1c5-c4d9-4002-8264-40c1251f33fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-98a5a1c5-c4d9-4002-8264-40c1251f33fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

