### PR TITLE
Report per-site search timeouts to Discord

### DIFF
--- a/api/controller/search.go
+++ b/api/controller/search.go
@@ -262,7 +262,7 @@ func recoverShopPanic(shopName string, aggregator *fetchResultAggregator) {
 }
 
 func recordShopSearchError(searchString, shopName string, err error, aggregator *fetchResultAggregator) {
-	if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+	if !errors.Is(err, context.Canceled) {
 		errMsg := fmt.Sprintf(
 			"Error encountered searching [%s] for [%s]: %s",
 			shopName,

--- a/api/controller/search_test.go
+++ b/api/controller/search_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"mtg-price-checker-sg/gateway"
@@ -499,6 +500,95 @@ func TestFetchCardsConcurrently_CollatesDiscordErrors(t *testing.T) {
 	}
 	if !strings.Contains(got, "- Recovered from panic in shop [PanicShop]: shop panic") {
 		t.Fatalf("expected PanicShop details in alert, got: %s", got)
+	}
+}
+
+func TestFetchCardsConcurrently_ReportsPerSiteTimeoutToDiscord(t *testing.T) {
+	shops := map[string]gateway.LGS{
+		"Timeout Shop": &MockLGS{
+			SearchFunc: func(ctx context.Context, searchStr string) ([]gateway.Card, error) {
+				return nil, context.DeadlineExceeded
+			},
+		},
+	}
+
+	var mu sync.Mutex
+	alertMessages := make([]string, 0, 1)
+	alertDone := make(chan struct{}, 1)
+
+	originalSendDiscordAlert := sendDiscordAlert
+	sendDiscordAlert = func(message string) {
+		mu.Lock()
+		alertMessages = append(alertMessages, message)
+		mu.Unlock()
+		select {
+		case alertDone <- struct{}{}:
+		default:
+		}
+	}
+	t.Cleanup(func() {
+		sendDiscordAlert = originalSendDiscordAlert
+	})
+
+	_, siteErrors := fetchCardsConcurrently(context.Background(), "Abrade", shops)
+	if len(siteErrors) != 1 {
+		t.Fatalf("expected 1 site error, got %d", len(siteErrors))
+	}
+	if !errors.Is(siteErrors["Timeout Shop"], context.DeadlineExceeded) {
+		t.Fatalf("expected deadline exceeded site error, got %v", siteErrors["Timeout Shop"])
+	}
+
+	select {
+	case <-alertDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for timeout discord alert")
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(alertMessages) != 1 {
+		t.Fatalf("expected exactly 1 alert, got %d", len(alertMessages))
+	}
+	if !strings.Contains(alertMessages[0], "- [Timeout Shop] context deadline exceeded") {
+		t.Fatalf("expected timeout shop in alert, got: %s", alertMessages[0])
+	}
+}
+
+func TestFetchCardsConcurrently_SkipsCanceledForDiscord(t *testing.T) {
+	shops := map[string]gateway.LGS{
+		"Canceled Shop": &MockLGS{
+			SearchFunc: func(ctx context.Context, searchStr string) ([]gateway.Card, error) {
+				return nil, context.Canceled
+			},
+		},
+	}
+
+	alertSent := make(chan struct{}, 1)
+	originalSendDiscordAlert := sendDiscordAlert
+	sendDiscordAlert = func(message string) {
+		select {
+		case alertSent <- struct{}{}:
+		default:
+		}
+	}
+	t.Cleanup(func() {
+		sendDiscordAlert = originalSendDiscordAlert
+	})
+
+	_, siteErrors := fetchCardsConcurrently(context.Background(), "Abrade", shops)
+	if len(siteErrors) != 1 {
+		t.Fatalf("expected 1 site error, got %d", len(siteErrors))
+	}
+	if !errors.Is(siteErrors["Canceled Shop"], context.Canceled) {
+		t.Fatalf("expected canceled site error, got %v", siteErrors["Canceled Shop"])
+	}
+
+	select {
+	case <-alertSent:
+		t.Fatal("did not expect discord alert for canceled search")
+	case <-time.After(200 * time.Millisecond):
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Per-site search timeouts (`context.DeadlineExceeded` from the 16s shop timeout) were previously recorded in API store errors but intentionally excluded from Discord alerts. This change reports them to Discord alongside other shop failures.

Client disconnect cancellations (`context.Canceled`) remain suppressed to avoid noisy alerts when users navigate away mid-search.

## Changes

- `recordShopSearchError` now sends Discord alerts for timeout errors
- Added tests covering timeout reporting and canceled-search suppression

## Testing

- `go test -mod=vendor -run 'TestFetchCardsConcurrently_' ./controller/...`
- `go test -mod=vendor -failfast -timeout 5m ./controller/...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0bac443b-6ead-4ba2-b2ca-1a8fe25744aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0bac443b-6ead-4ba2-b2ca-1a8fe25744aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

