### PR TITLE
Post scheduled job results to a dedicated Discord webhook

### DIFF
--- a/api/handler/analytics_keywords.go
+++ b/api/handler/analytics_keywords.go
@@ -24,8 +24,17 @@ var (
 	}
 )
 
-func runAnalyticsKeywordsExport(ctx context.Context) error {
+func runAnalyticsKeywordsExport(ctx context.Context) (err error) {
 	log.Printf("analytics keywords export: started")
+	var generatedAt string
+
+	defer func() {
+		if err != nil {
+			sendJobDiscordAlert(formatAnalyticsKeywordsExportFailure(err))
+			return
+		}
+		sendJobDiscordAlert(formatAnalyticsKeywordsExportSuccess(generatedAt))
+	}()
 
 	reporter, err := newGA4ReporterFunc(ctx)
 	if err != nil {
@@ -51,6 +60,7 @@ func runAnalyticsKeywordsExport(ctx context.Context) error {
 		return err
 	}
 
-	log.Printf("analytics keywords export: finished generatedAt=%s", report.GeneratedAt)
+	generatedAt = report.GeneratedAt
+	log.Printf("analytics keywords export: finished generatedAt=%s", generatedAt)
 	return nil
 }

--- a/api/handler/analytics_keywords_test.go
+++ b/api/handler/analytics_keywords_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -11,34 +12,19 @@ import (
 	"mtg-price-checker-sg/store/analyticsreport"
 )
 
-type mockAnalyticsReporter struct{}
-
-func (m *mockAnalyticsReporter) TopSearchTerms(_ context.Context, _, _ string, _ int) ([]ga4.SearchTermCount, error) {
-	return []ga4.SearchTermCount{{Term: "Opt", Count: 1}}, nil
-}
-
-func (m *mockAnalyticsReporter) TopSearchTermsLast24Hours(_ context.Context, _ time.Time, _ int) ([]ga4.SearchTermCount, error) {
-	return []ga4.SearchTermCount{{Term: "Opt", Count: 1}}, nil
-}
-
-type mockAnalyticsWriter struct {
-	written bool
-}
-
-func (m *mockAnalyticsWriter) Write(_ context.Context, _ *analyticskeywords.Report) error {
-	m.written = true
-	return nil
-}
-
 func TestHandle_RoutesAnalyticsKeywordsExportRun(t *testing.T) {
 	originalReporterFunc := newGA4ReporterFunc
 	originalBuildFunc := buildAnalyticsKeywordsReportFunc
 	originalWriterFunc := newAnalyticsReportWriterFunc
+	originalAlertFunc := sendJobDiscordAlert
 	defer func() {
 		newGA4ReporterFunc = originalReporterFunc
 		buildAnalyticsKeywordsReportFunc = originalBuildFunc
 		newAnalyticsReportWriterFunc = originalWriterFunc
+		sendJobDiscordAlert = originalAlertFunc
 	}()
+
+	sendJobDiscordAlert = func(string) {}
 
 	writer := &mockAnalyticsWriter{}
 	newGA4ReporterFunc = func(_ context.Context) (ga4.Reporter, error) {
@@ -66,4 +52,95 @@ func TestHandle_RoutesAnalyticsKeywordsExportRun(t *testing.T) {
 	if !writer.written {
 		t.Fatalf("expected analytics report to be written")
 	}
+}
+
+func TestRunAnalyticsKeywordsExport_SendsSuccessDiscordAlert(t *testing.T) {
+	originalReporterFunc := newGA4ReporterFunc
+	originalBuildFunc := buildAnalyticsKeywordsReportFunc
+	originalWriterFunc := newAnalyticsReportWriterFunc
+	originalAlertFunc := sendJobDiscordAlert
+	defer func() {
+		newGA4ReporterFunc = originalReporterFunc
+		buildAnalyticsKeywordsReportFunc = originalBuildFunc
+		newAnalyticsReportWriterFunc = originalWriterFunc
+		sendJobDiscordAlert = originalAlertFunc
+	}()
+
+	var gotAlert string
+	sendJobDiscordAlert = func(message string) {
+		gotAlert = message
+	}
+
+	writer := &mockAnalyticsWriter{}
+	newGA4ReporterFunc = func(_ context.Context) (ga4.Reporter, error) {
+		return &mockAnalyticsReporter{}, nil
+	}
+	buildAnalyticsKeywordsReportFunc = func(_ context.Context, _ ga4.Reporter, propertyID string, _ int) (*analyticskeywords.Report, error) {
+		return &analyticskeywords.Report{
+			GeneratedAt: "2026-07-11T12:00:00Z",
+			PropertyID:  propertyID,
+			EventName:   ga4.SearchEventName,
+		}, nil
+	}
+	newAnalyticsReportWriterFunc = func(_ context.Context) (analyticsreport.Writer, error) {
+		return writer, nil
+	}
+
+	if err := runAnalyticsKeywordsExport(context.Background()); err != nil {
+		t.Fatalf("runAnalyticsKeywordsExport: %v", err)
+	}
+	if !writer.written {
+		t.Fatal("expected analytics report to be written")
+	}
+
+	want := "Analytics keywords export finished: generatedAt=2026-07-11T12:00:00Z"
+	if gotAlert != want {
+		t.Fatalf("discord alert = %q, want %q", gotAlert, want)
+	}
+}
+
+func TestRunAnalyticsKeywordsExport_SendsFailureDiscordAlert(t *testing.T) {
+	originalReporterFunc := newGA4ReporterFunc
+	originalAlertFunc := sendJobDiscordAlert
+	defer func() {
+		newGA4ReporterFunc = originalReporterFunc
+		sendJobDiscordAlert = originalAlertFunc
+	}()
+
+	reportErr := errors.New("ga4 credentials missing")
+	var gotAlert string
+	sendJobDiscordAlert = func(message string) {
+		gotAlert = message
+	}
+	newGA4ReporterFunc = func(_ context.Context) (ga4.Reporter, error) {
+		return nil, reportErr
+	}
+
+	if err := runAnalyticsKeywordsExport(context.Background()); err == nil {
+		t.Fatal("expected error")
+	}
+
+	want := "Analytics keywords export failed: ga4 credentials missing"
+	if gotAlert != want {
+		t.Fatalf("discord alert = %q, want %q", gotAlert, want)
+	}
+}
+
+type mockAnalyticsReporter struct{}
+
+func (m *mockAnalyticsReporter) TopSearchTerms(_ context.Context, _, _ string, _ int) ([]ga4.SearchTermCount, error) {
+	return []ga4.SearchTermCount{{Term: "Opt", Count: 1}}, nil
+}
+
+func (m *mockAnalyticsReporter) TopSearchTermsLast24Hours(_ context.Context, _ time.Time, _ int) ([]ga4.SearchTermCount, error) {
+	return []ga4.SearchTermCount{{Term: "Opt", Count: 1}}, nil
+}
+
+type mockAnalyticsWriter struct {
+	written bool
+}
+
+func (m *mockAnalyticsWriter) Write(_ context.Context, _ *analyticskeywords.Report) error {
+	m.written = true
+	return nil
 }

--- a/api/handler/ck_refresh.go
+++ b/api/handler/ck_refresh.go
@@ -23,21 +23,34 @@ var (
 	ckPriceReportNowFunc = time.Now
 )
 
-func runCKPriceRefresh(ctx context.Context) error {
+func runCKPriceRefresh(ctx context.Context) (err error) {
 	log.Printf("ck price refresh: started")
+	var refreshedCount int
+	var topCount int
+	var bottomCount int
+	var generatedAt string
+
+	defer func() {
+		if err != nil {
+			sendJobDiscordAlert(formatCKPriceRefreshFailure(err))
+			return
+		}
+		sendJobDiscordAlert(formatCKPriceRefreshSuccess(refreshedCount, topCount, bottomCount, generatedAt))
+	}()
+
 	store, err := newCKRefreshStoreFunc(ctx)
 	if err != nil {
 		log.Printf("ck price refresh: failed opening dynamodb store: %v", err)
 		return err
 	}
 
-	count, err := refreshCKPricesFunc(ctx, store)
+	refreshedCount, err = refreshCKPricesFunc(ctx, store)
 	if err != nil {
 		log.Printf("ck price refresh: failed: %v", err)
 		return err
 	}
 
-	log.Printf("ck price refresh: finished refreshed=%d", count)
+	log.Printf("ck price refresh: finished refreshed=%d", refreshedCount)
 
 	changes, err := store.GetTopBottomPriceChanges(ctx)
 	if err != nil {
@@ -57,6 +70,9 @@ func runCKPriceRefresh(ctx context.Context) error {
 		return err
 	}
 
-	log.Printf("ck price refresh: exported price changes top=%d bottom=%d generatedAt=%s", len(report.Top), len(report.Bottom), report.GeneratedAt)
+	topCount = len(report.Top)
+	bottomCount = len(report.Bottom)
+	generatedAt = report.GeneratedAt
+	log.Printf("ck price refresh: exported price changes top=%d bottom=%d generatedAt=%s", topCount, bottomCount, generatedAt)
 	return nil
 }

--- a/api/handler/ck_refresh_test.go
+++ b/api/handler/ck_refresh_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -10,6 +11,89 @@ import (
 	"mtg-price-checker-sg/store/ckpricereport"
 	"mtg-price-checker-sg/store/ckprices"
 )
+
+func TestRunCKPriceRefresh_SendsSuccessDiscordAlert(t *testing.T) {
+	originalStoreFunc := newCKRefreshStoreFunc
+	originalRefreshFunc := refreshCKPricesFunc
+	originalWriterFunc := newCKPriceReportWriterFunc
+	originalNowFunc := ckPriceReportNowFunc
+	originalAlertFunc := sendJobDiscordAlert
+	defer func() {
+		newCKRefreshStoreFunc = originalStoreFunc
+		refreshCKPricesFunc = originalRefreshFunc
+		newCKPriceReportWriterFunc = originalWriterFunc
+		ckPriceReportNowFunc = originalNowFunc
+		sendJobDiscordAlert = originalAlertFunc
+	}()
+
+	var gotAlert string
+	sendJobDiscordAlert = func(message string) {
+		gotAlert = message
+	}
+
+	writer := &mockCKPriceReportWriter{}
+	newCKRefreshStoreFunc = func(_ context.Context) (ckprices.Store, error) {
+		return &mockCKRefreshStore{
+			changes: &ckprices.TopBottomPriceChanges{
+				Top:    []ckprices.PriceChangeListing{{NameKey: "bolt"}},
+				Bottom: []ckprices.PriceChangeListing{{NameKey: "counterspell"}},
+			},
+		}, nil
+	}
+	refreshCKPricesFunc = func(_ context.Context, _ ckprices.Store) (int, error) {
+		return 42, nil
+	}
+	newCKPriceReportWriterFunc = func(_ context.Context) (ckpricereport.Writer, error) {
+		return writer, nil
+	}
+	ckPriceReportNowFunc = func() time.Time {
+		return time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
+	}
+
+	if err := runCKPriceRefresh(context.Background()); err != nil {
+		t.Fatalf("runCKPriceRefresh: %v", err)
+	}
+	if !writer.written {
+		t.Fatal("expected ck price change report to be written")
+	}
+
+	want := "CK price refresh finished: refreshed=42, top=1, bottom=1, generatedAt=2026-07-11T12:00:00Z"
+	if gotAlert != want {
+		t.Fatalf("discord alert = %q, want %q", gotAlert, want)
+	}
+}
+
+func TestRunCKPriceRefresh_SendsFailureDiscordAlert(t *testing.T) {
+	originalRefreshFunc := refreshCKPricesFunc
+	originalStoreFunc := newCKRefreshStoreFunc
+	originalAlertFunc := sendJobDiscordAlert
+	defer func() {
+		refreshCKPricesFunc = originalRefreshFunc
+		newCKRefreshStoreFunc = originalStoreFunc
+		sendJobDiscordAlert = originalAlertFunc
+	}()
+
+	refreshErr := errors.New("mtgjson download failed")
+	var gotAlert string
+	sendJobDiscordAlert = func(message string) {
+		gotAlert = message
+	}
+	newCKRefreshStoreFunc = func(_ context.Context) (ckprices.Store, error) {
+		return &mockCKRefreshStore{}, nil
+	}
+	refreshCKPricesFunc = func(_ context.Context, _ ckprices.Store) (int, error) {
+		return 0, refreshErr
+	}
+
+	if err := runCKPriceRefresh(context.Background()); err == nil {
+		t.Fatal("expected error")
+	}
+
+	want := "CK price refresh failed: mtgjson download failed"
+	if gotAlert != want {
+		t.Fatalf("discord alert = %q, want %q", gotAlert, want)
+	}
+}
 
 type mockCKRefreshStore struct {
 	changes *ckprices.TopBottomPriceChanges
@@ -48,12 +132,16 @@ func TestHandle_RoutesCKPriceRefreshRun(t *testing.T) {
 	originalRefreshFunc := refreshCKPricesFunc
 	originalWriterFunc := newCKPriceReportWriterFunc
 	originalNowFunc := ckPriceReportNowFunc
+	originalAlertFunc := sendJobDiscordAlert
 	defer func() {
 		newCKRefreshStoreFunc = originalStoreFunc
 		refreshCKPricesFunc = originalRefreshFunc
 		newCKPriceReportWriterFunc = originalWriterFunc
 		ckPriceReportNowFunc = originalNowFunc
+		sendJobDiscordAlert = originalAlertFunc
 	}()
+
+	sendJobDiscordAlert = func(string) {}
 
 	writer := &mockCKPriceReportWriter{}
 	newCKRefreshStoreFunc = func(_ context.Context) (ckprices.Store, error) {

--- a/api/handler/job_discord.go
+++ b/api/handler/job_discord.go
@@ -1,0 +1,31 @@
+package handler
+
+import (
+	"fmt"
+
+	"mtg-price-checker-sg/pkg/alert"
+)
+
+var sendJobDiscordAlert = alert.SendJobDiscordAlert
+
+func formatCKPriceRefreshSuccess(refreshedCount, topCount, bottomCount int, generatedAt string) string {
+	return fmt.Sprintf(
+		"CK price refresh finished: refreshed=%d, top=%d, bottom=%d, generatedAt=%s",
+		refreshedCount,
+		topCount,
+		bottomCount,
+		generatedAt,
+	)
+}
+
+func formatCKPriceRefreshFailure(err error) string {
+	return fmt.Sprintf("CK price refresh failed: %v", err)
+}
+
+func formatAnalyticsKeywordsExportSuccess(generatedAt string) string {
+	return fmt.Sprintf("Analytics keywords export finished: generatedAt=%s", generatedAt)
+}
+
+func formatAnalyticsKeywordsExportFailure(err error) string {
+	return fmt.Sprintf("Analytics keywords export failed: %v", err)
+}

--- a/api/pkg/alert/discord.go
+++ b/api/pkg/alert/discord.go
@@ -8,18 +8,31 @@ import (
 	"os"
 )
 
+const (
+	DiscordWebhookURLEnv    = "DISCORD_WEBHOOK_URL"
+	JobDiscordWebhookURLEnv = "JOB_DISCORD_WEBHOOK_URL"
+)
+
 type DiscordPayload struct {
 	Content string `json:"content"`
 }
 
-// SendDiscordAlert sends a message to the configured Discord Webhook URL.
+// SendDiscordAlert sends a message to the search-error Discord webhook.
 // It is fire-and-forget; errors are logged but not returned to disrupt the main flow.
 func SendDiscordAlert(message string) {
-	webhookURL := os.Getenv("DISCORD_WEBHOOK_URL")
+	sendDiscordWebhook(DiscordWebhookURLEnv, message)
+}
+
+// SendJobDiscordAlert sends a message to the scheduled-job Discord webhook.
+// It is fire-and-forget; errors are logged but not returned to disrupt the main flow.
+func SendJobDiscordAlert(message string) {
+	sendDiscordWebhook(JobDiscordWebhookURLEnv, message)
+}
+
+func sendDiscordWebhook(webhookURLEnv, message string) {
+	webhookURL := os.Getenv(webhookURLEnv)
 	if webhookURL == "" {
-		// Log warning only once or just ignore if not configured?
-		// Better to log so user knows why alerts aren't sending.
-		log.Println("DISCORD_WEBHOOK_URL not set, skipping alert")
+		log.Printf("%s not set, skipping alert", webhookURLEnv)
 		return
 	}
 

--- a/api/pkg/alert/discord_test.go
+++ b/api/pkg/alert/discord_test.go
@@ -15,11 +15,18 @@ func init() {
 }
 
 func TestSendDiscordAlert(t *testing.T) {
-	// 1. Test Case: Success
+	testSendDiscordWebhook(t, DiscordWebhookURLEnv, SendDiscordAlert)
+}
+
+func TestSendJobDiscordAlert(t *testing.T) {
+	testSendDiscordWebhook(t, JobDiscordWebhookURLEnv, SendJobDiscordAlert)
+}
+
+func testSendDiscordWebhook(t *testing.T, webhookURLEnv string, sendAlert func(string)) {
+	t.Helper()
+
 	t.Run("Success", func(t *testing.T) {
-		// Mock server
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// specific assertions
 			if r.Method != http.MethodPost {
 				t.Errorf("Expected POST request, got %s", r.Method)
 			}
@@ -36,41 +43,44 @@ func TestSendDiscordAlert(t *testing.T) {
 				t.Errorf("Expected content 'Test Message', got '%s'", payload.Content)
 			}
 
-			w.WriteHeader(http.StatusNoContent) // 204 is typical for webhooks
+			w.WriteHeader(http.StatusNoContent)
 		}))
 		defer server.Close()
 
-		// Set ENV to mock server
-		t.Setenv("DISCORD_WEBHOOK_URL", server.URL)
-
-		// Call function
-		SendDiscordAlert("Test Message")
+		t.Setenv(webhookURLEnv, server.URL)
+		sendAlert("Test Message")
 	})
 
-	// 2. Test Case: No URL set (Should not panic)
 	t.Run("No URL Set", func(t *testing.T) {
-		t.Setenv("DISCORD_WEBHOOK_URL", "")
-		SendDiscordAlert("Should result in log but no panic")
+		t.Setenv(webhookURLEnv, "")
+		sendAlert("Should result in log but no panic")
 	})
 
-	// 3. Test Case: Server Error (Should handle gracefully)
 	t.Run("Server Error", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusInternalServerError)
 		}))
 		defer server.Close()
 
-		t.Setenv("DISCORD_WEBHOOK_URL", server.URL)
-
-		SendDiscordAlert("Test Message")
+		t.Setenv(webhookURLEnv, server.URL)
+		sendAlert("Test Message")
 	})
 }
 
 func TestSendDiscordAlert_Integration(t *testing.T) {
-	webhookURL := os.Getenv("DISCORD_WEBHOOK_URL")
+	webhookURL := os.Getenv(DiscordWebhookURLEnv)
 	if webhookURL == "" {
 		t.Skip("DISCORD_WEBHOOK_URL not set, skipping integration test")
 	}
 
 	SendDiscordAlert("Integration Test Message (Ignore this)")
+}
+
+func TestSendJobDiscordAlert_Integration(t *testing.T) {
+	webhookURL := os.Getenv(JobDiscordWebhookURLEnv)
+	if webhookURL == "" {
+		t.Skip("JOB_DISCORD_WEBHOOK_URL not set, skipping integration test")
+	}
+
+	SendJobDiscordAlert("Integration Test Message (Ignore this)")
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Discord notifications after each EventBridge-scheduled job run, using a **separate** webhook from search scrape errors.

- New env var: `JOB_DISCORD_WEBHOOK_URL` (job alerts)
- Existing env var unchanged: `DISCORD_WEBHOOK_URL` (search scrape errors)
- `mtg-price-ck-refresh` posts success/failure after each run
- `mtg-analytics-keywords-export` posts success/failure after each run

## Example messages

**Success**
- `CK price refresh finished: refreshed=12345, top=20, bottom=20, generatedAt=2026-07-11T12:00:00Z`
- `Analytics keywords export finished: generatedAt=2026-07-11T12:00:00Z`

**Failure**
- `CK price refresh failed: <error>`
- `Analytics keywords export failed: <error>`

## Deployment

Set `JOB_DISCORD_WEBHOOK_URL` on both scheduled Lambdas in AWS:
- `mtg-price-ck-refresh`
- `mtg-analytics-keywords-export`

If unset, jobs continue to run normally and alerts are skipped (logged once per attempt).

## Testing

- `go test -mod=vendor ./handler/... ./pkg/alert/...`
- Full `make test` hit an unrelated live Agora gateway network flake (`connection reset by peer`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b21cd6a8-ec6c-4f82-8df9-3d7b56a27b81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b21cd6a8-ec6c-4f82-8df9-3d7b56a27b81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

