### PR TITLE
Delete stale S3 assets on frontend deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,10 @@ generate-signature-directory:
 
 frontend-update: frontend-build
 	aws s3 sync frontend/dist s3://gishathfetch.com \
+		--delete \
 		--exclude ".well-known/http-message-signatures-directory" \
-		--exclude "robots.txt"
+		--exclude "robots.txt" \
+		--exclude "analytics/*"
 	@if [ -f frontend/dist/.well-known/http-message-signatures-directory ]; then \
 		export AWS_PAGER="" && aws s3 cp frontend/dist/.well-known/http-message-signatures-directory \
 			s3://gishathfetch.com/.well-known/http-message-signatures-directory \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `--delete` to the frontend S3 sync in `make deploy` so outdated Vite hashed assets are removed after each deploy.

Also excludes `analytics/*` so Lambda-managed exports (`analytics/top-search-keywords/latest.json`, `analytics/ck-price-changes/latest.json`) are not removed.

## Changes

- `Makefile` `frontend-update`: add `--delete` and `--exclude "analytics/*"` to `aws s3 sync`

## Notes

Existing exclusions are unchanged:
- `.well-known/http-message-signatures-directory` — uploaded separately with its own cache headers
- `robots.txt` — written by the analytics keywords Lambda

After merge, the next deploy will automatically prune stale `assets/*` files from the bucket.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-171e64d9-1567-45e9-95c2-3cc9ce0ebc69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-171e64d9-1567-45e9-95c2-3cc9ce0ebc69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

