### PR TITLE
Enable BinderPOS decklist API for Hideyoshi, MTG Asia, Fyendal Hobby, and Grey Ogre Games

### DIFF
--- a/api/gateway/fyendalhobby/search.go
+++ b/api/gateway/fyendalhobby/search.go
@@ -12,10 +12,6 @@ const StoreBaseURL = "https://fyendalhobby.com"
 const StoreShopifyDomain = "fyendal-hobby.myshopify.com"
 const StoreSearchURL = "/search?q=%s"
 
-// ScrapOnly skips the shared BinderPOS decklist portal while retaining the
-// Shopify domain mapping for documentation and live integration tests.
-const ScrapOnly = true
-
 type Store struct {
 	Name         string
 	BaseUrl      string
@@ -40,6 +36,6 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 		StoreShopifyDomain,
 		s.SearchUrl,
 		searchStr,
-		ScrapOnly,
+		false,
 	)
 }

--- a/api/gateway/fyendalhobby/search_test.go
+++ b/api/gateway/fyendalhobby/search_test.go
@@ -25,7 +25,7 @@ func Test_Search(t *testing.T) {
 			BaseURL:       StoreBaseURL,
 			SearchURL:     StoreSearchURL,
 			ShopifyDomain: StoreShopifyDomain,
-			ScrapOnly:     ScrapOnly,
+			ScrapOnly:     false,
 			Query:         "Abrade",
 		})
 	})

--- a/api/gateway/gog/search.go
+++ b/api/gateway/gog/search.go
@@ -12,10 +12,6 @@ const StoreBaseURL = "https://www.greyogregames.com"
 const StoreShopifyDomain = "grey-ogre-games-singapore.myshopify.com"
 const StoreSearchURL = "/search?q=%s"
 
-// ScrapOnly skips the shared BinderPOS decklist portal while retaining the
-// Shopify domain mapping for documentation and live integration tests.
-const ScrapOnly = true
-
 type Store struct {
 	Name         string
 	BaseUrl      string
@@ -40,6 +36,6 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 		StoreShopifyDomain,
 		s.SearchUrl,
 		searchStr,
-		ScrapOnly,
+		false,
 	)
 }

--- a/api/gateway/gog/search_test.go
+++ b/api/gateway/gog/search_test.go
@@ -25,7 +25,7 @@ func Test_Search(t *testing.T) {
 			BaseURL:       StoreBaseURL,
 			SearchURL:     StoreSearchURL,
 			ShopifyDomain: StoreShopifyDomain,
-			ScrapOnly:     ScrapOnly,
+			ScrapOnly:     false,
 			Query:         "Abrade",
 		})
 	})

--- a/api/gateway/hideyoshi/search.go
+++ b/api/gateway/hideyoshi/search.go
@@ -12,10 +12,6 @@ const StoreBaseURL = "https://hideyoshitcg.com"
 const StoreShopifyDomain = "bposacct-9.myshopify.com"
 const StoreSearchURL = "/search?q=%s"
 
-// ScrapOnly skips the shared BinderPOS decklist portal while retaining the
-// Shopify domain mapping for documentation and live integration tests.
-const ScrapOnly = true
-
 type Store struct {
 	Name         string
 	BaseUrl      string
@@ -40,6 +36,6 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 		StoreShopifyDomain,
 		s.SearchUrl,
 		searchStr,
-		ScrapOnly,
+		false,
 	)
 }

--- a/api/gateway/hideyoshi/search_test.go
+++ b/api/gateway/hideyoshi/search_test.go
@@ -28,7 +28,7 @@ func Test_Search(t *testing.T) {
 			BaseURL:       StoreBaseURL,
 			SearchURL:     StoreSearchURL,
 			ShopifyDomain: StoreShopifyDomain,
-			ScrapOnly:     ScrapOnly,
+			ScrapOnly:     false,
 			Query:         "Abrade",
 		})
 	})

--- a/api/gateway/mtgasia/search.go
+++ b/api/gateway/mtgasia/search.go
@@ -12,10 +12,6 @@ const StoreBaseURL = "https://www.mtg-asia.com"
 const StoreShopifyDomain = "mtgasia.myshopify.com"
 const StoreSearchURL = "/search?q=%s"
 
-// ScrapOnly skips the shared BinderPOS decklist portal while retaining the
-// Shopify domain mapping for documentation and live integration tests.
-const ScrapOnly = true
-
 type Store struct {
 	Name         string
 	BaseUrl      string
@@ -40,6 +36,6 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 		StoreShopifyDomain,
 		s.SearchUrl,
 		searchStr,
-		ScrapOnly,
+		false,
 	)
 }

--- a/api/gateway/mtgasia/search_test.go
+++ b/api/gateway/mtgasia/search_test.go
@@ -25,7 +25,7 @@ func Test_Search(t *testing.T) {
 			BaseURL:       StoreBaseURL,
 			SearchURL:     StoreSearchURL,
 			ShopifyDomain: StoreShopifyDomain,
-			ScrapOnly:     ScrapOnly,
+			ScrapOnly:     false,
 			Query:         "Abrade",
 		})
 	})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Enables the shared BinderPOS decklist portal (`portal.binderpos.com`) for four stores that previously had `ScrapOnly = true`:

- **Hideyoshi** (`bposacct-9.myshopify.com`)
- **MTG Asia** (`mtgasia.myshopify.com`)
- **Fyendal Hobby** (`fyendal-hobby.myshopify.com`)
- **Grey Ogre Games** (`grey-ogre-games-singapore.myshopify.com`)

Each store now participates in the standard BinderPOS search strategy chain (decklist and scrape, with 50/50 lead round-robin), matching stores like OneMtg, Flagship, and Hideout.

## Live test results

With `RUN_BINDERPOS_LIVE_TESTS=1`:

| Store | `Test_SearchByStorefrontAPI_SupportsAllBinderposStores` | `Test_Search` (full gateway) |
|-------|--------------------------------------------------------|------------------------------|
| Grey Ogre Games | PASS | PASS |
| MTG Asia | PASS | PASS |
| Hideyoshi | PASS | PASS |
| Fyendal Hobby | PASS | PASS |

`make test` also passes.

## Notes

- Removed the `ScrapOnly` constant from each gateway package; searches now pass `false` to the BinderPOS gateway, consistent with other decklist-enabled stores.
- Structure probe configs in store tests updated to `ScrapOnly: false` so decklist structure is validated on scrape fallback.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1eabbc20-b2df-481e-874d-9e4d08f423ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1eabbc20-b2df-481e-874d-9e4d08f423ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

