### PR TITLE
Rename Popular searches to Trending and add CK price increases

### DIFF
--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useId, useState } from "react";
-import { ArrowUp, ChevronDown, TrendingUp } from "react-feather";
+import { ChevronDown, TrendingUp } from "react-feather";
 import {
   BASE_URL,
   CK_PRICE_CHANGES_DISPLAY_LIMIT,
@@ -108,20 +108,6 @@ function TrendingSectionToggle({ isExpanded, collapsible, panelId, onToggle }) {
         className={`popular-searches-chevron${isExpanded ? " is-expanded" : ""}`}
       />
     </button>
-  );
-}
-
-function CKPriceIncreasesButtonLabel() {
-  return (
-    <>
-      Top ${" "}
-      <ArrowUp
-        size={12}
-        aria-hidden="true"
-        className="trending-price-increases-btn-icon"
-      />{" "}
-      (24 Hrs)
-    </>
   );
 }
 

--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -315,7 +315,7 @@ export default function TopSearchKeywords({
               }`}
               aria-expanded={showPriceIncreases}
               aria-controls={contentPanelId}
-              aria-label="Highest dollar increase in 24 hours"
+              aria-label="Top dollar increase in 24 hours"
               disabled={isLoadingPriceIncreases}
               onClick={handlePriceIncreasesToggle}
             >

--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -2,12 +2,14 @@ import { useEffect, useId, useState } from "react";
 import { ChevronDown, TrendingUp } from "react-feather";
 import {
   BASE_URL,
+  CK_PRICE_CHANGES_DISPLAY_LIMIT,
   DESKTOP_MIN_WIDTH_MEDIA_QUERY,
   TOP_SEARCH_KEYWORDS_DISPLAY_LIMIT,
   TOP_SEARCH_KEYWORDS_MOBILE_DISPLAY_LIMIT,
 } from "../constants";
+import useCKPriceIncreases from "../hooks/useCKPriceIncreases";
 import useMediaQuery from "../hooks/useMediaQuery";
-import { buildPopularSearchUrl } from "../utils/searchUrl";
+import { buildPopularSearchUrl, buildSearchQueryUrl } from "../utils/searchUrl";
 
 const LOADING_SKELETON_KEYS = [
   "top-search-keyword-skeleton-a",
@@ -51,7 +53,7 @@ function hasAnyKeywords(keywordsByPeriod) {
 function PeriodToggle({ period, onPeriodChange, disabled }) {
   return (
     <fieldset className="popular-search-period-toggle border-0 p-0 m-0">
-      <legend className="visually-hidden">Popular search time range</legend>
+      <legend className="visually-hidden">Trending search time range</legend>
       {PERIOD_OPTIONS.map((option) => (
         <button
           key={option.id}
@@ -70,8 +72,8 @@ function PeriodToggle({ period, onPeriodChange, disabled }) {
   );
 }
 
-function PopularSearchesToggle({ isExpanded, collapsible, panelId, onToggle }) {
-  const label = isExpanded ? "Popular searches" : "Show popular searches";
+function TrendingSectionToggle({ isExpanded, collapsible, panelId, onToggle }) {
+  const label = isExpanded ? "Trending" : "Show trending";
 
   if (!collapsible) {
     return (
@@ -109,6 +111,85 @@ function PopularSearchesToggle({ isExpanded, collapsible, panelId, onToggle }) {
   );
 }
 
+function CKPriceIncreasesPanel({
+  isVisible,
+  isLoading,
+  error,
+  priceIncreases,
+  searchQuery,
+  panelId,
+}) {
+  if (!isVisible) {
+    return null;
+  }
+
+  if (isLoading) {
+    return (
+      <div className="trending-price-increases" id={panelId}>
+        <p className="trending-price-increases-heading small text-muted mb-2">
+          Top CK price increases
+        </p>
+        <div className="popular-searches-pills">
+          {LOADING_SKELETON_KEYS.slice(0, CK_PRICE_CHANGES_DISPLAY_LIMIT).map(
+            (key) => (
+              <span
+                key={key}
+                className="placeholder rounded-pill popular-search-pill-skeleton"
+              />
+            ),
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="trending-price-increases" id={panelId}>
+        <p className="popular-searches-empty small text-muted mb-0">{error}</p>
+      </div>
+    );
+  }
+
+  if (priceIncreases.length === 0) {
+    return (
+      <div className="trending-price-increases" id={panelId}>
+        <p className="popular-searches-empty small text-muted mb-0">
+          No CK price increases available.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="trending-price-increases" id={panelId}>
+      <p className="trending-price-increases-heading small text-muted mb-2">
+        Top CK price increases
+      </p>
+      <ol className="trending-price-increases-list mb-0">
+        {priceIncreases.map((item, index) => {
+          const isActive = isMatchingTrendingSearch(item.cardName, searchQuery);
+
+          return (
+            <li key={`${item.cardName}-${index}`}>
+              <a
+                href={buildSearchQueryUrl(BASE_URL, item.cardName)}
+                className={`trending-price-increase-link${
+                  isActive ? " is-active" : ""
+                }`}
+                aria-label={`Search for ${item.cardName}`}
+                aria-current={isActive ? "page" : undefined}
+              >
+                {item.cardName}
+              </a>
+            </li>
+          );
+        })}
+      </ol>
+    </div>
+  );
+}
+
 function getDisplayLimit(isDesktop, showAllKeywords) {
   if (isDesktop) {
     return TOP_SEARCH_KEYWORDS_DISPLAY_LIMIT;
@@ -119,7 +200,7 @@ function getDisplayLimit(isDesktop, showAllKeywords) {
     : TOP_SEARCH_KEYWORDS_MOBILE_DISPLAY_LIMIT;
 }
 
-function isMatchingPopularSearch(keyword, searchQuery) {
+function isMatchingTrendingSearch(keyword, searchQuery) {
   const normalizedKeyword = String(keyword ?? "")
     .trim()
     .toLowerCase();
@@ -147,6 +228,14 @@ export default function TopSearchKeywords({
     () => !collapsible || defaultExpanded,
   );
   const [showAllKeywords, setShowAllKeywords] = useState(false);
+  const [showPriceIncreases, setShowPriceIncreases] = useState(false);
+  const {
+    priceIncreases,
+    isLoading: isLoadingPriceIncreases,
+    error: priceIncreasesError,
+    hasLoaded: hasLoadedPriceIncreases,
+    loadPriceIncreases,
+  } = useCKPriceIncreases();
   const isDesktop = useMediaQuery(DESKTOP_MIN_WIDTH_MEDIA_QUERY);
   const displayLimit = getDisplayLimit(isDesktop, showAllKeywords);
   const panelId = useId();
@@ -184,12 +273,21 @@ export default function TopSearchKeywords({
     setIsExpanded((expanded) => !expanded);
   };
 
-  const handlePopularSearchClick = (keyword) => {
+  const handleTrendingSearchClick = (keyword) => {
     if (window.gtag) {
       window.gtag("event", "popular_search_click", {
         search_term: keyword,
         popular_search_period: period,
       });
+    }
+  };
+
+  const handlePriceIncreasesToggle = async () => {
+    const nextVisible = !showPriceIncreases;
+    setShowPriceIncreases(nextVisible);
+
+    if (nextVisible && !hasLoadedPriceIncreases && !isLoadingPriceIncreases) {
+      await loadPriceIncreases();
     }
   };
 
@@ -199,7 +297,7 @@ export default function TopSearchKeywords({
         showContent ? " is-expanded" : " is-collapsed"
       }`}
     >
-      <PopularSearchesToggle
+      <TrendingSectionToggle
         isExpanded={isExpanded}
         collapsible={collapsible}
         panelId={panelId}
@@ -214,6 +312,20 @@ export default function TopSearchKeywords({
               onPeriodChange={handlePeriodChange}
               disabled={isLoading}
             />
+            <button
+              type="button"
+              className={`btn btn-sm trending-price-increases-btn${
+                showPriceIncreases ? " is-active" : ""
+              }`}
+              aria-expanded={showPriceIncreases}
+              aria-controls={`${panelId}-price-increases`}
+              disabled={isLoadingPriceIncreases}
+              onClick={handlePriceIncreasesToggle}
+            >
+              {showPriceIncreases
+                ? "Hide CK price increases"
+                : "Show CK price increases"}
+            </button>
           </div>
 
           {isLoading ? (
@@ -229,7 +341,7 @@ export default function TopSearchKeywords({
             <>
               <div className="popular-searches-pills">
                 {keywords.map((keyword) => {
-                  const isActive = isMatchingPopularSearch(
+                  const isActive = isMatchingTrendingSearch(
                     keyword,
                     searchQuery,
                   );
@@ -243,7 +355,7 @@ export default function TopSearchKeywords({
                       }`}
                       aria-label={`Search for ${keyword}`}
                       aria-current={isActive ? "page" : undefined}
-                      onClick={() => handlePopularSearchClick(keyword)}
+                      onClick={() => handleTrendingSearchClick(keyword)}
                     >
                       {keyword}
                     </a>
@@ -263,9 +375,18 @@ export default function TopSearchKeywords({
             </>
           ) : (
             <p className="popular-searches-empty small text-muted mb-0">
-              No popular searches in the last {selectedPeriodLabel}.
+              No trending searches in the last {selectedPeriodLabel}.
             </p>
           )}
+
+          <CKPriceIncreasesPanel
+            isVisible={showPriceIncreases}
+            isLoading={isLoadingPriceIncreases}
+            error={priceIncreasesError}
+            priceIncreases={priceIncreases}
+            searchQuery={searchQuery}
+            panelId={`${panelId}-price-increases`}
+          />
         </div>
       )}
     </div>

--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -114,7 +114,7 @@ function TrendingSectionToggle({ isExpanded, collapsible, panelId, onToggle }) {
 function CKPriceIncreasesButtonLabel() {
   return (
     <>
-      Highest ${" "}
+      Top ${" "}
       <ArrowUp
         size={12}
         aria-hidden="true"

--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -126,9 +126,6 @@ function CKPriceIncreasesPanel({
   if (isLoading) {
     return (
       <div className="trending-price-increases" id={panelId}>
-        <p className="trending-price-increases-heading small text-muted mb-2">
-          Top CK price increases
-        </p>
         <div className="popular-searches-pills">
           {LOADING_SKELETON_KEYS.slice(0, CK_PRICE_CHANGES_DISPLAY_LIMIT).map(
             (key) => (
@@ -163,29 +160,25 @@ function CKPriceIncreasesPanel({
 
   return (
     <div className="trending-price-increases" id={panelId}>
-      <p className="trending-price-increases-heading small text-muted mb-2">
-        Top CK price increases
-      </p>
-      <ol className="trending-price-increases-list mb-0">
-        {priceIncreases.map((item, index) => {
+      <div className="popular-searches-pills">
+        {priceIncreases.map((item) => {
           const isActive = isMatchingTrendingSearch(item.cardName, searchQuery);
 
           return (
-            <li key={`${item.cardName}-${index}`}>
-              <a
-                href={buildSearchQueryUrl(BASE_URL, item.cardName)}
-                className={`trending-price-increase-link${
-                  isActive ? " is-active" : ""
-                }`}
-                aria-label={`Search for ${item.cardName}`}
-                aria-current={isActive ? "page" : undefined}
-              >
-                {item.cardName}
-              </a>
-            </li>
+            <a
+              key={item.cardName}
+              href={buildSearchQueryUrl(BASE_URL, item.cardName)}
+              className={`btn btn-sm popular-search-pill text-decoration-none${
+                isActive ? " is-active" : ""
+              }`}
+              aria-label={`Search for ${item.cardName}`}
+              aria-current={isActive ? "page" : undefined}
+            >
+              {item.cardName}
+            </a>
           );
         })}
-      </ol>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -125,74 +125,60 @@ function CKPriceIncreasesButtonLabel() {
   );
 }
 
-function CKPriceIncreasesPanel({
-  isVisible,
+function CKPriceIncreasesContent({
   isLoading,
   error,
   priceIncreases,
   searchQuery,
-  panelId,
 }) {
-  if (!isVisible) {
-    return null;
-  }
-
   if (isLoading) {
     return (
-      <div className="trending-price-increases" id={panelId}>
-        <div className="popular-searches-pills">
-          {LOADING_SKELETON_KEYS.slice(0, CK_PRICE_CHANGES_DISPLAY_LIMIT).map(
-            (key) => (
-              <span
-                key={key}
-                className="placeholder rounded-pill popular-search-pill-skeleton"
-              />
-            ),
-          )}
-        </div>
+      <div className="popular-searches-pills">
+        {LOADING_SKELETON_KEYS.slice(0, CK_PRICE_CHANGES_DISPLAY_LIMIT).map(
+          (key) => (
+            <span
+              key={key}
+              className="placeholder rounded-pill popular-search-pill-skeleton"
+            />
+          ),
+        )}
       </div>
     );
   }
 
   if (error) {
     return (
-      <div className="trending-price-increases" id={panelId}>
-        <p className="popular-searches-empty small text-muted mb-0">{error}</p>
-      </div>
+      <p className="popular-searches-empty small text-muted mb-0">{error}</p>
     );
   }
 
   if (priceIncreases.length === 0) {
     return (
-      <div className="trending-price-increases" id={panelId}>
-        <p className="popular-searches-empty small text-muted mb-0">
-          No CK price increases available.
-        </p>
-      </div>
+      <p className="popular-searches-empty small text-muted mb-0">
+        No CK price increases available.
+      </p>
     );
   }
 
   return (
-    <div className="trending-price-increases" id={panelId}>
-      <div className="popular-searches-pills">
-        {priceIncreases.map((item) => {
-          const isActive = isMatchingTrendingSearch(item.cardName, searchQuery);
+    <div className="popular-searches-pills">
+      {priceIncreases.map((item) => {
+        const isActive = isMatchingTrendingSearch(item.cardName, searchQuery);
 
-          return (
-            <a
-              key={item.cardName}
-              href={buildSearchQueryUrl(BASE_URL, item.cardName)}
-              className={`btn btn-sm popular-search-pill text-decoration-none${
-                isActive ? " is-active" : ""
-              }`}
-              aria-label={`Search for ${item.cardName}`}
-              aria-current={isActive ? "page" : undefined}
-            >
-              {item.cardName}
-            </a>
-          );
-        })}
-      </div>
+        return (
+          <a
+            key={item.cardName}
+            href={buildSearchQueryUrl(BASE_URL, item.cardName)}
+            className={`btn btn-sm popular-search-pill text-decoration-none${
+              isActive ? " is-active" : ""
+            }`}
+            aria-label={`Search for ${item.cardName}`}
+            aria-current={isActive ? "page" : undefined}
+          >
+            {item.cardName}
+          </a>
+        );
+      })}
     </div>
   );
 }
@@ -262,6 +248,7 @@ export default function TopSearchKeywords({
   const handlePeriodChange = (nextPeriod) => {
     setPeriod(nextPeriod);
     setShowAllKeywords(false);
+    setShowPriceIncreases(false);
   };
 
   if (!isLoading && !hasAnyKeywords(keywordsByPeriod)) {
@@ -298,6 +285,8 @@ export default function TopSearchKeywords({
     }
   };
 
+  const contentPanelId = `${panelId}-content`;
+
   return (
     <div
       className={`${SECTION_CLASS_NAME}${
@@ -317,7 +306,7 @@ export default function TopSearchKeywords({
             <PeriodToggle
               period={period}
               onPeriodChange={handlePeriodChange}
-              disabled={isLoading}
+              disabled={isLoading || showPriceIncreases}
             />
             <button
               type="button"
@@ -325,7 +314,7 @@ export default function TopSearchKeywords({
                 showPriceIncreases ? " is-active" : ""
               }`}
               aria-expanded={showPriceIncreases}
-              aria-controls={`${panelId}-price-increases`}
+              aria-controls={contentPanelId}
               aria-label="Highest dollar increase in 24 hours"
               disabled={isLoadingPriceIncreases}
               onClick={handlePriceIncreasesToggle}
@@ -334,65 +323,65 @@ export default function TopSearchKeywords({
             </button>
           </div>
 
-          {isLoading ? (
-            <div className="popular-searches-pills">
-              {LOADING_SKELETON_KEYS.slice(0, displayLimit).map((key) => (
-                <span
-                  key={key}
-                  className="placeholder rounded-pill popular-search-pill-skeleton"
-                />
-              ))}
-            </div>
-          ) : keywords.length > 0 ? (
-            <>
+          <div id={contentPanelId}>
+            {showPriceIncreases ? (
+              <CKPriceIncreasesContent
+                isLoading={isLoadingPriceIncreases}
+                error={priceIncreasesError}
+                priceIncreases={priceIncreases}
+                searchQuery={searchQuery}
+              />
+            ) : isLoading ? (
               <div className="popular-searches-pills">
-                {keywords.map((keyword) => {
-                  const isActive = isMatchingTrendingSearch(
-                    keyword,
-                    searchQuery,
-                  );
-
-                  return (
-                    <a
-                      key={keyword}
-                      href={buildPopularSearchUrl(BASE_URL, keyword, period)}
-                      className={`btn btn-sm popular-search-pill text-decoration-none${
-                        isActive ? " is-active" : ""
-                      }`}
-                      aria-label={`Search for ${keyword}`}
-                      aria-current={isActive ? "page" : undefined}
-                      onClick={() => handleTrendingSearchClick(keyword)}
-                    >
-                      {keyword}
-                    </a>
-                  );
-                })}
+                {LOADING_SKELETON_KEYS.slice(0, displayLimit).map((key) => (
+                  <span
+                    key={key}
+                    className="placeholder rounded-pill popular-search-pill-skeleton"
+                  />
+                ))}
               </div>
-              {hasMoreKeywords && (
-                <button
-                  type="button"
-                  className="popular-searches-show-more"
-                  aria-expanded={showAllKeywords}
-                  onClick={() => setShowAllKeywords((expanded) => !expanded)}
-                >
-                  {showAllKeywords ? "Show less" : "Show more"}
-                </button>
-              )}
-            </>
-          ) : (
-            <p className="popular-searches-empty small text-muted mb-0">
-              No trending searches in the last {selectedPeriodLabel}.
-            </p>
-          )}
+            ) : keywords.length > 0 ? (
+              <>
+                <div className="popular-searches-pills">
+                  {keywords.map((keyword) => {
+                    const isActive = isMatchingTrendingSearch(
+                      keyword,
+                      searchQuery,
+                    );
 
-          <CKPriceIncreasesPanel
-            isVisible={showPriceIncreases}
-            isLoading={isLoadingPriceIncreases}
-            error={priceIncreasesError}
-            priceIncreases={priceIncreases}
-            searchQuery={searchQuery}
-            panelId={`${panelId}-price-increases`}
-          />
+                    return (
+                      <a
+                        key={keyword}
+                        href={buildPopularSearchUrl(BASE_URL, keyword, period)}
+                        className={`btn btn-sm popular-search-pill text-decoration-none${
+                          isActive ? " is-active" : ""
+                        }`}
+                        aria-label={`Search for ${keyword}`}
+                        aria-current={isActive ? "page" : undefined}
+                        onClick={() => handleTrendingSearchClick(keyword)}
+                      >
+                        {keyword}
+                      </a>
+                    );
+                  })}
+                </div>
+                {hasMoreKeywords && (
+                  <button
+                    type="button"
+                    className="popular-searches-show-more"
+                    aria-expanded={showAllKeywords}
+                    onClick={() => setShowAllKeywords((expanded) => !expanded)}
+                  >
+                    {showAllKeywords ? "Show less" : "Show more"}
+                  </button>
+                )}
+              </>
+            ) : (
+              <p className="popular-searches-empty small text-muted mb-0">
+                No trending searches in the last {selectedPeriodLabel}.
+              </p>
+            )}
+          </div>
         </div>
       )}
     </div>

--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useId, useState } from "react";
-import { ChevronDown, TrendingUp } from "react-feather";
+import { ArrowUp, ChevronDown, TrendingUp } from "react-feather";
 import {
   BASE_URL,
   CK_PRICE_CHANGES_DISPLAY_LIMIT,
@@ -108,6 +108,20 @@ function TrendingSectionToggle({ isExpanded, collapsible, panelId, onToggle }) {
         className={`popular-searches-chevron${isExpanded ? " is-expanded" : ""}`}
       />
     </button>
+  );
+}
+
+function CKPriceIncreasesButtonLabel() {
+  return (
+    <>
+      Highest ${" "}
+      <ArrowUp
+        size={12}
+        aria-hidden="true"
+        className="trending-price-increases-btn-icon"
+      />{" "}
+      (24 Hrs)
+    </>
   );
 }
 
@@ -312,12 +326,11 @@ export default function TopSearchKeywords({
               }`}
               aria-expanded={showPriceIncreases}
               aria-controls={`${panelId}-price-increases`}
+              aria-label="Highest dollar increase in 24 hours"
               disabled={isLoadingPriceIncreases}
               onClick={handlePriceIncreasesToggle}
             >
-              {showPriceIncreases
-                ? "Hide CK price increases"
-                : "Show CK price increases"}
+              <CKPriceIncreasesButtonLabel />
             </button>
           </div>
 

--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -301,11 +301,11 @@ export default function TopSearchKeywords({
               }`}
               aria-expanded={showPriceIncreases}
               aria-controls={contentPanelId}
-              aria-label="Top dollar increase in 24 hours"
+              aria-label="Top risers in 24 hours"
               disabled={isLoadingPriceIncreases}
               onClick={handlePriceIncreasesToggle}
             >
-              <CKPriceIncreasesButtonLabel />
+              Top risers (24h)
             </button>
           </div>
 

--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -306,7 +306,7 @@ export default function TopSearchKeywords({
             <PeriodToggle
               period={period}
               onPeriodChange={handlePeriodChange}
-              disabled={isLoading || showPriceIncreases}
+              disabled={isLoading}
             />
             <button
               type="button"

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -178,7 +178,11 @@ export const BASE_URL = "https://gishathfetch.com/";
 export const TOP_SEARCH_KEYWORDS_URL =
   "/analytics/top-search-keywords/latest.json";
 
+// Same-origin on production (served from gishathfetch.com via CloudFront).
+export const CK_PRICE_CHANGES_URL = "/analytics/ck-price-changes/latest.json";
+
 export const TOP_SEARCH_KEYWORDS_DISPLAY_LIMIT = 20;
+export const CK_PRICE_CHANGES_DISPLAY_LIMIT = 20;
 export const TOP_SEARCH_KEYWORDS_MOBILE_DISPLAY_LIMIT = 10;
 export const DESKTOP_MIN_WIDTH_MEDIA_QUERY = "(min-width: 768px)";
 

--- a/frontend/src/hooks/useCKPriceIncreases.js
+++ b/frontend/src/hooks/useCKPriceIncreases.js
@@ -1,0 +1,56 @@
+import { useCallback, useRef, useState } from "react";
+import { CK_PRICE_CHANGES_DISPLAY_LIMIT, CK_PRICE_CHANGES_URL } from "../constants";
+import { parseCKPriceIncreases } from "../utils/ckPriceChanges";
+
+export default function useCKPriceIncreases() {
+  const [priceIncreases, setPriceIncreases] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [hasLoaded, setHasLoaded] = useState(false);
+  const requestIdRef = useRef(0);
+
+  const loadPriceIncreases = useCallback(async () => {
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch(CK_PRICE_CHANGES_URL);
+      if (!response.ok) {
+        throw new Error(`Failed to load CK price changes (${response.status})`);
+      }
+
+      const payload = await response.json();
+      if (requestId !== requestIdRef.current) {
+        return;
+      }
+
+      setPriceIncreases(
+        parseCKPriceIncreases(payload, CK_PRICE_CHANGES_DISPLAY_LIMIT),
+      );
+      setHasLoaded(true);
+    } catch (loadError) {
+      if (requestId !== requestIdRef.current) {
+        return;
+      }
+
+      console.error("Failed to load CK price increases:", loadError);
+      setPriceIncreases([]);
+      setError("Could not load CK price increases.");
+      setHasLoaded(true);
+    } finally {
+      if (requestId === requestIdRef.current) {
+        setIsLoading(false);
+      }
+    }
+  }, []);
+
+  return {
+    priceIncreases,
+    isLoading,
+    error,
+    hasLoaded,
+    loadPriceIncreases,
+  };
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -675,11 +675,18 @@ ins.adsbygoogle.adsbygoogle-noablate {
 }
 
 .trending-price-increases-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.125rem;
   font-size: 0.75rem;
   border-radius: var(--bs-border-radius-sm);
   border: 1px solid var(--bs-border-color);
   background-color: var(--bs-body-bg);
   color: var(--bs-secondary-color);
+}
+
+.trending-price-increases-btn-icon {
+  flex-shrink: 0;
 }
 
 .trending-price-increases-btn.is-active {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -701,9 +701,3 @@ ins.adsbygoogle.adsbygoogle-noablate {
   border-color: var(--bs-primary);
   color: var(--bs-primary);
 }
-
-.trending-price-increases {
-  margin-top: 0.75rem;
-  padding-top: 0.75rem;
-  border-top: 1px solid var(--bs-border-color-translucent);
-}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -700,30 +700,3 @@ ins.adsbygoogle.adsbygoogle-noablate {
   padding-top: 0.75rem;
   border-top: 1px solid var(--bs-border-color-translucent);
 }
-
-.trending-price-increases-heading {
-  font-weight: 600;
-}
-
-.trending-price-increases-list {
-  display: grid;
-  gap: 0.375rem;
-  padding-left: 1.25rem;
-}
-
-.trending-price-increase-link {
-  color: var(--bs-body-color);
-  text-decoration: none;
-  font-size: 0.8125rem;
-}
-
-.trending-price-increase-link:hover,
-.trending-price-increase-link:focus-visible {
-  color: var(--bs-primary);
-  text-decoration: underline;
-}
-
-.trending-price-increase-link.is-active {
-  color: var(--bs-primary);
-  font-weight: 600;
-}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -577,6 +577,10 @@ ins.adsbygoogle.adsbygoogle-noablate {
 }
 
 .popular-searches-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
   margin-bottom: 0.625rem;
 }
 
@@ -668,4 +672,58 @@ ins.adsbygoogle.adsbygoogle-noablate {
   outline: 0;
   box-shadow: 0 0 0 0.2rem rgba(var(--bs-primary-rgb), 0.35);
   border-radius: var(--bs-border-radius-sm);
+}
+
+.trending-price-increases-btn {
+  font-size: 0.75rem;
+  border-radius: var(--bs-border-radius-sm);
+  border: 1px solid var(--bs-border-color);
+  background-color: var(--bs-body-bg);
+  color: var(--bs-secondary-color);
+}
+
+.trending-price-increases-btn.is-active {
+  background-color: rgba(var(--bs-primary-rgb), 0.12);
+  border-color: var(--bs-primary);
+  color: var(--bs-primary);
+}
+
+.trending-price-increases-btn:hover:not(:disabled):not(.is-active),
+.trending-price-increases-btn:focus-visible:not(:disabled):not(.is-active) {
+  background-color: rgba(var(--bs-primary-rgb), 0.15);
+  border-color: var(--bs-primary);
+  color: var(--bs-primary);
+}
+
+.trending-price-increases {
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--bs-border-color-translucent);
+}
+
+.trending-price-increases-heading {
+  font-weight: 600;
+}
+
+.trending-price-increases-list {
+  display: grid;
+  gap: 0.375rem;
+  padding-left: 1.25rem;
+}
+
+.trending-price-increase-link {
+  color: var(--bs-body-color);
+  text-decoration: none;
+  font-size: 0.8125rem;
+}
+
+.trending-price-increase-link:hover,
+.trending-price-increase-link:focus-visible {
+  color: var(--bs-primary);
+  text-decoration: underline;
+}
+
+.trending-price-increase-link.is-active {
+  color: var(--bs-primary);
+  font-weight: 600;
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -675,18 +675,11 @@ ins.adsbygoogle.adsbygoogle-noablate {
 }
 
 .trending-price-increases-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.125rem;
   font-size: 0.75rem;
   border-radius: var(--bs-border-radius-sm);
   border: 1px solid var(--bs-border-color);
   background-color: var(--bs-body-bg);
   color: var(--bs-secondary-color);
-}
-
-.trending-price-increases-btn-icon {
-  flex-shrink: 0;
 }
 
 .trending-price-increases-btn.is-active {

--- a/frontend/src/utils/ckPriceChanges.js
+++ b/frontend/src/utils/ckPriceChanges.js
@@ -1,0 +1,16 @@
+export function parseCKPriceIncreases(payload, limit = 20) {
+  if (!Array.isArray(payload?.top)) {
+    return [];
+  }
+
+  return payload.top
+    .map((item) => ({
+      cardName: typeof item?.cardName === "string" ? item.cardName.trim() : "",
+      priceChangePercent:
+        typeof item?.priceChangePercent === "number"
+          ? item.priceChangePercent
+          : null,
+    }))
+    .filter((item) => item.cardName.length > 0)
+    .slice(0, limit);
+}

--- a/frontend/src/utils/ckPriceChanges.test.js
+++ b/frontend/src/utils/ckPriceChanges.test.js
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseCKPriceIncreases } from "./ckPriceChanges.js";
+
+test("parseCKPriceIncreases returns top card names up to the display limit", () => {
+  const payload = {
+    top: [
+      { cardName: "Lightning Bolt", priceChangePercent: 15 },
+      { cardName: " Counterspell ", priceChangePercent: 10 },
+      { cardName: "", priceChangePercent: 5 },
+      { cardName: "Sol Ring", priceChangePercent: 5 },
+    ],
+  };
+
+  const increases = parseCKPriceIncreases(payload);
+
+  assert.equal(increases.length, 3);
+  assert.equal(increases[0].cardName, "Lightning Bolt");
+  assert.equal(increases[0].priceChangePercent, 15);
+  assert.equal(increases[1].cardName, "Counterspell");
+  assert.equal(increases[1].priceChangePercent, 10);
+});
+
+test("parseCKPriceIncreases returns an empty list for invalid payloads", () => {
+  assert.deepEqual(parseCKPriceIncreases(null), []);
+  assert.deepEqual(parseCKPriceIncreases({}), []);
+  assert.deepEqual(parseCKPriceIncreases({ top: "invalid" }), []);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Renames the homepage **Popular searches** section to **Trending**
- Adds a **Top $ Increase (24 Hrs)** button that lazily fetches `/analytics/ck-price-changes/latest.json`
- Clicking the button **replaces** the trending search pills with the top 20 CK price-increase card names (clickable pills)
- Clicking a period button (24 hours, 30 days, etc.) or toggling the button off switches back to trending searches

## Implementation

- New `useCKPriceIncreases` hook fetches the daily CK export on demand
- `parseCKPriceIncreases` utility extracts and validates the `top` rankings from the report payload
- CK price increases reuse the existing `popular-search-pill` styling for visual consistency

## Screenshots

### Desktop
![Trending section with Top dollar increase pills on desktop](https://cursor.com/artifacts/c/art-83d5860f-cc30-48b5-bbc8-46992516029d)

### Mobile
![Trending section with Top dollar increase pills on mobile](https://cursor.com/artifacts/c/art-af168b35-a70a-4e5d-84a3-96a28210e7ee)

## Test plan

- [x] `node --test src/utils/ckPriceChanges.test.js`
- [x] `biome check` on changed frontend files
- [x] Manual UI check: Top $ Increase replaces trending pills; period buttons switch back (desktop + mobile)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e22e59a-60fd-451f-aced-46b20bed3cf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e22e59a-60fd-451f-aced-46b20bed3cf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

