### PR TITLE
Add priceChangePercent to CK price refresh job

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,38 +149,6 @@ retail listing per card name, and batch-writes the index. Search verifies the
 query against Scryfall before looking up DynamoDB and omits stale entries older
 than 48 hours.
 
-To query the largest price movers without scanning the full table, add a sparse
-GSI named `priceChangePercent-index` on `CK_DYNAMODB_TABLE`:
-
-- Partition key: `priceChangeIndexPK` (String)
-- Sort key: `priceChangePercent` (Number)
-
-The refresh job writes `priceChangeIndexPK = "CURRENT"` only for listings that
-have a `priceChangePercent`. `GetPriceChangesByPercent(ctx, true, 20)` is then
-equivalent to `ORDER BY priceChangePercent ASC LIMIT 20`, and
-`GetPriceChangesByPercent(ctx, false, 20)` is `ORDER BY priceChangePercent DESC
-LIMIT 20`. Until the GSI exists, those methods fall back to a table scan.
-
-```bash
-aws dynamodb update-table \
-  --table-name "$CK_DYNAMODB_TABLE" \
-  --attribute-definitions \
-      AttributeName=priceChangeIndexPK,AttributeType=S \
-      AttributeName=priceChangePercent,AttributeType=N \
-  --global-secondary-index-updates '[
-    {
-      "Create": {
-        "IndexName": "priceChangePercent-index",
-        "KeySchema": [
-          {"AttributeName": "priceChangeIndexPK", "KeyType": "HASH"},
-          {"AttributeName": "priceChangePercent", "KeyType": "RANGE"}
-        ],
-        "Projection": {"ProjectionType": "ALL"}
-      }
-    }
-  ]'
-```
-
 ```mermaid
 sequenceDiagram
     participant EB as EventBridge

--- a/README.md
+++ b/README.md
@@ -149,6 +149,38 @@ retail listing per card name, and batch-writes the index. Search verifies the
 query against Scryfall before looking up DynamoDB and omits stale entries older
 than 48 hours.
 
+To query the largest price movers without scanning the full table, add a sparse
+GSI named `priceChangePercent-index` on `CK_DYNAMODB_TABLE`:
+
+- Partition key: `priceChangeIndexPK` (String)
+- Sort key: `priceChangePercent` (Number)
+
+The refresh job writes `priceChangeIndexPK = "CURRENT"` only for listings that
+have a `priceChangePercent`. `GetPriceChangesByPercent(ctx, true, 20)` is then
+equivalent to `ORDER BY priceChangePercent ASC LIMIT 20`, and
+`GetPriceChangesByPercent(ctx, false, 20)` is `ORDER BY priceChangePercent DESC
+LIMIT 20`. Until the GSI exists, those methods fall back to a table scan.
+
+```bash
+aws dynamodb update-table \
+  --table-name "$CK_DYNAMODB_TABLE" \
+  --attribute-definitions \
+      AttributeName=priceChangeIndexPK,AttributeType=S \
+      AttributeName=priceChangePercent,AttributeType=N \
+  --global-secondary-index-updates '[
+    {
+      "Create": {
+        "IndexName": "priceChangePercent-index",
+        "KeySchema": [
+          {"AttributeName": "priceChangeIndexPK", "KeyType": "HASH"},
+          {"AttributeName": "priceChangePercent", "KeyType": "RANGE"}
+        ],
+        "Projection": {"ProjectionType": "ALL"}
+      }
+    }
+  ]'
+```
+
 ```mermaid
 sequenceDiagram
     participant EB as EventBridge

--- a/api/controller/ckprice/ckprice_test.go
+++ b/api/controller/ckprice/ckprice_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"mtg-price-checker-sg/gateway/cardkingdom"
+	"mtg-price-checker-sg/store/ckprices"
 
 	"github.com/stretchr/testify/require"
 )
@@ -22,6 +23,10 @@ func (m *mockStore) GetByNameKey(_ context.Context, nameKey string) (*cardkingdo
 		return m.listings[nameKey], nil
 	}
 	return m.listing, nil
+}
+
+func (m *mockStore) GetTopBottomPriceChanges(_ context.Context) (*ckprices.TopBottomPriceChanges, error) {
+	return &ckprices.TopBottomPriceChanges{}, nil
 }
 
 func (m *mockStore) PutAll(_ context.Context, _ map[string]cardkingdom.Listing) (string, error) {

--- a/api/controller/ckprice/ckprice_test.go
+++ b/api/controller/ckprice/ckprice_test.go
@@ -25,6 +25,10 @@ func (m *mockStore) GetByNameKey(_ context.Context, nameKey string) (*cardkingdo
 	return m.listing, nil
 }
 
+func (m *mockStore) GetPriceChangesByPercent(_ context.Context, _ bool, _ int) ([]ckprices.PriceChangeListing, error) {
+	return nil, nil
+}
+
 func (m *mockStore) GetTopBottomPriceChanges(_ context.Context) (*ckprices.TopBottomPriceChanges, error) {
 	return &ckprices.TopBottomPriceChanges{}, nil
 }

--- a/api/gateway/cardkingdom/types.go
+++ b/api/gateway/cardkingdom/types.go
@@ -14,12 +14,13 @@ type Product struct {
 
 // Listing is the cheapest in-stock Card Kingdom offer for a card name.
 type Listing struct {
-	CardName  string  `json:"cardName"`
-	Edition   string  `json:"edition"`
-	PriceUsd  float64 `json:"priceUsd"`
-	URL       string  `json:"url"`
-	Quantity  int     `json:"quantity"`
-	IsFoil    bool    `json:"isFoil"`
-	UpdatedAt string  `json:"updatedAt,omitempty"`
-	SyncedAt  string  `json:"syncedAt,omitempty"`
+	CardName           string  `json:"cardName"`
+	Edition            string  `json:"edition"`
+	PriceUsd           float64 `json:"priceUsd"`
+	PriceChangePercent *int    `json:"priceChangePercent,omitempty"`
+	URL                string  `json:"url"`
+	Quantity           int     `json:"quantity"`
+	IsFoil             bool    `json:"isFoil"`
+	UpdatedAt          string  `json:"updatedAt,omitempty"`
+	SyncedAt           string  `json:"syncedAt,omitempty"`
 }

--- a/api/gateway/util/dedicated_proxy_test.go
+++ b/api/gateway/util/dedicated_proxy_test.go
@@ -86,7 +86,7 @@ func TestGetDedicatedProxyRejectsPartialSegments(t *testing.T) {
 	got := GetDedicatedProxy()
 	require.Len(t, got, 7)
 
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		require.Equal(t, DedicatedProxy{}, got[i], "slot %d should reject non-4-segment config", i+1)
 	}
 }

--- a/api/handler/ck_refresh_test.go
+++ b/api/handler/ck_refresh_test.go
@@ -15,6 +15,10 @@ func (m *mockCKRefreshStore) GetByNameKey(_ context.Context, _ string) (*cardkin
 	return nil, nil
 }
 
+func (m *mockCKRefreshStore) GetPriceChangesByPercent(_ context.Context, _ bool, _ int) ([]ckprices.PriceChangeListing, error) {
+	return nil, nil
+}
+
 func (m *mockCKRefreshStore) GetTopBottomPriceChanges(_ context.Context) (*ckprices.TopBottomPriceChanges, error) {
 	return &ckprices.TopBottomPriceChanges{}, nil
 }

--- a/api/handler/ck_refresh_test.go
+++ b/api/handler/ck_refresh_test.go
@@ -15,6 +15,10 @@ func (m *mockCKRefreshStore) GetByNameKey(_ context.Context, _ string) (*cardkin
 	return nil, nil
 }
 
+func (m *mockCKRefreshStore) GetTopBottomPriceChanges(_ context.Context) (*ckprices.TopBottomPriceChanges, error) {
+	return &ckprices.TopBottomPriceChanges{}, nil
+}
+
 func (m *mockCKRefreshStore) PutAll(_ context.Context, _ map[string]cardkingdom.Listing) (string, error) {
 	return "", nil
 }

--- a/api/store/ckprices/dynamodb.go
+++ b/api/store/ckprices/dynamodb.go
@@ -18,21 +18,23 @@ import (
 )
 
 const (
+	batchGetLimit     = 100
 	batchWriteLimit   = 25
 	syncMetadataKey   = "__sync__"
 	syncMetadataLabel = "CK price sync metadata"
 )
 
 type dynamoRecord struct {
-	NameKey   string  `dynamodbav:"nameKey"`
-	CardName  string  `dynamodbav:"cardName"`
-	Edition   string  `dynamodbav:"edition"`
-	PriceUsd  float64 `dynamodbav:"priceUsd"`
-	URL       string  `dynamodbav:"url"`
-	Quantity  int     `dynamodbav:"quantity"`
-	IsFoil    bool    `dynamodbav:"isFoil"`
-	UpdatedAt string  `dynamodbav:"updatedAt"`
-	SyncedAt  string  `dynamodbav:"syncedAt"`
+	NameKey            string  `dynamodbav:"nameKey"`
+	CardName           string  `dynamodbav:"cardName"`
+	Edition            string  `dynamodbav:"edition"`
+	PriceUsd           float64 `dynamodbav:"priceUsd"`
+	PriceChangePercent *int    `dynamodbav:"priceChangePercent,omitempty"`
+	URL                string  `dynamodbav:"url"`
+	Quantity           int     `dynamodbav:"quantity"`
+	IsFoil             bool    `dynamodbav:"isFoil"`
+	UpdatedAt          string  `dynamodbav:"updatedAt"`
+	SyncedAt           string  `dynamodbav:"syncedAt"`
 }
 
 type syncMetadataRecord struct {
@@ -84,18 +86,30 @@ func (s *DynamoDBStore) GetByNameKey(ctx context.Context, nameKey string) (*card
 	}
 
 	return &cardkingdom.Listing{
-		CardName:  record.CardName,
-		Edition:   record.Edition,
-		PriceUsd:  record.PriceUsd,
-		URL:       record.URL,
-		Quantity:  record.Quantity,
-		IsFoil:    record.IsFoil,
-		UpdatedAt: record.UpdatedAt,
-		SyncedAt:  record.SyncedAt,
+		CardName:           record.CardName,
+		Edition:            record.Edition,
+		PriceUsd:           record.PriceUsd,
+		PriceChangePercent: record.PriceChangePercent,
+		URL:                record.URL,
+		Quantity:           record.Quantity,
+		IsFoil:             record.IsFoil,
+		UpdatedAt:          record.UpdatedAt,
+		SyncedAt:           record.SyncedAt,
 	}, nil
 }
 
 func (s *DynamoDBStore) PutAll(ctx context.Context, listings map[string]cardkingdom.Listing) (string, error) {
+	nameKeys := make([]string, 0, len(listings))
+	for nameKey := range listings {
+		nameKeys = append(nameKeys, nameKey)
+	}
+
+	existing, err := s.batchGetExisting(ctx, nameKeys)
+	if err != nil {
+		return "", err
+	}
+	listings = listingsWithPriceChange(existing, listings)
+
 	syncedAt := time.Now().UTC().Format(time.RFC3339)
 	writeRequests := make([]types.WriteRequest, 0, len(listings)+1)
 	for nameKey, listing := range listings {
@@ -135,16 +149,66 @@ func (s *DynamoDBStore) PutAll(ctx context.Context, listings map[string]cardking
 
 func dynamoRecordFromListing(nameKey string, listing cardkingdom.Listing, syncedAt string) dynamoRecord {
 	return dynamoRecord{
-		NameKey:   nameKey,
-		CardName:  listing.CardName,
-		Edition:   listing.Edition,
-		PriceUsd:  listing.PriceUsd,
-		URL:       listing.URL,
-		Quantity:  listing.Quantity,
-		IsFoil:    listing.IsFoil,
-		UpdatedAt: listing.UpdatedAt,
-		SyncedAt:  syncedAt,
+		NameKey:            nameKey,
+		CardName:           listing.CardName,
+		Edition:            listing.Edition,
+		PriceUsd:           listing.PriceUsd,
+		PriceChangePercent: listing.PriceChangePercent,
+		URL:                listing.URL,
+		Quantity:           listing.Quantity,
+		IsFoil:             listing.IsFoil,
+		UpdatedAt:          listing.UpdatedAt,
+		SyncedAt:           syncedAt,
 	}
+}
+
+func (s *DynamoDBStore) batchGetExisting(ctx context.Context, nameKeys []string) (map[string]dynamoRecord, error) {
+	existing := make(map[string]dynamoRecord, len(nameKeys))
+	if len(nameKeys) == 0 {
+		return existing, nil
+	}
+
+	for start := 0; start < len(nameKeys); start += batchGetLimit {
+		end := min(start+batchGetLimit, len(nameKeys))
+		batch := nameKeys[start:end]
+
+		keys := make([]map[string]types.AttributeValue, len(batch))
+		for i, nameKey := range batch {
+			keys[i] = map[string]types.AttributeValue{
+				"nameKey": &types.AttributeValueMemberS{Value: nameKey},
+			}
+		}
+
+		pending := map[string]types.KeysAndAttributes{
+			s.tableName: {Keys: keys},
+		}
+		for len(pending) > 0 {
+			output, err := s.client.BatchGetItem(ctx, &dynamodb.BatchGetItemInput{
+				RequestItems: pending,
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			for _, item := range output.Responses[s.tableName] {
+				var record dynamoRecord
+				if err := attributevalue.UnmarshalMap(item, &record); err != nil {
+					return nil, err
+				}
+				if record.NameKey == syncMetadataKey {
+					continue
+				}
+				existing[record.NameKey] = record
+			}
+
+			if len(output.UnprocessedKeys) == 0 {
+				break
+			}
+			pending = output.UnprocessedKeys
+		}
+	}
+
+	return existing, nil
 }
 
 func (s *DynamoDBStore) writeBatch(ctx context.Context, batch []types.WriteRequest) error {

--- a/api/store/ckprices/dynamodb.go
+++ b/api/store/ckprices/dynamodb.go
@@ -85,17 +85,44 @@ func (s *DynamoDBStore) GetByNameKey(ctx context.Context, nameKey string) (*card
 		return nil, err
 	}
 
-	return &cardkingdom.Listing{
-		CardName:           record.CardName,
-		Edition:            record.Edition,
-		PriceUsd:           record.PriceUsd,
-		PriceChangePercent: record.PriceChangePercent,
-		URL:                record.URL,
-		Quantity:           record.Quantity,
-		IsFoil:             record.IsFoil,
-		UpdatedAt:          record.UpdatedAt,
-		SyncedAt:           record.SyncedAt,
-	}, nil
+	listing, ok := listingFromRecord(record)
+	if !ok {
+		return nil, nil
+	}
+	return &listing, nil
+}
+
+func (s *DynamoDBStore) GetTopBottomPriceChanges(ctx context.Context) (*TopBottomPriceChanges, error) {
+	listings := make([]PriceChangeListing, 0)
+	var exclusiveStartKey map[string]types.AttributeValue
+
+	for {
+		output, err := s.client.Scan(ctx, &dynamodb.ScanInput{
+			TableName:         aws.String(s.tableName),
+			ExclusiveStartKey: exclusiveStartKey,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		for _, item := range output.Items {
+			var record dynamoRecord
+			if err := attributevalue.UnmarshalMap(item, &record); err != nil {
+				return nil, err
+			}
+			if listing, ok := priceChangeListingFromRecord(record); ok {
+				listings = append(listings, listing)
+			}
+		}
+
+		if len(output.LastEvaluatedKey) == 0 {
+			break
+		}
+		exclusiveStartKey = output.LastEvaluatedKey
+	}
+
+	rankings := topBottomPriceChanges(listings, PriceChangeRankingLimit)
+	return &rankings, nil
 }
 
 func (s *DynamoDBStore) PutAll(ctx context.Context, listings map[string]cardkingdom.Listing) (string, error) {
@@ -160,6 +187,37 @@ func dynamoRecordFromListing(nameKey string, listing cardkingdom.Listing, synced
 		UpdatedAt:          listing.UpdatedAt,
 		SyncedAt:           syncedAt,
 	}
+}
+
+func listingFromRecord(record dynamoRecord) (cardkingdom.Listing, bool) {
+	if record.NameKey == syncMetadataKey {
+		return cardkingdom.Listing{}, false
+	}
+	return cardkingdom.Listing{
+		CardName:           record.CardName,
+		Edition:            record.Edition,
+		PriceUsd:           record.PriceUsd,
+		PriceChangePercent: record.PriceChangePercent,
+		URL:                record.URL,
+		Quantity:           record.Quantity,
+		IsFoil:             record.IsFoil,
+		UpdatedAt:          record.UpdatedAt,
+		SyncedAt:           record.SyncedAt,
+	}, true
+}
+
+func priceChangeListingFromRecord(record dynamoRecord) (PriceChangeListing, bool) {
+	if record.NameKey == syncMetadataKey || record.PriceChangePercent == nil {
+		return PriceChangeListing{}, false
+	}
+	listing, ok := listingFromRecord(record)
+	if !ok {
+		return PriceChangeListing{}, false
+	}
+	return PriceChangeListing{
+		NameKey: record.NameKey,
+		Listing: listing,
+	}, true
 }
 
 func (s *DynamoDBStore) batchGetExisting(ctx context.Context, nameKeys []string) (map[string]dynamoRecord, error) {

--- a/api/store/ckprices/dynamodb.go
+++ b/api/store/ckprices/dynamodb.go
@@ -18,10 +18,12 @@ import (
 )
 
 const (
-	batchGetLimit     = 100
-	batchWriteLimit   = 25
-	syncMetadataKey   = "__sync__"
-	syncMetadataLabel = "CK price sync metadata"
+	batchGetLimit            = 100
+	batchWriteLimit          = 25
+	priceChangeIndexName     = "priceChangePercent-index"
+	priceChangeIndexPKValue  = "CURRENT"
+	syncMetadataKey          = "__sync__"
+	syncMetadataLabel        = "CK price sync metadata"
 )
 
 type dynamoRecord struct {
@@ -30,6 +32,7 @@ type dynamoRecord struct {
 	Edition            string  `dynamodbav:"edition"`
 	PriceUsd           float64 `dynamodbav:"priceUsd"`
 	PriceChangePercent *int    `dynamodbav:"priceChangePercent,omitempty"`
+	PriceChangeIndexPK *string `dynamodbav:"priceChangeIndexPK,omitempty"`
 	URL                string  `dynamodbav:"url"`
 	Quantity           int     `dynamodbav:"quantity"`
 	IsFoil             bool    `dynamodbav:"isFoil"`
@@ -92,7 +95,60 @@ func (s *DynamoDBStore) GetByNameKey(ctx context.Context, nameKey string) (*card
 	return &listing, nil
 }
 
+func (s *DynamoDBStore) GetPriceChangesByPercent(ctx context.Context, ascending bool, limit int) ([]PriceChangeListing, error) {
+	if limit <= 0 {
+		limit = PriceChangeRankingLimit
+	}
+
+	listings, err := s.queryPriceChangesByPercent(ctx, ascending, limit)
+	if err == nil {
+		return listings, nil
+	}
+	if !isMissingPriceChangeIndex(err) {
+		return nil, err
+	}
+
+	scanned, scanErr := s.scanPriceChangeListings(ctx)
+	if scanErr != nil {
+		return nil, scanErr
+	}
+	return priceChangesByPercentFromListings(scanned, ascending, limit), nil
+}
+
 func (s *DynamoDBStore) GetTopBottomPriceChanges(ctx context.Context) (*TopBottomPriceChanges, error) {
+	top, err := s.GetPriceChangesByPercent(ctx, false, PriceChangeRankingLimit)
+	if err != nil {
+		return nil, err
+	}
+	bottom, err := s.GetPriceChangesByPercent(ctx, true, PriceChangeRankingLimit)
+	if err != nil {
+		return nil, err
+	}
+	return &TopBottomPriceChanges{
+		Top:    top,
+		Bottom: bottom,
+	}, nil
+}
+
+func (s *DynamoDBStore) queryPriceChangesByPercent(ctx context.Context, ascending bool, limit int) ([]PriceChangeListing, error) {
+	output, err := s.client.Query(ctx, &dynamodb.QueryInput{
+		TableName:              aws.String(s.tableName),
+		IndexName:              aws.String(priceChangeIndexName),
+		KeyConditionExpression: aws.String("priceChangeIndexPK = :pk"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":pk": &types.AttributeValueMemberS{Value: priceChangeIndexPKValue},
+		},
+		ScanIndexForward: aws.Bool(ascending),
+		Limit:            aws.Int32(int32(limit)),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return priceChangeListingsFromItems(output.Items)
+}
+
+func (s *DynamoDBStore) scanPriceChangeListings(ctx context.Context) ([]PriceChangeListing, error) {
 	listings := make([]PriceChangeListing, 0)
 	var exclusiveStartKey map[string]types.AttributeValue
 
@@ -105,15 +161,11 @@ func (s *DynamoDBStore) GetTopBottomPriceChanges(ctx context.Context) (*TopBotto
 			return nil, err
 		}
 
-		for _, item := range output.Items {
-			var record dynamoRecord
-			if err := attributevalue.UnmarshalMap(item, &record); err != nil {
-				return nil, err
-			}
-			if listing, ok := priceChangeListingFromRecord(record); ok {
-				listings = append(listings, listing)
-			}
+		batch, err := priceChangeListingsFromItems(output.Items)
+		if err != nil {
+			return nil, err
 		}
+		listings = append(listings, batch...)
 
 		if len(output.LastEvaluatedKey) == 0 {
 			break
@@ -121,8 +173,7 @@ func (s *DynamoDBStore) GetTopBottomPriceChanges(ctx context.Context) (*TopBotto
 		exclusiveStartKey = output.LastEvaluatedKey
 	}
 
-	rankings := topBottomPriceChanges(listings, PriceChangeRankingLimit)
-	return &rankings, nil
+	return listings, nil
 }
 
 func (s *DynamoDBStore) PutAll(ctx context.Context, listings map[string]cardkingdom.Listing) (string, error) {
@@ -175,7 +226,7 @@ func (s *DynamoDBStore) PutAll(ctx context.Context, listings map[string]cardking
 }
 
 func dynamoRecordFromListing(nameKey string, listing cardkingdom.Listing, syncedAt string) dynamoRecord {
-	return dynamoRecord{
+	record := dynamoRecord{
 		NameKey:            nameKey,
 		CardName:           listing.CardName,
 		Edition:            listing.Edition,
@@ -187,6 +238,11 @@ func dynamoRecordFromListing(nameKey string, listing cardkingdom.Listing, synced
 		UpdatedAt:          listing.UpdatedAt,
 		SyncedAt:           syncedAt,
 	}
+	if listing.PriceChangePercent != nil {
+		indexPK := priceChangeIndexPKValue
+		record.PriceChangeIndexPK = &indexPK
+	}
+	return record
 }
 
 func listingFromRecord(record dynamoRecord) (cardkingdom.Listing, bool) {
@@ -218,6 +274,31 @@ func priceChangeListingFromRecord(record dynamoRecord) (PriceChangeListing, bool
 		NameKey: record.NameKey,
 		Listing: listing,
 	}, true
+}
+
+func priceChangeListingsFromItems(items []map[string]types.AttributeValue) ([]PriceChangeListing, error) {
+	listings := make([]PriceChangeListing, 0, len(items))
+	for _, item := range items {
+		var record dynamoRecord
+		if err := attributevalue.UnmarshalMap(item, &record); err != nil {
+			return nil, err
+		}
+		if listing, ok := priceChangeListingFromRecord(record); ok {
+			listings = append(listings, listing)
+		}
+	}
+	return listings, nil
+}
+
+func isMissingPriceChangeIndex(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "index") &&
+		(strings.Contains(message, "not found") ||
+			strings.Contains(message, "does not have the specified index") ||
+			strings.Contains(message, "validationexception"))
 }
 
 func (s *DynamoDBStore) batchGetExisting(ctx context.Context, nameKeys []string) (map[string]dynamoRecord, error) {

--- a/api/store/ckprices/dynamodb_test.go
+++ b/api/store/ckprices/dynamodb_test.go
@@ -30,6 +30,20 @@ func TestDynamoRecordFromListing(t *testing.T) {
 	require.Equal(t, syncedAt, record.SyncedAt)
 	require.NotNil(t, record.PriceChangePercent)
 	require.Equal(t, 12, *record.PriceChangePercent)
+	require.NotNil(t, record.PriceChangeIndexPK)
+	require.Equal(t, priceChangeIndexPKValue, *record.PriceChangeIndexPK)
+}
+
+func TestDynamoRecordFromListing_OmitsPriceChangeIndexWithoutPercent(t *testing.T) {
+	syncedAt := time.Date(2026, 6, 28, 15, 30, 0, 0, time.UTC).Format(time.RFC3339)
+	record := dynamoRecordFromListing("new card", cardkingdom.Listing{
+		CardName:  "New Card",
+		PriceUsd:  1.49,
+		UpdatedAt: "2026-06-28T00:00:00Z",
+	}, syncedAt)
+
+	require.Nil(t, record.PriceChangePercent)
+	require.Nil(t, record.PriceChangeIndexPK)
 }
 
 func TestDynamoRecordMarshalIncludesSyncedAt(t *testing.T) {

--- a/api/store/ckprices/dynamodb_test.go
+++ b/api/store/ckprices/dynamodb_test.go
@@ -13,19 +13,23 @@ import (
 
 func TestDynamoRecordFromListing(t *testing.T) {
 	syncedAt := time.Date(2026, 6, 28, 15, 30, 0, 0, time.UTC).Format(time.RFC3339)
+	priceChangePercent := 12
 	record := dynamoRecordFromListing("lightning bolt", cardkingdom.Listing{
-		CardName:  "Lightning Bolt",
-		Edition:   "Fourth Edition",
-		PriceUsd:  1.49,
-		URL:       "https://www.cardkingdom.com/mtg/fourth-edition/lightning-bolt",
-		Quantity:  0,
-		IsFoil:    false,
-		UpdatedAt: "2026-06-28T00:00:00Z",
+		CardName:           "Lightning Bolt",
+		Edition:            "Fourth Edition",
+		PriceUsd:           1.49,
+		PriceChangePercent: &priceChangePercent,
+		URL:                "https://www.cardkingdom.com/mtg/fourth-edition/lightning-bolt",
+		Quantity:           0,
+		IsFoil:             false,
+		UpdatedAt:          "2026-06-28T00:00:00Z",
 	}, syncedAt)
 
 	require.Equal(t, "lightning bolt", record.NameKey)
 	require.Equal(t, "2026-06-28T00:00:00Z", record.UpdatedAt)
 	require.Equal(t, syncedAt, record.SyncedAt)
+	require.NotNil(t, record.PriceChangePercent)
+	require.Equal(t, 12, *record.PriceChangePercent)
 }
 
 func TestDynamoRecordMarshalIncludesSyncedAt(t *testing.T) {
@@ -37,6 +41,21 @@ func TestDynamoRecordMarshalIncludesSyncedAt(t *testing.T) {
 	av, ok := item["syncedAt"].(*types.AttributeValueMemberS)
 	require.True(t, ok)
 	require.Equal(t, syncedAt, av.Value)
+}
+
+func TestDynamoRecordMarshalIncludesPriceChangePercent(t *testing.T) {
+	syncedAt := time.Date(2026, 6, 28, 15, 30, 0, 0, time.UTC).Format(time.RFC3339)
+	priceChangePercent := -8
+	record := dynamoRecordFromListing("lightning bolt", cardkingdom.Listing{
+		UpdatedAt:          "2026-06-28T00:00:00Z",
+		PriceChangePercent: &priceChangePercent,
+	}, syncedAt)
+	item, err := attributevalue.MarshalMap(record)
+	require.NoError(t, err)
+	require.Contains(t, item, "priceChangePercent")
+	av, ok := item["priceChangePercent"].(*types.AttributeValueMemberN)
+	require.True(t, ok)
+	require.Equal(t, "-8", av.Value)
 }
 
 func TestSyncMetadataRecordMarshal(t *testing.T) {

--- a/api/store/ckprices/price_change.go
+++ b/api/store/ckprices/price_change.go
@@ -1,0 +1,30 @@
+package ckprices
+
+import (
+	"math"
+
+	"mtg-price-checker-sg/gateway/cardkingdom"
+)
+
+func computePriceChangePercent(previousPriceUsd, currentPriceUsd float64) *int {
+	if previousPriceUsd <= 0 {
+		return nil
+	}
+
+	changePercent := int(math.Round((currentPriceUsd - previousPriceUsd) / previousPriceUsd * 100))
+	return &changePercent
+}
+
+func listingsWithPriceChange(
+	existing map[string]dynamoRecord,
+	listings map[string]cardkingdom.Listing,
+) map[string]cardkingdom.Listing {
+	enriched := make(map[string]cardkingdom.Listing, len(listings))
+	for nameKey, listing := range listings {
+		if previous, ok := existing[nameKey]; ok {
+			listing.PriceChangePercent = computePriceChangePercent(previous.PriceUsd, listing.PriceUsd)
+		}
+		enriched[nameKey] = listing
+	}
+	return enriched
+}

--- a/api/store/ckprices/price_change.go
+++ b/api/store/ckprices/price_change.go
@@ -71,3 +71,11 @@ func topBottomPriceChanges(listings []PriceChangeListing, limit int) TopBottomPr
 		Bottom: bottom,
 	}
 }
+
+func priceChangesByPercentFromListings(listings []PriceChangeListing, ascending bool, limit int) []PriceChangeListing {
+	rankings := topBottomPriceChanges(listings, limit)
+	if ascending {
+		return rankings.Bottom
+	}
+	return rankings.Top
+}

--- a/api/store/ckprices/price_change.go
+++ b/api/store/ckprices/price_change.go
@@ -2,6 +2,8 @@ package ckprices
 
 import (
 	"math"
+	"slices"
+	"strings"
 
 	"mtg-price-checker-sg/gateway/cardkingdom"
 )
@@ -27,4 +29,45 @@ func listingsWithPriceChange(
 		enriched[nameKey] = listing
 	}
 	return enriched
+}
+
+func topBottomPriceChanges(listings []PriceChangeListing, limit int) TopBottomPriceChanges {
+	if limit <= 0 {
+		limit = PriceChangeRankingLimit
+	}
+
+	changed := make([]PriceChangeListing, 0, len(listings))
+	for _, listing := range listings {
+		if listing.PriceChangePercent == nil {
+			continue
+		}
+		changed = append(changed, listing)
+	}
+
+	top := append([]PriceChangeListing(nil), changed...)
+	slices.SortFunc(top, func(a, b PriceChangeListing) int {
+		if *a.PriceChangePercent != *b.PriceChangePercent {
+			return *b.PriceChangePercent - *a.PriceChangePercent
+		}
+		return strings.Compare(a.NameKey, b.NameKey)
+	})
+	if len(top) > limit {
+		top = top[:limit]
+	}
+
+	bottom := append([]PriceChangeListing(nil), changed...)
+	slices.SortFunc(bottom, func(a, b PriceChangeListing) int {
+		if *a.PriceChangePercent != *b.PriceChangePercent {
+			return *a.PriceChangePercent - *b.PriceChangePercent
+		}
+		return strings.Compare(a.NameKey, b.NameKey)
+	})
+	if len(bottom) > limit {
+		bottom = bottom[:limit]
+	}
+
+	return TopBottomPriceChanges{
+		Top:    top,
+		Bottom: bottom,
+	}
 }

--- a/api/store/ckprices/price_change_test.go
+++ b/api/store/ckprices/price_change_test.go
@@ -1,6 +1,7 @@
 package ckprices
 
 import (
+	"strconv"
 	"testing"
 
 	"mtg-price-checker-sg/gateway/cardkingdom"
@@ -36,6 +37,62 @@ func TestComputePriceChangePercent(t *testing.T) {
 	t.Run("missing previous price", func(t *testing.T) {
 		require.Nil(t, computePriceChangePercent(0, 4.99))
 	})
+}
+
+func TestTopBottomPriceChanges(t *testing.T) {
+	percent := func(value int) *int {
+		return &value
+	}
+	listing := func(nameKey string, change int) PriceChangeListing {
+		return PriceChangeListing{
+			NameKey: nameKey,
+			Listing: cardkingdom.Listing{
+				CardName:           nameKey,
+				PriceChangePercent: percent(change),
+			},
+		}
+	}
+
+	listings := make([]PriceChangeListing, 0, 51)
+	for i := 1; i <= 25; i++ {
+		listings = append(listings, listing("increase-"+strconv.Itoa(i), i))
+	}
+	for i := 1; i <= 25; i++ {
+		listings = append(listings, listing("decrease-"+strconv.Itoa(i), -i))
+	}
+	listings = append(listings, PriceChangeListing{
+		NameKey: "no-change",
+		Listing: cardkingdom.Listing{CardName: "No Change"},
+	})
+
+	rankings := topBottomPriceChanges(listings, PriceChangeRankingLimit)
+
+	require.Len(t, rankings.Top, PriceChangeRankingLimit)
+	require.Equal(t, 25, *rankings.Top[0].PriceChangePercent)
+	require.Equal(t, 6, *rankings.Top[19].PriceChangePercent)
+
+	require.Len(t, rankings.Bottom, PriceChangeRankingLimit)
+	require.Equal(t, -25, *rankings.Bottom[0].PriceChangePercent)
+	require.Equal(t, -6, *rankings.Bottom[19].PriceChangePercent)
+}
+
+func TestPriceChangeListingFromRecord(t *testing.T) {
+	change := 15
+	listing, ok := priceChangeListingFromRecord(dynamoRecord{
+		NameKey:            "lightning bolt",
+		CardName:           "Lightning Bolt",
+		PriceUsd:           1.49,
+		PriceChangePercent: &change,
+	})
+	require.True(t, ok)
+	require.Equal(t, "lightning bolt", listing.NameKey)
+	require.Equal(t, 15, *listing.PriceChangePercent)
+
+	_, ok = priceChangeListingFromRecord(dynamoRecord{NameKey: syncMetadataKey})
+	require.False(t, ok)
+
+	_, ok = priceChangeListingFromRecord(dynamoRecord{NameKey: "new card", CardName: "New Card"})
+	require.False(t, ok)
 }
 
 func TestListingsWithPriceChange(t *testing.T) {

--- a/api/store/ckprices/price_change_test.go
+++ b/api/store/ckprices/price_change_test.go
@@ -39,6 +39,38 @@ func TestComputePriceChangePercent(t *testing.T) {
 	})
 }
 
+func TestPriceChangesByPercentFromListings(t *testing.T) {
+	percent := func(value int) *int {
+		return &value
+	}
+	listing := func(nameKey string, change int) PriceChangeListing {
+		return PriceChangeListing{
+			NameKey: nameKey,
+			Listing: cardkingdom.Listing{
+				CardName:           nameKey,
+				PriceChangePercent: percent(change),
+			},
+		}
+	}
+
+	listings := []PriceChangeListing{
+		listing("a", 30),
+		listing("b", 10),
+		listing("c", -30),
+		listing("d", -10),
+	}
+
+	bottom := priceChangesByPercentFromListings(listings, true, 2)
+	require.Len(t, bottom, 2)
+	require.Equal(t, -30, *bottom[0].PriceChangePercent)
+	require.Equal(t, -10, *bottom[1].PriceChangePercent)
+
+	top := priceChangesByPercentFromListings(listings, false, 2)
+	require.Len(t, top, 2)
+	require.Equal(t, 30, *top[0].PriceChangePercent)
+	require.Equal(t, 10, *top[1].PriceChangePercent)
+}
+
 func TestTopBottomPriceChanges(t *testing.T) {
 	percent := func(value int) *int {
 		return &value

--- a/api/store/ckprices/price_change_test.go
+++ b/api/store/ckprices/price_change_test.go
@@ -1,0 +1,58 @@
+package ckprices
+
+import (
+	"testing"
+
+	"mtg-price-checker-sg/gateway/cardkingdom"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestComputePriceChangePercent(t *testing.T) {
+	t.Run("increase", func(t *testing.T) {
+		change := computePriceChangePercent(10, 12)
+		require.NotNil(t, change)
+		require.Equal(t, 20, *change)
+	})
+
+	t.Run("decrease", func(t *testing.T) {
+		change := computePriceChangePercent(10, 8)
+		require.NotNil(t, change)
+		require.Equal(t, -20, *change)
+	})
+
+	t.Run("rounds to nearest integer", func(t *testing.T) {
+		change := computePriceChangePercent(3, 3.34)
+		require.NotNil(t, change)
+		require.Equal(t, 11, *change)
+	})
+
+	t.Run("no change", func(t *testing.T) {
+		change := computePriceChangePercent(4.99, 4.99)
+		require.NotNil(t, change)
+		require.Equal(t, 0, *change)
+	})
+
+	t.Run("missing previous price", func(t *testing.T) {
+		require.Nil(t, computePriceChangePercent(0, 4.99))
+	})
+}
+
+func TestListingsWithPriceChange(t *testing.T) {
+	existing := map[string]dynamoRecord{
+		"lightning bolt": {PriceUsd: 1.00},
+		"counterspell":   {PriceUsd: 2.00},
+	}
+
+	enriched := listingsWithPriceChange(existing, map[string]cardkingdom.Listing{
+		"lightning bolt": {PriceUsd: 1.10},
+		"counterspell":   {PriceUsd: 1.80},
+		"new card":       {PriceUsd: 5.00},
+	})
+
+	require.NotNil(t, enriched["lightning bolt"].PriceChangePercent)
+	require.Equal(t, 10, *enriched["lightning bolt"].PriceChangePercent)
+	require.NotNil(t, enriched["counterspell"].PriceChangePercent)
+	require.Equal(t, -10, *enriched["counterspell"].PriceChangePercent)
+	require.Nil(t, enriched["new card"].PriceChangePercent)
+}

--- a/api/store/ckprices/store.go
+++ b/api/store/ckprices/store.go
@@ -24,6 +24,9 @@ type TopBottomPriceChanges struct {
 // Store persists Card Kingdom cheapest-by-name listings.
 type Store interface {
 	GetByNameKey(ctx context.Context, nameKey string) (*cardkingdom.Listing, error)
+	// GetPriceChangesByPercent returns listings ordered by priceChangePercent.
+	// ascending=true is equivalent to SQL ORDER BY priceChangePercent ASC LIMIT n.
+	GetPriceChangesByPercent(ctx context.Context, ascending bool, limit int) ([]PriceChangeListing, error)
 	GetTopBottomPriceChanges(ctx context.Context) (*TopBottomPriceChanges, error)
 	PutAll(ctx context.Context, listings map[string]cardkingdom.Listing) (syncedAt string, err error)
 }

--- a/api/store/ckprices/store.go
+++ b/api/store/ckprices/store.go
@@ -6,8 +6,24 @@ import (
 	"mtg-price-checker-sg/gateway/cardkingdom"
 )
 
+const PriceChangeRankingLimit = 20
+
+// PriceChangeListing ranks a Card Kingdom listing by its latest price change percent.
+type PriceChangeListing struct {
+	NameKey string `json:"nameKey"`
+	cardkingdom.Listing
+}
+
+// TopBottomPriceChanges holds the largest price increases and decreases from the
+// most recent CK price job run.
+type TopBottomPriceChanges struct {
+	Top    []PriceChangeListing `json:"top"`
+	Bottom []PriceChangeListing `json:"bottom"`
+}
+
 // Store persists Card Kingdom cheapest-by-name listings.
 type Store interface {
 	GetByNameKey(ctx context.Context, nameKey string) (*cardkingdom.Listing, error)
+	GetTopBottomPriceChanges(ctx context.Context) (*TopBottomPriceChanges, error)
 	PutAll(ctx context.Context, listings map[string]cardkingdom.Listing) (syncedAt string, err error)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `priceChangePercent` field to Card Kingdom listings written by the CK price refresh job. On each run, the job compares the new price against the previous DynamoDB value and stores the rounded integer percentage change:

- **Positive** values = price increase since the last job run
- **Negative** values = price decrease since the last job run
- **Omitted** for cards that did not exist in the previous run

Also adds store methods to retrieve price movers by percent change, backed by a sparse DynamoDB GSI when configured.

## Implementation

- `PutAll` batch-reads existing listings before writing so each card can be compared to its prior price.
- Percentage is computed as `round((new - old) / old * 100)`.
- Listings with a change percent also write `priceChangeIndexPK = "CURRENT"` for a sparse GSI.
- `GetPriceChangesByPercent(ctx, ascending, limit)` maps directly to SQL ordering:
  - `ascending=true` → `ORDER BY priceChangePercent ASC LIMIT n`
  - `ascending=false` → `ORDER BY priceChangePercent DESC LIMIT n`
- `GetTopBottomPriceChanges` calls that helper for bottom/top 20.
- Without the GSI, both methods fall back to a table scan.

## Testing

- `go test ./store/ckprices/... ./controller/ckprice/... ./handler/...`
- `make test` (live gateway tests may flake on transient upstream/network errors)
- `go fix ./...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2db80d9e-50ca-4c94-bd1c-2e4f251e9eff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2db80d9e-50ca-4c94-bd1c-2e4f251e9eff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

