### PR TITLE
Add multi-transport retries for net/http store scrapers

### DIFF
--- a/api/gateway/agora/search.go
+++ b/api/gateway/agora/search.go
@@ -3,7 +3,6 @@ package agora
 import (
 	"context"
 	"log"
-	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -52,22 +51,10 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 		}.Encode(),
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL.String(), nil)
-	if err != nil {
-		return cards, err
-	}
-	if err := gateway.PrepareOutboundRequest(ctx, req, gateway.OutboundRequestOptions{
+	resp, err := gateway.DoOutboundGET(ctx, apiURL.String(), gateway.OutboundRequestOptions{
 		Style:   gateway.OutboundStyleHTML,
 		PageURL: apiURL,
-	}); err != nil {
-		return cards, err
-	}
-
-	client, err := gateway.NewOutboundHTTPClient(config.AgoraSearchAttemptTimeout)
-	if err != nil {
-		return cards, err
-	}
-	resp, err := client.Do(req)
+	}, config.AgoraSearchAttemptTimeout)
 	if err != nil {
 		return cards, err
 	}

--- a/api/gateway/cardsandcollection/search.go
+++ b/api/gateway/cardsandcollection/search.go
@@ -166,19 +166,14 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 
 	apiURL := s.BaseUrl + StoreApiURL
 	requestBody := fmt.Appendf(nil, `{"query":{"bool":{"should":[{"simple_query_string":{"query":"%s","fields":["name","setCode","setName"],"default_operator":"AND"}},{"multi_match":{"query":"%s","type":"phrase_prefix","fields":["name","setCode","setName"]}}]}},"post_filter":{"bool":{"must":{"terms":{"collectableContext.raw":["MTG","ACCESSORY"]}}}},"aggs":{"productCategory4":{"filter":{"bool":{"must":{"terms":{"collectableContext.raw":["MTG","ACCESSORY"]}}}},"aggs":{"productCategory.raw":{"terms":{"field":"productCategory.raw","size":50}},"productCategory.raw_count":{"cardinality":{"field":"productCategory.raw"}}}}},"size":20,"sort":[{"quantityOnSale":"desc"}]}`, searchStr, searchStr)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewBuffer(requestBody))
-	if err != nil {
-		return cards, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	if err := gateway.PrepareOutboundRequest(ctx, req, gateway.OutboundRequestOptions{}); err != nil {
-		return cards, err
-	}
-	client, err := gateway.NewOutboundHTTPClient(config.SearchAttemptTimeout)
-	if err != nil {
-		return cards, err
-	}
-	resp, err := client.Do(req)
+	resp, err := gateway.DoOutboundRoundTrip(ctx, gateway.OutboundRequestOptions{}, config.SearchAttemptTimeout, func() (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewBuffer(requestBody))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		return req, nil
+	})
 	if err != nil {
 		return cards, err
 	}

--- a/api/gateway/duellerpoint/search.go
+++ b/api/gateway/duellerpoint/search.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"mtg-price-checker-sg/gateway/util"
-	"net/http"
 	"net/url"
 	"strings"
 
@@ -47,21 +46,10 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 		}.Encode(),
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL.String(), nil)
-	if err != nil {
-		return cards, err
-	}
-	if err := gateway.PrepareOutboundRequest(ctx, req, gateway.OutboundRequestOptions{
+	resp, err := gateway.DoOutboundGET(ctx, apiURL.String(), gateway.OutboundRequestOptions{
 		Style:   gateway.OutboundStyleHTML,
 		PageURL: apiURL,
-	}); err != nil {
-		return cards, err
-	}
-	client, err := gateway.NewOutboundHTTPClient(config.SearchAttemptTimeout)
-	if err != nil {
-		return cards, err
-	}
-	resp, err := client.Do(req)
+	}, config.SearchAttemptTimeout)
 	if err != nil {
 		return cards, err
 	}

--- a/api/gateway/fivemana/search.go
+++ b/api/gateway/fivemana/search.go
@@ -6,7 +6,6 @@ import (
 	"mtg-price-checker-sg/gateway"
 	"mtg-price-checker-sg/gateway/util"
 	"mtg-price-checker-sg/pkg/config"
-	"net/http"
 	"net/url"
 	"strings"
 
@@ -46,22 +45,11 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 		}.Encode(),
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL.String(), nil)
-	if err != nil {
-		return cards, err
-	}
-	if err := gateway.PrepareOutboundRequest(ctx, req, gateway.OutboundRequestOptions{
+	resp, err := gateway.DoOutboundGET(ctx, apiURL.String(), gateway.OutboundRequestOptions{
 		Style:              gateway.OutboundStyleHTML,
 		PageURL:            apiURL,
 		ShopifySGDCurrency: true,
-	}); err != nil {
-		return cards, err
-	}
-	client, err := gateway.NewOutboundHTTPClient(config.SearchAttemptTimeout)
-	if err != nil {
-		return cards, err
-	}
-	resp, err := client.Do(req)
+	}, config.SearchAttemptTimeout)
 	if err != nil {
 		return cards, err
 	}

--- a/api/gateway/moxandlotus/search.go
+++ b/api/gateway/moxandlotus/search.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -139,18 +138,7 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 		}.Encode(),
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	if err := gateway.PrepareOutboundRequest(ctx, req, gateway.OutboundRequestOptions{}); err != nil {
-		return cards, err
-	}
-	client, err := gateway.NewOutboundHTTPClient(config.SearchAttemptTimeout)
-	if err != nil {
-		return cards, err
-	}
-	resp, err := client.Do(req)
+	resp, err := gateway.DoOutboundGET(ctx, apiURL.String(), gateway.OutboundRequestOptions{}, config.SearchAttemptTimeout)
 	if err != nil {
 		return cards, err
 	}

--- a/api/gateway/outbound_get.go
+++ b/api/gateway/outbound_get.go
@@ -18,16 +18,31 @@ type outboundAttempt struct {
 }
 
 // DoOutboundGET performs a GET with direct, dedicated-proxy, and dynamic-proxy
-// fallback. Transient 403/429 responses advance to the next transport.
+// fallback. Transient errors and 403/429 responses advance to the next transport.
 func DoOutboundGET(
 	ctx context.Context,
 	requestURL string,
 	opts OutboundRequestOptions,
 	timeout time.Duration,
 ) (*http.Response, error) {
+	return DoOutboundRoundTrip(ctx, opts, timeout, func() (*http.Request, error) {
+		return http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	})
+}
+
+// DoOutboundRoundTrip performs an HTTP round trip with direct, dedicated-proxy,
+// and dynamic-proxy fallback. Transient errors and 403/429 responses advance to
+// the next transport. buildReq is called for each attempt so callers can supply
+// a fresh request body when needed.
+func DoOutboundRoundTrip(
+	ctx context.Context,
+	opts OutboundRequestOptions,
+	timeout time.Duration,
+	buildReq func() (*http.Request, error),
+) (*http.Response, error) {
 	var failures []string
 	for _, attempt := range buildOutboundGETAttempts(timeout, opts.SkipDirect) {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+		req, err := buildReq()
 		if err != nil {
 			return nil, err
 		}
@@ -47,9 +62,9 @@ func DoOutboundGET(
 		return resp, nil
 	}
 	if len(failures) == 0 {
-		return nil, fmt.Errorf("outbound get failed")
+		return nil, fmt.Errorf("outbound request failed")
 	}
-	return nil, fmt.Errorf("outbound get failed: %s", strings.Join(failures, "; "))
+	return nil, fmt.Errorf("outbound request failed: %s", strings.Join(failures, "; "))
 }
 
 func buildOutboundGETAttempts(timeout time.Duration, skipDirect bool) []outboundAttempt {

--- a/api/gateway/outbound_get_test.go
+++ b/api/gateway/outbound_get_test.go
@@ -1,8 +1,10 @@
 package gateway
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -94,4 +96,55 @@ func TestDoOutboundGET_DirectForbiddenWithoutProxy(t *testing.T) {
 	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "direct: status 403")
+}
+
+func TestDoOutboundGET_ContinuesAfterDirectTimeout(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("DEDICATED_PROXY_1", "127.0.0.1|9|u|p")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	_, err := DoOutboundGET(
+		context.Background(),
+		server.URL,
+		OutboundRequestOptions{SkipWebBotAuth: true},
+		50*time.Millisecond,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "direct:")
+	require.Contains(t, err.Error(), "dedicated-1:")
+}
+
+func TestDoOutboundRoundTrip_RebuildsPOSTBodyPerAttempt(t *testing.T) {
+	clearProxyEnv(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.Equal(t, `{"q":"test"}`, string(body))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	payload := []byte(`{"q":"test"}`)
+	resp, err := DoOutboundRoundTrip(
+		context.Background(),
+		OutboundRequestOptions{SkipWebBotAuth: true},
+		2*time.Second,
+		func() (*http.Request, error) {
+			return http.NewRequestWithContext(
+				context.Background(),
+				http.MethodPost,
+				server.URL,
+				bytes.NewBuffer(payload),
+			)
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
 }

--- a/api/gateway/tcgmarketplace/search.go
+++ b/api/gateway/tcgmarketplace/search.go
@@ -161,25 +161,22 @@ func isSurgeFoil(extraInfo []string, name string) bool {
 func getApiResponse(ctx context.Context, payload []byte, accessTokenConfigured bool) (response, error) {
 	var res response
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cardLinkAPI, bytes.NewBuffer(payload))
-	if err != nil {
-		return res, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.ContentLength = int64(len(payload))
-
 	var requestContext []string
 	if !accessTokenConfigured {
 		requestContext = append(requestContext, "access_token_configured=false")
 	}
 
-	client, err := gateway.NewOutboundHTTPClient(config.SearchAttemptTimeout)
+	resp, err := gateway.DoOutboundRoundTrip(ctx, gateway.OutboundRequestOptions{}, config.SearchAttemptTimeout, func() (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, cardLinkAPI, bytes.NewBuffer(payload))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.ContentLength = int64(len(payload))
+		return req, nil
+	})
 	if err != nil {
-		return res, err
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return res, gateway.WrapHTTPRequestError(err, req, requestContext...)
+		return res, gateway.WrapHTTPRequestError(err, nil, requestContext...)
 	}
 	defer resp.Body.Close()
 

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -65,7 +65,7 @@ Some tests in `api/gateway/binderpos/*_test.go` hit real stores and proxies. The
 | Item | Value | Source | Notes |
 |------|--------|--------|--------|
 | Outbound proxy policy | Random dedicated → dynamic → direct | `selectOutboundProxy` in `api/gateway/collector.go` | Same single-attempt policy as default optimized colly collectors. When `DEDICATED_PROXY_*` is configured, each search picks one dedicated proxy uniformly at random. |
-| `net/http` scrapers / APIs | Random dedicated proxy | `NewOutboundHTTPClient` in `api/gateway/outbound_get.go` | Used by Agora, Dueller's Point, 5 Mana, Mox & Lotus, Cards & Collections, and TCG Marketplace instead of `http.DefaultClient`. |
+| `net/http` scrapers / APIs | Direct → dedicated proxies → dynamic fallback | `DoOutboundGET` / `DoOutboundRoundTrip` in `api/gateway/outbound_get.go` | Used by Agora, Dueller's Point, 5 Mana, Mox & Lotus, Cards & Collections, and TCG Marketplace. Each transport is tried once per search; timeouts, connection errors, 403, and 429 advance to the next transport. |
 | Cards Central API | Direct only | `http.Client` in `api/gateway/cardscentral/search.go` | Always uses a direct client; does not route through dedicated or dynamic proxies. |
 
 ---


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Store scrapers that used `NewOutboundHTTPClient` (single random proxy or direct, no fallback) now use `DoOutboundGET` / `DoOutboundRoundTrip`, which retry across transports when a request fails.

**Affected stores:** Agora Hobby, Dueller's Point, 5 Mana, Mox & Lotus, Cards & Collections, TCG Marketplace.

**Retry triggers:** timeouts, connection errors, HTTP 403, HTTP 429.

**Fallback order:** direct → each configured dedicated proxy → dynamic proxy (when configured).

## Motivation

Agora Hobby (and similar stores) could fail with `Client.Timeout exceeded while awaiting headers` after a single 10s attempt. There was no transport fallback, unlike structure probes and BinderPOS stores.

## Changes

- Added `DoOutboundRoundTrip` for arbitrary HTTP methods (POST support for Cards & Collections and TCG Marketplace).
- Refactored `DoOutboundGET` to delegate to `DoOutboundRoundTrip`.
- Migrated all six `net/http` store scrapers to the fallback path.
- Added unit tests for timeout fallback and POST body rebuild.
- Updated `docs/search-strategies-retries-timeouts.md`.

## Notes

- Each transport still gets one attempt per search with the existing per-attempt timeout (10s for Agora, 5s for others).
- The overall per-store deadline remains 16s (`PerSiteTimeout`), so later fallbacks may have less time if an earlier attempt runs the full timeout.
- No frontend changes; retries are backend-only within a single search request.

## Testing

- `make test` (pass)
- New unit tests: `TestDoOutboundGET_ContinuesAfterDirectTimeout`, `TestDoOutboundRoundTrip_RebuildsPOSTBodyPerAttempt`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-17c72666-fa57-431e-bd9c-9abda8c79145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-17c72666-fa57-431e-bd9c-9abda8c79145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

