### PR TITLE
Add favourite store presets with Saved Cards search shortcut

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,7 @@
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.1",
-        "vite": "^7.3.2"
+        "vite": "^7.3.6"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -16,6 +16,7 @@ const Modals = lazy(() => import("./components/Modals"));
 import { BASE_URL, LGS_MAP, LGS_OPTIONS, MIN_SEARCH_LENGTH } from "./constants";
 // --- Hooks ---
 import useCart from "./hooks/useCart";
+import useFavouriteStores from "./hooks/useFavouriteStores";
 import useSearch from "./hooks/useSearch";
 import useTopSearchKeywords from "./hooks/useTopSearchKeywords";
 
@@ -33,6 +34,15 @@ export default function App() {
     clearCart,
     isCardInCart,
   } = useCart();
+
+  const {
+    favouriteStores,
+    hasFavourites,
+    saveFavourites,
+    favouritesMatchSelection,
+    favouriteStoresFeedback,
+    showFavouriteStoresFeedback,
+  } = useFavouriteStores();
 
   const {
     searchQuery,
@@ -60,6 +70,8 @@ export default function App() {
     toggleStore,
     selectAllStores,
     selectNoStores,
+    applyStoreSelection,
+    searchLastQueryWithStores,
     performSearch,
     cancelSearch,
     retrySearch,
@@ -143,6 +155,40 @@ export default function App() {
     ],
   );
 
+  const handleLoadFavourites = useCallback(() => {
+    if (!hasFavourites) {
+      return;
+    }
+
+    applyStoreSelection(favouriteStores);
+  }, [applyStoreSelection, favouriteStores, hasFavourites]);
+
+  const handleSaveFavourites = useCallback(() => {
+    saveFavourites(selectedStores);
+  }, [saveFavourites, selectedStores]);
+
+  const handleSearchWithFavouriteStores = useCallback(() => {
+    if (!hasFavourites) {
+      return;
+    }
+
+    setShowCart(false);
+    setShowSuggestions(false);
+    const { searched } = searchLastQueryWithStores(favouriteStores);
+    if (!searched) {
+      showFavouriteStoresFeedback(
+        "Favourite stores applied. Enter a card name to search.",
+      );
+    }
+  }, [
+    favouriteStores,
+    hasFavourites,
+    searchLastQueryWithStores,
+    setShowCart,
+    setShowSuggestions,
+    showFavouriteStoresFeedback,
+  ]);
+
   // --- Main Render ---
   return (
     <div id="top" className="container-xl my-3 px-3 pb-3">
@@ -168,6 +214,10 @@ export default function App() {
         onStoreToggle={toggleStore}
         onSelectAll={selectAllStores}
         onSelectNone={selectNoStores}
+        onLoadFavourites={handleLoadFavourites}
+        onSaveFavourites={handleSaveFavourites}
+        hasFavourites={hasFavourites}
+        favouritesMatchSelection={favouritesMatchSelection(selectedStores)}
         onCloseSuggestions={() => setShowSuggestions(false)}
         searchError={searchError}
         storesWarning={storesWarning}
@@ -211,7 +261,9 @@ export default function App() {
         onShowFaq={() => setModalType("FAQ")}
       />
 
-      <CartActionFeedback message={cartActionFeedback} />
+      <CartActionFeedback
+        message={cartActionFeedback || favouriteStoresFeedback}
+      />
 
       <Suspense fallback={null}>
         <CartOffcanvas
@@ -221,6 +273,8 @@ export default function App() {
           isCardInCart={isCardInCart}
           removeFromCart={removeFromCart}
           onSearchStore={handleCardSearch}
+          onSearchWithFavouriteStores={handleSearchWithFavouriteStores}
+          hasFavourites={hasFavourites}
           onClearCart={clearCart}
           baseUrl={BASE_URL}
         />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -41,7 +41,6 @@ export default function App() {
     saveFavourites,
     favouritesMatchSelection,
     favouriteStoresFeedback,
-    showFavouriteStoresFeedback,
   } = useFavouriteStores();
 
   const {
@@ -71,7 +70,6 @@ export default function App() {
     selectAllStores,
     selectNoStores,
     applyStoreSelection,
-    searchLastQueryWithStores,
     performSearch,
     cancelSearch,
     retrySearch,
@@ -167,28 +165,6 @@ export default function App() {
     saveFavourites(selectedStores);
   }, [saveFavourites, selectedStores]);
 
-  const handleSearchWithFavouriteStores = useCallback(() => {
-    if (!hasFavourites) {
-      return;
-    }
-
-    setShowCart(false);
-    setShowSuggestions(false);
-    const { searched } = searchLastQueryWithStores(favouriteStores);
-    if (!searched) {
-      showFavouriteStoresFeedback(
-        "Favourite stores applied. Enter a card name to search.",
-      );
-    }
-  }, [
-    favouriteStores,
-    hasFavourites,
-    searchLastQueryWithStores,
-    setShowCart,
-    setShowSuggestions,
-    showFavouriteStoresFeedback,
-  ]);
-
   // --- Main Render ---
   return (
     <div id="top" className="container-xl my-3 px-3 pb-3">
@@ -273,8 +249,6 @@ export default function App() {
           isCardInCart={isCardInCart}
           removeFromCart={removeFromCart}
           onSearchStore={handleCardSearch}
-          onSearchWithFavouriteStores={handleSearchWithFavouriteStores}
-          hasFavourites={hasFavourites}
           onClearCart={clearCart}
           baseUrl={BASE_URL}
         />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -153,6 +153,30 @@ export default function App() {
     ],
   );
 
+  const handleCardSearchWithFavourites = useCallback(
+    (e, cardName) => {
+      if (e?.preventDefault) e.preventDefault();
+      if (!hasFavourites) {
+        return;
+      }
+
+      setSearchQuery(cardName);
+      setShowCart(false);
+      setShowSuggestions(false);
+      applyStoreSelection(favouriteStores);
+      performSearch(cardName, favouriteStores);
+    },
+    [
+      applyStoreSelection,
+      favouriteStores,
+      hasFavourites,
+      performSearch,
+      setSearchQuery,
+      setShowCart,
+      setShowSuggestions,
+    ],
+  );
+
   const handleLoadFavourites = useCallback(() => {
     if (!hasFavourites) {
       return;
@@ -249,6 +273,8 @@ export default function App() {
           isCardInCart={isCardInCart}
           removeFromCart={removeFromCart}
           onSearchStore={handleCardSearch}
+          onSearchWithFavouriteStores={handleCardSearchWithFavourites}
+          hasFavourites={hasFavourites}
           onClearCart={clearCart}
           baseUrl={BASE_URL}
         />

--- a/frontend/src/components/Card.jsx
+++ b/frontend/src/components/Card.jsx
@@ -83,7 +83,7 @@ const Card = ({
               </a>
               <button
                 type="button"
-                className="btn btn-warning btn-sm cartFavSearchBtn"
+                className="btn btn-dark btn-sm cartFavSearchBtn"
                 disabled={!hasFavourites}
                 aria-label="Search with favourite stores"
                 title={

--- a/frontend/src/components/Card.jsx
+++ b/frontend/src/components/Card.jsx
@@ -2,6 +2,7 @@ import {
   CheckSquare,
   FolderPlus,
   Search as SearchIcon,
+  Star,
   Trash2,
 } from "react-feather";
 import { formatSavedAt } from "../hooks/useCart";
@@ -15,6 +16,8 @@ const Card = ({
   removeFromCart,
   removeFromCartByCard,
   onSearchStore,
+  onSearchWithFavouriteStores,
+  hasFavourites = false,
   baseUrl,
 }) => {
   const qualityFoil = [];
@@ -71,7 +74,7 @@ const Card = ({
         </div>
         <div>
           {isCart ? (
-            <div className="d-flex justify-content-center gap-1">
+            <div className="d-flex flex-wrap justify-content-center gap-1">
               <a
                 href={`${baseUrl}?s=${encodeURIComponent(card.name)}&src=${encodeURIComponent(card.src)}`}
                 className="btn btn-primary btn-sm cartSearchBtn"
@@ -79,6 +82,22 @@ const Card = ({
               >
                 <SearchIcon size={12} className="cartIcon" /> Search
               </a>
+              <button
+                type="button"
+                className="btn btn-outline-primary btn-sm cartFavSearchBtn"
+                disabled={!hasFavourites}
+                aria-label="Search with favourite stores"
+                title={
+                  hasFavourites
+                    ? "Search with favourite stores"
+                    : "Save favourite stores on the search page first"
+                }
+                onClick={(e) => onSearchWithFavouriteStores?.(e, card.name)}
+              >
+                <Star size={12} className="cartIcon" aria-hidden="true" />
+                <SearchIcon size={12} className="cartIcon" aria-hidden="true" />{" "}
+                Fav
+              </button>
               <button
                 type="button"
                 className="removeFromCartBtn btn btn-danger btn-sm"

--- a/frontend/src/components/Card.jsx
+++ b/frontend/src/components/Card.jsx
@@ -94,7 +94,7 @@ const Card = ({
                 onClick={(e) => onSearchWithFavouriteStores?.(e, card.name)}
               >
                 <SearchIcon size={12} className="cartIcon" aria-hidden="true" />{" "}
-                Fav.
+                Favourite
               </button>
               <button
                 type="button"

--- a/frontend/src/components/Card.jsx
+++ b/frontend/src/components/Card.jsx
@@ -2,7 +2,6 @@ import {
   CheckSquare,
   FolderPlus,
   Search as SearchIcon,
-  Star,
   Trash2,
 } from "react-feather";
 import { formatSavedAt } from "../hooks/useCart";
@@ -84,7 +83,7 @@ const Card = ({
               </a>
               <button
                 type="button"
-                className="btn btn-outline-primary btn-sm cartFavSearchBtn"
+                className="btn btn-warning btn-sm cartFavSearchBtn"
                 disabled={!hasFavourites}
                 aria-label="Search with favourite stores"
                 title={
@@ -94,7 +93,6 @@ const Card = ({
                 }
                 onClick={(e) => onSearchWithFavouriteStores?.(e, card.name)}
               >
-                <Star size={12} className="cartIcon" aria-hidden="true" />
                 <SearchIcon size={12} className="cartIcon" aria-hidden="true" />{" "}
                 Fav
               </button>

--- a/frontend/src/components/Card.jsx
+++ b/frontend/src/components/Card.jsx
@@ -94,7 +94,7 @@ const Card = ({
                 onClick={(e) => onSearchWithFavouriteStores?.(e, card.name)}
               >
                 <SearchIcon size={12} className="cartIcon" aria-hidden="true" />{" "}
-                Fav
+                Fav.
               </button>
               <button
                 type="button"

--- a/frontend/src/components/CartOffcanvas.jsx
+++ b/frontend/src/components/CartOffcanvas.jsx
@@ -1,6 +1,5 @@
 import { useMemo, useState } from "react";
 import { Button, Form, Offcanvas } from "react-bootstrap";
-import { Search as SearchIcon, Star } from "react-feather";
 import AdComponent from "./AdComponent";
 import Card from "./Card";
 
@@ -11,8 +10,6 @@ const CartOffcanvas = ({
   isCardInCart,
   removeFromCart,
   onSearchStore,
-  onSearchWithFavouriteStores,
-  hasFavourites,
   onClearCart,
   baseUrl,
 }) => {
@@ -49,26 +46,6 @@ const CartOffcanvas = ({
           When a card is saved, a snapshot of it from that point in time is
           taken. If there is any change in its price or availability, it will
           not be updated automatically.
-        </div>
-
-        <div className="mb-4">
-          <Button
-            variant="primary"
-            size="sm"
-            className="w-100 d-inline-flex align-items-center justify-content-center gap-1"
-            disabled={!hasFavourites}
-            onClick={onSearchWithFavouriteStores}
-          >
-            <Star size={14} aria-hidden="true" />
-            <SearchIcon size={14} aria-hidden="true" />
-            Search with favourite stores
-          </Button>
-          {!hasFavourites && (
-            <output className="small text-muted mt-2 d-block">
-              No stores have been added to favourites yet. Open Stores on the
-              search page and tap &ldquo;Save Fav.&rdquo;.
-            </output>
-          )}
         </div>
 
         {cart.length > 0 && (

--- a/frontend/src/components/CartOffcanvas.jsx
+++ b/frontend/src/components/CartOffcanvas.jsx
@@ -66,7 +66,7 @@ const CartOffcanvas = ({
           {!hasFavourites && (
             <output className="small text-muted mt-2 d-block">
               No stores have been added to favourites yet. Open Stores on the
-              search page and tap &ldquo;Save favourites&rdquo;.
+              search page and tap &ldquo;Save Fav.&rdquo;.
             </output>
           )}
         </div>

--- a/frontend/src/components/CartOffcanvas.jsx
+++ b/frontend/src/components/CartOffcanvas.jsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { Button, Form, Offcanvas } from "react-bootstrap";
+import { Search as SearchIcon, Star } from "react-feather";
 import AdComponent from "./AdComponent";
 import Card from "./Card";
 
@@ -10,6 +11,8 @@ const CartOffcanvas = ({
   isCardInCart,
   removeFromCart,
   onSearchStore,
+  onSearchWithFavouriteStores,
+  hasFavourites,
   onClearCart,
   baseUrl,
 }) => {
@@ -46,6 +49,26 @@ const CartOffcanvas = ({
           When a card is saved, a snapshot of it from that point in time is
           taken. If there is any change in its price or availability, it will
           not be updated automatically.
+        </div>
+
+        <div className="mb-4">
+          <Button
+            variant="primary"
+            size="sm"
+            className="w-100 d-inline-flex align-items-center justify-content-center gap-1"
+            disabled={!hasFavourites}
+            onClick={onSearchWithFavouriteStores}
+          >
+            <Star size={14} aria-hidden="true" />
+            <SearchIcon size={14} aria-hidden="true" />
+            Search with favourite stores
+          </Button>
+          {!hasFavourites && (
+            <output className="small text-muted mt-2 d-block">
+              No stores have been added to favourites yet. Open Stores on the
+              search page and tap &ldquo;Save favourites&rdquo;.
+            </output>
+          )}
         </div>
 
         {cart.length > 0 && (

--- a/frontend/src/components/CartOffcanvas.jsx
+++ b/frontend/src/components/CartOffcanvas.jsx
@@ -10,6 +10,8 @@ const CartOffcanvas = ({
   isCardInCart,
   removeFromCart,
   onSearchStore,
+  onSearchWithFavouriteStores,
+  hasFavourites,
   onClearCart,
   baseUrl,
 }) => {
@@ -78,6 +80,8 @@ const CartOffcanvas = ({
                     isCardInCart={isCardInCart}
                     removeFromCart={removeFromCart}
                     onSearchStore={onSearchStore}
+                    onSearchWithFavouriteStores={onSearchWithFavouriteStores}
+                    hasFavourites={hasFavourites}
                     baseUrl={baseUrl}
                   />
                 ))}
@@ -100,6 +104,10 @@ const CartOffcanvas = ({
                         isCardInCart={isCardInCart}
                         removeFromCart={removeFromCart}
                         onSearchStore={onSearchStore}
+                        onSearchWithFavouriteStores={
+                          onSearchWithFavouriteStores
+                        }
+                        hasFavourites={hasFavourites}
                         baseUrl={baseUrl}
                       />
                     ))}

--- a/frontend/src/components/SearchForm.jsx
+++ b/frontend/src/components/SearchForm.jsx
@@ -23,6 +23,10 @@ const SearchForm = ({
   onStoreToggle,
   onSelectAll,
   onSelectNone,
+  onLoadFavourites,
+  onSaveFavourites,
+  hasFavourites,
+  favouritesMatchSelection,
   onCloseSuggestions,
   searchError,
   storesWarning,
@@ -290,6 +294,10 @@ const SearchForm = ({
           onToggle={onStoreToggle}
           onSelectAll={onSelectAll}
           onSelectNone={onSelectNone}
+          onLoadFavourites={onLoadFavourites}
+          onSaveFavourites={onSaveFavourites}
+          hasFavourites={hasFavourites}
+          favouritesMatchSelection={favouritesMatchSelection}
           collapsible
           collapseOnSearch={isSearching}
           defaultExpanded={false}

--- a/frontend/src/components/StoreSelector.jsx
+++ b/frontend/src/components/StoreSelector.jsx
@@ -1,5 +1,5 @@
 import { memo, useEffect, useId, useMemo, useState } from "react";
-import { ChevronDown, MapPin, Star } from "react-feather";
+import { ChevronDown, MapPin } from "react-feather";
 
 const SECTION_CLASS_NAME = "store-selector-section google-anno-skip mb-3";
 
@@ -131,8 +131,7 @@ const StoreSelector = memo(
                   disabled={!hasFavourites}
                   onClick={onLoadFavourites}
                 >
-                  <Star size={12} aria-hidden="true" className="me-1" />
-                  Load Fav.
+                  Load Fav Stores
                 </button>
                 <button
                   type="button"
@@ -140,8 +139,7 @@ const StoreSelector = memo(
                   aria-label="Save current selection as favourite stores"
                   onClick={onSaveFavourites}
                 >
-                  <Star size={12} aria-hidden="true" className="me-1" />
-                  Save Fav.
+                  Save Fav Stores
                 </button>
               </fieldset>
               <span

--- a/frontend/src/components/StoreSelector.jsx
+++ b/frontend/src/components/StoreSelector.jsx
@@ -131,7 +131,7 @@ const StoreSelector = memo(
                   disabled={!hasFavourites}
                   onClick={onLoadFavourites}
                 >
-                  Load Fav. Stores
+                  Load Favourite
                 </button>
                 <button
                   type="button"
@@ -139,7 +139,7 @@ const StoreSelector = memo(
                   aria-label="Save current selection as favourite stores"
                   onClick={onSaveFavourites}
                 >
-                  Save Fav. Stores
+                  Save Favourite
                 </button>
               </fieldset>
               <span

--- a/frontend/src/components/StoreSelector.jsx
+++ b/frontend/src/components/StoreSelector.jsx
@@ -132,7 +132,7 @@ const StoreSelector = memo(
                   onClick={onLoadFavourites}
                 >
                   <Star size={12} aria-hidden="true" className="me-1" />
-                  Load favourites
+                  Load Fav.
                 </button>
                 <button
                   type="button"
@@ -141,7 +141,7 @@ const StoreSelector = memo(
                   onClick={onSaveFavourites}
                 >
                   <Star size={12} aria-hidden="true" className="me-1" />
-                  Save favourites
+                  Save Fav.
                 </button>
               </fieldset>
               <span

--- a/frontend/src/components/StoreSelector.jsx
+++ b/frontend/src/components/StoreSelector.jsx
@@ -1,5 +1,5 @@
 import { memo, useEffect, useId, useMemo, useState } from "react";
-import { ChevronDown, MapPin } from "react-feather";
+import { ChevronDown, MapPin, Star } from "react-feather";
 
 const SECTION_CLASS_NAME = "store-selector-section google-anno-skip mb-3";
 
@@ -14,6 +14,10 @@ const StoreSelector = memo(
     onToggle,
     onSelectAll,
     onSelectNone,
+    onLoadFavourites,
+    onSaveFavourites,
+    hasFavourites = false,
+    favouritesMatchSelection = false,
     collapsible = true,
     collapseOnSearch = false,
     defaultExpanded = true,
@@ -91,7 +95,7 @@ const StoreSelector = memo(
             <div className="store-selector-controls">
               <fieldset className="store-selector-bulk-toggle border-0 p-0 m-0">
                 <legend className="visually-hidden">
-                  Select all or no stores
+                  Select all, no, or favourite stores
                 </legend>
                 <button
                   type="button"
@@ -112,6 +116,32 @@ const StoreSelector = memo(
                   onClick={onSelectNone}
                 >
                   None
+                </button>
+                <span
+                  className="store-selector-bulk-divider"
+                  aria-hidden="true"
+                />
+                <button
+                  type="button"
+                  className={`btn btn-sm store-selector-bulk-btn store-selector-fav-btn${
+                    favouritesMatchSelection ? " is-active" : ""
+                  }`}
+                  aria-pressed={favouritesMatchSelection}
+                  aria-label="Load favourite stores"
+                  disabled={!hasFavourites}
+                  onClick={onLoadFavourites}
+                >
+                  <Star size={12} aria-hidden="true" className="me-1" />
+                  Load favourites
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-sm store-selector-bulk-btn store-selector-fav-btn"
+                  aria-label="Save current selection as favourite stores"
+                  onClick={onSaveFavourites}
+                >
+                  <Star size={12} aria-hidden="true" className="me-1" />
+                  Save favourites
                 </button>
               </fieldset>
               <span

--- a/frontend/src/components/StoreSelector.jsx
+++ b/frontend/src/components/StoreSelector.jsx
@@ -131,7 +131,7 @@ const StoreSelector = memo(
                   disabled={!hasFavourites}
                   onClick={onLoadFavourites}
                 >
-                  Load Fav Stores
+                  Load Fav. Stores
                 </button>
                 <button
                   type="button"
@@ -139,7 +139,7 @@ const StoreSelector = memo(
                   aria-label="Save current selection as favourite stores"
                   onClick={onSaveFavourites}
                 >
-                  Save Fav Stores
+                  Save Fav. Stores
                 </button>
               </fieldset>
               <span

--- a/frontend/src/hooks/useFavouriteStores.js
+++ b/frontend/src/hooks/useFavouriteStores.js
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  loadFavouriteStoresFromStorage,
+  persistFavouriteStores,
+  storeSelectionsMatch,
+  validateFavouriteStores,
+} from "../utils/favouriteStores";
+
+const FAVOURITE_STORES_FEEDBACK_DURATION_MS = 2500;
+
+export default function useFavouriteStores() {
+  const [favouriteStores, setFavouriteStores] = useState(
+    loadFavouriteStoresFromStorage,
+  );
+  const [favouriteStoresFeedback, setFavouriteStoresFeedback] = useState(null);
+  const feedbackTimeoutRef = useRef(null);
+
+  const showFavouriteStoresFeedback = useCallback((message) => {
+    if (feedbackTimeoutRef.current) {
+      clearTimeout(feedbackTimeoutRef.current);
+    }
+
+    setFavouriteStoresFeedback(message);
+    feedbackTimeoutRef.current = setTimeout(() => {
+      setFavouriteStoresFeedback(null);
+      feedbackTimeoutRef.current = null;
+    }, FAVOURITE_STORES_FEEDBACK_DURATION_MS);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (feedbackTimeoutRef.current) {
+        clearTimeout(feedbackTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const saveFavourites = useCallback(
+    (stores) => {
+      const validated = validateFavouriteStores(stores);
+      persistFavouriteStores(validated);
+      setFavouriteStores(validated);
+
+      if (validated.length === 0) {
+        showFavouriteStoresFeedback("Favourite stores cleared");
+        return;
+      }
+
+      const storeLabel = validated.length === 1 ? "store" : "stores";
+      showFavouriteStoresFeedback(
+        `${validated.length} ${storeLabel} saved as favourites`,
+      );
+    },
+    [showFavouriteStoresFeedback],
+  );
+
+  const favouritesMatchSelection = useCallback(
+    (selectedStores) => storeSelectionsMatch(favouriteStores, selectedStores),
+    [favouriteStores],
+  );
+
+  return {
+    favouriteStores,
+    hasFavourites: favouriteStores.length > 0,
+    saveFavourites,
+    favouritesMatchSelection,
+    favouriteStoresFeedback,
+    showFavouriteStoresFeedback,
+  };
+}

--- a/frontend/src/hooks/useFavouriteStores.js
+++ b/frontend/src/hooks/useFavouriteStores.js
@@ -65,6 +65,5 @@ export default function useFavouriteStores() {
     saveFavourites,
     favouritesMatchSelection,
     favouriteStoresFeedback,
-    showFavouriteStoresFeedback,
   };
 }

--- a/frontend/src/hooks/useSearch.js
+++ b/frontend/src/hooks/useSearch.js
@@ -580,26 +580,6 @@ export default function useSearch() {
     persistSelectedStores(stores);
   }, []);
 
-  const searchLastQueryWithStores = useCallback(
-    (stores) => {
-      const resolvedStores = resolveStoresToSearch(stores);
-      applyStoreSelection(resolvedStores);
-
-      const { query } = lastSearchRef.current;
-      if (
-        query &&
-        query.length >= MIN_SEARCH_LENGTH &&
-        query.length <= MAX_SEARCH_LENGTH
-      ) {
-        performSearch(query, resolvedStores);
-        return { searched: true, query };
-      }
-
-      return { searched: false };
-    },
-    [applyStoreSelection, performSearch, resolveStoresToSearch],
-  );
-
   // --- Initialization ---
   // Note: performSearch is included in deps but is stable (empty dep array in useCallback)
   // This effect should only run once on mount, not when selectedStores changes
@@ -652,7 +632,6 @@ export default function useSearch() {
     selectAllStores,
     selectNoStores,
     applyStoreSelection,
-    searchLastQueryWithStores,
     performSearch,
     cancelSearch,
     retrySearch,

--- a/frontend/src/hooks/useSearch.js
+++ b/frontend/src/hooks/useSearch.js
@@ -574,6 +574,32 @@ export default function useSearch() {
     persistSelectedStores([]);
   };
 
+  const applyStoreSelection = useCallback((stores) => {
+    setStoresWarning(null);
+    setSelectedStores(stores);
+    persistSelectedStores(stores);
+  }, []);
+
+  const searchLastQueryWithStores = useCallback(
+    (stores) => {
+      const resolvedStores = resolveStoresToSearch(stores);
+      applyStoreSelection(resolvedStores);
+
+      const { query } = lastSearchRef.current;
+      if (
+        query &&
+        query.length >= MIN_SEARCH_LENGTH &&
+        query.length <= MAX_SEARCH_LENGTH
+      ) {
+        performSearch(query, resolvedStores);
+        return { searched: true, query };
+      }
+
+      return { searched: false };
+    },
+    [applyStoreSelection, performSearch, resolveStoresToSearch],
+  );
+
   // --- Initialization ---
   // Note: performSearch is included in deps but is stable (empty dep array in useCallback)
   // This effect should only run once on mount, not when selectedStores changes
@@ -625,6 +651,8 @@ export default function useSearch() {
     toggleStore,
     selectAllStores,
     selectNoStores,
+    applyStoreSelection,
+    searchLastQueryWithStores,
     performSearch,
     cancelSearch,
     retrySearch,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -230,7 +230,8 @@ body {
 
 .addCartBtn,
 .removeFromCartBtn,
-.cartSearchBtn {
+.cartSearchBtn,
+.cartFavSearchBtn {
   font-size: 11px;
   padding-bottom: 5px;
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -161,6 +161,25 @@ body {
   color: var(--bs-primary);
 }
 
+.store-selector-bulk-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.store-selector-bulk-divider {
+  display: inline-block;
+  width: 1px;
+  align-self: stretch;
+  min-height: 1.5rem;
+  margin: 0 0.125rem;
+  background-color: var(--bs-border-color);
+}
+
+.store-selector-fav-btn {
+  display: inline-flex;
+  align-items: center;
+}
+
 .store-selector-count {
   white-space: nowrap;
 }

--- a/frontend/src/utils/favouriteStores.js
+++ b/frontend/src/utils/favouriteStores.js
@@ -1,0 +1,78 @@
+import { LGS_OPTIONS } from "../constants";
+
+export const FAVOURITE_STORES_STORAGE_KEY = "lgsFavourites";
+
+/**
+ * @param {string[]} stores
+ * @returns {string[]}
+ */
+export function validateFavouriteStores(stores) {
+  if (!Array.isArray(stores)) {
+    return [];
+  }
+
+  const validStores = new Set(LGS_OPTIONS);
+  return stores.filter((store) => validStores.has(store));
+}
+
+/**
+ * @param {string[]} left
+ * @param {string[]} right
+ * @returns {boolean}
+ */
+export function storeSelectionsMatch(left, right) {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  const leftSet = new Set(left);
+  return right.every((store) => leftSet.has(store));
+}
+
+/**
+ * @returns {string[]}
+ */
+export function loadFavouriteStoresFromStorage() {
+  try {
+    const stored = localStorage.getItem(FAVOURITE_STORES_STORAGE_KEY);
+    if (stored === null) {
+      return [];
+    }
+
+    const decoded = decodeURIComponent(stored);
+    if (decoded === "") {
+      return [];
+    }
+
+    return validateFavouriteStores(decoded.split(","));
+  } catch (err) {
+    console.error("Failed to load favourite stores:", err);
+    return [];
+  }
+}
+
+/**
+ * @param {string[]} stores
+ */
+export function persistFavouriteStores(stores) {
+  try {
+    const validated = validateFavouriteStores(stores);
+    localStorage.setItem(
+      FAVOURITE_STORES_STORAGE_KEY,
+      encodeURIComponent(validated.join(",")),
+    );
+  } catch (err) {
+    console.error("Failed to save favourite stores:", err);
+  }
+}
+
+/**
+ * @returns {boolean}
+ */
+export function hasStoredFavouriteStores() {
+  try {
+    return localStorage.getItem(FAVOURITE_STORES_STORAGE_KEY) !== null;
+  } catch {
+    return false;
+  }
+}

--- a/frontend/src/utils/favouriteStores.test.js
+++ b/frontend/src/utils/favouriteStores.test.js
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { LGS_OPTIONS } from "../constants.js";
+import {
+  storeSelectionsMatch,
+  validateFavouriteStores,
+} from "./favouriteStores.js";
+
+assert.deepEqual(validateFavouriteStores(["Hideout", "Unknown Store"]), [
+  "Hideout",
+]);
+assert.deepEqual(validateFavouriteStores(null), []);
+assert.deepEqual(validateFavouriteStores(LGS_OPTIONS), LGS_OPTIONS);
+
+assert.equal(storeSelectionsMatch(["Hideout"], ["Hideout"]), true);
+assert.equal(
+  storeSelectionsMatch(["Hideout", "OneMtg"], ["OneMtg", "Hideout"]),
+  true,
+);
+assert.equal(storeSelectionsMatch(["Hideout"], ["Hideout", "OneMtg"]), false);
+assert.equal(storeSelectionsMatch([], []), true);
+
+console.log("favouriteStores tests passed");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds localStorage-backed **favourite store presets**, separate from the existing `lgsSelected` last-used selection.

### Store selector
- **Load Favourite** — applies the saved preset (disabled when empty; active when current selection matches)
- **Save Favourite** — saves the current selection with toast feedback (e.g. "3 stores saved as favourites")

### Saved Cards
- Each saved card has a dark **Favourite** button with white text and search icon to search that card across favourite stores
- Disabled until favourite stores have been saved on the search page

Favourites are stored under `lgsFavourites` in localStorage and validated against `LGS_OPTIONS`.

## Screenshots

### Store selector (desktop)

![Store selector with Load Favourite and Save Favourite buttons on desktop](https://cursor.com/artifacts/c/art-01799037-b26e-4dcd-b5c0-96267aa59024)

### Store selector (mobile)

![Store selector with Load Favourite and Save Favourite buttons on mobile](https://cursor.com/artifacts/c/art-777c279d-ca17-41aa-a183-3e65621be756)

### Saved Cards with Favourite button (desktop)

![Saved Cards with Favourite search button on desktop](https://cursor.com/artifacts/c/art-f2e1dc9d-2409-481e-b102-ab84775d085e)

### Saved Cards with Favourite button (mobile)

![Saved Cards with Favourite search button on mobile](https://cursor.com/artifacts/c/art-282599fe-391a-4870-b799-a7999e185fc1)

## Testing

- `make test` (pass)
- `cd frontend && npm run lint` (pass)
- Added `frontend/src/utils/favouriteStores.test.js` for validation/matching helpers
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1d3e4fd-e9d0-408f-8ccd-a44afd79b97f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1d3e4fd-e9d0-408f-8ccd-a44afd79b97f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

