### PR TITLE
Fix in-feed ads shifting when post-search sort changes

### DIFF
--- a/frontend/src/components/AdComponent.jsx
+++ b/frontend/src/components/AdComponent.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 import { ADSENSE_CLIENT, ADSENSE_DISPLAY_AD_SLOT } from "../constants";
 
 const UNFILLED_COLLAPSE_MS = 2000;
@@ -67,202 +67,208 @@ function canFallbackToDisplay({ fallbackSlot, layoutKey, useFallback }) {
   return Boolean(fallbackSlot && layoutKey && !useFallback);
 }
 
-const AdComponent = ({
-  lazyLoad = false,
-  collapseWhenUnfilled = true,
-  slot = ADSENSE_DISPLAY_AD_SLOT,
-  layoutKey,
-  fallbackSlot,
-}) => {
-  const containerRef = useRef(null);
-  const insRef = useRef(null);
-  const fallbackLoggedRef = useRef(false);
-  const [collapsed, setCollapsed] = useState(false);
-  const [isFilled, setIsFilled] = useState(false);
-  const [isNearViewport, setIsNearViewport] = useState(!lazyLoad);
-  const [useFallback, setUseFallback] = useState(false);
-
-  const activeSlot = useFallback && fallbackSlot ? fallbackSlot : slot;
-  const activeLayoutKey = useFallback ? undefined : layoutKey;
-  const isInFeedFormat = Boolean(activeLayoutKey);
-
-  useEffect(() => {
-    if (!lazyLoad) return;
-
-    const containerEl = containerRef.current;
-    if (!containerEl) return;
-
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          setIsNearViewport(true);
-          observer.disconnect();
-        }
-      },
-      { rootMargin: LAZY_LOAD_ROOT_MARGIN },
-    );
-
-    observer.observe(containerEl);
-
-    return () => observer.disconnect();
-  }, [lazyLoad]);
-
-  // Re-run when switching to display fallback so adsbygoogle.push targets the new <ins>.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: useFallback remounts the ad slot.
-  useEffect(() => {
-    if (!isNearViewport) return;
-
-    const insEl = insRef.current;
-    if (!insEl) return;
-
-    let cancelled = false;
-
-    const cleanupWait = waitForAdSenseScript(() => {
-      if (cancelled) return;
-      pushAdSlot(insEl);
-    });
-
-    return () => {
-      cancelled = true;
-      cleanupWait();
-    };
-  }, [isNearViewport, useFallback]);
-
-  useEffect(() => {
-    if (!collapseWhenUnfilled || !isNearViewport) return;
-
-    const insEl = insRef.current;
-    if (!insEl) return;
-
-    let cancelled = false;
-    const collapseMs = lazyLoad
-      ? LAZY_UNFILLED_COLLAPSE_MS
-      : UNFILLED_COLLAPSE_MS;
-
-    const tryDisplayFallback = (reason) => {
-      if (canFallbackToDisplay({ fallbackSlot, layoutKey, useFallback })) {
-        if (!fallbackLoggedRef.current) {
-          console.info(
-            "[AdComponent] In-feed ad unfilled; falling back to display ad",
-            {
-              reason,
-              inFeedSlot: slot,
-              displaySlot: fallbackSlot,
-              lazyLoad,
-            },
-          );
-          fallbackLoggedRef.current = true;
-        }
-        setUseFallback(true);
-        setIsFilled(false);
-        return true;
-      }
-      return false;
-    };
-
-    const maybeCollapse = () => {
-      if (cancelled) return;
-
-      const adStatus = insEl.getAttribute("data-ad-status");
-      if (adStatus === "unfilled") {
-        if (tryDisplayFallback("unfilled")) return;
-        setCollapsed(true);
-        setIsFilled(false);
-        return;
-      }
-
-      if (hasFilledAd(insEl)) {
-        setCollapsed(false);
-        setIsFilled(true);
-      }
-    };
-
-    maybeCollapse();
-
-    const timeoutId = window.setTimeout(() => {
-      if (cancelled) return;
-      if (!hasFilledAd(insEl)) {
-        if (tryDisplayFallback("timeout")) return;
-        setCollapsed(true);
-      }
-    }, collapseMs);
-
-    const observer = new MutationObserver(maybeCollapse);
-    observer.observe(insEl, {
-      childList: true,
-      subtree: true,
-      attributes: true,
-      attributeFilter: ["data-ad-status", "data-adsbygoogle-status"],
-    });
-
-    return () => {
-      cancelled = true;
-      window.clearTimeout(timeoutId);
-      observer.disconnect();
-    };
-  }, [
-    collapseWhenUnfilled,
-    isNearViewport,
-    lazyLoad,
-    useFallback,
-    fallbackSlot,
+const AdComponent = memo(
+  ({
+    lazyLoad = false,
+    collapseWhenUnfilled = true,
+    slot = ADSENSE_DISPLAY_AD_SLOT,
     layoutKey,
-    slot,
-  ]);
+    fallbackSlot,
+  }) => {
+    const containerRef = useRef(null);
+    const insRef = useRef(null);
+    const fallbackLoggedRef = useRef(false);
+    const [collapsed, setCollapsed] = useState(false);
+    const [isFilled, setIsFilled] = useState(false);
+    const [isNearViewport, setIsNearViewport] = useState(!lazyLoad);
+    const [useFallback, setUseFallback] = useState(false);
 
-  if (collapsed) return null;
+    const activeSlot = useFallback && fallbackSlot ? fallbackSlot : slot;
+    const activeLayoutKey = useFallback ? undefined : layoutKey;
+    const isInFeedFormat = Boolean(activeLayoutKey);
 
-  if (lazyLoad && !isNearViewport) {
+    useEffect(() => {
+      if (!lazyLoad) return;
+
+      const containerEl = containerRef.current;
+      if (!containerEl) return;
+
+      const observer = new IntersectionObserver(
+        ([entry]) => {
+          if (entry.isIntersecting) {
+            setIsNearViewport(true);
+            observer.disconnect();
+          }
+        },
+        { rootMargin: LAZY_LOAD_ROOT_MARGIN },
+      );
+
+      observer.observe(containerEl);
+
+      return () => observer.disconnect();
+    }, [lazyLoad]);
+
+    // Re-run when switching to display fallback so adsbygoogle.push targets the new <ins>.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: useFallback remounts the ad slot.
+    useEffect(() => {
+      if (!isNearViewport) return;
+
+      const insEl = insRef.current;
+      if (!insEl) return;
+
+      let cancelled = false;
+
+      const cleanupWait = waitForAdSenseScript(() => {
+        if (cancelled) return;
+        pushAdSlot(insEl);
+      });
+
+      return () => {
+        cancelled = true;
+        cleanupWait();
+      };
+    }, [isNearViewport, useFallback]);
+
+    useEffect(() => {
+      if (!collapseWhenUnfilled || !isNearViewport) return;
+
+      const insEl = insRef.current;
+      if (!insEl) return;
+
+      let cancelled = false;
+      const collapseMs = lazyLoad
+        ? LAZY_UNFILLED_COLLAPSE_MS
+        : UNFILLED_COLLAPSE_MS;
+
+      const tryDisplayFallback = (reason) => {
+        if (canFallbackToDisplay({ fallbackSlot, layoutKey, useFallback })) {
+          if (!fallbackLoggedRef.current) {
+            console.info(
+              "[AdComponent] In-feed ad unfilled; falling back to display ad",
+              {
+                reason,
+                inFeedSlot: slot,
+                displaySlot: fallbackSlot,
+                lazyLoad,
+              },
+            );
+            fallbackLoggedRef.current = true;
+          }
+          setUseFallback(true);
+          setIsFilled(false);
+          return true;
+        }
+        return false;
+      };
+
+      const maybeCollapse = () => {
+        if (cancelled) return;
+
+        const adStatus = insEl.getAttribute("data-ad-status");
+        if (adStatus === "unfilled") {
+          if (tryDisplayFallback("unfilled")) return;
+          setCollapsed(true);
+          setIsFilled(false);
+          return;
+        }
+
+        if (hasFilledAd(insEl)) {
+          setCollapsed(false);
+          setIsFilled(true);
+        }
+      };
+
+      maybeCollapse();
+
+      const timeoutId = window.setTimeout(() => {
+        if (cancelled) return;
+        if (!hasFilledAd(insEl)) {
+          if (tryDisplayFallback("timeout")) return;
+          setCollapsed(true);
+        }
+      }, collapseMs);
+
+      const observer = new MutationObserver(maybeCollapse);
+      observer.observe(insEl, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ["data-ad-status", "data-adsbygoogle-status"],
+      });
+
+      return () => {
+        cancelled = true;
+        window.clearTimeout(timeoutId);
+        observer.disconnect();
+      };
+    }, [
+      collapseWhenUnfilled,
+      isNearViewport,
+      lazyLoad,
+      useFallback,
+      fallbackSlot,
+      layoutKey,
+      slot,
+    ]);
+
+    if (collapsed) return null;
+
+    if (lazyLoad && !isNearViewport) {
+      return (
+        <div
+          ref={containerRef}
+          className="ad-large d-print-none w-100"
+          style={{ height: 1, overflow: "hidden" }}
+          aria-hidden="true"
+        />
+      );
+    }
+
     return (
       <div
         ref={containerRef}
-        className="ad-large d-print-none w-100"
-        style={{ height: 1, overflow: "hidden" }}
-        aria-hidden="true"
-      />
-    );
-  }
-
-  return (
-    <div
-      ref={containerRef}
-      className="ad-large text-center d-print-none d-block d-sm-block w-100"
-      style={{ overflow: "hidden" }}
-    >
-      {isFilled && (
-        <div className="text-center mb-2" style={{ fontSize: "11px" }}>
-          <a
-            href="https://www.patreon.com/GishathFetch"
-            target="_blank"
-            rel="noreferrer"
-          >
-            Follow / Support Gishath Fetch on Patreon
-          </a>
-        </div>
-      )}
-      <div
-        className={isFilled ? "ad-slot-filled" : "ad-slot-pending"}
+        className="ad-large text-center d-print-none d-block d-sm-block w-100"
         style={{ overflow: "hidden" }}
       >
-        <ins
-          key={useFallback ? "display-fallback" : "primary"}
-          ref={insRef}
-          className="adsbygoogle"
-          style={{ display: "block", width: "100%", maxWidth: "100%" }}
-          data-ad-client={ADSENSE_CLIENT}
-          data-ad-slot={activeSlot}
-          data-ad-format={isInFeedFormat ? "fluid" : "auto"}
-          data-full-width-responsive={isInFeedFormat ? undefined : "true"}
-          {...(isInFeedFormat ? { "data-ad-layout-key": activeLayoutKey } : {})}
-        ></ins>
-      </div>
-      {isFilled && (
-        <div className="text-secondary" style={{ fontSize: "11px" }}>
-          Advertisement
+        {isFilled && (
+          <div className="text-center mb-2" style={{ fontSize: "11px" }}>
+            <a
+              href="https://www.patreon.com/GishathFetch"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Follow / Support Gishath Fetch on Patreon
+            </a>
+          </div>
+        )}
+        <div
+          className={isFilled ? "ad-slot-filled" : "ad-slot-pending"}
+          style={{ overflow: "hidden" }}
+        >
+          <ins
+            key={useFallback ? "display-fallback" : "primary"}
+            ref={insRef}
+            className="adsbygoogle"
+            style={{ display: "block", width: "100%", maxWidth: "100%" }}
+            data-ad-client={ADSENSE_CLIENT}
+            data-ad-slot={activeSlot}
+            data-ad-format={isInFeedFormat ? "fluid" : "auto"}
+            data-full-width-responsive={isInFeedFormat ? undefined : "true"}
+            {...(isInFeedFormat
+              ? { "data-ad-layout-key": activeLayoutKey }
+              : {})}
+          ></ins>
         </div>
-      )}
-    </div>
-  );
-};
+        {isFilled && (
+          <div className="text-secondary" style={{ fontSize: "11px" }}>
+            Advertisement
+          </div>
+        )}
+      </div>
+    );
+  },
+);
+
+AdComponent.displayName = "AdComponent";
 
 export default AdComponent;

--- a/frontend/src/components/SearchResults.jsx
+++ b/frontend/src/components/SearchResults.jsx
@@ -7,6 +7,11 @@ import {
 } from "../constants";
 import useMediaQuery from "../hooks/useMediaQuery";
 import useResultFilters from "../hooks/useResultFilters";
+import {
+  buildSearchResultFeedItems,
+  computeInFeedAdSlots,
+  searchResultCardKey,
+} from "../utils/searchResultFeed";
 import AdComponent from "./AdComponent";
 import Card from "./Card";
 import CardKingdomPrice from "./CardKingdomPrice";
@@ -87,37 +92,41 @@ const SearchResults = ({
     ? MAX_IN_FEED_ADS_DESKTOP
     : MAX_IN_FEED_ADS_MOBILE;
 
-  const inFeedAdSlots = useMemo(() => {
-    if (filteredResults.length <= adDisplayInterval) {
-      return [];
-    }
-
-    const slots = [];
-    for (let i = 0; i < filteredResults.length; i++) {
-      const position = i + 1;
-      if (
-        position % adDisplayInterval !== 0 ||
-        position === filteredResults.length
-      ) {
-        continue;
-      }
-      if (slots.length >= maxInFeedAds) break;
-      slots.push({ cardIndex: i, slotIndex: slots.length });
-    }
-    return slots;
-  }, [filteredResults.length, adDisplayInterval, maxInFeedAds]);
-
-  const inFeedAdSlotIndices = useMemo(
-    () => new Set(inFeedAdSlots.map(({ cardIndex }) => cardIndex)),
-    [inFeedAdSlots],
+  const inFeedAdSlots = useMemo(
+    () =>
+      computeInFeedAdSlots(
+        filteredResults.length,
+        adDisplayInterval,
+        maxInFeedAds,
+      ),
+    [filteredResults.length, adDisplayInterval, maxInFeedAds],
   );
 
-  const inFeedAdSlotIndexByCard = useMemo(() => {
-    const slotIndexByCard = new Map();
-    for (const { cardIndex, slotIndex } of inFeedAdSlots) {
-      slotIndexByCard.set(cardIndex, slotIndex);
+  const resultFeedItems = useMemo(
+    () =>
+      buildSearchResultFeedItems(filteredResults, {
+        adDisplayInterval,
+        maxInFeedAds,
+      }),
+    [filteredResults, adDisplayInterval, maxInFeedAds],
+  );
+
+  const inFeedAdElementsBySlot = useMemo(() => {
+    const elementsBySlot = new Map();
+    for (const { slotIndex } of inFeedAdSlots) {
+      elementsBySlot.set(
+        slotIndex,
+        <div key={`in-feed-ad-${slotIndex}`} className="col-12 mb-4">
+          <AdComponent
+            lazyLoad={slotIndex !== 0}
+            slot={ADSENSE_IN_FEED_AD_SLOT}
+            layoutKey={ADSENSE_IN_FEED_LAYOUT_KEY}
+            fallbackSlot={ADSENSE_DISPLAY_AD_SLOT}
+          />
+        </div>,
+      );
     }
-    return slotIndexByCard;
+    return elementsBySlot;
   }, [inFeedAdSlots]);
 
   const resultsAnchorRef = useRef(null);
@@ -211,41 +220,24 @@ const SearchResults = ({
                 ) : (
                   <div id="result" className="mb-3 text-center">
                     <div className="row">
-                      {filteredResults.flatMap((card, i) => {
-                        const cardKey = `${card.src}-${card.url}-${card.price}-${card.quality}`;
-                        const items = [
+                      {resultFeedItems.map((item) => {
+                        if (item.type === "ad") {
+                          return inFeedAdElementsBySlot.get(item.slotIndex);
+                        }
+
+                        return (
                           <Card
-                            key={cardKey}
-                            card={card}
-                            index={i}
+                            key={searchResultCardKey(item.card)}
+                            card={item.card}
+                            index={item.cardIndex}
                             isCardInCart={isCardInCart}
                             addToCart={addToCart}
                             removeFromCart={removeFromCart}
                             removeFromCartByCard={removeFromCartByCard}
                             onSearchStore={onSearchStore}
                             baseUrl={baseUrl}
-                          />,
-                        ];
-
-                        if (inFeedAdSlotIndices.has(i)) {
-                          const inFeedSlotIndex =
-                            inFeedAdSlotIndexByCard.get(i);
-                          items.push(
-                            <div
-                              key={`in-feed-ad-${inFeedSlotIndex}`}
-                              className="col-12 mb-4"
-                            >
-                              <AdComponent
-                                lazyLoad={inFeedSlotIndex !== 0}
-                                slot={ADSENSE_IN_FEED_AD_SLOT}
-                                layoutKey={ADSENSE_IN_FEED_LAYOUT_KEY}
-                                fallbackSlot={ADSENSE_DISPLAY_AD_SLOT}
-                              />
-                            </div>,
-                          );
-                        }
-
-                        return items;
+                          />
+                        );
                       })}
                     </div>
                   </div>

--- a/frontend/src/utils/searchResultFeed.js
+++ b/frontend/src/utils/searchResultFeed.js
@@ -1,0 +1,53 @@
+import { cardIdentityKey } from "./cardIdentity.js";
+
+export function searchResultCardKey(card) {
+  return `${cardIdentityKey(card)}-${card.url}-${card.price}`;
+}
+
+export function computeInFeedAdSlots(
+  resultCount,
+  adDisplayInterval,
+  maxInFeedAds,
+) {
+  if (resultCount <= adDisplayInterval) {
+    return [];
+  }
+
+  const slots = [];
+  for (let cardIndex = 0; cardIndex < resultCount; cardIndex++) {
+    const position = cardIndex + 1;
+    if (position % adDisplayInterval !== 0 || position === resultCount) {
+      continue;
+    }
+    if (slots.length >= maxInFeedAds) {
+      break;
+    }
+    slots.push({ cardIndex, slotIndex: slots.length });
+  }
+  return slots;
+}
+
+export function buildSearchResultFeedItems(
+  cards,
+  { adDisplayInterval, maxInFeedAds },
+) {
+  const adSlots = computeInFeedAdSlots(
+    cards.length,
+    adDisplayInterval,
+    maxInFeedAds,
+  );
+  const adSlotIndexByCard = new Map(
+    adSlots.map(({ cardIndex, slotIndex }) => [cardIndex, slotIndex]),
+  );
+
+  const items = [];
+  for (let cardIndex = 0; cardIndex < cards.length; cardIndex++) {
+    items.push({ type: "card", card: cards[cardIndex], cardIndex });
+
+    const slotIndex = adSlotIndexByCard.get(cardIndex);
+    if (slotIndex !== undefined) {
+      items.push({ type: "ad", slotIndex });
+    }
+  }
+  return items;
+}

--- a/frontend/src/utils/searchResultFeed.test.js
+++ b/frontend/src/utils/searchResultFeed.test.js
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import {
+  buildSearchResultFeedItems,
+  computeInFeedAdSlots,
+} from "./searchResultFeed.js";
+
+const feedAdIndices = (feedItems) =>
+  feedItems
+    .map((item, index) => (item.type === "ad" ? index : -1))
+    .filter((index) => index >= 0);
+
+assert.deepEqual(computeInFeedAdSlots(32, 8, 3), [
+  { cardIndex: 7, slotIndex: 0 },
+  { cardIndex: 15, slotIndex: 1 },
+  { cardIndex: 23, slotIndex: 2 },
+]);
+
+assert.deepEqual(computeInFeedAdSlots(24, 8, 3), [
+  { cardIndex: 7, slotIndex: 0 },
+  { cardIndex: 15, slotIndex: 1 },
+]);
+
+assert.deepEqual(computeInFeedAdSlots(8, 8, 3), []);
+assert.deepEqual(computeInFeedAdSlots(9, 8, 3), [
+  { cardIndex: 7, slotIndex: 0 },
+]);
+
+const cards = Array.from({ length: 20 }, (_, id) => ({ id }));
+const feedOptions = { adDisplayInterval: 8, maxInFeedAds: 3 };
+const ascendingFeed = buildSearchResultFeedItems(cards, feedOptions);
+const descendingFeed = buildSearchResultFeedItems(
+  [...cards].reverse(),
+  feedOptions,
+);
+
+assert.deepEqual(feedAdIndices(ascendingFeed), feedAdIndices(descendingFeed));
+assert.deepEqual(feedAdIndices(ascendingFeed), [8, 17]);
+
+const shuffledCards = [
+  cards[3],
+  cards[0],
+  cards[19],
+  ...cards.slice(4, 19),
+  cards[1],
+  cards[2],
+];
+const shuffledFeed = buildSearchResultFeedItems(shuffledCards, feedOptions);
+assert.deepEqual(feedAdIndices(shuffledFeed), feedAdIndices(ascendingFeed));
+
+console.log("searchResultFeed tests passed");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When changing the post-search **Sort by** control (price low/high), in-feed ads could appear to jump in the results feed. Ads are meant to stay at fixed positions (every 8 cards on desktop, every 4 on mobile), while only the cards around them reorder.

This change makes ad placement and rendering more stable across sort changes.

## Cause

In-feed ads were already decoupled from card `Fragment` keys (see #228), but each sort still recreated fresh `AdComponent` React elements inside `flatMap`. That could remount AdSense slots and cause visible shifting/reloading when cards reordered.

## Fix

- Extract feed planning into `searchResultFeed.js` (`computeInFeedAdSlots`, `buildSearchResultFeedItems`, `searchResultCardKey`)
- Render from an explicit feed item list (card / ad entries)
- Memoize in-feed ad elements so they only change when result count or ad interval changes — not when sort order changes
- Wrap `AdComponent` in `React.memo` to avoid unnecessary re-renders when cards reorder
- Add unit tests verifying ad feed indices stay fixed when cards are reordered

## Test plan

- [x] `node frontend/src/utils/searchResultFeed.test.js`
- [x] `cd frontend && npm run lint`
- [ ] Manual: run a search with 16+ results, note in-feed ad positions, toggle **Sort by** between price low/high — ads should stay at the same feed positions while cards reorder
- [ ] Manual: toggle filters that change result count (e.g. cheapest per store) — ad slots may add/remove as before when count changes

## Screenshots

No visible layout change on initial render; this is a behavioral stability fix when toggling sort. Ads should remain at the same positions in the feed after sort changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9c90888-8348-4ece-8177-82344852f0e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9c90888-8348-4ece-8177-82344852f0e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

