### PR TITLE
Lower default search attempt timeout to 5s, keep Agora at 10s

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ before being returned.
 1. The handler parses `s` (the search string, minimum 3 characters) and an
    optional `lgs` filter (comma-separated store names; empty means all stores).
 2. The controller instantiates each selected store and runs **one goroutine per
-   store**, each bounded by a 20s per-site timeout (`config.PerSiteTimeout`).
+   store**, each bounded by a 16s per-site timeout (`config.PerSiteTimeout`).
 3. Each store's results are merged into a shared aggregator. A per-store failure
    is recorded but never blocks the others, so a search returns whatever
    succeeded (partial success).

--- a/api/gateway/agora/search.go
+++ b/api/gateway/agora/search.go
@@ -52,6 +52,7 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 	var cards []gateway.Card
 
 	c := gateway.NewOptimizedCollectorNoRetryDirect(ctx)
+	c.SetRequestTimeout(config.AgoraSearchAttemptTimeout)
 
 	c.OnHTML("div#store_listingcontainer", func(e *colly.HTMLElement) {
 		e.ForEach("div.store-item", func(_ int, el *colly.HTMLElement) {

--- a/api/gateway/binderpos/storefront.go
+++ b/api/gateway/binderpos/storefront.go
@@ -2,12 +2,14 @@ package binderpos
 
 import (
 	"time"
+
+	"mtg-price-checker-sg/pkg/config"
 )
 
 const (
 	binderposDecklistAPIURL = "https://portal.binderpos.com/external/shopify/decklist"
 	binderposDecklistType   = "mtg"
-	binderposAttemptTimeout = 10 * time.Second
+	binderposAttemptTimeout = config.SearchAttemptTimeout
 
 	// binderposDecklistMaxAttempts bounds how many times a single decklist call
 	// is sent (initial try plus retries) when the shared portal host responds

--- a/api/gateway/collector.go
+++ b/api/gateway/collector.go
@@ -245,7 +245,7 @@ func configureRequestOptimizations(c *colly.Collector, enforceDedicatedProxyLeas
 // Base collector defaults used by all optimized collectors.
 func applyCollectorDefaults(c *colly.Collector) {
 	c.DisableCookies()
-	c.SetRequestTimeout(config.PerSiteTimeout)
+	c.SetRequestTimeout(config.SearchAttemptTimeout)
 }
 
 // Dedicated proxy lease lifecycle helpers.

--- a/api/gateway/shopifysuggest/proxy_fallback.go
+++ b/api/gateway/shopifysuggest/proxy_fallback.go
@@ -6,15 +6,11 @@ import (
 	"net/http"
 	"net/url"
 	"sync/atomic"
-	"time"
 
 	"mtg-price-checker-sg/gateway"
 	"mtg-price-checker-sg/gateway/util"
+	"mtg-price-checker-sg/pkg/config"
 )
-
-// suggestAttemptTimeout bounds a single suggest endpoint attempt so a slow or
-// throttling upstream cannot stall the whole fallback chain.
-const suggestAttemptTimeout = 10 * time.Second
 
 // shopifySuggestDedicatedProxySeq advances once per dedicated-proxy suggest
 // attempt so traffic round-robins evenly across the configured dedicated
@@ -64,7 +60,7 @@ func buildSearchAttempts() []searchAttempt {
 	attempts := []searchAttempt{
 		{
 			strategy: "direct",
-			client:   &http.Client{Timeout: suggestAttemptTimeout},
+			client:   &http.Client{Timeout: config.SearchAttemptTimeout},
 		},
 	}
 
@@ -122,7 +118,7 @@ func newProxyClient(proxyURL string) (*http.Client, error) {
 	}
 
 	return &http.Client{
-		Timeout: suggestAttemptTimeout,
+		Timeout: config.SearchAttemptTimeout,
 		Transport: &http.Transport{
 			Proxy: http.ProxyURL(parsedProxyURL),
 		},

--- a/api/gateway/shopifysuggest/retry_test.go
+++ b/api/gateway/shopifysuggest/retry_test.go
@@ -8,6 +8,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"mtg-price-checker-sg/pkg/config"
 )
 
 func TestIsRetriableSuggestStatus(t *testing.T) {
@@ -98,7 +100,7 @@ func TestDoSuggestGETWithRetry_SucceedsAfter429WithRetryAfter(t *testing.T) {
 	}))
 	defer server.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), suggestAttemptTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), config.SearchAttemptTimeout)
 	defer cancel()
 
 	body, err := doSuggestGETWithRetry(ctx, server.Client(), server.URL, suggestRequestOpts{})
@@ -125,7 +127,7 @@ func TestDoSuggestGETWithRetry_SucceedsAfterTransient503(t *testing.T) {
 	}))
 	defer server.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), suggestAttemptTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), config.SearchAttemptTimeout)
 	defer cancel()
 
 	_, err := doSuggestGETWithRetry(ctx, server.Client(), server.URL, suggestRequestOpts{})
@@ -145,7 +147,7 @@ func TestDoSuggestGETWithRetry_ExhaustsRetriesOnPersistent429(t *testing.T) {
 	}))
 	defer server.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), suggestAttemptTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), config.SearchAttemptTimeout)
 	defer cancel()
 
 	_, err := doSuggestGETWithRetry(ctx, server.Client(), server.URL, suggestRequestOpts{})
@@ -171,7 +173,7 @@ func TestDoSuggestGETWithRetry_SendsShopifyLocalizationCookie(t *testing.T) {
 	}))
 	defer server.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), suggestAttemptTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), config.SearchAttemptTimeout)
 	defer cancel()
 
 	_, err := doSuggestGETWithRetry(ctx, server.Client(), server.URL, suggestRequestOpts{
@@ -193,7 +195,7 @@ func TestDoSuggestGETWithRetry_DoesNotRetryNonRetriableStatus(t *testing.T) {
 	}))
 	defer server.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), suggestAttemptTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), config.SearchAttemptTimeout)
 	defer cancel()
 
 	_, err := doSuggestGETWithRetry(ctx, server.Client(), server.URL, suggestRequestOpts{})

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -19,7 +19,7 @@ const (
 	EnvProd  = "prod"
 	EnvLocal = "local"
 	UseProxy         = true
-	PerSiteTimeout   = 20 * time.Second
+	PerSiteTimeout   = 16 * time.Second
 	// SearchAttemptTimeout bounds a single search strategy attempt (BinderPOS step,
 	// Shopify suggest transport, or default colly scrape).
 	SearchAttemptTimeout = 5 * time.Second

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -20,6 +20,11 @@ const (
 	EnvLocal = "local"
 	UseProxy         = true
 	PerSiteTimeout   = 20 * time.Second
+	// SearchAttemptTimeout bounds a single search strategy attempt (BinderPOS step,
+	// Shopify suggest transport, or default colly scrape).
+	SearchAttemptTimeout = 5 * time.Second
+	// AgoraSearchAttemptTimeout is the per-attempt cap for Agora Hobby only.
+	AgoraSearchAttemptTimeout = 10 * time.Second
 	// DynamicProxyEnv contains an authenticated proxy URL used for explicit
 	// dynamic-proxy fallback attempts, which BinderPOS now reserves for the
 	// final fallback after dedicated and direct/no-proxy attempts.

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -9,7 +9,9 @@ This document records **where** the app configures search behavior, **timeouts**
 | Item | Value | Source | Notes |
 |------|--------|--------|--------|
 | Per-store deadline | 20s | `config.PerSiteTimeout` in `api/pkg/config/config.go`; used in `searchShop` as `context.WithTimeout` in `api/controller/search.go` | One goroutine per selected store; each `LGS.Search` runs under this cap. |
-| Colly request timeout (default scrapers) | 20s | `applyCollectorDefaults` → `c.SetRequestTimeout(config.PerSiteTimeout)` in `api/gateway/collector.go` | Overrides gocolly’s default 10s for optimized collectors. |
+| Per-attempt timeout (default) | 5s | `config.SearchAttemptTimeout` in `api/pkg/config/config.go` | Bounds each BinderPOS strategy step, Shopify suggest transport, and default colly scrape request. |
+| Agora per-attempt timeout | 10s | `config.AgoraSearchAttemptTimeout` in `api/pkg/config/config.go`; applied in `api/gateway/agora/search.go` | Agora keeps a longer single-scrape cap. |
+| Colly request timeout (default scrapers) | 5s | `applyCollectorDefaults` → `c.SetRequestTimeout(config.SearchAttemptTimeout)` in `api/gateway/collector.go` | Overrides gocolly’s default 10s for optimized collectors. |
 | Minimum end-to-end response time | 1s | `responseThreshold` in `searchShops` in `api/controller/search.go` | If all stores finish in under 1s, the handler **sleeps** the remainder so the API “feels” less instant. |
 | Colly HTTP retries | None | `api/gateway/collector.go` (`configureRequestOptimizations`, `registerNoRetryErrorHandler`) | **Single HTTP attempt** per colly request path; no automatic colly/gateway retry of failed visits. |
 | BinderPOS store concurrency | 12 | `binderposMaxConcurrent` in `api/controller/search.go` | Semaphore limits how many binderpos-backed shops run at once. Non-binderpos stores are not limited by this gate. |
@@ -46,14 +48,14 @@ Some tests in `api/gateway/binderpos/*_test.go` hit real stores and proxies. The
 
 | Scenario | Order of strategies (each step is one attempt) | Per-step attempt timeout / HTTP client |
 |----------|--------------------------------------------------|----------------------------------------|
-| `shopifyDomain` **non-empty** (normal) | 1) **api-dedicated** → 2) **api-direct** → 3) **scrap-dedicated** → 4) **scrap-direct** → 5) **api-dynamic** → 6) **scrap-dynamic** | **10s** per step: `binderposAttemptTimeout` in `api/gateway/binderpos/storefront.go`; `runWithAttemptTimeout` in `storefront_search.go`. HTTP clients in `storefront_client.go` use the same `binderposAttemptTimeout`. |
-| `shopifyDomain` **empty** or **`ScrapOnly`** | **scrap-dedicated** → **scrap-direct** → **scrap-dynamic** (three `runWithAttemptTimeout` steps) | **10s** per step (same constant). No API attempts. |
+| `shopifyDomain` **non-empty** (normal) | 1) **api-dedicated** → 2) **api-direct** → 3) **scrap-dedicated** → 4) **scrap-direct** → 5) **api-dynamic** → 6) **scrap-dynamic** | **5s** per step: `binderposAttemptTimeout` (`config.SearchAttemptTimeout`) in `api/gateway/binderpos/storefront.go`; `runWithAttemptTimeout` in `storefront_search.go`. HTTP clients in `storefront_client.go` use the same constant. |
+| `shopifyDomain` **empty** or **`ScrapOnly`** | **scrap-dedicated** → **scrap-direct** → **scrap-dynamic** (three `runWithAttemptTimeout` steps) | **5s** per step (same constant). No API attempts. |
 
 | Item | Value | Source | Notes |
 |------|--------|--------|--------|
 | **api-dedicated** proxy selection (storefront HTTP client) | Round-robin | `nextBinderposStorefrontProxyURL` + `binderposDedicatedProxySeq` in `api/gateway/binderpos/storefront_client.go` | When `UseLeasedDedicatedProxy` is **false** (default in `api/pkg/config/config.go`), each storefront API call cycles **proxy₁ → … → proxyₙ** then repeats, using all URLs from `GetDedicatedProxyURLs()`. When `UseLeasedDedicatedProxy` is **true**, selection is unchanged: `LeaseDedicatedProxyURL` from the dedicated pool. |
 | **api-dynamic** proxy selection (storefront HTTP client) | Fixed env URL | `searchByStorefrontAPIDynamic` in `api/gateway/binderpos/storefront_client.go` | Uses `DYNAMIC_PROXY` as the authenticated proxy URL for the final BinderPOS API fallback attempt. |
-| Colly for BinderPOS scrapes | 10s | `SetRequestTimeout(binderposAttemptTimeout)` in `api/gateway/binderpos/scrap.go` | Tighter than generic `PerSiteTimeout` (20s) for binderpos scrape collectors. |
+| Colly for BinderPOS scrapes | 5s | `SetRequestTimeout(binderposAttemptTimeout)` in `api/gateway/binderpos/scrap.go` | Same as `config.SearchAttemptTimeout`. |
 | “Retries” | N/A (sequential fallbacks) | `searchWithFallback` | Stops on first **success**; returns last error if all attempts fail. This is **not** exponential backoff retry of a single request. |
 
 ---

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -8,7 +8,7 @@ This document records **where** the app configures search behavior, **timeouts**
 
 | Item | Value | Source | Notes |
 |------|--------|--------|--------|
-| Per-store deadline | 20s | `config.PerSiteTimeout` in `api/pkg/config/config.go`; used in `searchShop` as `context.WithTimeout` in `api/controller/search.go` | One goroutine per selected store; each `LGS.Search` runs under this cap. |
+| Per-store deadline | 16s | `config.PerSiteTimeout` in `api/pkg/config/config.go`; used in `searchShop` as `context.WithTimeout` in `api/controller/search.go` | One goroutine per selected store; each `LGS.Search` runs under this cap. |
 | Per-attempt timeout (default) | 5s | `config.SearchAttemptTimeout` in `api/pkg/config/config.go` | Bounds each BinderPOS strategy step, Shopify suggest transport, and default colly scrape request. |
 | Agora per-attempt timeout | 10s | `config.AgoraSearchAttemptTimeout` in `api/pkg/config/config.go`; applied in `api/gateway/agora/search.go` | Agora keeps a longer single-scrape cap. |
 | Colly request timeout (default scrapers) | 5s | `applyCollectorDefaults` → `c.SetRequestTimeout(config.SearchAttemptTimeout)` in `api/gateway/collector.go` | Overrides gocolly’s default 10s for optimized collectors. |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds `config.SearchAttemptTimeout` (**5s**) as the default per-attempt cap for BinderPOS strategy steps, Shopify suggest transports, and default colly scrapers.
- Adds `config.AgoraSearchAttemptTimeout` (**10s**) and applies it explicitly in the Agora gateway so Agora keeps a longer single-scrape budget.
- Lowers the overall per-store deadline (`PerSiteTimeout`) from **20s** to **16s**.

## Motivation

Hideyoshi and other BinderPOS scrape-only stores were spending up to 10s per fallback strategy. Tighter 5s attempt timeouts fail faster on rate-limited or slow upstreams, while the 16s per-store cap keeps multi-strategy stores from running too long overall.

## Changes

| Area | Before | After |
|------|--------|-------|
| BinderPOS per-step timeout | 10s | 5s |
| Shopify suggest per-transport timeout | 10s | 5s |
| Default colly request timeout | 20s | 5s |
| Agora colly request timeout | 20s | **10s** |
| Per-store deadline (`PerSiteTimeout`) | 20s | **16s** |

## Testing

- `make test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f44a0320-8eed-4da2-ad25-73d7665d9614"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f44a0320-8eed-4da2-ad25-73d7665d9614"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

