### PR TITLE
Export CK top/bottom 20 price changes to S3 after daily refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,10 +195,7 @@ Example report shape:
 
 #### IAM permissions for `mtg-price-ck-refresh`
 
-The shared `lambda-mtg` role must allow `s3:PutObject` on the export prefix (defaults to `arn:aws:s3:::gishathfetch.com/analytics/ck-price-changes/*`). Optional Lambda environment variables:
-
-- `CK_PRICE_CHANGES_S3_BUCKET` — destination bucket (default `gishathfetch.com`)
-- `CK_PRICE_CHANGES_S3_KEY_PREFIX` — object key prefix (default `analytics/ck-price-changes`)
+The shared `lambda-mtg` role must allow `s3:PutObject` on the export prefix (`arn:aws:s3:::gishathfetch.com/analytics/ck-price-changes/*`).
 
 ## 🔎 Search flow
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ flowchart TB
     EB -->|action: ck-price-refresh-run| RefreshLambda
     RefreshLambda -->|download bz2 archives| MTGJSON
     RefreshLambda -->|batch write cheapest CK retail| DDB
+    RefreshLambda -->|write latest.json| S3
     EB -->|action: analytics-keywords-export-run| AnalyticsLambda
     AnalyticsLambda -->|GA4 Data API| GA4
     AnalyticsLambda -->|write latest.json| S3
@@ -78,7 +79,7 @@ flowchart TB
 | Frontend CDN | CloudFront → `gishathfetch.com` | Serves the React SPA from S3 |
 | Search API | API Gateway → `api.gishathfetch.com` | Routes `GET /?s=...&lgs=...` to the search Lambda |
 | Search Lambda | `mtg-price-scrapper` | Concurrent LGS scraping; optional CK price lookup from DynamoDB |
-| CK refresh Lambda | `mtg-price-ck-refresh` | Daily MTGJSON download and DynamoDB index rebuild |
+| CK refresh Lambda | `mtg-price-ck-refresh` | Daily MTGJSON download, DynamoDB index rebuild, and CK price change export to S3 |
 | Analytics keywords Lambda | `mtg-analytics-keywords-export` | Daily GA4 export of top search keywords to S3 |
 | Scheduler | EventBridge (`ck-price-refresh-daily`, `analytics-keywords-export-daily`) | Invokes refresh/export Lambdas with action payloads |
 | CK price store | DynamoDB (`CK_DYNAMODB_TABLE`) | Cheapest CK retail price per verified card name |
@@ -155,6 +156,7 @@ sequenceDiagram
     participant R as mtg-price-ck-refresh
     participant M as MTGJSON
     participant D as DynamoDB
+    participant S3 as S3 gishathfetch.com
     participant S as mtg-price-scrapper
     participant SF as Scryfall
     participant U as User
@@ -162,6 +164,8 @@ sequenceDiagram
     EB->>R: daily ck-price-refresh-run
     R->>M: download AllPricesToday + AllPrintings
     R->>D: PutAll cheapest CK retail by name
+    R->>D: query top/bottom 20 price changes
+    R->>S3: analytics/ck-price-changes/latest.json
     U->>S: GET /?s=Lightning+Bolt
     par LGS scrape + CK lookup
         S->>S: scrape selected stores
@@ -170,6 +174,31 @@ sequenceDiagram
     end
     S-->>U: data + cardKingdomPrice
 ```
+
+S3 output (default bucket `gishathfetch.com`, prefix `analytics/ck-price-changes/`):
+
+- `latest.json` — most recent export of the top 20 CK price increases and decreases, overwritten on each daily run
+
+The export Lambda writes to the same bucket as the frontend SPA so the report can be served same-origin through CloudFront when needed. The object is uploaded with `Cache-Control: public, max-age=3600`.
+
+Example report shape:
+
+```json
+{
+  "generatedAt": "2026-07-11T12:00:00Z",
+  "syncedAt": "2026-07-11T00:00:00Z",
+  "rankingLimit": 20,
+  "top": [{"nameKey": "lightning bolt", "cardName": "Lightning Bolt", "priceUsd": 1.25, "priceChangePercent": 15}],
+  "bottom": [{"nameKey": "counterspell", "cardName": "Counterspell", "priceUsd": 0.75, "priceChangePercent": -10}]
+}
+```
+
+#### IAM permissions for `mtg-price-ck-refresh`
+
+The shared `lambda-mtg` role must allow `s3:PutObject` on the export prefix (defaults to `arn:aws:s3:::gishathfetch.com/analytics/ck-price-changes/*`). Optional Lambda environment variables:
+
+- `CK_PRICE_CHANGES_S3_BUCKET` — destination bucket (default `gishathfetch.com`)
+- `CK_PRICE_CHANGES_S3_KEY_PREFIX` — object key prefix (default `analytics/ck-price-changes`)
 
 ## 🔎 Search flow
 

--- a/api/handler/ck_refresh.go
+++ b/api/handler/ck_refresh.go
@@ -3,8 +3,10 @@ package handler
 import (
 	"context"
 	"log"
+	"time"
 
 	"mtg-price-checker-sg/controller/ckprice"
+	"mtg-price-checker-sg/store/ckpricereport"
 	"mtg-price-checker-sg/store/ckprices"
 )
 
@@ -15,6 +17,10 @@ var (
 		return ckprices.NewDynamoDBStore(ctx)
 	}
 	refreshCKPricesFunc = ckprice.RefreshPrices
+	newCKPriceReportWriterFunc = func(ctx context.Context) (ckpricereport.Writer, error) {
+		return ckpricereport.NewS3Writer(ctx)
+	}
+	ckPriceReportNowFunc = time.Now
 )
 
 func runCKPriceRefresh(ctx context.Context) error {
@@ -32,5 +38,25 @@ func runCKPriceRefresh(ctx context.Context) error {
 	}
 
 	log.Printf("ck price refresh: finished refreshed=%d", count)
+
+	changes, err := store.GetTopBottomPriceChanges(ctx)
+	if err != nil {
+		log.Printf("ck price refresh: failed reading price changes: %v", err)
+		return err
+	}
+
+	writer, err := newCKPriceReportWriterFunc(ctx)
+	if err != nil {
+		log.Printf("ck price refresh: failed opening s3 writer: %v", err)
+		return err
+	}
+
+	report := ckpricereport.NewReport(changes, ckPriceReportNowFunc())
+	if err = writer.Write(ctx, report); err != nil {
+		log.Printf("ck price refresh: failed writing price change report: %v", err)
+		return err
+	}
+
+	log.Printf("ck price refresh: exported price changes top=%d bottom=%d generatedAt=%s", len(report.Top), len(report.Bottom), report.GeneratedAt)
 	return nil
 }

--- a/api/handler/ck_refresh_test.go
+++ b/api/handler/ck_refresh_test.go
@@ -4,12 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"mtg-price-checker-sg/gateway/cardkingdom"
+	"mtg-price-checker-sg/store/ckpricereport"
 	"mtg-price-checker-sg/store/ckprices"
 )
 
-type mockCKRefreshStore struct{}
+type mockCKRefreshStore struct {
+	changes *ckprices.TopBottomPriceChanges
+}
 
 func (m *mockCKRefreshStore) GetByNameKey(_ context.Context, _ string) (*cardkingdom.Listing, error) {
 	return nil, nil
@@ -20,6 +24,9 @@ func (m *mockCKRefreshStore) GetPriceChangesByPercent(_ context.Context, _ bool,
 }
 
 func (m *mockCKRefreshStore) GetTopBottomPriceChanges(_ context.Context) (*ckprices.TopBottomPriceChanges, error) {
+	if m.changes != nil {
+		return m.changes, nil
+	}
 	return &ckprices.TopBottomPriceChanges{}, nil
 }
 
@@ -27,19 +34,39 @@ func (m *mockCKRefreshStore) PutAll(_ context.Context, _ map[string]cardkingdom.
 	return "", nil
 }
 
+type mockCKPriceReportWriter struct {
+	written bool
+}
+
+func (m *mockCKPriceReportWriter) Write(_ context.Context, _ *ckpricereport.Report) error {
+	m.written = true
+	return nil
+}
+
 func TestHandle_RoutesCKPriceRefreshRun(t *testing.T) {
 	originalStoreFunc := newCKRefreshStoreFunc
 	originalRefreshFunc := refreshCKPricesFunc
+	originalWriterFunc := newCKPriceReportWriterFunc
+	originalNowFunc := ckPriceReportNowFunc
 	defer func() {
 		newCKRefreshStoreFunc = originalStoreFunc
 		refreshCKPricesFunc = originalRefreshFunc
+		newCKPriceReportWriterFunc = originalWriterFunc
+		ckPriceReportNowFunc = originalNowFunc
 	}()
 
+	writer := &mockCKPriceReportWriter{}
 	newCKRefreshStoreFunc = func(_ context.Context) (ckprices.Store, error) {
 		return &mockCKRefreshStore{}, nil
 	}
 	refreshCKPricesFunc = func(_ context.Context, _ ckprices.Store) (int, error) {
 		return 1, nil
+	}
+	newCKPriceReportWriterFunc = func(_ context.Context) (ckpricereport.Writer, error) {
+		return writer, nil
+	}
+	ckPriceReportNowFunc = func() time.Time {
+		return time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
 	}
 
 	event, err := json.Marshal(map[string]string{"action": ckPriceRefreshRunAction})
@@ -49,5 +76,8 @@ func TestHandle_RoutesCKPriceRefreshRun(t *testing.T) {
 
 	if _, err = Handle(context.Background(), event); err != nil {
 		t.Fatalf("handle event: %v", err)
+	}
+	if !writer.written {
+		t.Fatalf("expected ck price change report to be written")
 	}
 }

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -67,6 +67,17 @@ const (
 	AnalyticsS3KeyPrefixEnv = "ANALYTICS_S3_KEY_PREFIX"
 	// AnalyticsS3DefaultKeyPrefix is the default object key prefix under the frontend bucket.
 	AnalyticsS3DefaultKeyPrefix = "analytics/top-search-keywords"
+	// CKPriceChangesS3BucketEnv overrides the destination bucket for exported CK price change reports.
+	CKPriceChangesS3BucketEnv = "CK_PRICE_CHANGES_S3_BUCKET"
+	// CKPriceChangesS3DefaultBucket is the frontend S3 bucket served by CloudFront.
+	CKPriceChangesS3DefaultBucket = AnalyticsS3DefaultBucket
+	// CKPriceChangesS3KeyPrefixEnv is the object key prefix for exported CK price change reports.
+	CKPriceChangesS3KeyPrefixEnv = "CK_PRICE_CHANGES_S3_KEY_PREFIX"
+	// CKPriceChangesS3DefaultKeyPrefix is the default object key prefix under the frontend bucket.
+	CKPriceChangesS3DefaultKeyPrefix = "analytics/ck-price-changes"
+	// CKPriceChangesLatestJSONCacheControl is applied to latest.json so CloudFront can cache it
+	// between daily exports without a separate invalidation.
+	CKPriceChangesLatestJSONCacheControl = AnalyticsLatestJSONCacheControl
 	// AnalyticsLatestJSONCacheControl is applied to latest.json so CloudFront can cache it
 	// between daily exports without a separate invalidation.
 	AnalyticsLatestJSONCacheControl = "public, max-age=3600"

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -67,14 +67,10 @@ const (
 	AnalyticsS3KeyPrefixEnv = "ANALYTICS_S3_KEY_PREFIX"
 	// AnalyticsS3DefaultKeyPrefix is the default object key prefix under the frontend bucket.
 	AnalyticsS3DefaultKeyPrefix = "analytics/top-search-keywords"
-	// CKPriceChangesS3BucketEnv overrides the destination bucket for exported CK price change reports.
-	CKPriceChangesS3BucketEnv = "CK_PRICE_CHANGES_S3_BUCKET"
-	// CKPriceChangesS3DefaultBucket is the frontend S3 bucket served by CloudFront.
-	CKPriceChangesS3DefaultBucket = AnalyticsS3DefaultBucket
-	// CKPriceChangesS3KeyPrefixEnv is the object key prefix for exported CK price change reports.
-	CKPriceChangesS3KeyPrefixEnv = "CK_PRICE_CHANGES_S3_KEY_PREFIX"
-	// CKPriceChangesS3DefaultKeyPrefix is the default object key prefix under the frontend bucket.
-	CKPriceChangesS3DefaultKeyPrefix = "analytics/ck-price-changes"
+	// CKPriceChangesS3Bucket is the frontend S3 bucket for exported CK price change reports.
+	CKPriceChangesS3Bucket = AnalyticsS3DefaultBucket
+	// CKPriceChangesS3KeyPrefix is the object key prefix for exported CK price change reports.
+	CKPriceChangesS3KeyPrefix = "analytics/ck-price-changes"
 	// CKPriceChangesLatestJSONCacheControl is applied to latest.json so CloudFront can cache it
 	// between daily exports without a separate invalidation.
 	CKPriceChangesLatestJSONCacheControl = AnalyticsLatestJSONCacheControl

--- a/api/store/ckpricereport/report.go
+++ b/api/store/ckpricereport/report.go
@@ -1,0 +1,40 @@
+package ckpricereport
+
+import (
+	"time"
+
+	"mtg-price-checker-sg/store/ckprices"
+)
+
+// Report is the daily CK price change export written to S3.
+type Report struct {
+	GeneratedAt  string                       `json:"generatedAt"`
+	SyncedAt     string                       `json:"syncedAt,omitempty"`
+	RankingLimit int                          `json:"rankingLimit"`
+	Top          []ckprices.PriceChangeListing `json:"top"`
+	Bottom       []ckprices.PriceChangeListing `json:"bottom"`
+}
+
+// NewReport builds an export payload from the latest DynamoDB price change rankings.
+func NewReport(changes *ckprices.TopBottomPriceChanges, generatedAt time.Time) *Report {
+	if changes == nil {
+		changes = &ckprices.TopBottomPriceChanges{}
+	}
+
+	return &Report{
+		GeneratedAt:  generatedAt.UTC().Format(time.RFC3339),
+		SyncedAt:     syncedAtFromChanges(changes),
+		RankingLimit: ckprices.PriceChangeRankingLimit,
+		Top:          changes.Top,
+		Bottom:       changes.Bottom,
+	}
+}
+
+func syncedAtFromChanges(changes *ckprices.TopBottomPriceChanges) string {
+	for _, listing := range append(changes.Top, changes.Bottom...) {
+		if listing.SyncedAt != "" {
+			return listing.SyncedAt
+		}
+	}
+	return ""
+}

--- a/api/store/ckpricereport/report_test.go
+++ b/api/store/ckpricereport/report_test.go
@@ -1,0 +1,52 @@
+package ckpricereport
+
+import (
+	"testing"
+	"time"
+
+	"mtg-price-checker-sg/gateway/cardkingdom"
+	"mtg-price-checker-sg/store/ckprices"
+)
+
+func TestNewReportIncludesSyncedAtAndRankings(t *testing.T) {
+	increase := 15
+	decrease := -10
+	changes := &ckprices.TopBottomPriceChanges{
+		Top: []ckprices.PriceChangeListing{
+			{
+				NameKey: "lightning bolt",
+				Listing: cardkingdom.Listing{
+					CardName:           "Lightning Bolt",
+					PriceUsd:           1.25,
+					PriceChangePercent: &increase,
+					SyncedAt:           "2026-07-11T00:00:00Z",
+				},
+			},
+		},
+		Bottom: []ckprices.PriceChangeListing{
+			{
+				NameKey: "counterspell",
+				Listing: cardkingdom.Listing{
+					CardName:           "Counterspell",
+					PriceUsd:           0.75,
+					PriceChangePercent: &decrease,
+					SyncedAt:           "2026-07-11T00:00:00Z",
+				},
+			},
+		},
+	}
+
+	report := NewReport(changes, time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC))
+	if report.GeneratedAt != "2026-07-11T12:00:00Z" {
+		t.Fatalf("unexpected generatedAt: %q", report.GeneratedAt)
+	}
+	if report.SyncedAt != "2026-07-11T00:00:00Z" {
+		t.Fatalf("unexpected syncedAt: %q", report.SyncedAt)
+	}
+	if report.RankingLimit != ckprices.PriceChangeRankingLimit {
+		t.Fatalf("unexpected ranking limit: %d", report.RankingLimit)
+	}
+	if len(report.Top) != 1 || len(report.Bottom) != 1 {
+		t.Fatalf("unexpected rankings: top=%d bottom=%d", len(report.Top), len(report.Bottom))
+	}
+}

--- a/api/store/ckpricereport/s3.go
+++ b/api/store/ckpricereport/s3.go
@@ -5,8 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
-	"strings"
 
 	"mtg-price-checker-sg/pkg/config"
 
@@ -35,18 +33,8 @@ var loadAWSConfig = func(ctx context.Context) (aws.Config, error) {
 	return awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(config.AWSRegion))
 }
 
-// NewS3Writer builds an S3 writer from environment configuration.
+// NewS3Writer builds an S3 writer for the frontend CK price change export path.
 func NewS3Writer(ctx context.Context) (*S3Writer, error) {
-	bucket := strings.TrimSpace(os.Getenv(config.CKPriceChangesS3BucketEnv))
-	if bucket == "" {
-		bucket = config.CKPriceChangesS3DefaultBucket
-	}
-
-	prefix := strings.Trim(strings.TrimSpace(os.Getenv(config.CKPriceChangesS3KeyPrefixEnv)), "/")
-	if prefix == "" {
-		prefix = config.CKPriceChangesS3DefaultKeyPrefix
-	}
-
 	cfg, err := loadAWSConfig(ctx)
 	if err != nil {
 		return nil, err
@@ -54,8 +42,8 @@ func NewS3Writer(ctx context.Context) (*S3Writer, error) {
 
 	return &S3Writer{
 		client: s3.NewFromConfig(cfg),
-		bucket: bucket,
-		prefix: prefix,
+		bucket: config.CKPriceChangesS3Bucket,
+		prefix: config.CKPriceChangesS3KeyPrefix,
 	}, nil
 }
 

--- a/api/store/ckpricereport/s3.go
+++ b/api/store/ckpricereport/s3.go
@@ -1,0 +1,89 @@
+package ckpricereport
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"mtg-price-checker-sg/pkg/config"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// Writer persists CK price change reports to S3.
+type Writer interface {
+	Write(ctx context.Context, report *Report) error
+}
+
+type objectWriter interface {
+	PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error)
+}
+
+// S3Writer uploads JSON reports to a configured bucket and key prefix.
+type S3Writer struct {
+	client objectWriter
+	bucket string
+	prefix string
+}
+
+var loadAWSConfig = func(ctx context.Context) (aws.Config, error) {
+	return awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(config.AWSRegion))
+}
+
+// NewS3Writer builds an S3 writer from environment configuration.
+func NewS3Writer(ctx context.Context) (*S3Writer, error) {
+	bucket := strings.TrimSpace(os.Getenv(config.CKPriceChangesS3BucketEnv))
+	if bucket == "" {
+		bucket = config.CKPriceChangesS3DefaultBucket
+	}
+
+	prefix := strings.Trim(strings.TrimSpace(os.Getenv(config.CKPriceChangesS3KeyPrefixEnv)), "/")
+	if prefix == "" {
+		prefix = config.CKPriceChangesS3DefaultKeyPrefix
+	}
+
+	cfg, err := loadAWSConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &S3Writer{
+		client: s3.NewFromConfig(cfg),
+		bucket: bucket,
+		prefix: prefix,
+	}, nil
+}
+
+func (w *S3Writer) Write(ctx context.Context, report *Report) error {
+	if report == nil {
+		return fmt.Errorf("ckpricereport: report is required")
+	}
+
+	payload, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	key := w.objectKey("latest.json")
+	_, err = w.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:       aws.String(w.bucket),
+		Key:          aws.String(key),
+		Body:         bytes.NewReader(payload),
+		ContentType:  aws.String("application/json"),
+		CacheControl: aws.String(config.CKPriceChangesLatestJSONCacheControl),
+	})
+	if err != nil {
+		return fmt.Errorf("ckpricereport: put s3://%s/%s: %w", w.bucket, key, err)
+	}
+
+	return nil
+}
+
+func (w *S3Writer) objectKey(name string) string {
+	return w.prefix + "/" + name
+}

--- a/api/store/ckpricereport/s3_test.go
+++ b/api/store/ckpricereport/s3_test.go
@@ -1,0 +1,101 @@
+package ckpricereport
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"testing"
+
+	"mtg-price-checker-sg/pkg/config"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+type mockS3Object struct {
+	body         []byte
+	contentType  string
+	cacheControl string
+}
+
+type mockS3Client struct {
+	objects map[string]mockS3Object
+}
+
+func (m *mockS3Client) PutObject(_ context.Context, input *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	if m.objects == nil {
+		m.objects = make(map[string]mockS3Object)
+	}
+
+	body, err := io.ReadAll(input.Body)
+	if err != nil {
+		return nil, err
+	}
+	m.objects[aws.ToString(input.Key)] = mockS3Object{
+		body:         body,
+		contentType:  aws.ToString(input.ContentType),
+		cacheControl: aws.ToString(input.CacheControl),
+	}
+	return &s3.PutObjectOutput{}, nil
+}
+
+func TestNewS3WriterDefaultsToFrontendBucket(t *testing.T) {
+	t.Setenv(config.CKPriceChangesS3BucketEnv, "")
+	t.Setenv(config.CKPriceChangesS3KeyPrefixEnv, "")
+
+	writer, err := NewS3Writer(context.Background())
+	if err != nil {
+		t.Fatalf("new s3 writer: %v", err)
+	}
+	if writer.bucket != config.CKPriceChangesS3DefaultBucket {
+		t.Fatalf("expected bucket %q, got %q", config.CKPriceChangesS3DefaultBucket, writer.bucket)
+	}
+	if writer.prefix != config.CKPriceChangesS3DefaultKeyPrefix {
+		t.Fatalf("expected prefix %q, got %q", config.CKPriceChangesS3DefaultKeyPrefix, writer.prefix)
+	}
+}
+
+func TestS3Writer_WriteUploadsLatestObject(t *testing.T) {
+	mockClient := &mockS3Client{}
+	writer := &S3Writer{
+		client: mockClient,
+		bucket: config.CKPriceChangesS3DefaultBucket,
+		prefix: config.CKPriceChangesS3DefaultKeyPrefix,
+	}
+
+	report := &Report{
+		GeneratedAt:  "2026-07-11T12:00:00Z",
+		SyncedAt:     "2026-07-11T00:00:00Z",
+		RankingLimit: 20,
+		Top:          nil,
+		Bottom:       nil,
+	}
+
+	if err := writer.Write(context.Background(), report); err != nil {
+		t.Fatalf("write report: %v", err)
+	}
+
+	if len(mockClient.objects) != 1 {
+		t.Fatalf("expected 1 object, got %d", len(mockClient.objects))
+	}
+
+	latestKey := config.CKPriceChangesS3DefaultKeyPrefix + "/latest.json"
+	object, ok := mockClient.objects[latestKey]
+	if !ok {
+		t.Fatalf("missing latest object")
+	}
+	if object.contentType != "application/json" {
+		t.Fatalf("expected application/json content type, got %q", object.contentType)
+	}
+	if object.cacheControl != config.CKPriceChangesLatestJSONCacheControl {
+		t.Fatalf("expected cache control %q, got %q", config.CKPriceChangesLatestJSONCacheControl, object.cacheControl)
+	}
+
+	var decoded Report
+	if err := json.Unmarshal(object.body, &decoded); err != nil {
+		t.Fatalf("decode report: %v", err)
+	}
+	if decoded.GeneratedAt != report.GeneratedAt {
+		t.Fatalf("unexpected decoded report: %+v", decoded)
+	}
+}

--- a/api/store/ckpricereport/s3_test.go
+++ b/api/store/ckpricereport/s3_test.go
@@ -39,19 +39,16 @@ func (m *mockS3Client) PutObject(_ context.Context, input *s3.PutObjectInput, _ 
 	return &s3.PutObjectOutput{}, nil
 }
 
-func TestNewS3WriterDefaultsToFrontendBucket(t *testing.T) {
-	t.Setenv(config.CKPriceChangesS3BucketEnv, "")
-	t.Setenv(config.CKPriceChangesS3KeyPrefixEnv, "")
-
+func TestNewS3WriterUsesFrontendExportPath(t *testing.T) {
 	writer, err := NewS3Writer(context.Background())
 	if err != nil {
 		t.Fatalf("new s3 writer: %v", err)
 	}
-	if writer.bucket != config.CKPriceChangesS3DefaultBucket {
-		t.Fatalf("expected bucket %q, got %q", config.CKPriceChangesS3DefaultBucket, writer.bucket)
+	if writer.bucket != config.CKPriceChangesS3Bucket {
+		t.Fatalf("expected bucket %q, got %q", config.CKPriceChangesS3Bucket, writer.bucket)
 	}
-	if writer.prefix != config.CKPriceChangesS3DefaultKeyPrefix {
-		t.Fatalf("expected prefix %q, got %q", config.CKPriceChangesS3DefaultKeyPrefix, writer.prefix)
+	if writer.prefix != config.CKPriceChangesS3KeyPrefix {
+		t.Fatalf("expected prefix %q, got %q", config.CKPriceChangesS3KeyPrefix, writer.prefix)
 	}
 }
 
@@ -59,8 +56,8 @@ func TestS3Writer_WriteUploadsLatestObject(t *testing.T) {
 	mockClient := &mockS3Client{}
 	writer := &S3Writer{
 		client: mockClient,
-		bucket: config.CKPriceChangesS3DefaultBucket,
-		prefix: config.CKPriceChangesS3DefaultKeyPrefix,
+		bucket: config.CKPriceChangesS3Bucket,
+		prefix: config.CKPriceChangesS3KeyPrefix,
 	}
 
 	report := &Report{
@@ -79,7 +76,7 @@ func TestS3Writer_WriteUploadsLatestObject(t *testing.T) {
 		t.Fatalf("expected 1 object, got %d", len(mockClient.objects))
 	}
 
-	latestKey := config.CKPriceChangesS3DefaultKeyPrefix + "/latest.json"
+	latestKey := config.CKPriceChangesS3KeyPrefix + "/latest.json"
 	object, ok := mockClient.objects[latestKey]
 	if !ok {
 		t.Fatalf("missing latest object")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `mtg-price-ck-refresh` Lambda now writes the top 20 Card Kingdom price increases and decreases to S3 after each daily DynamoDB refresh. The file is overwritten on every EventBridge run and is not consumed by the frontend yet.

## Changes

- After `PutAll`, the refresh handler queries `GetTopBottomPriceChanges` from DynamoDB and exports the rankings.
- New `api/store/ckpricereport` package mirrors the analytics keywords S3 writer pattern.
- Fixed destination: `s3://gishathfetch.com/analytics/ck-price-changes/latest.json`

## Example output

```json
{
  "generatedAt": "2026-07-11T12:00:00Z",
  "syncedAt": "2026-07-11T00:00:00Z",
  "rankingLimit": 20,
  "top": [{"nameKey": "lightning bolt", "cardName": "Lightning Bolt", "priceUsd": 1.25, "priceChangePercent": 15}],
  "bottom": [{"nameKey": "counterspell", "cardName": "Counterspell", "priceUsd": 0.75, "priceChangePercent": -10}]
}
```

## IAM (manual step)

The shared `lambda-mtg` role needs `s3:PutObject` on the export prefix:

```
arn:aws:s3:::gishathfetch.com/analytics/ck-price-changes/*
```

## Testing

- `go test ./handler/... ./store/ckpricereport/... ./controller/ckprice/... ./store/ckprices/...`
- `go fix ./...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-beb2d9bc-5aa8-466f-9c6d-f6f9594cc346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-beb2d9bc-5aa8-466f-9c6d-f6f9594cc346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

