### PR TITLE
docs: fix CORS note in AGENTS.md Cloud-specific instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ Follow the [UI deliverables](#ui-deliverables) rules above. In short:
 
 ### Frontend API connection
 
-The frontend SPA points to `api.gishathfetch.com` (see `frontend/src/constants.js`). CORS headers on the API allow `gishathfetch.com` and local dev origins (`localhost:5173`). To test the full search flow through the browser, either use the computerUse agent to navigate (it works via fetch from the page) or add a Vite proxy configuration temporarily (revert before committing).
+The frontend SPA points to `api.gishathfetch.com` (see `frontend/src/constants.js`). The Go code allows `http://localhost:5173` in CORS origins, but the production API Gateway may not forward the `Origin` header correctly, resulting in missing `Access-Control-Allow-Origin` responses. To test the full search flow locally in a browser, add a Vite proxy configuration temporarily (revert before committing). The frontend UI itself loads and renders correctly without the API — only live search requires a working API connection.
 
 ### Backend local mode
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Corrects the CORS documentation in `AGENTS.md` Cloud-specific instructions. The previous note claimed the production API allows `http://localhost:5173` via CORS headers, but the API Gateway does not reliably forward the `Origin` header to the Lambda function, resulting in missing `Access-Control-Allow-Origin` responses in practice.

### Change

Updated the Frontend API connection section to accurately describe the CORS limitation and recommend using a Vite proxy for local browser testing.

### Environment verification

The full development environment was set up and verified:

| Check | Result |
|-------|--------|
| Go 1.26.5 installed | Matches `api/go.mod` requirement |
| `make test` | 32/35 packages pass; 3 gateway tests fail due to transient network issues (connection resets to external stores) |
| `npm run lint` | Runs successfully (pre-existing lint warnings only) |
| `npm run dev` | Vite v7.3.6 serves on port 5173 |
| `go run ./cmd/main.go` | Searches 7 stores for "Opt", returns 60+ cards in ~3.5s |
| Frontend loads in browser | UI renders correctly with search, stores, popular pills |

![Frontend homepage loading correctly in Chrome](https://cursor.com/artifacts/c/art-a9e86632-8527-4903-acfa-0556e37d400b)

Backend local run output showing successful card search across 7 Singapore stores:
[backend_local_run.log](https://cursor.com/artifacts/c/art-7d591e93-f7fc-4d6b-b71e-d6c3fb23ae6a)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5894ee8a-9bd2-4bc1-958b-c45c098a4fdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5894ee8a-9bd2-4bc1-958b-c45c098a4fdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

