### PR TITLE
Fix MTG Asia and Grey Ogre Shopify price mismatches

### DIFF
--- a/api/gateway/gog/search.go
+++ b/api/gateway/gog/search.go
@@ -25,8 +25,9 @@ func NewLGS() gateway.LGS {
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
 	return shopifysuggest.Search(ctx, shopifysuggest.Options{
 		Config: shopifysuggest.Config{
-			StoreName: s.Name,
-			BaseURL:   s.BaseUrl,
+			StoreName:           s.Name,
+			BaseURL:             s.BaseUrl,
+			ShopifyLocalization: shopifysuggest.ShopifyLocalizationSingapore,
 		},
 		SearchStr:       searchStr,
 		BuildQuery:      shopifysuggest.PlainQuery,

--- a/api/gateway/mtgasia/search.go
+++ b/api/gateway/mtgasia/search.go
@@ -25,8 +25,9 @@ func NewLGS() gateway.LGS {
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
 	return shopifysuggest.Search(ctx, shopifysuggest.Options{
 		Config: shopifysuggest.Config{
-			StoreName: s.Name,
-			BaseURL:   s.BaseUrl,
+			StoreName:           s.Name,
+			BaseURL:             s.BaseUrl,
+			ShopifyLocalization: shopifysuggest.ShopifyLocalizationSingapore,
 		},
 		SearchStr:       searchStr,
 		BuildQuery:      shopifysuggest.PlainQuery,

--- a/api/gateway/shopifysuggest/proxy_fallback.go
+++ b/api/gateway/shopifysuggest/proxy_fallback.go
@@ -130,7 +130,7 @@ func newProxyClient(proxyURL string) (*http.Client, error) {
 }
 
 func fetchAndMapProducts(ctx context.Context, client *http.Client, apiURL string, opts Options) ([]gateway.Card, error) {
-	products, err := fetchProducts(ctx, client, apiURL)
+	products, err := fetchProducts(ctx, client, apiURL, suggestRequestOptsFromConfig(opts.Config))
 	if err != nil {
 		return nil, err
 	}

--- a/api/gateway/shopifysuggest/proxy_fallback_test.go
+++ b/api/gateway/shopifysuggest/proxy_fallback_test.go
@@ -36,7 +36,7 @@ func TestFetchProductsRateLimited(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := fetchProducts(context.Background(), srv.Client(), srv.URL)
+	_, err := fetchProducts(context.Background(), srv.Client(), srv.URL, suggestRequestOpts{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "429")
 	require.Equal(t, int32(suggestRetryMaxAttempts), calls.Load())
@@ -49,7 +49,7 @@ func TestFetchProductsSuccess(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	products, err := fetchProducts(context.Background(), srv.Client(), srv.URL)
+	products, err := fetchProducts(context.Background(), srv.Client(), srv.URL, suggestRequestOpts{})
 	require.NoError(t, err)
 	require.Len(t, products, 1)
 	require.Equal(t, "Opt", products[0].Title)
@@ -63,7 +63,7 @@ func TestFetchProductsSuccessGzip(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	products, err := fetchProducts(context.Background(), srv.Client(), srv.URL)
+	products, err := fetchProducts(context.Background(), srv.Client(), srv.URL, suggestRequestOpts{})
 	require.NoError(t, err)
 	require.Len(t, products, 1)
 	require.Equal(t, "Opt", products[0].Title)

--- a/api/gateway/shopifysuggest/retry.go
+++ b/api/gateway/shopifysuggest/retry.go
@@ -42,11 +42,20 @@ func isRetriableSuggestStatus(status int) bool {
 	return ok
 }
 
+// suggestRequestOpts configures outbound suggest and product-JSON GET requests.
+type suggestRequestOpts struct {
+	shopifyLocalization string
+}
+
+func suggestRequestOptsFromConfig(cfg Config) suggestRequestOpts {
+	return suggestRequestOpts{shopifyLocalization: cfg.ShopifyLocalization}
+}
+
 // doSuggestGETWithRetry sends a GET request, retrying transient rate-limit/5xx
 // responses and network errors with jittered exponential backoff bounded by
 // ctx. Each send uses a fresh User-Agent. On success it returns the response
 // body. On failure it returns the last observed error.
-func doSuggestGETWithRetry(ctx context.Context, client *http.Client, requestURL string) ([]byte, error) {
+func doSuggestGETWithRetry(ctx context.Context, client *http.Client, requestURL string, reqOpts suggestRequestOpts) ([]byte, error) {
 	var lastErr error
 
 	for attempt := 0; attempt < suggestRetryMaxAttempts; attempt++ {
@@ -61,6 +70,9 @@ func doSuggestGETWithRetry(ctx context.Context, client *http.Client, requestURL 
 			PageURL: pageURL,
 		}); err != nil {
 			return nil, err
+		}
+		if reqOpts.shopifyLocalization != "" {
+			req.AddCookie(&http.Cookie{Name: "localization", Value: reqOpts.shopifyLocalization})
 		}
 
 		resp, err := client.Do(req)

--- a/api/gateway/shopifysuggest/retry_test.go
+++ b/api/gateway/shopifysuggest/retry_test.go
@@ -101,7 +101,7 @@ func TestDoSuggestGETWithRetry_SucceedsAfter429WithRetryAfter(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), suggestAttemptTimeout)
 	defer cancel()
 
-	body, err := doSuggestGETWithRetry(ctx, server.Client(), server.URL)
+	body, err := doSuggestGETWithRetry(ctx, server.Client(), server.URL, suggestRequestOpts{})
 	if err != nil {
 		t.Fatalf("expected success after Retry-After retry, got %v", err)
 	}
@@ -128,7 +128,7 @@ func TestDoSuggestGETWithRetry_SucceedsAfterTransient503(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), suggestAttemptTimeout)
 	defer cancel()
 
-	_, err := doSuggestGETWithRetry(ctx, server.Client(), server.URL)
+	_, err := doSuggestGETWithRetry(ctx, server.Client(), server.URL, suggestRequestOpts{})
 	if err != nil {
 		t.Fatalf("expected success after retries, got %v", err)
 	}
@@ -148,7 +148,7 @@ func TestDoSuggestGETWithRetry_ExhaustsRetriesOnPersistent429(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), suggestAttemptTimeout)
 	defer cancel()
 
-	_, err := doSuggestGETWithRetry(ctx, server.Client(), server.URL)
+	_, err := doSuggestGETWithRetry(ctx, server.Client(), server.URL, suggestRequestOpts{})
 	if err == nil {
 		t.Fatal("expected error after exhausting retries")
 	}
@@ -157,6 +157,31 @@ func TestDoSuggestGETWithRetry_ExhaustsRetriesOnPersistent429(t *testing.T) {
 	}
 	if got := calls.Load(); got != int32(suggestRetryMaxAttempts) {
 		t.Fatalf("expected %d calls, got %d", suggestRetryMaxAttempts, got)
+	}
+}
+
+func TestDoSuggestGETWithRetry_SendsShopifyLocalizationCookie(t *testing.T) {
+	var gotCookie string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if c, err := r.Cookie("localization"); err == nil {
+			gotCookie = c.Value
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), suggestAttemptTimeout)
+	defer cancel()
+
+	_, err := doSuggestGETWithRetry(ctx, server.Client(), server.URL, suggestRequestOpts{
+		shopifyLocalization: ShopifyLocalizationSingapore,
+	})
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if gotCookie != ShopifyLocalizationSingapore {
+		t.Fatalf("expected localization cookie %q, got %q", ShopifyLocalizationSingapore, gotCookie)
 	}
 }
 
@@ -171,7 +196,7 @@ func TestDoSuggestGETWithRetry_DoesNotRetryNonRetriableStatus(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), suggestAttemptTimeout)
 	defer cancel()
 
-	_, err := doSuggestGETWithRetry(ctx, server.Client(), server.URL)
+	_, err := doSuggestGETWithRetry(ctx, server.Client(), server.URL, suggestRequestOpts{})
 	if err == nil {
 		t.Fatal("expected error for 404 response")
 	}

--- a/api/gateway/shopifysuggest/search.go
+++ b/api/gateway/shopifysuggest/search.go
@@ -17,10 +17,18 @@ const SearchPath = "/search/suggest.json"
 // search endpoint will return per request (the platform caps this at 10).
 const predictiveSearchLimit = "10"
 
+// ShopifyLocalizationSingapore is the Shopify market cookie value for
+// Singapore storefronts. Without it, Accept-Language defaults can return
+// prices from a different market than the public site shows to local users.
+const ShopifyLocalizationSingapore = "SG"
+
 // Config identifies a Shopify storefront that exposes predictive search.
 type Config struct {
 	StoreName string
 	BaseURL   string
+	// ShopifyLocalization, when set, is sent as Shopify's localization cookie on
+	// suggest and product JSON requests so responses use that market's prices.
+	ShopifyLocalization string
 }
 
 // Options controls query shaping and product-to-card mapping for a search.
@@ -127,8 +135,8 @@ func buildSuggestURL(opts Options) (string, error) {
 // the raw products. Transient rate-limit/5xx responses are retried on the same
 // transport, honoring Retry-After when Shopify provides it. Persistent failures
 // are reported as errors so the caller can fall back to another transport.
-func fetchProducts(ctx context.Context, client *http.Client, apiURL string) ([]Product, error) {
-	body, err := doSuggestGETWithRetry(ctx, client, apiURL)
+func fetchProducts(ctx context.Context, client *http.Client, apiURL string, reqOpts suggestRequestOpts) ([]Product, error) {
+	body, err := doSuggestGETWithRetry(ctx, client, apiURL, reqOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/api/gateway/shopifysuggest/structure_probe.go
+++ b/api/gateway/shopifysuggest/structure_probe.go
@@ -23,7 +23,7 @@ func ProbeSuggestStructure(ctx context.Context, opts Options) error {
 
 	var lastErr error
 	for _, attempt := range buildSearchAttempts() {
-		body, err := doSuggestGETWithRetry(ctx, attempt.client, apiURL)
+		body, err := doSuggestGETWithRetry(ctx, attempt.client, apiURL, suggestRequestOptsFromConfig(opts.Config))
 		if err != nil {
 			lastErr = annotateSuggestAttemptError(1, attempt.strategy, err)
 			continue

--- a/api/gateway/shopifysuggest/variant.go
+++ b/api/gateway/shopifysuggest/variant.go
@@ -40,15 +40,13 @@ type productVariant struct {
 // product's variants (name, set, image, URL); the variant supplies price,
 // stock, condition, and foil.
 //
-// If the detail request fails, the predictive-search card is returned as a
-// resilience fallback so a transient upstream error does not drop the store
-// from results. That fallback price is the predictive-search price_min, which
-// is the pre-existing (pre-resolution) behavior.
+// If the detail request fails, the product is omitted so a misleading
+// predictive-search price_min is never shown to users.
 func resolveVariantCards(ctx context.Context, client *http.Client, cfg Config, product Product, base gateway.Card) []gateway.Card {
-	detail, err := fetchProductDetail(ctx, client, cfg.BaseURL, product.Handle)
+	detail, err := fetchProductDetail(ctx, client, cfg, product.Handle)
 	if err != nil {
 		log.Printf("shopifysuggest: variant resolution failed for %s [%s]: %v", cfg.StoreName, product.Handle, err)
-		return []gateway.Card{base}
+		return nil
 	}
 
 	cards := make([]gateway.Card, 0, len(detail.Variants))
@@ -72,18 +70,18 @@ func resolveVariantCards(ctx context.Context, client *http.Client, cfg Config, p
 // fetchProductDetail retrieves and decodes a Shopify product JSON document for
 // the given handle using the supplied client (which carries whichever transport
 // won the suggest fallback).
-func fetchProductDetail(ctx context.Context, client *http.Client, baseURL, handle string) (productDetail, error) {
+func fetchProductDetail(ctx context.Context, client *http.Client, cfg Config, handle string) (productDetail, error) {
 	handle = strings.TrimSpace(handle)
 	if handle == "" {
 		return productDetail{}, fmt.Errorf("shopifysuggest: empty product handle")
 	}
 
-	base, err := url.Parse(strings.TrimSpace(baseURL))
+	base, err := url.Parse(strings.TrimSpace(cfg.BaseURL))
 	if err != nil {
-		return productDetail{}, fmt.Errorf("shopifysuggest: invalid base URL %q: %w", baseURL, err)
+		return productDetail{}, fmt.Errorf("shopifysuggest: invalid base URL %q: %w", cfg.BaseURL, err)
 	}
 	if base.Host == "" {
-		return productDetail{}, fmt.Errorf("shopifysuggest: invalid base URL %q: missing host", baseURL)
+		return productDetail{}, fmt.Errorf("shopifysuggest: invalid base URL %q: missing host", cfg.BaseURL)
 	}
 
 	// Preserve the base URL's scheme and host; only the path identifies the
@@ -93,7 +91,7 @@ func fetchProductDetail(ctx context.Context, client *http.Client, baseURL, handl
 	detailURL.RawQuery = ""
 	detailURL.Fragment = ""
 
-	body, err := doSuggestGETWithRetry(ctx, client, detailURL.String())
+	body, err := doSuggestGETWithRetry(ctx, client, detailURL.String(), suggestRequestOptsFromConfig(cfg))
 	if err != nil {
 		return productDetail{}, err
 	}

--- a/api/gateway/shopifysuggest/variant_test.go
+++ b/api/gateway/shopifysuggest/variant_test.go
@@ -94,10 +94,9 @@ func TestResolveVariantCardsCorrectsFoilPerVariant(t *testing.T) {
 	require.True(t, cards[1].IsFoil)
 }
 
-// TestResolveVariantCardsFallsBackOnError verifies that a failed detail fetch
-// preserves the predictive-search card so a transient upstream error does not
-// drop the store from the results.
-func TestResolveVariantCardsFallsBackOnError(t *testing.T) {
+// TestResolveVariantCardsDropsOnError verifies that a failed detail fetch omits
+// the product rather than returning a misleading predictive-search price_min.
+func TestResolveVariantCardsDropsOnError(t *testing.T) {
 	srv := newDetailServer(t, "", http.StatusInternalServerError)
 	defer srv.Close()
 
@@ -107,8 +106,7 @@ func TestResolveVariantCardsFallsBackOnError(t *testing.T) {
 
 	cards := resolveVariantCards(context.Background(), srv.Client(), cfg, product, base)
 
-	require.Len(t, cards, 1)
-	require.Equal(t, base.Price, cards[0].Price)
+	require.Empty(t, cards)
 }
 
 // TestResolveVariantCardsDropsWhenAllOutOfStock verifies that a product whose


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes intermittent and systematic price mismatches for MTG Asia (and Grey Ogre Games, which shares the same Shopify suggest + variant-resolution path).

**Cause 1 — intermittent wrong price (often much lower), usually fixed on re-search**

Shopify predictive search reports `price_min` (cheapest variant, including out-of-stock). When the follow-up `/products/<handle>.js` fetch failed (rate limit, timeout, 5xx), we fell back to that misleading suggest price. A second search often succeeded at variant resolution and showed a better price.

**Fix:** On variant-resolution failure, omit the product instead of returning the suggest `price_min` fallback.

**Cause 2 — prices consistently off vs the Singapore storefront**

Outbound JSON requests used `Accept-Language: en-US` without Shopify's `localization=SG` cookie. That caused suggest and product JSON to return a different market's prices than local users see on the site (e.g. S$0.50 on mtg-asia.com vs $1.00 from our scraper).

**Fix:** Send `localization=SG` on suggest and product JSON requests for MTG Asia and Grey Ogre Games.

## Verification

- `make test` passes
- Live probe for *Abrade [Secrets of Strixhaven: Mystical Archive]* now returns **S$0.50** (was **$1.00** before this change)

## Notes

- A missing MTG Asia result after a transient upstream error is preferable to showing a price that cannot be purchased.
- Variant-resolution failures are still logged: `shopifysuggest: variant resolution failed for MTG Asia [...]`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75df0950-2876-4630-8dcf-0d165e9dd599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75df0950-2876-4630-8dcf-0d165e9dd599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

