### PR TITLE
Require exactly four segments in parseDedicatedProxy

### DIFF
--- a/api/gateway/util/dedicated_proxy.go
+++ b/api/gateway/util/dedicated_proxy.go
@@ -19,23 +19,17 @@ func parseDedicatedProxy(raw string) DedicatedProxy {
 		return DedicatedProxy{}
 	}
 
-	parts := strings.SplitN(raw, "|", 4)
+	parts := strings.Split(raw, "|")
+	if len(parts) != 4 {
+		return DedicatedProxy{}
+	}
 
-	// Be defensive: if there are fewer than 4 segments, fill what we can.
-	proxy := DedicatedProxy{}
-	if len(parts) > 0 {
-		proxy.Host = strings.TrimSpace(parts[0])
+	return DedicatedProxy{
+		Host:     strings.TrimSpace(parts[0]),
+		Port:     strings.TrimSpace(parts[1]),
+		Username: strings.TrimSpace(parts[2]),
+		Password: strings.TrimSpace(parts[3]),
 	}
-	if len(parts) > 1 {
-		proxy.Port = strings.TrimSpace(parts[1])
-	}
-	if len(parts) > 2 {
-		proxy.Username = strings.TrimSpace(parts[2])
-	}
-	if len(parts) > 3 {
-		proxy.Password = strings.TrimSpace(parts[3])
-	}
-	return proxy
 }
 
 func GetDedicatedProxy() []DedicatedProxy {

--- a/api/gateway/util/dedicated_proxy_test.go
+++ b/api/gateway/util/dedicated_proxy_test.go
@@ -71,12 +71,12 @@ func TestGetDedicatedProxyReturnsEmptyStringsWhenEnvVarsAreEmpty(t *testing.T) {
 	}
 }
 
-func TestGetDedicatedProxyParsesPartialSegments(t *testing.T) {
-	// Slots 1–3: partial pipe segments; 4–7: unset (empty string).
+func TestGetDedicatedProxyRejectsPartialSegments(t *testing.T) {
 	raw := []string{
-		"host-1",             // missing port/username/password
-		"host-2|2222",        // missing username/password
-		"host-3|3333|user-3", // missing password
+		"host-1",
+		"host-2|2222",
+		"host-3|3333|user-3",
+		"host-4|4444|user-4|pass-4|extra",
 		"", "", "", "",
 	}
 	for i, v := range raw {
@@ -86,20 +86,9 @@ func TestGetDedicatedProxyParsesPartialSegments(t *testing.T) {
 	got := GetDedicatedProxy()
 	require.Len(t, got, 7)
 
-	require.Equal(t, "host-1", got[0].Host)
-	require.Equal(t, "", got[0].Port)
-	require.Equal(t, "", got[0].Username)
-	require.Equal(t, "", got[0].Password)
-
-	require.Equal(t, "host-2", got[1].Host)
-	require.Equal(t, "2222", got[1].Port)
-	require.Equal(t, "", got[1].Username)
-	require.Equal(t, "", got[1].Password)
-
-	require.Equal(t, "host-3", got[2].Host)
-	require.Equal(t, "3333", got[2].Port)
-	require.Equal(t, "user-3", got[2].Username)
-	require.Equal(t, "", got[2].Password)
+	for i := 0; i < 4; i++ {
+		require.Equal(t, DedicatedProxy{}, got[i], "slot %d should reject non-4-segment config", i+1)
+	}
 }
 
 func TestBuildProxyURL(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`parseDedicatedProxy` now accepts only the full `host|port|username|password` format. Inputs with fewer than four pipe-separated segments, or more than four, return an empty `DedicatedProxy` instead of partially filling fields.

## Changes

- Replace `strings.SplitN(..., 4)` and conditional segment assignment with `strings.Split` and a strict `len(parts) == 4` check
- Rename/update the util test to assert partial and extra-segment configs are rejected

## Testing

- `cd api && go test -mod=vendor -failfast ./gateway/util/...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65526730-a995-4334-9242-6062fa3c7985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65526730-a995-4334-9242-6062fa3c7985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

