### PR TITLE
Fix HTML gateway gzip decompression (Dueller's Point, 5 Mana)

### DIFF
--- a/api/gateway/duellerpoint/search.go
+++ b/api/gateway/duellerpoint/search.go
@@ -63,7 +63,12 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 	}
 	defer resp.Body.Close()
 
-	doc, err := goquery.NewDocumentFromReader(resp.Body)
+	body, err := gateway.ReadResponseBody(resp)
+	if err != nil {
+		return cards, err
+	}
+
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(string(body)))
 	if err != nil {
 		return cards, err
 	}

--- a/api/gateway/fivemana/search.go
+++ b/api/gateway/fivemana/search.go
@@ -62,7 +62,12 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 	}
 	defer resp.Body.Close()
 
-	doc, err := goquery.NewDocumentFromReader(resp.Body)
+	body, err := gateway.ReadResponseBody(resp)
+	if err != nil {
+		return cards, err
+	}
+
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(string(body)))
 	if err != nil {
 		return cards, err
 	}

--- a/api/gateway/gatewaytest/html_probe.go
+++ b/api/gateway/gatewaytest/html_probe.go
@@ -3,7 +3,6 @@ package gatewaytest
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -76,7 +75,7 @@ func RequireHTMLBodyContains(t *testing.T, ctx context.Context, probeURL string,
 	defer resp.Body.Close()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := gateway.ReadResponseBody(resp)
 	require.NoError(t, err)
 	require.Contains(t, string(body), marker, fmt.Sprintf("page %s missing marker %q", probeURL, marker))
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

HTML store gateways that use `PrepareOutboundRequest` with `OutboundStyleHTML` were parsing gzip-compressed response bodies directly. That header disables Go's automatic decompression, so goquery saw binary data and returned zero cards.

## Affected gateways

| Gateway | Status |
|---------|--------|
| **Dueller's Point** | Fixed — was returning 0 cards |
| **5 Mana** | Fixed — same bug pattern |
| All other 18 store gateways | Already safe |

## Full audit results

**Fixed in this PR:**
- `duellerpoint/search.go` — `goquery.NewDocumentFromReader(resp.Body)` → `ReadResponseBody` + `strings.NewReader`
- `fivemana/search.go` — same fix
- `gatewaytest/html_probe.go` `RequireHTMLBodyContains` — test helper had the same issue

**Already safe (no change needed):**
- **Colly-based** (Agora, 11 BinderPOS stores) — colly decompresses gzip in its HTTP backend before `OnHTML`
- **JSON APIs** using `PrepareOutboundRequest{}` or `OutboundStyleJSON` (Cards Central, Mox & Lotus, Cards & Collections, Card Kingdom, Shopify suggest stores) — no manual `Accept-Encoding: gzip`
- **Already using `ReadResponseBody`** (TCG Marketplace, Cards & Collections, shopifysuggest retry, scryfall verify, binderpos structure probe, `RequireHTMLStructure`)

## Root cause

`PrepareOutboundRequest` sets `Accept-Encoding: gzip` for HTML requests. Go's `net/http` does not auto-decompress when that header is set manually — callers must use `gateway.ReadResponseBody`.

## Verification

- Dueller's Point "Abrade" → 10 in-stock cards
- 5 Mana "Lightning Bolt" → 7 in-stock cards (0 before fix when response is gzip)
- `go test -mod=vendor -failfast -timeout 5m ./gateway/... ./controller/...` passes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4555d7ca-2091-4324-b4f8-c240f4349211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4555d7ca-2091-4324-b4f8-c240f4349211"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

