### PR TITLE
Highlight active popular search when query matches

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -226,6 +226,7 @@ export default function App() {
           <TopSearchKeywords
             keywordsByPeriod={topSearchKeywordsByPeriod}
             isLoading={isLoadingTopSearchKeywords}
+            searchQuery={searchQuery}
             collapsible
             collapseOnSearch={isSearching}
             defaultExpanded={

--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -119,9 +119,25 @@ function getDisplayLimit(isDesktop, showAllKeywords) {
     : TOP_SEARCH_KEYWORDS_MOBILE_DISPLAY_LIMIT;
 }
 
+function isMatchingPopularSearch(keyword, searchQuery) {
+  const normalizedKeyword = String(keyword ?? "")
+    .trim()
+    .toLowerCase();
+  const normalizedQuery = String(searchQuery ?? "")
+    .trim()
+    .toLowerCase();
+
+  return (
+    normalizedKeyword.length > 0 &&
+    normalizedQuery.length > 0 &&
+    normalizedKeyword === normalizedQuery
+  );
+}
+
 export default function TopSearchKeywords({
   keywordsByPeriod,
   isLoading,
+  searchQuery = "",
   collapsible = false,
   collapseOnSearch = false,
   defaultExpanded = false,
@@ -212,17 +228,27 @@ export default function TopSearchKeywords({
           ) : keywords.length > 0 ? (
             <>
               <div className="popular-searches-pills">
-                {keywords.map((keyword) => (
-                  <a
-                    key={keyword}
-                    href={buildPopularSearchUrl(BASE_URL, keyword, period)}
-                    className="btn btn-sm popular-search-pill text-decoration-none"
-                    aria-label={`Search for ${keyword}`}
-                    onClick={() => handlePopularSearchClick(keyword)}
-                  >
-                    {keyword}
-                  </a>
-                ))}
+                {keywords.map((keyword) => {
+                  const isActive = isMatchingPopularSearch(
+                    keyword,
+                    searchQuery,
+                  );
+
+                  return (
+                    <a
+                      key={keyword}
+                      href={buildPopularSearchUrl(BASE_URL, keyword, period)}
+                      className={`btn btn-sm popular-search-pill text-decoration-none${
+                        isActive ? " is-active" : ""
+                      }`}
+                      aria-label={`Search for ${keyword}`}
+                      aria-current={isActive ? "page" : undefined}
+                      onClick={() => handlePopularSearchClick(keyword)}
+                    >
+                      {keyword}
+                    </a>
+                  );
+                })}
               </div>
               {hasMoreKeywords && (
                 <button

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -623,8 +623,14 @@ ins.adsbygoogle.adsbygoogle-noablate {
   color: var(--bs-secondary-color);
 }
 
-.popular-search-pill:hover,
-.popular-search-pill:focus-visible {
+.popular-search-pill.is-active {
+  background-color: var(--bs-primary);
+  border-color: var(--bs-primary);
+  color: var(--bs-white);
+}
+
+.popular-search-pill:hover:not(.is-active),
+.popular-search-pill:focus-visible:not(.is-active) {
   background-color: rgba(var(--bs-primary-rgb), 0.15);
   border-color: var(--bs-primary);
   color: var(--bs-primary);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When the current search query matches one of the visible popular search pills, that pill is shown in an active state so users can see their search is a popular term.

## Changes

- Pass `searchQuery` from `App` into `TopSearchKeywords`
- Compare each pill keyword to the current query (trimmed, case-insensitive)
- Apply `is-active` styling and `aria-current="page"` on the matching pill
- Add CSS for the active pill, consistent with the period toggle buttons

## Screenshots

### Desktop

![Popular search active state on desktop](https://cursor.com/artifacts/c/art-888b10ec-717a-4c7e-824b-03cceb141e18)

### Mobile

![Popular search active state on mobile](https://cursor.com/artifacts/c/art-f19b8522-2761-4ce9-b056-c6d38b6ea976)

## Testing

- `make test`
- `cd frontend && npm run lint` (format fix applied to `TopSearchKeywords.jsx`)
- Manual verification via local dev server with `?s=The Mind Stone` and expanded popular searches panel
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6bdc2c2c-f5e4-495e-af58-228d755fc7bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6bdc2c2c-f5e4-495e-af58-228d755fc7bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

