### PR TITLE
Match Top risers button styling and selection to trending toggles

### DIFF
--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -50,24 +50,28 @@ function hasAnyKeywords(keywordsByPeriod) {
   );
 }
 
-function PeriodToggle({ period, onPeriodChange, disabled }) {
+function PeriodToggle({ period, onPeriodChange, disabled, showPriceIncreases }) {
   return (
     <fieldset className="popular-search-period-toggle border-0 p-0 m-0">
       <legend className="visually-hidden">Trending search time range</legend>
-      {PERIOD_OPTIONS.map((option) => (
-        <button
-          key={option.id}
-          type="button"
-          className={`btn btn-sm popular-search-period-btn${
-            period === option.id ? " is-active" : ""
-          }`}
-          disabled={disabled}
-          aria-pressed={period === option.id}
-          onClick={() => onPeriodChange(option.id)}
-        >
-          {option.label}
-        </button>
-      ))}
+      {PERIOD_OPTIONS.map((option) => {
+        const isActive = !showPriceIncreases && period === option.id;
+
+        return (
+          <button
+            key={option.id}
+            type="button"
+            className={`btn btn-sm popular-search-period-btn${
+              isActive ? " is-active" : ""
+            }`}
+            disabled={disabled}
+            aria-pressed={isActive}
+            onClick={() => onPeriodChange(option.id)}
+          >
+            {option.label}
+          </button>
+        );
+      })}
     </fieldset>
   );
 }
@@ -232,6 +236,10 @@ export default function TopSearchKeywords({
   }, [collapseOnSearch]);
 
   const handlePeriodChange = (nextPeriod) => {
+    if (!showPriceIncreases && nextPeriod === period) {
+      return;
+    }
+
     setPeriod(nextPeriod);
     setShowAllKeywords(false);
     setShowPriceIncreases(false);
@@ -262,11 +270,14 @@ export default function TopSearchKeywords({
     }
   };
 
-  const handlePriceIncreasesToggle = async () => {
-    const nextVisible = !showPriceIncreases;
-    setShowPriceIncreases(nextVisible);
+  const handlePriceIncreasesSelect = async () => {
+    if (showPriceIncreases) {
+      return;
+    }
 
-    if (nextVisible && !hasLoadedPriceIncreases && !isLoadingPriceIncreases) {
+    setShowPriceIncreases(true);
+
+    if (!hasLoadedPriceIncreases && !isLoadingPriceIncreases) {
       await loadPriceIncreases();
     }
   };
@@ -293,6 +304,7 @@ export default function TopSearchKeywords({
               period={period}
               onPeriodChange={handlePeriodChange}
               disabled={isLoading}
+              showPriceIncreases={showPriceIncreases}
             />
             <button
               type="button"
@@ -300,11 +312,10 @@ export default function TopSearchKeywords({
                 showPriceIncreases ? " is-active" : ""
               }`}
               aria-pressed={showPriceIncreases}
-              aria-expanded={showPriceIncreases}
               aria-controls={contentPanelId}
               aria-label="Top risers in 24 hours"
               disabled={isLoadingPriceIncreases}
-              onClick={handlePriceIncreasesToggle}
+              onClick={handlePriceIncreasesSelect}
             >
               Top risers (24h)
             </button>

--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -296,9 +296,10 @@ export default function TopSearchKeywords({
             />
             <button
               type="button"
-              className={`btn btn-sm trending-price-increases-btn${
+              className={`btn btn-sm popular-search-period-btn${
                 showPriceIncreases ? " is-active" : ""
               }`}
+              aria-pressed={showPriceIncreases}
               aria-expanded={showPriceIncreases}
               aria-controls={contentPanelId}
               aria-label="Top risers in 24 hours"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -673,24 +673,3 @@ ins.adsbygoogle.adsbygoogle-noablate {
   box-shadow: 0 0 0 0.2rem rgba(var(--bs-primary-rgb), 0.35);
   border-radius: var(--bs-border-radius-sm);
 }
-
-.trending-price-increases-btn {
-  font-size: 0.75rem;
-  border-radius: var(--bs-border-radius-sm);
-  border: 1px solid var(--bs-border-color);
-  background-color: var(--bs-body-bg);
-  color: var(--bs-secondary-color);
-}
-
-.trending-price-increases-btn.is-active {
-  background-color: rgba(var(--bs-primary-rgb), 0.12);
-  border-color: var(--bs-primary);
-  color: var(--bs-primary);
-}
-
-.trending-price-increases-btn:hover:not(:disabled):not(.is-active),
-.trending-price-increases-btn:focus-visible:not(:disabled):not(.is-active) {
-  background-color: rgba(var(--bs-primary-rgb), 0.15);
-  border-color: var(--bs-primary);
-  color: var(--bs-primary);
-}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns the **Top risers (24h)** control with the existing trending period buttons (24 hours, 30 days, etc.) in both appearance and behavior.

## Changes

- Reuse the shared `popular-search-period-btn` styles instead of a separate `trending-price-increases-btn` class
- Treat period buttons and Top risers as a single-choice control group: only one can be active at a time
- Clicking Top risers again no longer toggles it off; selecting a period switches back to trending searches
- Clicking the already-selected period while trending is shown is now a no-op, matching period-toggle behavior

## Screenshots

### Desktop — 24 hours active
![Desktop trending controls with 24 hours active](https://cursor.com/artifacts/c/art-4ac19d3f-4af0-4551-8105-80f7f1a6a3f7)

### Desktop — Top risers active
![Desktop trending controls with Top risers active](https://cursor.com/artifacts/c/art-82b280fb-575f-43dd-a120-49629562b113)

### Mobile — Top risers active
![Mobile trending controls with Top risers active](https://cursor.com/artifacts/c/art-6e1c4d8a-19e3-49a8-9d9a-95f3914e4ba7)

## Testing

- Verified in browser: Top risers matches period button styling and stays selected until another control is chosen
- `make test` hit an unrelated live gateway timeout in `gateway/duellerpoint` (transient upstream/network)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48d19957-2947-4af1-8db6-f8f9ea820cd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48d19957-2947-4af1-8db6-f8f9ea820cd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

