### PR TITLE
Route non-BinderPOS stores through random dedicated proxy

### DIFF
--- a/api/gateway/agora/fixtures_test.go
+++ b/api/gateway/agora/fixtures_test.go
@@ -1,0 +1,25 @@
+package agora
+
+const outOfStockStoreItemHTML = `
+<div id="store_listingcontainer">
+  <div class="store-item">
+    <div class="store-item-stock">Stock: 0</div>
+    <div class="store-item-price">$1.50</div>
+    <div class="store-item-cat">[DMU] Dominaria United - Near Mint</div>
+    <div class="store-item-title">Abrade</div>
+    <div class="store-item-img" data-img="https://agorahobby.com/img/abrade.jpg"></div>
+  </div>
+</div>
+`
+
+const inStockStoreItemHTML = `
+<div id="store_listingcontainer">
+  <div class="store-item">
+    <div class="store-item-stock">Stock: 3</div>
+    <div class="store-item-price">$2.00</div>
+    <div class="store-item-cat">[DMU] Dominaria United - Near Mint</div>
+    <div class="store-item-title">Abrade FOIL</div>
+    <div class="store-item-img" data-img="https://agorahobby.com/img/abrade-foil.jpg"></div>
+  </div>
+</div>
+`

--- a/api/gateway/agora/search.go
+++ b/api/gateway/agora/search.go
@@ -51,7 +51,7 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 	searchURL := apiURL.String()
 	var cards []gateway.Card
 
-	c := gateway.NewOptimizedCollectorNoRetryDirect(ctx)
+	c := gateway.NewOptimizedCollectorNoRetry(ctx)
 	c.SetRequestTimeout(config.AgoraSearchAttemptTimeout)
 
 	c.OnHTML("div#store_listingcontainer", func(e *colly.HTMLElement) {

--- a/api/gateway/agora/search.go
+++ b/api/gateway/agora/search.go
@@ -3,6 +3,7 @@ package agora
 import (
 	"context"
 	"log"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -11,7 +12,7 @@ import (
 	"mtg-price-checker-sg/gateway/util"
 	"mtg-price-checker-sg/pkg/config"
 
-	"github.com/gocolly/colly/v2"
+	"github.com/PuerkitoBio/goquery"
 )
 
 const StoreName = "Agora Hobby"
@@ -34,9 +35,11 @@ func NewLGS() gateway.LGS {
 }
 
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
+	var cards []gateway.Card
+
 	baseURL, err := url.Parse(s.BaseUrl)
 	if err != nil {
-		return nil, err
+		return cards, err
 	}
 
 	apiURL := &url.URL{
@@ -48,79 +51,107 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 			"searchfield": {searchStr},
 		}.Encode(),
 	}
-	searchURL := apiURL.String()
-	var cards []gateway.Card
 
-	c := gateway.NewOptimizedCollectorNoRetry(ctx)
-	c.SetRequestTimeout(config.AgoraSearchAttemptTimeout)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL.String(), nil)
+	if err != nil {
+		return cards, err
+	}
+	if err := gateway.PrepareOutboundRequest(ctx, req, gateway.OutboundRequestOptions{
+		Style:   gateway.OutboundStyleHTML,
+		PageURL: apiURL,
+	}); err != nil {
+		return cards, err
+	}
 
-	c.OnHTML("div#store_listingcontainer", func(e *colly.HTMLElement) {
-		e.ForEach("div.store-item", func(_ int, el *colly.HTMLElement) {
-			var (
-				isInstock bool
-				price     float64
-				quality   string
-			)
+	client, err := gateway.NewOutboundHTTPClient(config.AgoraSearchAttemptTimeout)
+	if err != nil {
+		return cards, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return cards, err
+	}
+	defer resp.Body.Close()
 
-			// in stock
-			if el.ChildText("div.store-item-stock") != "Stock: 0" {
-				isInstock = true
-			}
+	body, err := gateway.ReadResponseBody(resp)
+	if err != nil {
+		return cards, err
+	}
 
-			// price
-			priceStr := strings.TrimSpace(el.ChildText("div.store-item-price"))
-			priceStr = strings.Replace(priceStr, "$", "", -1)
-			priceStr = strings.Replace(priceStr, ",", "", -1)
-			price, _ = strconv.ParseFloat(strings.TrimSpace(priceStr), 64)
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(string(body)))
+	if err != nil {
+		return cards, err
+	}
 
-			// quality
-			qualityStr := el.ChildText("div.store-item-cat")
-			qualityStrSlice := strings.Split(qualityStr, " - ")
-			if len(qualityStrSlice) == 2 {
-				quality = strings.TrimSpace(qualityStrSlice[1])
-			}
-
-			var (
-				extraInfo []string
-				set       string
-			)
-			if strings.Contains(el.ChildText("div.store-item-cat"), "]") {
-				set = el.ChildText("div.store-item-cat")[:strings.Index(el.ChildText("div.store-item-cat"), "]")+1]
-				extraInfo = append(extraInfo, set)
-			}
-
-			// name
-			name := el.ChildText("div.store-item-title")
-
-			// url
-			cleanPageURL, err := url.Parse(strings.TrimSpace(searchURL))
-			if err != nil {
-				log.Printf("error parsing url for %s with value [%s]: %v", s.Name, searchURL, err)
-				return
-			}
-			cleanPageURL.RawQuery = url.Values{
-				"category":    []string{storeCategoryMTG},
-				"searchfield": []string{searchStr},
-				"utm_source":  []string{config.UtmSource},
-			}.Encode()
-
-			if !isInstock || price <= 0 {
-				return
-			}
-
-			cards = append(cards, gateway.Card{
-				Name:      strings.TrimSpace(name),
-				Url:       strings.TrimSpace(cleanPageURL.String()),
-				InStock:   true,
-				IsFoil:    strings.Contains(name, "FOIL"), // case sensitive
-				Price:     price,
-				Source:    s.Name,
-				Img:       strings.TrimSpace(el.ChildAttr("div.store-item-img", "data-img")),
-				Quality:   util.MapQuality(quality),
-				ExtraInfo: extraInfo,
-			})
-		})
+	doc.Find("div#store_listingcontainer div.store-item").Each(func(_ int, se *goquery.Selection) {
+		card, ok := parseStoreItem(se, s.Name, apiURL, searchStr)
+		if ok {
+			cards = append(cards, card)
+		}
 	})
 
-	return cards, gateway.VisitWithProxyInfo(c, searchURL)
+	return cards, nil
+}
+
+func parseStoreItem(se *goquery.Selection, storeName string, apiURL *url.URL, searchStr string) (gateway.Card, bool) {
+	if se.Find("div.store-item-stock").Text() == "Stock: 0" {
+		return gateway.Card{}, false
+	}
+
+	priceStr := strings.TrimSpace(se.Find("div.store-item-price").Text())
+	priceStr = strings.Replace(priceStr, "$", "", -1)
+	priceStr = strings.Replace(priceStr, ",", "", -1)
+	price, err := strconv.ParseFloat(strings.TrimSpace(priceStr), 64)
+	if err != nil || price <= 0 {
+		return gateway.Card{}, false
+	}
+
+	categoryText := se.Find("div.store-item-cat").Text()
+	quality := ""
+	qualityParts := strings.Split(categoryText, " - ")
+	if len(qualityParts) == 2 {
+		quality = strings.TrimSpace(qualityParts[1])
+	}
+
+	var extraInfo []string
+	if strings.Contains(categoryText, "]") {
+		set := categoryText[:strings.Index(categoryText, "]")+1]
+		extraInfo = append(extraInfo, set)
+	}
+
+	name := strings.TrimSpace(se.Find("div.store-item-title").Text())
+	if name == "" {
+		return gateway.Card{}, false
+	}
+
+	cardURL, err := buildCardURL(apiURL, searchStr)
+	if err != nil {
+		log.Printf("error parsing url for %s with value [%s]: %v", storeName, apiURL.String(), err)
+		return gateway.Card{}, false
+	}
+
+	return gateway.Card{
+		Name:      name,
+		Url:       cardURL,
+		InStock:   true,
+		IsFoil:    strings.Contains(name, "FOIL"),
+		Price:     price,
+		Source:    storeName,
+		Img:       strings.TrimSpace(se.Find("div.store-item-img").AttrOr("data-img", "")),
+		Quality:   util.MapQuality(quality),
+		ExtraInfo: extraInfo,
+	}, true
+}
+
+func buildCardURL(apiURL *url.URL, searchStr string) (string, error) {
+	cleanPageURL, err := url.Parse(apiURL.String())
+	if err != nil {
+		return "", err
+	}
+	cleanPageURL.RawQuery = url.Values{
+		"category":    []string{storeCategoryMTG},
+		"searchfield": []string{searchStr},
+		"utm_source":  []string{config.UtmSource},
+	}.Encode()
+	return cleanPageURL.String(), nil
 }

--- a/api/gateway/agora/search_test.go
+++ b/api/gateway/agora/search_test.go
@@ -2,13 +2,44 @@ package agora
 
 import (
 	"context"
+	"net/url"
 	"strings"
 	"testing"
 
 	"mtg-price-checker-sg/gateway/gatewaytest"
 
+	"github.com/PuerkitoBio/goquery"
 	"github.com/stretchr/testify/require"
 )
+
+func Test_ParseStoreItemSkipsOutOfStock(t *testing.T) {
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(outOfStockStoreItemHTML))
+	require.NoError(t, err)
+
+	apiURL, err := url.Parse(StoreBaseURL + StoreSearchPath + "?category=mtg&searchfield=Abrade")
+	require.NoError(t, err)
+
+	card, ok := parseStoreItem(doc.Find("div.store-item").First(), StoreName, apiURL, "Abrade")
+	require.False(t, ok)
+	require.Empty(t, card.Name)
+}
+
+func Test_ParseStoreItemKeepsInStock(t *testing.T) {
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(inStockStoreItemHTML))
+	require.NoError(t, err)
+
+	apiURL, err := url.Parse(StoreBaseURL + StoreSearchPath + "?category=mtg&searchfield=Abrade")
+	require.NoError(t, err)
+
+	card, ok := parseStoreItem(doc.Find("div.store-item").First(), StoreName, apiURL, "Abrade")
+	require.True(t, ok)
+	require.Equal(t, "Abrade FOIL", card.Name)
+	require.True(t, card.InStock)
+	require.True(t, card.IsFoil)
+	require.Equal(t, 2.0, card.Price)
+	require.Equal(t, "[DMU]", card.ExtraInfo[0])
+	require.Contains(t, card.Url, "utm_source=")
+}
 
 func Test_Search(t *testing.T) {
 	s := NewLGS()

--- a/api/gateway/cardsandcollection/search.go
+++ b/api/gateway/cardsandcollection/search.go
@@ -174,7 +174,11 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 	if err := gateway.PrepareOutboundRequest(ctx, req, gateway.OutboundRequestOptions{}); err != nil {
 		return cards, err
 	}
-	resp, err := http.DefaultClient.Do(req)
+	client, err := gateway.NewOutboundHTTPClient(config.SearchAttemptTimeout)
+	if err != nil {
+		return cards, err
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return cards, err
 	}

--- a/api/gateway/cardscentral/search.go
+++ b/api/gateway/cardscentral/search.go
@@ -71,7 +71,10 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 		return cards, err
 	}
 
-	client := &http.Client{Timeout: 15 * time.Second}
+	client, err := gateway.NewOutboundHTTPClient(15 * time.Second)
+	if err != nil {
+		return cards, err
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return cards, err

--- a/api/gateway/collector.go
+++ b/api/gateway/collector.go
@@ -268,28 +268,39 @@ func leaseDedicatedProxyIfNeeded(enforceDedicatedProxyLease bool) (string, func(
 	return leasedDedicatedProxyURL, releaseDedicatedProxy
 }
 
-// applyInitialProxy configures the transport for the first and only request for this collector, mirroring
-// the prior "initial attempt" proxy policy without any follow-up attempts.
-func applyInitialProxy(c *colly.Collector, leasedDedicatedProxyURL string) (string, string) {
+// selectOutboundProxy picks the proxy mode and URL for a single outbound attempt.
+// When leasedDedicatedProxyURL is non-empty it is used; otherwise a random dedicated
+// proxy is chosen when configured, then dynamic proxy, then direct.
+func selectOutboundProxy(leasedDedicatedProxyURL string) (mode string, proxyURL string) {
 	if !config.UseProxy {
-		return clearProxy(c)
+		return "direct", ""
 	}
 	if leasedDedicatedProxyURL != "" {
-		c.SetProxy(leasedDedicatedProxyURL)
 		return "dedicated", leasedDedicatedProxyURL
 	}
 	if proxyURL, ok := randomDedicatedProxyURL(""); ok {
-		c.SetProxy(proxyURL)
 		return "dedicated", proxyURL
 	}
 	if proxyURL := DynamicProxyURL(); proxyURL != "" {
-		if err := c.SetProxy(proxyURL); err == nil {
-			return "dynamic", proxyURL
-		} else {
+		return "dynamic", proxyURL
+	}
+	return "direct", ""
+}
+
+// applyInitialProxy configures the transport for the first and only request for this collector, mirroring
+// the prior "initial attempt" proxy policy without any follow-up attempts.
+func applyInitialProxy(c *colly.Collector, leasedDedicatedProxyURL string) (string, string) {
+	mode, proxyURL := selectOutboundProxy(leasedDedicatedProxyURL)
+	if proxyURL == "" {
+		return clearProxy(c)
+	}
+	if err := c.SetProxy(proxyURL); err != nil {
+		if mode == "dynamic" {
 			log.Printf("invalid dynamic proxy configured: %v", err)
 		}
+		return clearProxy(c)
 	}
-	return clearProxy(c)
+	return mode, proxyURL
 }
 
 // Colly callback registration helpers.

--- a/api/gateway/duellerpoint/search.go
+++ b/api/gateway/duellerpoint/search.go
@@ -57,7 +57,11 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 	}); err != nil {
 		return cards, err
 	}
-	resp, err := http.DefaultClient.Do(req)
+	client, err := gateway.NewOutboundHTTPClient(config.SearchAttemptTimeout)
+	if err != nil {
+		return cards, err
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return cards, err
 	}

--- a/api/gateway/fivemana/search.go
+++ b/api/gateway/fivemana/search.go
@@ -56,7 +56,11 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 	}); err != nil {
 		return cards, err
 	}
-	resp, err := http.DefaultClient.Do(req)
+	client, err := gateway.NewOutboundHTTPClient(config.SearchAttemptTimeout)
+	if err != nil {
+		return cards, err
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return cards, err
 	}

--- a/api/gateway/moxandlotus/search.go
+++ b/api/gateway/moxandlotus/search.go
@@ -146,7 +146,11 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 	if err := gateway.PrepareOutboundRequest(ctx, req, gateway.OutboundRequestOptions{}); err != nil {
 		return cards, err
 	}
-	resp, err := http.DefaultClient.Do(req)
+	client, err := gateway.NewOutboundHTTPClient(config.SearchAttemptTimeout)
+	if err != nil {
+		return cards, err
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return cards, err
 	}

--- a/api/gateway/outbound_get.go
+++ b/api/gateway/outbound_get.go
@@ -117,6 +117,17 @@ func outboundStatusFailure(strategy string, resp *http.Response) string {
 	return msg + " (" + trimmed + ")"
 }
 
+// NewOutboundHTTPClient returns an HTTP client that routes through a random dedicated
+// proxy when configured, otherwise dynamic proxy, otherwise direct. The policy matches
+// optimized colly collectors used by non-BinderPOS scrapers.
+func NewOutboundHTTPClient(timeout time.Duration) (*http.Client, error) {
+	_, proxyURL := selectOutboundProxy("")
+	if proxyURL == "" {
+		return &http.Client{Timeout: timeout}, nil
+	}
+	return newProxyHTTPClient(proxyURL, timeout)
+}
+
 func newProxyHTTPClient(proxyURL string, timeout time.Duration) (*http.Client, error) {
 	parsedProxyURL, err := url.Parse(proxyURL)
 	if err != nil {

--- a/api/gateway/outbound_get_test.go
+++ b/api/gateway/outbound_get_test.go
@@ -19,6 +19,25 @@ func clearProxyEnv(t *testing.T) {
 	t.Setenv("DYNAMIC_PROXY", "")
 }
 
+func TestNewOutboundHTTPClient(t *testing.T) {
+	clearProxyEnv(t)
+
+	t.Run("returns direct client when no proxy is configured", func(t *testing.T) {
+		client, err := NewOutboundHTTPClient(2 * time.Second)
+		require.NoError(t, err)
+		require.NotNil(t, client)
+		require.Nil(t, client.Transport)
+	})
+
+	t.Run("returns dedicated proxy client when configured", func(t *testing.T) {
+		t.Setenv("DEDICATED_PROXY_1", "1.2.3.4|8080|user|pass")
+		client, err := NewOutboundHTTPClient(2 * time.Second)
+		require.NoError(t, err)
+		require.NotNil(t, client)
+		require.NotNil(t, client.Transport)
+	})
+}
+
 func TestDoOutboundGET_DirectSuccess(t *testing.T) {
 	clearProxyEnv(t)
 

--- a/api/gateway/tcgmarketplace/search.go
+++ b/api/gateway/tcgmarketplace/search.go
@@ -173,7 +173,11 @@ func getApiResponse(ctx context.Context, payload []byte, accessTokenConfigured b
 		requestContext = append(requestContext, "access_token_configured=false")
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	client, err := gateway.NewOutboundHTTPClient(config.SearchAttemptTimeout)
+	if err != nil {
+		return res, err
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return res, gateway.WrapHTTPRequestError(err, req, requestContext...)
 	}

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -60,7 +60,15 @@ Some tests in `api/gateway/binderpos/*_test.go` hit real stores and proxies. The
 
 ---
 
-## Frontend: `useSearch` (API + Scryfall)
+## Backend: non-BinderPOS stores (Agora, Cards Central, Dueller's Point, 5 Mana, Mox & Lotus, Cards & Collections, TCG Marketplace)
+
+| Item | Value | Source | Notes |
+|------|--------|--------|--------|
+| Outbound proxy policy | Random dedicated → dynamic → direct | `selectOutboundProxy` in `api/gateway/collector.go` | Same single-attempt policy as default optimized colly collectors. When `DEDICATED_PROXY_*` is configured, each search picks one dedicated proxy uniformly at random. |
+| Colly scrapers (Agora) | Random dedicated proxy | `NewOptimizedCollectorNoRetry` in `api/gateway/agora/search.go` | Uses `applyInitialProxy` via `configureRequestOptimizations`. |
+| `net/http` scrapers / APIs | Random dedicated proxy | `NewOutboundHTTPClient` in `api/gateway/outbound_get.go` | Used by Cards Central, Dueller's Point, 5 Mana, Mox & Lotus, Cards & Collections, and TCG Marketplace instead of `http.DefaultClient`. |
+
+---
 
 Constants live in `frontend/src/hooks/useSearch.js` (and related).
 

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -65,8 +65,7 @@ Some tests in `api/gateway/binderpos/*_test.go` hit real stores and proxies. The
 | Item | Value | Source | Notes |
 |------|--------|--------|--------|
 | Outbound proxy policy | Random dedicated → dynamic → direct | `selectOutboundProxy` in `api/gateway/collector.go` | Same single-attempt policy as default optimized colly collectors. When `DEDICATED_PROXY_*` is configured, each search picks one dedicated proxy uniformly at random. |
-| Colly scrapers (Agora) | Random dedicated proxy | `NewOptimizedCollectorNoRetry` in `api/gateway/agora/search.go` | Uses `applyInitialProxy` via `configureRequestOptimizations`. |
-| `net/http` scrapers / APIs | Random dedicated proxy | `NewOutboundHTTPClient` in `api/gateway/outbound_get.go` | Used by Cards Central, Dueller's Point, 5 Mana, Mox & Lotus, Cards & Collections, and TCG Marketplace instead of `http.DefaultClient`. |
+| `net/http` scrapers / APIs | Random dedicated proxy | `NewOutboundHTTPClient` in `api/gateway/outbound_get.go` | Used by Agora, Cards Central, Dueller's Point, 5 Mana, Mox & Lotus, Cards & Collections, and TCG Marketplace instead of `http.DefaultClient`. |
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Non-BinderPOS store gateways now use the same outbound proxy policy as BinderPOS scrapes: pick a random dedicated proxy when `DEDICATED_PROXY_*` is configured, otherwise fall back to `DYNAMIC_PROXY`, then direct.

Agora is also refactored from Colly to `net/http` + goquery so it matches the other custom HTTP store gateways.

## Changes

- Extract `selectOutboundProxy` in `api/gateway/collector.go` so colly and `net/http` share one policy.
- Add `NewOutboundHTTPClient` in `api/gateway/outbound_get.go` for stdlib HTTP callers.
- Update custom HTTP store gateways to use `NewOutboundHTTPClient`:
  - Agora (refactored from Colly to `net/http` + goquery)
  - Cards Central
  - Dueller's Point
  - 5 Mana
  - Mox & Lotus
  - Cards & Collections
  - TCG Marketplace
- Add offline Agora fixture tests for `parseStoreItem`.
- Document the non-BinderPOS proxy policy in `docs/search-strategies-retries-timeouts.md`.

## Testing

- `make test` (live gateway tests can be flaky through dedicated proxies in this environment; offline Agora parse tests pass)
- `cd api && go fix ./...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39092221-bf95-45b6-a3c9-5331c6f97a61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39092221-bf95-45b6-a3c9-5331c6f97a61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

