### PR TITLE
Use direct HTTP client for Cards Central search

### DIFF
--- a/api/gateway/cardscentral/search.go
+++ b/api/gateway/cardscentral/search.go
@@ -71,10 +71,7 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 		return cards, err
 	}
 
-	client, err := gateway.NewOutboundHTTPClient(15 * time.Second)
-	if err != nil {
-		return cards, err
-	}
+	client := &http.Client{Timeout: 15 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
 		return cards, err

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -65,7 +65,8 @@ Some tests in `api/gateway/binderpos/*_test.go` hit real stores and proxies. The
 | Item | Value | Source | Notes |
 |------|--------|--------|--------|
 | Outbound proxy policy | Random dedicated → dynamic → direct | `selectOutboundProxy` in `api/gateway/collector.go` | Same single-attempt policy as default optimized colly collectors. When `DEDICATED_PROXY_*` is configured, each search picks one dedicated proxy uniformly at random. |
-| `net/http` scrapers / APIs | Random dedicated proxy | `NewOutboundHTTPClient` in `api/gateway/outbound_get.go` | Used by Agora, Cards Central, Dueller's Point, 5 Mana, Mox & Lotus, Cards & Collections, and TCG Marketplace instead of `http.DefaultClient`. |
+| `net/http` scrapers / APIs | Random dedicated proxy | `NewOutboundHTTPClient` in `api/gateway/outbound_get.go` | Used by Agora, Dueller's Point, 5 Mana, Mox & Lotus, Cards & Collections, and TCG Marketplace instead of `http.DefaultClient`. |
+| Cards Central API | Direct only | `http.Client` in `api/gateway/cardscentral/search.go` | Always uses a direct client; does not route through dedicated or dynamic proxies. |
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cards Central search requests now always use a direct `http.Client` instead of routing through dedicated or dynamic proxies via `NewOutboundHTTPClient`.

## Motivation

Cards Central exposes a public JSON API (`/api/lgs/search`) that works reliably over direct connections. Using proxies was unnecessary and could contribute to rate limiting or connection issues.

## Changes

- `api/gateway/cardscentral/search.go`: replace `gateway.NewOutboundHTTPClient` with a direct `http.Client` (15s timeout unchanged).
- `docs/search-strategies-retries-timeouts.md`: document Cards Central's direct-only outbound policy.

## Testing

- `go test -mod=vendor -failfast -timeout 5m ./gateway/cardscentral/...` — pass
- `make test` — Cards Central and controller tests pass; full suite hit a transient Agora live test failure (`connection reset by peer` on proxy), unrelated to this change
- `go fix ./...` — no changes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf8946c5-823e-466b-a014-675cd4b8bf7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf8946c5-823e-466b-a014-675cd4b8bf7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

