### PR TITLE
Update Go to 1.26.5 and run go fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ For any PR that includes UI changes:
 
 ### Go version requirement
 
-The project requires Go 1.26.3 (per `api/go.mod`). The update script installs it to `/usr/local/go`. You must have `/usr/local/go/bin` in your PATH:
+The project requires Go 1.26.5 (per `api/go.mod`). The update script installs it to `/usr/local/go`. You must have `/usr/local/go/bin` in your PATH:
 
 ```bash
 export PATH="/usr/local/go/bin:$PATH"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine AS build
+FROM golang:1.26.5-alpine AS build
 WORKDIR /mtg-price-checker
 # Copy dependencies list
 COPY api ./api

--- a/api/controller/search.go
+++ b/api/controller/search.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"maps"
 	"mtg-price-checker-sg/gateway"
 	"mtg-price-checker-sg/gateway/agora"
 	// "mtg-price-checker-sg/gateway/arcanesanctum"
@@ -139,8 +140,6 @@ func fetchCardsConcurrently(ctx context.Context, searchString string, shops map[
 	start := time.Now()
 
 	for shopName, lgs := range shops {
-		shopName := shopName
-		lgs := lgs
 		wg.Go(func() {
 			searchShop(ctx, searchString, shopName, lgs, binderposGate, aggregator)
 		})
@@ -218,9 +217,7 @@ func (f *fetchResultAggregator) snapshot() ([]gateway.Card, map[string]error, []
 
 	cards := append([]gateway.Card(nil), f.cards...)
 	siteErrors := make(map[string]error, len(f.siteErrors))
-	for shopName, err := range f.siteErrors {
-		siteErrors[shopName] = err
-	}
+	maps.Copy(siteErrors, f.siteErrors)
 	discordErrorMessages := append([]string(nil), f.discordErrorMessages...)
 
 	return cards, siteErrors, discordErrorMessages
@@ -361,13 +358,13 @@ func parseSearchErrorMessage(message, searchString string) (shopName, details st
 
 	withoutPrefix := strings.TrimPrefix(message, prefix)
 	const shopSuffix = "] for ["
-	shopSuffixIndex := strings.Index(withoutPrefix, shopSuffix)
-	if shopSuffixIndex == -1 {
+	before, after, ok0 := strings.Cut(withoutPrefix, shopSuffix)
+	if !ok0 {
 		return "", "", false
 	}
 
-	shopName = withoutPrefix[:shopSuffixIndex]
-	withoutShop := withoutPrefix[shopSuffixIndex+len(shopSuffix):]
+	shopName = before
+	withoutShop := after
 
 	searchSuffix := fmt.Sprintf("%s]: ", searchString)
 	if !strings.HasPrefix(withoutShop, searchSuffix) {

--- a/api/gateway/binderpos/scrap.go
+++ b/api/gateway/binderpos/scrap.go
@@ -81,8 +81,8 @@ func buildSafeSearchURL(baseUrl, searchUrlTemplate, searchStr string) string {
 
 	if len(parts) > 1 {
 		qVals := url.Values{}
-		pairs := strings.Split(parts[1], "&")
-		for _, pair := range pairs {
+		pairs := strings.SplitSeq(parts[1], "&")
+		for pair := range pairs {
 			kv := strings.SplitN(pair, "=", 2)
 			if len(kv) == 2 {
 				val := kv[1]
@@ -319,7 +319,7 @@ func scrapVariant1(ctx context.Context, storeName, baseUrl, searchUrl, searchStr
 			addNowAttrs := el.ChildAttrs("div.addNow", "onclick")
 
 			if len(addNowTexts) > 0 {
-				for i := 0; i < len(addNowTexts); i++ {
+				for i := range addNowTexts {
 					isInstock = addNowTexts[i] != ""
 
 					if isInstock {

--- a/api/gateway/binderpos/storefront_decklist_retry.go
+++ b/api/gateway/binderpos/storefront_decklist_retry.go
@@ -43,7 +43,7 @@ func isRetriableDecklistStatus(status int) bool {
 func doDecklistRequestWithRetry(ctx context.Context, client *http.Client, newRequest func() (*http.Request, error)) (*http.Response, error) {
 	var lastErr error
 
-	for attempt := 0; attempt < binderposDecklistMaxAttempts; attempt++ {
+	for attempt := range binderposDecklistMaxAttempts {
 		req, err := newRequest()
 		if err != nil {
 			return nil, err

--- a/api/gateway/binderpos/storefront_decklist_retry_test.go
+++ b/api/gateway/binderpos/storefront_decklist_retry_test.go
@@ -94,7 +94,7 @@ func TestParseRetryAfter(t *testing.T) {
 }
 
 func TestDecklistBackoffDelayIsBoundedAndGrows(t *testing.T) {
-	for attempt := 0; attempt < 6; attempt++ {
+	for attempt := range 6 {
 		d := decklistBackoffDelay(attempt)
 		if d <= 0 {
 			t.Fatalf("attempt %d: expected positive delay, got %s", attempt, d)

--- a/api/gateway/binderpos/storefront_portal_gate_test.go
+++ b/api/gateway/binderpos/storefront_portal_gate_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAcquireBinderposPortalSlotLimitsConcurrency(t *testing.T) {
 	releases := make([]func(), 0, binderposPortalMaxConcurrent)
-	for i := 0; i < binderposPortalMaxConcurrent; i++ {
+	for i := range binderposPortalMaxConcurrent {
 		release, err := acquireBinderposPortalSlot(context.Background())
 		if err != nil {
 			t.Fatalf("unexpected error acquiring slot %d: %v", i, err)

--- a/api/gateway/binderpos/storefront_routing_test.go
+++ b/api/gateway/binderpos/storefront_routing_test.go
@@ -37,7 +37,7 @@ func TestShouldStartWithDecklist_SplitsConsecutiveCallsEvenly(t *testing.T) {
 
 	const calls = 10
 	decklistCount := 0
-	for i := 0; i < calls; i++ {
+	for range calls {
 		if shouldStartWithDecklist() {
 			decklistCount++
 		}

--- a/api/gateway/cardsandcollection/search.go
+++ b/api/gateway/cardsandcollection/search.go
@@ -165,7 +165,7 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 	)
 
 	apiURL := s.BaseUrl + StoreApiURL
-	requestBody := []byte(fmt.Sprintf(`{"query":{"bool":{"should":[{"simple_query_string":{"query":"%s","fields":["name","setCode","setName"],"default_operator":"AND"}},{"multi_match":{"query":"%s","type":"phrase_prefix","fields":["name","setCode","setName"]}}]}},"post_filter":{"bool":{"must":{"terms":{"collectableContext.raw":["MTG","ACCESSORY"]}}}},"aggs":{"productCategory4":{"filter":{"bool":{"must":{"terms":{"collectableContext.raw":["MTG","ACCESSORY"]}}}},"aggs":{"productCategory.raw":{"terms":{"field":"productCategory.raw","size":50}},"productCategory.raw_count":{"cardinality":{"field":"productCategory.raw"}}}}},"size":20,"sort":[{"quantityOnSale":"desc"}]}`, searchStr, searchStr))
+	requestBody := fmt.Appendf(nil, `{"query":{"bool":{"should":[{"simple_query_string":{"query":"%s","fields":["name","setCode","setName"],"default_operator":"AND"}},{"multi_match":{"query":"%s","type":"phrase_prefix","fields":["name","setCode","setName"]}}]}},"post_filter":{"bool":{"must":{"terms":{"collectableContext.raw":["MTG","ACCESSORY"]}}}},"aggs":{"productCategory4":{"filter":{"bool":{"must":{"terms":{"collectableContext.raw":["MTG","ACCESSORY"]}}}},"aggs":{"productCategory.raw":{"terms":{"field":"productCategory.raw","size":50}},"productCategory.raw_count":{"cardinality":{"field":"productCategory.raw"}}}}},"size":20,"sort":[{"quantityOnSale":"desc"}]}`, searchStr, searchStr)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewBuffer(requestBody))
 	if err != nil {
 		return cards, err

--- a/api/gateway/collector_test.go
+++ b/api/gateway/collector_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -324,13 +325,7 @@ func TestRandomBrowserUserAgent(t *testing.T) {
 		t.Fatalf("expected random browser user-agent to be non-empty")
 	}
 
-	found := false
-	for _, candidate := range browserUserAgents {
-		if got == candidate {
-			found = true
-			break
-		}
-	}
+	found := slices.Contains(browserUserAgents, got)
 	if !found {
 		t.Fatalf("expected user-agent to be chosen from browserUserAgents list, got %q", got)
 	}

--- a/api/gateway/gatewaytest/live_probes.go
+++ b/api/gateway/gatewaytest/live_probes.go
@@ -96,7 +96,7 @@ func RequireMoxAndLotusAPIStructure(t *testing.T, ctx context.Context, query str
 // RequireCardsAndCollectionAPIStructure verifies the catalog search API response shape.
 func RequireCardsAndCollectionAPIStructure(t *testing.T, ctx context.Context, baseURL, query string) {
 	t.Helper()
-	requestBody := []byte(fmt.Sprintf(`{"query":{"bool":{"should":[{"simple_query_string":{"query":"%s","fields":["name","setCode","setName"],"default_operator":"AND"}},{"multi_match":{"query":"%s","type":"phrase_prefix","fields":["name","setCode","setName"]}}]}},"post_filter":{"bool":{"must":{"terms":{"collectableContext.raw":["MTG","ACCESSORY"]}}}},"aggs":{"productCategory4":{"filter":{"bool":{"must":{"terms":{"collectableContext.raw":["MTG","ACCESSORY"]}}}},"aggs":{"productCategory.raw":{"terms":{"field":"productCategory.raw","size":50}},"productCategory.raw_count":{"cardinality":{"field":"productCategory.raw"}}}}},"size":20,"sort":[{"quantityOnSale":"desc"}]}`, query, query))
+	requestBody := fmt.Appendf(nil, `{"query":{"bool":{"should":[{"simple_query_string":{"query":"%s","fields":["name","setCode","setName"],"default_operator":"AND"}},{"multi_match":{"query":"%s","type":"phrase_prefix","fields":["name","setCode","setName"]}}]}},"post_filter":{"bool":{"must":{"terms":{"collectableContext.raw":["MTG","ACCESSORY"]}}}},"aggs":{"productCategory4":{"filter":{"bool":{"must":{"terms":{"collectableContext.raw":["MTG","ACCESSORY"]}}}},"aggs":{"productCategory.raw":{"terms":{"field":"productCategory.raw","size":50}},"productCategory.raw_count":{"cardinality":{"field":"productCategory.raw"}}}}},"size":20,"sort":[{"quantityOnSale":"desc"}]}`, query, query)
 	RequireJSONStructure(t, ctx, JSONProbe{
 		Method: "POST",
 		URL:    strings.TrimRight(baseURL, "/") + "/api/catalog/",
@@ -140,7 +140,7 @@ func RequireCardsCentralAPIStructure(t *testing.T, ctx context.Context, baseURL,
 // RequireTCGMarketplaceAPIStructure verifies the TCG Marketplace advanced search API shape.
 func RequireTCGMarketplaceAPIStructure(t *testing.T, ctx context.Context, accessToken, query string) {
 	t.Helper()
-	requestBody := []byte(fmt.Sprintf(`{"access_token":%q,"name":%q,"category":3,"order":"name_asc"}`, accessToken, query))
+	requestBody := fmt.Appendf(nil, `{"access_token":%q,"name":%q,"category":3,"order":"name_asc"}`, accessToken, query)
 	RequireJSONStructure(t, ctx, JSONProbe{
 		Method: "POST",
 		URL:    "https://thetcgmarketplace.com:3501/encoder/advancedsearch",

--- a/api/gateway/shopifysuggest/retry.go
+++ b/api/gateway/shopifysuggest/retry.go
@@ -58,7 +58,7 @@ func suggestRequestOptsFromConfig(cfg Config) suggestRequestOpts {
 func doSuggestGETWithRetry(ctx context.Context, client *http.Client, requestURL string, reqOpts suggestRequestOpts) ([]byte, error) {
 	var lastErr error
 
-	for attempt := 0; attempt < suggestRetryMaxAttempts; attempt++ {
+	for attempt := range suggestRetryMaxAttempts {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
 		if err != nil {
 			return nil, err

--- a/api/gateway/tcgmarketplace/search.go
+++ b/api/gateway/tcgmarketplace/search.go
@@ -28,18 +28,18 @@ type response struct {
 	Data   struct {
 		Message string `json:"message"`
 		Data    []struct {
-			Name                  string      `json:"name"`
-			Setcode               string      `json:"setcode"`
-			Setname               string      `json:"setname"`
-			Image                 string      `json:"image"`
-			Language              string      `json:"language"`
-			CrdFoilType           interface{} `json:"crd_foil_type"`
-			Rarity                string      `json:"rarity"`
-			Available             interface{} `json:"available"`
-			From                  interface{} `json:"from"`
-			NonFoilReferencePrice interface{} `json:"non_foil_reference_price"`
-			FoilReferencePrice    interface{} `json:"foil_reference_price"`
-			URL                   string      `json:"url"`
+			Name                  string `json:"name"`
+			Setcode               string `json:"setcode"`
+			Setname               string `json:"setname"`
+			Image                 string `json:"image"`
+			Language              string `json:"language"`
+			CrdFoilType           any    `json:"crd_foil_type"`
+			Rarity                string `json:"rarity"`
+			Available             any    `json:"available"`
+			From                  any    `json:"from"`
+			NonFoilReferencePrice any    `json:"non_foil_reference_price"`
+			FoilReferencePrice    any    `json:"foil_reference_price"`
+			URL                   string `json:"url"`
 		} `json:"data"`
 	} `json:"data"`
 	Meta struct {

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module mtg-price-checker-sg
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/PuerkitoBio/goquery v1.11.0

--- a/api/handler/search.go
+++ b/api/handler/search.go
@@ -106,27 +106,23 @@ func Search(ctx context.Context, request events.APIGatewayProxyRequest) (events.
 	)
 
 	var wg sync.WaitGroup
-	wg.Add(1)
 
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		inStockCards, storeErrors, searchErr = searchFunc(ctx, controller.SearchInput{
 			SearchString: searchString,
 			Lgs:          lgs,
 		})
-	}()
+	})
 
 	if config.CKPriceLookupEnabled() {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			price, err := lookupCKPriceFunc(ctx, searchString)
 			if err != nil {
 				log.Printf("ck price lookup for [%s]: %v", searchString, err)
 				return
 			}
 			ckPrice = price
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/api/store/ckprices/dynamodb.go
+++ b/api/store/ckprices/dynamodb.go
@@ -36,10 +36,10 @@ type dynamoRecord struct {
 }
 
 type syncMetadataRecord struct {
-	NameKey       string `dynamodbav:"nameKey"`
-	CardName      string `dynamodbav:"cardName"`
-	SyncedAt      string `dynamodbav:"syncedAt"`
-	ListingCount  int    `dynamodbav:"listingCount"`
+	NameKey      string `dynamodbav:"nameKey"`
+	CardName     string `dynamodbav:"cardName"`
+	SyncedAt     string `dynamodbav:"syncedAt"`
+	ListingCount int    `dynamodbav:"listingCount"`
 }
 
 type DynamoDBStore struct {
@@ -123,10 +123,7 @@ func (s *DynamoDBStore) PutAll(ctx context.Context, listings map[string]cardking
 	})
 
 	for start := 0; start < len(writeRequests); start += batchWriteLimit {
-		end := start + batchWriteLimit
-		if end > len(writeRequests) {
-			end = len(writeRequests)
-		}
+		end := min(start+batchWriteLimit, len(writeRequests))
 		batch := writeRequests[start:end]
 		if err := s.writeBatch(ctx, batch); err != nil {
 			return "", err


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the repository from Go 1.26.4 to **Go 1.26.5** and applies `go fix` modernizations across the codebase.

## Version updates

| File | Old | New |
|------|-----|-----|
| `api/go.mod` | 1.26.4 | 1.26.5 |
| `Dockerfile` | `golang:1.26.4-alpine` | `golang:1.26.5-alpine` |
| `AGENTS.md` | 1.26.3 (stale) | 1.26.5 |

CI already reads Go version from `api/go.mod` via `go-version-file`, so no workflow changes were required.

## go fix changes

`go fix ./...` applied modern Go idioms in 13 source files:

- Removed redundant loop-variable shadowing (no longer needed since Go 1.22 loop var semantics)
- Replaced manual map copies with `maps.Copy`
- Replaced `strings.Index` + slicing with `strings.Cut`

## Validation

- `go mod tidy` — pass
- `go mod vendor` — pass
- `make test` — pass (all packages)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8303ba37-a821-46e6-add9-769fadd1899f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8303ba37-a821-46e6-add9-769fadd1899f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

