### PR TITLE
Shopify suggest: dedicated-first proxy and cap variant resolution at 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,12 +211,11 @@ storefront's Shopify predictive search endpoint (`/search/suggest.json`) through
 a shared gateway. Results are filtered to in-stock Magic singles and mapped into
 cards using store-specific title/tag conventions (Fyendal Hobby additionally
 scopes suggest to its MTG singles product type). On error the chain advances
-through proxy tiers (**direct → dedicated → dynamic**); an empty but error-free
+through proxy tiers (**dedicated → direct → dynamic**); an empty but error-free
 response counts as success and stops the chain. Each attempt is bounded by a 10s
 timeout (`suggestAttemptTimeout`).
 
-MTG Asia and Grey Ogre Games additionally **resolve variants**: after suggest
-returns a product, a follow-up request to `/products/<handle>.js` emits one card
+MTG Asia, Grey Ogre Games, and Fyendal Hobby additionally **resolve variants** for the first five suggest products: a follow-up request to `/products/<handle>.js` emits one card
 per in-stock variant with the variant's real price and condition. Shopify's
 predictive search only reports a product-level `price_min` (the cheapest variant
 regardless of stock), so variant resolution ensures the cheapest *purchasable*
@@ -227,10 +226,10 @@ resilience fallback.
 flowchart TD
     A[Shopify suggest store search] --> B[GET /search/suggest.json]
     B --> C{error?}
-    C -- direct failed --> D[dedicated proxy]
+    C -- dedicated failed --> D[direct]
     C -- success --> E[filter in-stock Magic products]
     D --> F{error?}
-    F -- dedicated failed --> G[dynamic proxy]
+    F -- direct failed --> G[dynamic proxy]
     F -- success --> E
     G --> E
     E --> H{ResolveVariants?}

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ flowchart TD
     F -- success --> E
     G --> E
     E --> H{ResolveVariants?}
-    H -- yes --> I[GET /products/handle.js per product]
+    H -- yes --> I[GET /products/handle.js per product on rotating dedicated proxy]
     I --> J[one card per in-stock variant]
     H -- no --> K[one card per suggest product]
 ```

--- a/api/gateway/shopifysuggest/proxy_fallback.go
+++ b/api/gateway/shopifysuggest/proxy_fallback.go
@@ -74,6 +74,25 @@ func buildSearchAttempts() []searchAttempt {
 	return attempts
 }
 
+// productDetailClient selects the HTTP client for a product JSON fetch. Tests may
+// replace this to inject a local client.
+var productDetailClient = defaultProductDetailClient
+
+// defaultProductDetailClient returns a fresh client for each product detail
+// request. Dedicated proxies are round-robined so variant resolution spreads
+// load across IPs instead of reusing the transport that won the suggest
+// fallback. When no dedicated proxies are configured, direct is used, then
+// dynamic when available.
+func defaultProductDetailClient() *http.Client {
+	if client, ok := dedicatedProxyClient(); ok {
+		return client
+	}
+	if client, ok := dynamicProxyClient(); ok {
+		return client
+	}
+	return &http.Client{Timeout: config.SearchAttemptTimeout}
+}
+
 // dedicatedProxyClient returns an HTTP client bound to the next dedicated proxy
 // in round-robin order, or ok=false when none are configured.
 func dedicatedProxyClient() (*http.Client, bool) {
@@ -129,7 +148,7 @@ func fetchAndMapProducts(ctx context.Context, client *http.Client, apiURL string
 	if err != nil {
 		return nil, err
 	}
-	return mapProducts(ctx, client, opts, products), nil
+	return mapProducts(ctx, opts, products), nil
 }
 
 func annotateSuggestAttemptError(attempt int, strategy string, err error) error {

--- a/api/gateway/shopifysuggest/proxy_fallback.go
+++ b/api/gateway/shopifysuggest/proxy_fallback.go
@@ -27,9 +27,9 @@ type searchAttempt struct {
 // searchWithProxyFallback runs the suggest request through an ordered set of
 // transports, returning the first successful result. Each transport retries
 // transient rate-limit/5xx responses on the same connection (honoring
-// Retry-After) before the chain advances, so a healthy direct connection never
-// incurs proxy cost while a rate-limited endpoint still resolves via dedicated
-// and then dynamic proxies.
+// Retry-After) before the chain advances. Dedicated proxies are tried first so
+// cloud/datacenter egress is less likely to trip Shopify throttling; direct and
+// dynamic transports follow when dedicated is unavailable or exhausted.
 func searchWithProxyFallback(ctx context.Context, opts Options, apiURL string) ([]gateway.Card, error) {
 	return runSearchAttempts(ctx, buildSearchAttempts(), opts, apiURL)
 }
@@ -53,20 +53,19 @@ func runSearchAttempts(ctx context.Context, attempts []searchAttempt, opts Optio
 	return cards, err
 }
 
-// buildSearchAttempts builds the ordered fallback chain. The direct attempt is
-// always present; the dedicated and dynamic proxy attempts are appended only
-// when their respective proxies are configured.
+// buildSearchAttempts builds the ordered fallback chain: dedicated proxy (when
+// configured), then direct, then dynamic proxy (when configured).
 func buildSearchAttempts() []searchAttempt {
-	attempts := []searchAttempt{
-		{
-			strategy: "direct",
-			client:   &http.Client{Timeout: config.SearchAttemptTimeout},
-		},
-	}
+	var attempts []searchAttempt
 
 	if client, ok := dedicatedProxyClient(); ok {
 		attempts = append(attempts, searchAttempt{strategy: "dedicated", client: client})
 	}
+
+	attempts = append(attempts, searchAttempt{
+		strategy: "direct",
+		client:   &http.Client{Timeout: config.SearchAttemptTimeout},
+	})
 
 	if client, ok := dynamicProxyClient(); ok {
 		attempts = append(attempts, searchAttempt{strategy: "dynamic", client: client})

--- a/api/gateway/shopifysuggest/proxy_fallback_test.go
+++ b/api/gateway/shopifysuggest/proxy_fallback_test.go
@@ -175,6 +175,56 @@ func TestBuildSearchAttemptsProxyConfiguration(t *testing.T) {
 	require.Equal(t, "direct", attempts[1].strategy)
 }
 
+func TestProductDetailClientRotatesDedicatedProxies(t *testing.T) {
+	t.Setenv("DEDICATED_PROXY_1", "1.2.3.4|8080|user|pass")
+	t.Setenv("DEDICATED_PROXY_2", "5.6.7.8|8080|user|pass")
+	t.Setenv("DEDICATED_PROXY_3", "9.10.11.12|8080|user|pass")
+	t.Setenv("DEDICATED_PROXY_4", "")
+	t.Setenv("DEDICATED_PROXY_5", "")
+	t.Setenv("DEDICATED_PROXY_6", "")
+	t.Setenv("DEDICATED_PROXY_7", "")
+	t.Setenv("DYNAMIC_PROXY", "")
+
+	seen := make([]string, 0, 3)
+	for range 3 {
+		client := defaultProductDetailClient()
+		require.NotNil(t, client)
+		transport, ok := client.Transport.(*http.Transport)
+		require.True(t, ok)
+		require.NotNil(t, transport.Proxy)
+		req, err := http.NewRequest(http.MethodGet, "https://shop.example/products/card.js", nil)
+		require.NoError(t, err)
+		proxyURL, err := transport.Proxy(req)
+		require.NoError(t, err)
+		require.NotNil(t, proxyURL)
+		seen = append(seen, proxyURL.Host)
+	}
+
+	require.Equal(t, []string{"1.2.3.4:8080", "5.6.7.8:8080", "9.10.11.12:8080"}, seen)
+}
+
+func TestProductDetailClientFallsBackToDirectWithoutProxies(t *testing.T) {
+	t.Setenv("DEDICATED_PROXY_1", "")
+	t.Setenv("DEDICATED_PROXY_2", "")
+	t.Setenv("DEDICATED_PROXY_3", "")
+	t.Setenv("DEDICATED_PROXY_4", "")
+	t.Setenv("DEDICATED_PROXY_5", "")
+	t.Setenv("DEDICATED_PROXY_6", "")
+	t.Setenv("DEDICATED_PROXY_7", "")
+	t.Setenv("DYNAMIC_PROXY", "")
+
+	client := defaultProductDetailClient()
+	require.NotNil(t, client)
+	transport, ok := client.Transport.(*http.Transport)
+	if ok && transport != nil && transport.Proxy != nil {
+		req, err := http.NewRequest(http.MethodGet, "https://shop.example/products/card.js", nil)
+		require.NoError(t, err)
+		proxyURL, err := transport.Proxy(req)
+		require.NoError(t, err)
+		require.Nil(t, proxyURL)
+	}
+}
+
 func gzipJSON(t *testing.T, body string) []byte {
 	t.Helper()
 	var buf bytes.Buffer

--- a/api/gateway/shopifysuggest/proxy_fallback_test.go
+++ b/api/gateway/shopifysuggest/proxy_fallback_test.go
@@ -84,14 +84,14 @@ func TestRunSearchAttemptsFallsBackOnRateLimit(t *testing.T) {
 	defer srv.Close()
 
 	attempts := []searchAttempt{
-		{strategy: "direct", client: srv.Client()},
 		{strategy: "dedicated", client: srv.Client()},
+		{strategy: "direct", client: srv.Client()},
 	}
 
 	cards, err := runSearchAttempts(context.Background(), attempts, Options{Config: Config{StoreName: "Test"}, MapProduct: mapAllProducts}, srv.URL)
 	require.NoError(t, err)
 	require.Len(t, cards, 1)
-	require.Equal(t, int32(suggestRetryMaxAttempts+1), hits.Load(), "expected direct retries then dedicated success")
+	require.Equal(t, int32(suggestRetryMaxAttempts+1), hits.Load(), "expected dedicated retries then direct success")
 }
 
 // TestRunSearchAttemptsReturnsLastError verifies that when every transport
@@ -131,8 +131,8 @@ func TestRunSearchAttemptsStopsAtFirstSuccess(t *testing.T) {
 	defer shouldNotBeHit.Close()
 
 	attempts := []searchAttempt{
-		{strategy: "direct", client: healthy.Client()},
-		{strategy: "dedicated", client: shouldNotBeHit.Client()},
+		{strategy: "dedicated", client: healthy.Client()},
+		{strategy: "direct", client: shouldNotBeHit.Client()},
 	}
 
 	cards, err := runSearchAttempts(context.Background(), attempts, Options{Config: Config{StoreName: "Test"}, MapProduct: mapAllProducts}, healthy.URL)
@@ -158,19 +158,21 @@ func TestBuildSearchAttemptsProxyConfiguration(t *testing.T) {
 	t.Setenv("DEDICATED_PROXY_1", "1.2.3.4|8080|user|pass")
 	attempts = buildSearchAttempts()
 	require.Len(t, attempts, 2)
-	require.Equal(t, "direct", attempts[0].strategy)
-	require.Equal(t, "dedicated", attempts[1].strategy)
+	require.Equal(t, "dedicated", attempts[0].strategy)
+	require.Equal(t, "direct", attempts[1].strategy)
 
 	t.Setenv("DYNAMIC_PROXY", "http://5.6.7.8:9090")
 	attempts = buildSearchAttempts()
 	require.Len(t, attempts, 3)
+	require.Equal(t, "dedicated", attempts[0].strategy)
+	require.Equal(t, "direct", attempts[1].strategy)
 	require.Equal(t, "dynamic", attempts[2].strategy)
 
 	t.Setenv("USE_DYNAMIC_PROXY", "false")
 	attempts = buildSearchAttempts()
 	require.Len(t, attempts, 2)
-	require.Equal(t, "direct", attempts[0].strategy)
-	require.Equal(t, "dedicated", attempts[1].strategy)
+	require.Equal(t, "dedicated", attempts[0].strategy)
+	require.Equal(t, "direct", attempts[1].strategy)
 }
 
 func gzipJSON(t *testing.T, body string) []byte {

--- a/api/gateway/shopifysuggest/search.go
+++ b/api/gateway/shopifysuggest/search.go
@@ -17,6 +17,11 @@ const SearchPath = "/search/suggest.json"
 // search endpoint will return per request (the platform caps this at 10).
 const predictiveSearchLimit = "10"
 
+// variantResolveMaxProducts caps how many suggest products receive a follow-up
+// /products/<handle>.js fetch when ResolveVariants is enabled. Additional
+// eligible products are mapped from predictive-search fields only.
+const variantResolveMaxProducts = 5
+
 // ShopifyLocalizationSingapore is the Shopify market cookie value for
 // Singapore storefronts. Without it, Accept-Language defaults can return
 // prices from a different market than the public site shows to local users.
@@ -83,13 +88,13 @@ type suggestResponse struct {
 // products into cards using the supplied options.
 //
 // Shopify's predictive search endpoint can rate limit (HTTP 429) or otherwise
-// throttle direct traffic. Each transport retries transient failures on the
+// throttle traffic. Each transport retries transient failures on the
 // same connection, honoring Retry-After when present, before the request is
-// attempted through an ordered fallback chain: a direct connection first, then
-// a dedicated proxy, and finally the shared dynamic proxy. The first transport
-// that succeeds wins; later transports only run when the previous one exhausts
-// its retries (network failure, persistent non-200 status such as 429, or an
-// unparsable body).
+// attempted through an ordered fallback chain: a dedicated proxy first (when
+// configured), then a direct connection, and finally the shared dynamic proxy.
+// The first transport that succeeds wins; later transports only run when the
+// previous one exhausts its retries (network failure, persistent non-200 status
+// such as 429, or an unparsable body).
 func Search(ctx context.Context, opts Options) ([]gateway.Card, error) {
 	if opts.MapProduct == nil {
 		return nil, fmt.Errorf("shopifysuggest: MapProduct is required")
@@ -149,15 +154,19 @@ func fetchProducts(ctx context.Context, client *http.Client, apiURL string, reqO
 }
 
 // mapProducts filters the suggest products down to in-stock Magic cards and
-// maps them into gateway cards. When opts.ResolveVariants is set, each product
-// is expanded into one card per in-stock variant (see resolveVariantCards);
-// otherwise a single card is emitted from the predictive-search fields.
+// maps them into gateway cards. When opts.ResolveVariants is set, the first
+// variantResolveMaxProducts eligible products are expanded into one card per
+// in-stock variant (see resolveVariantCards); additional eligible products
+// use predictive-search fields only. When ResolveVariants is false, each
+// product emits a single suggest card.
 //
 // The HTTP client is threaded through so variant resolution reuses the same
 // transport that won the suggest fallback (direct, dedicated, or dynamic
 // proxy), avoiding a fresh, possibly-throttled connection per product.
 func mapProducts(ctx context.Context, client *http.Client, opts Options, products []Product) []gateway.Card {
 	cards := make([]gateway.Card, 0, len(products))
+	variantResolveRemaining := variantResolveMaxProducts
+
 	for _, product := range products {
 		if !product.Available {
 			continue
@@ -176,7 +185,16 @@ func mapProducts(ctx context.Context, client *http.Client, opts Options, product
 			continue
 		}
 
-		cards = append(cards, resolveVariantCards(ctx, client, opts.Config, product, base)...)
+		if variantResolveRemaining > 0 {
+			resolved := resolveVariantCards(ctx, client, opts.Config, product, base)
+			if len(resolved) > 0 {
+				cards = append(cards, resolved...)
+			}
+			variantResolveRemaining--
+			continue
+		}
+
+		cards = append(cards, base)
 	}
 	return cards
 }

--- a/api/gateway/shopifysuggest/search.go
+++ b/api/gateway/shopifysuggest/search.go
@@ -160,10 +160,10 @@ func fetchProducts(ctx context.Context, client *http.Client, apiURL string, reqO
 // use predictive-search fields only. When ResolveVariants is false, each
 // product emits a single suggest card.
 //
-// The HTTP client is threaded through so variant resolution reuses the same
-// transport that won the suggest fallback (direct, dedicated, or dynamic
-// proxy), avoiding a fresh, possibly-throttled connection per product.
-func mapProducts(ctx context.Context, client *http.Client, opts Options, products []Product) []gateway.Card {
+// Product detail requests use productDetailClient, which round-robins dedicated
+// proxies so variant resolution does not pile onto the transport that fetched
+// suggest.json.
+func mapProducts(ctx context.Context, opts Options, products []Product) []gateway.Card {
 	cards := make([]gateway.Card, 0, len(products))
 	variantResolveRemaining := variantResolveMaxProducts
 
@@ -186,7 +186,7 @@ func mapProducts(ctx context.Context, client *http.Client, opts Options, product
 		}
 
 		if variantResolveRemaining > 0 {
-			resolved := resolveVariantCards(ctx, client, opts.Config, product, base)
+			resolved := resolveVariantCards(ctx, productDetailClient(), opts.Config, product, base)
 			if len(resolved) > 0 {
 				cards = append(cards, resolved...)
 			}

--- a/api/gateway/shopifysuggest/search_test.go
+++ b/api/gateway/shopifysuggest/search_test.go
@@ -57,7 +57,11 @@ func TestMapProductsVariantResolveLimit(t *testing.T) {
 		},
 	}
 
-	cards := mapProducts(context.Background(), srv.Client(), opts, products)
+	oldProductDetailClient := productDetailClient
+	productDetailClient = func() *http.Client { return srv.Client() }
+	t.Cleanup(func() { productDetailClient = oldProductDetailClient })
+
+	cards := mapProducts(context.Background(), opts, products)
 
 	require.Equal(t, int32(variantResolveMaxProducts), detailCalls.Load())
 	require.Len(t, cards, variantResolveMaxProducts+2)

--- a/api/gateway/shopifysuggest/search_test.go
+++ b/api/gateway/shopifysuggest/search_test.go
@@ -1,0 +1,72 @@
+package shopifysuggest
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"mtg-price-checker-sg/gateway"
+)
+
+const singleVariantDetail = `{"variants": [
+	{"id": 1, "title": "Near Mint", "price": 250, "available": true}
+]}`
+
+func TestMapProductsVariantResolveLimit(t *testing.T) {
+	var detailCalls atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/products/") && strings.HasSuffix(r.URL.Path, ".js") {
+			detailCalls.Add(1)
+			_, _ = w.Write([]byte(singleVariantDetail))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	products := make([]Product, 0, variantResolveMaxProducts+2)
+	for i := range variantResolveMaxProducts + 2 {
+		products = append(products, Product{
+			Title:       "Card",
+			Handle:      fmt.Sprintf("card-%d", i),
+			Available:   true,
+			ProductType: "MTG Single Cards",
+			Price:       "1.00",
+		})
+	}
+
+	cfg := Config{StoreName: "Test", BaseURL: srv.URL}
+	opts := Options{
+		Config:          cfg,
+		ResolveVariants: true,
+		MapProduct: func(cfg Config, product Product) (gateway.Card, bool) {
+			return gateway.Card{
+				Name:    product.Title,
+				Source:  cfg.StoreName,
+				Price:   1.00,
+				InStock: true,
+				Url:     srv.URL + "/products/" + product.Handle,
+			}, true
+		},
+	}
+
+	cards := mapProducts(context.Background(), srv.Client(), opts, products)
+
+	require.Equal(t, int32(variantResolveMaxProducts), detailCalls.Load())
+	require.Len(t, cards, variantResolveMaxProducts+2)
+
+	for i, card := range cards {
+		if i < variantResolveMaxProducts {
+			require.Equal(t, 2.50, card.Price, "product %d should use resolved variant price", i)
+			continue
+		}
+		require.Equal(t, 1.00, card.Price, "product %d should fall back to suggest price", i)
+	}
+}

--- a/api/gateway/shopifysuggest/variant.go
+++ b/api/gateway/shopifysuggest/variant.go
@@ -68,8 +68,8 @@ func resolveVariantCards(ctx context.Context, client *http.Client, cfg Config, p
 }
 
 // fetchProductDetail retrieves and decodes a Shopify product JSON document for
-// the given handle using the supplied client (which carries whichever transport
-// won the suggest fallback).
+// the given handle using the supplied client (typically from productDetailClient,
+// which round-robins dedicated proxies across variant resolution requests).
 func fetchProductDetail(ctx context.Context, client *http.Client, cfg Config, handle string) (productDetail, error) {
 	handle = strings.TrimSpace(handle)
 	if handle == "" {

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -73,6 +73,16 @@ Constants live in `frontend/src/hooks/useSearch.js` (and related).
 
 ---
 
+## Backend: Shopify suggest (`api/gateway/shopifysuggest`)
+
+| Item | Value | Source | Notes |
+|------|--------|--------|--------|
+| Proxy fallback order | **dedicated → direct → dynamic** | `buildSearchAttempts` in `api/gateway/shopifysuggest/proxy_fallback.go` | Dedicated proxies are tried first when configured; direct and dynamic follow. |
+| Per-transport retries | 3 | `suggestRetryMaxAttempts` in `api/gateway/shopifysuggest/retry.go` | Retries 429/5xx on the same transport with capped backoff / Retry-After before advancing. |
+| Variant resolution cap | 5 products | `variantResolveMaxProducts` in `api/gateway/shopifysuggest/search.go` | When `ResolveVariants` is true, only the first five eligible suggest products fetch `/products/<handle>.js`; later products use suggest fields only. |
+
+---
+
 ## How to keep this file accurate
 
 1. When adding or changing **timeouts, intervals, concurrency, or strategy order**, update the relevant table and cite the file (paths above are stable).

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -78,6 +78,7 @@ Constants live in `frontend/src/hooks/useSearch.js` (and related).
 | Item | Value | Source | Notes |
 |------|--------|--------|--------|
 | Proxy fallback order | **dedicated → direct → dynamic** | `buildSearchAttempts` in `api/gateway/shopifysuggest/proxy_fallback.go` | Dedicated proxies are tried first when configured; direct and dynamic follow. |
+| Product detail client | **round-robin dedicated**, else dynamic, else direct | `defaultProductDetailClient` in `api/gateway/shopifysuggest/proxy_fallback.go` | Each `/products/<handle>.js` fetch uses the next dedicated proxy instead of reusing the suggest transport. |
 | Per-transport retries | 3 | `suggestRetryMaxAttempts` in `api/gateway/shopifysuggest/retry.go` | Retries 429/5xx on the same transport with capped backoff / Retry-After before advancing. |
 | Variant resolution cap | 5 products | `variantResolveMaxProducts` in `api/gateway/shopifysuggest/search.go` | When `ResolveVariants` is true, only the first five eligible suggest products fetch `/products/<handle>.js`; later products use suggest fields only. |
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reduces Shopify suggest 503 failures by changing how `shopifysuggest` reaches storefronts and how many follow-up product JSON requests it makes.

## Changes

### Proxy fallback order: dedicated → direct → dynamic

`buildSearchAttempts` now tries dedicated proxies first (when configured), then direct, then dynamic. This mirrors BinderPOS API strategy and avoids cloud/Lambda egress hitting Shopify throttling before residential proxies.

### Variant resolution capped at 5 products

When `ResolveVariants` is enabled (Fyendal Hobby, MTG Asia, Grey Ogre Games), only the **first five eligible** suggest products fetch `/products/<handle>.js`. Additional eligible products still appear using predictive-search fields.

### Product detail fetches spread across dedicated proxies

Each `/products/<handle>.js` request now round-robins dedicated proxies via `defaultProductDetailClient`, instead of reusing the transport that won the suggest fallback. This spreads up to 6 requests (1 suggest + 5 detail) across different dedicated IPs when configured. Falls back to dynamic, then direct, when no dedicated proxies are set.

## Testing

- `go test -mod=vendor ./gateway/shopifysuggest/...`
- `make test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69c3657f-c045-4439-8976-1402d8f26a60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69c3657f-c045-4439-8976-1402d8f26a60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

