### PR TITLE
Fix S3 asset cleanup: scope delete to assets/ and document IAM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,11 @@ generate-signature-directory:
 
 frontend-update: frontend-build
 	aws s3 sync frontend/dist s3://gishathfetch.com \
-		--delete \
 		--exclude ".well-known/http-message-signatures-directory" \
 		--exclude "robots.txt" \
 		--exclude "ads.txt" \
 		--exclude "analytics/*"
+	aws s3 sync frontend/dist/assets s3://gishathfetch.com/assets --delete
 	@if [ -f frontend/dist/.well-known/http-message-signatures-directory ]; then \
 		export AWS_PAGER="" && aws s3 cp frontend/dist/.well-known/http-message-signatures-directory \
 			s3://gishathfetch.com/.well-known/http-message-signatures-directory \

--- a/README.md
+++ b/README.md
@@ -121,8 +121,17 @@ available same-origin through CloudFront. The object is uploaded with
 `Cache-Control: public, max-age=3600` so edge caches can serve it between daily
 exports without a separate invalidation.
 
-Frontend deploys exclude `robots.txt` from `aws s3 sync` so the daily Lambda export
-remains the source of truth for the live file.
+Frontend deploys exclude `robots.txt` and `ads.txt` from `aws s3 sync` so the daily
+Lambda export and any manually managed ad-network file remain the source of truth
+for those objects. Stale Vite hashed bundles under `assets/` are pruned in a
+separate `aws s3 sync ... --delete` scoped to that prefix only.
+
+#### IAM permissions for GitHub Actions deploy
+
+The `github-actions-gishathfetch-deploy` role (used by `.github/workflows/deploy-on-merge.yml`)
+must allow `s3:DeleteObject` on `arn:aws:s3:::gishathfetch.com/assets/*` so asset
+pruning succeeds. Without it, deploy fails after upload and old hashed bundles
+remain in the bucket.
 
 Example report shape:
 

--- a/README.md
+++ b/README.md
@@ -121,17 +121,8 @@ available same-origin through CloudFront. The object is uploaded with
 `Cache-Control: public, max-age=3600` so edge caches can serve it between daily
 exports without a separate invalidation.
 
-Frontend deploys exclude `robots.txt` and `ads.txt` from `aws s3 sync` so the daily
-Lambda export and any manually managed ad-network file remain the source of truth
-for those objects. Stale Vite hashed bundles under `assets/` are pruned in a
-separate `aws s3 sync ... --delete` scoped to that prefix only.
-
-#### IAM permissions for GitHub Actions deploy
-
-The `github-actions-gishathfetch-deploy` role (used by `.github/workflows/deploy-on-merge.yml`)
-must allow `s3:DeleteObject` on `arn:aws:s3:::gishathfetch.com/assets/*` so asset
-pruning succeeds. Without it, deploy fails after upload and old hashed bundles
-remain in the bucket.
+Frontend deploys exclude `robots.txt` from `aws s3 sync` so the daily Lambda export
+remains the source of truth for the live file.
 
 Example report shape:
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After #258/#259 merged, deploy still left old `assets/*` files in S3. The post-merge deploy workflow failed with `AccessDenied` on `s3:DeleteObject` — the `github-actions-gishathfetch-deploy` role can upload but not delete.

Bucket-wide `--delete` also attempted to remove unrelated objects (`map.js`, `edhrec-top-100-cards-weekly.html`, `multicolor-lands.html`, legacy root JS/CSS, etc.) that are not part of the Vite build.

## Fix

- Upload the full `frontend/dist` tree without `--delete` (existing exclusions unchanged)
- Prune stale hashed bundles with a second sync scoped to `assets/` only

## Required AWS change (manual)

Add `s3:DeleteObject` on `arn:aws:s3:::gishathfetch.com/assets/*` to the `github-actions-gishathfetch-deploy` role policy.

After IAM is updated, merge this PR and re-run deploy to prune accumulated stale assets.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-171e64d9-1567-45e9-95c2-3cc9ce0ebc69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-171e64d9-1567-45e9-95c2-3cc9ce0ebc69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

