### PR TITLE
fix(fivemana): skip sold-out listings in search results

### DIFF
--- a/api/gateway/fivemana/fixtures_test.go
+++ b/api/gateway/fivemana/fixtures_test.go
@@ -1,0 +1,56 @@
+package fivemana
+
+const soldOutProductHTML = `
+<ul class="grid product-grid">
+<li class="grid__item">
+<div class="card-wrapper product-card-wrapper">
+  <div class="card card--standard card--media">
+    <div class="card__inner">
+      <div class="card__media">
+        <img src="//5-mana.sg/cdn/shop/files/ten-rings.png" alt="The Ten Rings [Marvel Super Heroes]">
+      </div>
+      <div class="card__content">
+        <div class="card__badge bottom left"><span class="badge badge--bottom-left">Sold out</span></div>
+      </div>
+    </div>
+    <div class="card__content">
+      <h3 class="card__heading h5">
+        <a href="/products/the-ten-rings-marvel-super-heroes">The Ten Rings [Marvel Super Heroes]</a>
+      </h3>
+      <div class="price price--sold-out">
+        <div class="price__sale">
+          <span class="price-item price-item--sale price-item--last">$9.90 SGD</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+</li>
+</ul>
+`
+
+const inStockProductHTML = `
+<ul class="grid product-grid">
+<li class="grid__item">
+<div class="card-wrapper product-card-wrapper">
+  <div class="card card--standard card--media">
+    <div class="card__inner">
+      <div class="card__media">
+        <img src="//5-mana.sg/cdn/shop/files/abrade.png" alt="Abrade [Foundations]">
+      </div>
+    </div>
+    <div class="card__content">
+      <h3 class="card__heading h5">
+        <a href="/products/abrade-foundations">Abrade [Foundations]</a>
+      </h3>
+      <div class="price">
+        <div class="price__sale">
+          <span class="price-item price-item--sale price-item--last">$0.40 SGD</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+</li>
+</ul>
+`

--- a/api/gateway/fivemana/search.go
+++ b/api/gateway/fivemana/search.go
@@ -73,40 +73,50 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 	}
 
 	doc.Find("ul.product-grid li").Each(func(i int, se *goquery.Selection) {
-		c := gateway.Card{
-			Source: s.Name,
-		}
-
-		// name e.g. Rhystic Study (Anime Borderless) [Wilds of Eldraine: Enchanting Tales] [Foil]
-		c.Name = strings.TrimSpace(strings.Replace(se.Find("h3.card__heading.h5 a").Text(), "[Foil]", "", -1))
-
-		c.IsFoil = strings.Contains(strings.ToLower(se.Find("h3.card__heading.h5 a").Text()), "[foil]")
-
-		c.Url = StoreBaseURL + se.Find("h3.card__heading a").AttrOr("href", "")
-		c.Img = se.Find("div.card__media img").AttrOr("src", "")
-		c.InStock = true
-
-		price, err := util.ParsePrice(se.Find("span.price-item.price-item--sale.price-item--last").Text())
-		if err != nil {
-			c.InStock = false
-		}
-		c.Price = price
-
-		// url
-		cleanPageURL, err := url.Parse(c.Url)
-		if err != nil {
-			log.Printf("error parsing url for %s with value [%s]: %v", s.Name, c.Url, err)
-			return
-		}
-		cleanPageURL.RawQuery = url.Values{
-			"utm_source": []string{config.UtmSource},
-		}.Encode()
-		c.Url = cleanPageURL.String()
-
-		if c.Name != "" && c.InStock {
-			cards = append(cards, c)
+		card, ok := parseProductCard(se, s.Name)
+		if ok {
+			cards = append(cards, card)
 		}
 	})
 
 	return cards, nil
+}
+
+func parseProductCard(se *goquery.Selection, storeName string) (gateway.Card, bool) {
+	// Shopify's availability filter can still surface sold-out listings; the theme
+	// marks them with price--sold-out and a "Sold out" badge.
+	if se.Find("div.price.price--sold-out").Length() > 0 {
+		return gateway.Card{}, false
+	}
+
+	c := gateway.Card{
+		Source: storeName,
+	}
+
+	// name e.g. Rhystic Study (Anime Borderless) [Wilds of Eldraine: Enchanting Tales] [Foil]
+	heading := se.Find("h3.card__heading.h5 a")
+	c.Name = strings.TrimSpace(strings.Replace(heading.Text(), "[Foil]", "", -1))
+	c.IsFoil = strings.Contains(strings.ToLower(heading.Text()), "[foil]")
+
+	c.Url = StoreBaseURL + se.Find("h3.card__heading a").AttrOr("href", "")
+	c.Img = se.Find("div.card__media img").AttrOr("src", "")
+	c.InStock = true
+
+	price, err := util.ParsePrice(se.Find("span.price-item.price-item--sale.price-item--last").Text())
+	if err != nil {
+		c.InStock = false
+	}
+	c.Price = price
+
+	cleanPageURL, err := url.Parse(c.Url)
+	if err != nil {
+		log.Printf("error parsing url for %s with value [%s]: %v", storeName, c.Url, err)
+		return gateway.Card{}, false
+	}
+	cleanPageURL.RawQuery = url.Values{
+		"utm_source": []string{config.UtmSource},
+	}.Encode()
+	c.Url = cleanPageURL.String()
+
+	return c, c.Name != "" && c.InStock
 }

--- a/api/gateway/fivemana/search_test.go
+++ b/api/gateway/fivemana/search_test.go
@@ -2,10 +2,34 @@ package fivemana
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"mtg-price-checker-sg/gateway/gatewaytest"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/stretchr/testify/require"
 )
+
+func Test_ParseProductCardSkipsSoldOut(t *testing.T) {
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(soldOutProductHTML))
+	require.NoError(t, err)
+
+	card, ok := parseProductCard(doc.Find("ul.product-grid li").First(), StoreName)
+	require.False(t, ok, "sold-out listing should be skipped")
+	require.Empty(t, card.Name)
+}
+
+func Test_ParseProductCardKeepsInStock(t *testing.T) {
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(inStockProductHTML))
+	require.NoError(t, err)
+
+	card, ok := parseProductCard(doc.Find("ul.product-grid li").First(), StoreName)
+	require.True(t, ok)
+	require.Equal(t, "Abrade [Foundations]", card.Name)
+	require.True(t, card.InStock)
+	require.Equal(t, 0.40, card.Price)
+}
 
 func Test_Search(t *testing.T) {
 	s := NewLGS()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

5 Mana search was returning out-of-stock cards (e.g. **The Ten Rings**) even though the gateway already requests `filter.v.availability=1`. Shopify's search page still lists sold-out products with a visible price, so the scraper treated them as purchasable.

This change detects the theme's `price--sold-out` marker on each product card and skips those listings.

## Root cause

- The availability URL filter does not fully exclude sold-out products on 5-mana.sg.
- Sold-out cards still expose a price in `span.price-item--sale`, so the previous logic (`InStock = true` unless price parsing fails) incorrectly kept them.

## Fix

- Extract card parsing into `parseProductCard`.
- Skip cards whose price container has the `price--sold-out` class.
- Add fixture-based unit tests for sold-out vs in-stock HTML snippets.

## Validation

- `go test -mod=vendor ./gateway/fivemana/...` — pass
- `make test` — pass
- Live check: searching "The Ten Rings" now returns only in-stock related results (e.g. Shang-Chi and the Ten Rings Commander); the sold-out single is omitted.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c57b9256-30f5-4222-a193-226701a6e79c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c57b9256-30f5-4222-a193-226701a6e79c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

