### PR TITLE
Remove unused quantity field from CK price store

### DIFF
--- a/api/gateway/cardkingdom/index.go
+++ b/api/gateway/cardkingdom/index.go
@@ -18,13 +18,11 @@ func BuildCheapestByName(products []Product, updatedAt time.Time) map[string]Lis
 			continue
 		}
 
-		quantity64, _ := product.QtyRetail.Int64()
 		considerCheapestListing(cheapestByName, Listing{
 			CardName:  product.Name,
 			Edition:   product.Edition,
 			PriceUsd:  priceUsd,
 			URL:       listingBaseURL + strings.TrimPrefix(product.URL, "/"),
-			Quantity:  int(quantity64),
 			IsFoil:    strings.EqualFold(strings.TrimSpace(product.IsFoil), "true"),
 			UpdatedAt: updatedAtValue,
 		})

--- a/api/gateway/cardkingdom/index_test.go
+++ b/api/gateway/cardkingdom/index_test.go
@@ -14,7 +14,6 @@ func TestBuildCheapestByName(t *testing.T) {
 			Name:        "Lightning Bolt",
 			Edition:     "Alpha",
 			PriceRetail: "999.99",
-			QtyRetail:   "1",
 			URL:         "mtg/alpha/lightning-bolt",
 			IsFoil:      "false",
 		},
@@ -22,7 +21,6 @@ func TestBuildCheapestByName(t *testing.T) {
 			Name:        "Lightning Bolt",
 			Edition:     "Fourth Edition",
 			PriceRetail: "1.49",
-			QtyRetail:   "12",
 			URL:         "mtg/fourth-edition/lightning-bolt",
 			IsFoil:      "false",
 		},
@@ -30,7 +28,6 @@ func TestBuildCheapestByName(t *testing.T) {
 			Name:        "Lightning Bolt",
 			Edition:     "Modern Masters",
 			PriceRetail: "3.99",
-			QtyRetail:   "4",
 			URL:         "mtg/modern-masters/lightning-bolt-foil",
 			IsFoil:      "true",
 		},
@@ -38,7 +35,6 @@ func TestBuildCheapestByName(t *testing.T) {
 			Name:        "Counterspell",
 			Edition:     "Ice Age",
 			PriceRetail: "0",
-			QtyRetail:   "1",
 			URL:         "mtg/ice-age/counterspell",
 			IsFoil:      "false",
 		},
@@ -51,7 +47,6 @@ func TestBuildCheapestByName(t *testing.T) {
 	require.Equal(t, "Lightning Bolt", listing.CardName)
 	require.Equal(t, "Fourth Edition", listing.Edition)
 	require.InDelta(t, 1.49, listing.PriceUsd, 0.001)
-	require.Equal(t, 12, listing.Quantity)
 	require.False(t, listing.IsFoil)
 	require.Equal(t, "https://www.cardkingdom.com/mtg/fourth-edition/lightning-bolt", listing.URL)
 	require.Equal(t, updatedAt.Format(time.RFC3339), listing.UpdatedAt)
@@ -64,7 +59,6 @@ func TestBuildCheapestByName_DoubleFacedCardIndexesFaceNames(t *testing.T) {
 			Name:        "Jennifer Walters",
 			Edition:     "Marvel Super Heroes",
 			PriceRetail: "10.99",
-			QtyRetail:   "8",
 			URL:         "mtg/marvel-super-heroes/jennifer-walters",
 			IsFoil:      "false",
 		},
@@ -72,7 +66,6 @@ func TestBuildCheapestByName_DoubleFacedCardIndexesFaceNames(t *testing.T) {
 			Name:        "Jennifer Walters",
 			Edition:     "Marvel Super Heroes Variants",
 			PriceRetail: "24.99",
-			QtyRetail:   "3",
 			URL:         "mtg/marvel-super-heroes-variants/jennifer-walters-0328-borderless",
 			IsFoil:      "false",
 		},

--- a/api/gateway/cardkingdom/mtgjson_fetch.go
+++ b/api/gateway/cardkingdom/mtgjson_fetch.go
@@ -366,7 +366,6 @@ func applyPrintingAggregate(
 			Edition:   setName,
 			PriceUsd:  aggregate.price.normal,
 			URL:       aggregate.cardKingdom,
-			Quantity:  0,
 			IsFoil:    false,
 			UpdatedAt: updatedAtValue,
 		})
@@ -389,7 +388,6 @@ func applyPrintingAggregate(
 		Edition:   setName,
 		PriceUsd:  aggregate.price.foil,
 		URL:       foilURL,
-		Quantity:  0,
 		IsFoil:    true,
 		UpdatedAt: updatedAtValue,
 	})

--- a/api/gateway/cardkingdom/pricelist_test.go
+++ b/api/gateway/cardkingdom/pricelist_test.go
@@ -32,7 +32,6 @@ func TestUnmarshalPricelistPayload(t *testing.T) {
 	cheapest := BuildCheapestByName(payload.Data, mustParseTime(t, "2026-06-28T07:07:57Z"))
 	listing := cheapest["lightning bolt"]
 	require.InDelta(t, 0.35, listing.PriceUsd, 0.001)
-	require.Equal(t, 15, listing.Quantity)
 }
 
 func mustParseTime(t *testing.T, value string) time.Time {

--- a/api/gateway/cardkingdom/types.go
+++ b/api/gateway/cardkingdom/types.go
@@ -7,19 +7,17 @@ type Product struct {
 	Name        string      `json:"name"`
 	Edition     string      `json:"edition"`
 	PriceRetail json.Number `json:"price_retail"`
-	QtyRetail   json.Number `json:"qty_retail"`
 	URL         string      `json:"url"`
 	IsFoil      string      `json:"is_foil"`
 }
 
-// Listing is the cheapest in-stock Card Kingdom offer for a card name.
+// Listing is the cheapest Card Kingdom retail offer for a card name.
 type Listing struct {
 	CardName           string  `json:"cardName"`
 	Edition            string  `json:"edition"`
 	PriceUsd           float64 `json:"priceUsd"`
 	PriceChangePercent *int    `json:"priceChangePercent,omitempty"`
 	URL                string  `json:"url"`
-	Quantity           int     `json:"quantity"`
 	IsFoil             bool    `json:"isFoil"`
 	UpdatedAt          string  `json:"updatedAt,omitempty"`
 	SyncedAt           string  `json:"syncedAt,omitempty"`

--- a/api/store/ckprices/dynamodb.go
+++ b/api/store/ckprices/dynamodb.go
@@ -34,7 +34,6 @@ type dynamoRecord struct {
 	PriceChangePercent *int    `dynamodbav:"priceChangePercent,omitempty"`
 	PriceChangeIndexPK *string `dynamodbav:"priceChangeIndexPK,omitempty"`
 	URL                string  `dynamodbav:"url"`
-	Quantity           int     `dynamodbav:"quantity"`
 	IsFoil             bool    `dynamodbav:"isFoil"`
 	UpdatedAt          string  `dynamodbav:"updatedAt"`
 	SyncedAt           string  `dynamodbav:"syncedAt"`
@@ -233,7 +232,6 @@ func dynamoRecordFromListing(nameKey string, listing cardkingdom.Listing, synced
 		PriceUsd:           listing.PriceUsd,
 		PriceChangePercent: listing.PriceChangePercent,
 		URL:                listing.URL,
-		Quantity:           listing.Quantity,
 		IsFoil:             listing.IsFoil,
 		UpdatedAt:          listing.UpdatedAt,
 		SyncedAt:           syncedAt,
@@ -255,7 +253,6 @@ func listingFromRecord(record dynamoRecord) (cardkingdom.Listing, bool) {
 		PriceUsd:           record.PriceUsd,
 		PriceChangePercent: record.PriceChangePercent,
 		URL:                record.URL,
-		Quantity:           record.Quantity,
 		IsFoil:             record.IsFoil,
 		UpdatedAt:          record.UpdatedAt,
 		SyncedAt:           record.SyncedAt,

--- a/api/store/ckprices/dynamodb_test.go
+++ b/api/store/ckprices/dynamodb_test.go
@@ -20,7 +20,6 @@ func TestDynamoRecordFromListing(t *testing.T) {
 		PriceUsd:           1.49,
 		PriceChangePercent: &priceChangePercent,
 		URL:                "https://www.cardkingdom.com/mtg/fourth-edition/lightning-bolt",
-		Quantity:           0,
 		IsFoil:             false,
 		UpdatedAt:          "2026-06-28T00:00:00Z",
 	}, syncedAt)
@@ -44,6 +43,14 @@ func TestDynamoRecordFromListing_OmitsPriceChangeIndexWithoutPercent(t *testing.
 
 	require.Nil(t, record.PriceChangePercent)
 	require.Nil(t, record.PriceChangeIndexPK)
+}
+
+func TestDynamoRecordMarshalOmitsQuantity(t *testing.T) {
+	syncedAt := time.Date(2026, 6, 28, 15, 30, 0, 0, time.UTC).Format(time.RFC3339)
+	record := dynamoRecordFromListing("lightning bolt", cardkingdom.Listing{UpdatedAt: "2026-06-28T00:00:00Z"}, syncedAt)
+	item, err := attributevalue.MarshalMap(record)
+	require.NoError(t, err)
+	require.NotContains(t, item, "quantity")
 }
 
 func TestDynamoRecordMarshalIncludesSyncedAt(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the unused `quantity` field from the Card Kingdom price pipeline. The `gishathfetch-ck-prices` DynamoDB table always stored `0` because MTGJSON retail prices do not include stock counts, and the application never read or displayed this field.

## Changes

- Drop `quantity` from `cardkingdom.Listing` and DynamoDB `dynamoRecord`
- Stop parsing `qty_retail` from the Card Kingdom pricelist API
- Remove hardcoded `Quantity: 0` assignments in MTGJSON ingestion
- Add a regression test asserting DynamoDB marshaling omits `quantity`

## Behaviour

- Search API `cardKingdomPrice` responses no longer include a `quantity` field
- The next CK price refresh will write items without `quantity`; existing rows keep the stale attribute until overwritten (DynamoDB is schemaless, so no migration is required)

## Testing

- `go test -mod=vendor ./gateway/cardkingdom/... ./store/ckprices/... ./controller/ckprice/... ./handler/...` — pass
- `make test` — one unrelated transient failure in `gateway/agora` live test (`connection reset by peer`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bfad7aec-5c7a-4c60-8cef-5413b8c1f576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bfad7aec-5c7a-4c60-8cef-5413b8c1f576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

