### PR TITLE
Add display ad fallback when in-feed AdSense slots are unfilled

### DIFF
--- a/frontend/src/components/AdComponent.jsx
+++ b/frontend/src/components/AdComponent.jsx
@@ -76,6 +76,7 @@ const AdComponent = ({
 }) => {
   const containerRef = useRef(null);
   const insRef = useRef(null);
+  const fallbackLoggedRef = useRef(false);
   const [collapsed, setCollapsed] = useState(false);
   const [isFilled, setIsFilled] = useState(false);
   const [isNearViewport, setIsNearViewport] = useState(!lazyLoad);
@@ -138,8 +139,20 @@ const AdComponent = ({
       ? LAZY_UNFILLED_COLLAPSE_MS
       : UNFILLED_COLLAPSE_MS;
 
-    const tryDisplayFallback = () => {
+    const tryDisplayFallback = (reason) => {
       if (canFallbackToDisplay({ fallbackSlot, layoutKey, useFallback })) {
+        if (!fallbackLoggedRef.current) {
+          console.info(
+            "[AdComponent] In-feed ad unfilled; falling back to display ad",
+            {
+              reason,
+              inFeedSlot: slot,
+              displaySlot: fallbackSlot,
+              lazyLoad,
+            },
+          );
+          fallbackLoggedRef.current = true;
+        }
         setUseFallback(true);
         setIsFilled(false);
         return true;
@@ -152,7 +165,7 @@ const AdComponent = ({
 
       const adStatus = insEl.getAttribute("data-ad-status");
       if (adStatus === "unfilled") {
-        if (tryDisplayFallback()) return;
+        if (tryDisplayFallback("unfilled")) return;
         setCollapsed(true);
         setIsFilled(false);
         return;
@@ -169,7 +182,7 @@ const AdComponent = ({
     const timeoutId = window.setTimeout(() => {
       if (cancelled) return;
       if (!hasFilledAd(insEl)) {
-        if (tryDisplayFallback()) return;
+        if (tryDisplayFallback("timeout")) return;
         setCollapsed(true);
       }
     }, collapseMs);
@@ -194,6 +207,7 @@ const AdComponent = ({
     useFallback,
     fallbackSlot,
     layoutKey,
+    slot,
   ]);
 
   if (collapsed) return null;

--- a/frontend/src/components/AdComponent.jsx
+++ b/frontend/src/components/AdComponent.jsx
@@ -63,18 +63,27 @@ function waitForAdSenseScript(callback) {
   };
 }
 
+function canFallbackToDisplay({ fallbackSlot, layoutKey, useFallback }) {
+  return Boolean(fallbackSlot && layoutKey && !useFallback);
+}
+
 const AdComponent = ({
   lazyLoad = false,
   collapseWhenUnfilled = true,
   slot = ADSENSE_DISPLAY_AD_SLOT,
   layoutKey,
+  fallbackSlot,
 }) => {
   const containerRef = useRef(null);
   const insRef = useRef(null);
   const [collapsed, setCollapsed] = useState(false);
   const [isFilled, setIsFilled] = useState(false);
   const [isNearViewport, setIsNearViewport] = useState(!lazyLoad);
-  const isInFeedFormat = Boolean(layoutKey);
+  const [useFallback, setUseFallback] = useState(false);
+
+  const activeSlot = useFallback && fallbackSlot ? fallbackSlot : slot;
+  const activeLayoutKey = useFallback ? undefined : layoutKey;
+  const isInFeedFormat = Boolean(activeLayoutKey);
 
   useEffect(() => {
     if (!lazyLoad) return;
@@ -97,6 +106,8 @@ const AdComponent = ({
     return () => observer.disconnect();
   }, [lazyLoad]);
 
+  // Re-run when switching to display fallback so adsbygoogle.push targets the new <ins>.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: useFallback remounts the ad slot.
   useEffect(() => {
     if (!isNearViewport) return;
 
@@ -114,7 +125,7 @@ const AdComponent = ({
       cancelled = true;
       cleanupWait();
     };
-  }, [isNearViewport]);
+  }, [isNearViewport, useFallback]);
 
   useEffect(() => {
     if (!collapseWhenUnfilled || !isNearViewport) return;
@@ -127,11 +138,21 @@ const AdComponent = ({
       ? LAZY_UNFILLED_COLLAPSE_MS
       : UNFILLED_COLLAPSE_MS;
 
+    const tryDisplayFallback = () => {
+      if (canFallbackToDisplay({ fallbackSlot, layoutKey, useFallback })) {
+        setUseFallback(true);
+        setIsFilled(false);
+        return true;
+      }
+      return false;
+    };
+
     const maybeCollapse = () => {
       if (cancelled) return;
 
       const adStatus = insEl.getAttribute("data-ad-status");
       if (adStatus === "unfilled") {
+        if (tryDisplayFallback()) return;
         setCollapsed(true);
         setIsFilled(false);
         return;
@@ -147,7 +168,10 @@ const AdComponent = ({
 
     const timeoutId = window.setTimeout(() => {
       if (cancelled) return;
-      if (!hasFilledAd(insEl)) setCollapsed(true);
+      if (!hasFilledAd(insEl)) {
+        if (tryDisplayFallback()) return;
+        setCollapsed(true);
+      }
     }, collapseMs);
 
     const observer = new MutationObserver(maybeCollapse);
@@ -163,7 +187,14 @@ const AdComponent = ({
       window.clearTimeout(timeoutId);
       observer.disconnect();
     };
-  }, [collapseWhenUnfilled, isNearViewport, lazyLoad]);
+  }, [
+    collapseWhenUnfilled,
+    isNearViewport,
+    lazyLoad,
+    useFallback,
+    fallbackSlot,
+    layoutKey,
+  ]);
 
   if (collapsed) return null;
 
@@ -200,14 +231,15 @@ const AdComponent = ({
         style={{ overflow: "hidden" }}
       >
         <ins
+          key={useFallback ? "display-fallback" : "primary"}
           ref={insRef}
           className="adsbygoogle"
           style={{ display: "block", width: "100%", maxWidth: "100%" }}
           data-ad-client={ADSENSE_CLIENT}
-          data-ad-slot={slot}
+          data-ad-slot={activeSlot}
           data-ad-format={isInFeedFormat ? "fluid" : "auto"}
           data-full-width-responsive={isInFeedFormat ? undefined : "true"}
-          {...(isInFeedFormat ? { "data-ad-layout-key": layoutKey } : {})}
+          {...(isInFeedFormat ? { "data-ad-layout-key": activeLayoutKey } : {})}
         ></ins>
       </div>
       {isFilled && (

--- a/frontend/src/components/SearchResults.jsx
+++ b/frontend/src/components/SearchResults.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef } from "react";
 import {
+  ADSENSE_DISPLAY_AD_SLOT,
   ADSENSE_IN_FEED_AD_SLOT,
   ADSENSE_IN_FEED_LAYOUT_KEY,
   DESKTOP_MIN_WIDTH_MEDIA_QUERY,
@@ -238,6 +239,7 @@ const SearchResults = ({
                                 lazyLoad={inFeedSlotIndex !== 0}
                                 slot={ADSENSE_IN_FEED_AD_SLOT}
                                 layoutKey={ADSENSE_IN_FEED_LAYOUT_KEY}
+                                fallbackSlot={ADSENSE_DISPLAY_AD_SLOT}
                               />
                             </div>,
                           );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When an in-feed AdSense placement does not fill, the slot now remounts as a responsive display ad before collapsing entirely. This helps monetize search results while the dedicated in-feed unit (`7667010672`) ramps up inventory.

## Changes

- **`AdComponent`**: Added optional `fallbackSlot` prop. On `data-ad-status="unfilled"` or fill timeout, if a fallback is configured for an in-feed placement, swap to a fresh `<ins>` with display format (`auto`, no layout key) and request fill again. Collapse only if the fallback also fails.
- **`SearchResults`**: Passes `fallbackSlot={ADSENSE_DISPLAY_AD_SLOT}` for in-feed placements between result cards.
- **Debug logging**: `console.info` when fallback triggers, including reason (`unfilled` or `timeout`), slot IDs, and whether the placement is lazy-loaded.

## Behavior

1. Try in-feed unit first (fluid format + layout key).
2. If unfilled within ~2s (first slot) or ~4s (lazy slots), remount with display slot.
3. If display fallback also unfills, collapse as before (no blank placeholder).

Example console output:

```
[AdComponent] In-feed ad unfilled; falling back to display ad
  { reason: "unfilled", inFeedSlot: "7667010672", displaySlot: "6707964257", lazyLoad: false }
```

Footer and cart ads are unchanged (no fallback prop).

## Testing

- `npm run lint` (frontend)
- `make test` (full suite)

## Notes

Screenshots were not included because ad visibility depends on live AdSense fill in production. To verify locally: search a high-volume card (e.g. "Sol Ring"), open DevTools console, and confirm fallback logs when in-feed reports `data-ad-status="unfilled"`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d44a52f-f46f-47b0-a1dd-4286143204a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d44a52f-f46f-47b0-a1dd-4286143204a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

