### PR TITLE
Add card name asc/desc sort options to saved cards list

### DIFF
--- a/frontend/src/components/CartOffcanvas.jsx
+++ b/frontend/src/components/CartOffcanvas.jsx
@@ -23,8 +23,33 @@ const CartOffcanvas = ({
     }
   };
 
+  const displayedCart = useMemo(() => {
+    const withIndex = cart.map((card, index) => ({
+      ...card,
+      originalIndex: index,
+    }));
+
+    if (sortOption === "name-asc") {
+      return [...withIndex].sort((a, b) =>
+        (a.name || "").localeCompare(b.name || "", undefined, {
+          sensitivity: "base",
+        }),
+      );
+    }
+
+    if (sortOption === "name-desc") {
+      return [...withIndex].sort((a, b) =>
+        (b.name || "").localeCompare(a.name || "", undefined, {
+          sensitivity: "base",
+        }),
+      );
+    }
+
+    return withIndex;
+  }, [cart, sortOption]);
+
   const groupedCart = useMemo(() => {
-    if (sortOption === "default") return null;
+    if (sortOption !== "store") return null;
 
     const groups = {};
     cart.forEach((card, index) => {
@@ -61,6 +86,8 @@ const CartOffcanvas = ({
               size="sm"
             >
               <option value="default">Saved Order</option>
+              <option value="name-asc">Card Name Asc</option>
+              <option value="name-desc">Card Name Desc</option>
               <option value="store">Store</option>
             </Form.Select>
           </Form.Group>
@@ -68,14 +95,15 @@ const CartOffcanvas = ({
 
         {cart.length > 0 ? (
           <>
-            {sortOption === "default" && (
+            {(sortOption === "default" ||
+              sortOption === "name-asc" ||
+              sortOption === "name-desc") && (
               <div className="row">
-                {cart.map((card, i) => (
+                {displayedCart.map((card) => (
                   <Card
-                    // biome-ignore lint/suspicious/noArrayIndexKey: Cart items do not have unique IDs
-                    key={i}
+                    key={card.originalIndex}
                     card={card}
-                    index={i}
+                    index={card.originalIndex}
                     isCart={true}
                     isCardInCart={isCardInCart}
                     removeFromCart={removeFromCart}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **Card Name Asc** and **Card Name Desc** to the Saved Cards sort dropdown, alongside the existing Saved Order and Store options.

Sorting is case-insensitive via `localeCompare` and preserves each card's original cart index so remove/update actions still target the correct saved item.

## Changes

- `frontend/src/components/CartOffcanvas.jsx`
  - New sort options: `name-asc`, `name-desc`
  - Shared `displayedCart` memo for default and name-based sorts
  - Store grouping logic unchanged

## Screenshots

### Desktop — Card Name Asc selected

![Saved cards list sorted by card name ascending on desktop](https://cursor.com/artifacts/c/art-0276e543-8986-4ae4-8aeb-98277c75c293)

### Mobile — Card Name Asc selected

![Saved cards list sorted by card name ascending on mobile](https://cursor.com/artifacts/c/art-b5b15734-3cdf-4cd1-8673-5c4b7a73da78)

## Testing

- `npx biome check src/components/CartOffcanvas.jsx`
- Manual UI verification with sample saved cards (Arcane Signet, Lightning Bolt, Zombie Master) sorted A→Z
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e6da8378-5015-4ae9-a6e1-673f23ff7ff0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6da8378-5015-4ae9-a6e1-673f23ff7ff0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

