### PR TITLE
Mock up top risers pills with green up-arrow percentage prefix

### DIFF
--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useId, useState } from "react";
-import { ChevronDown, TrendingUp } from "react-feather";
+import { ArrowUp, ChevronDown, TrendingUp } from "react-feather";
 import {
   BASE_URL,
   CK_PRICE_CHANGES_DISPLAY_LIMIT,
@@ -9,6 +9,7 @@ import {
 } from "../constants";
 import useCKPriceIncreases from "../hooks/useCKPriceIncreases";
 import useMediaQuery from "../hooks/useMediaQuery";
+import { formatPriceChangePercent } from "../utils/ckPriceChanges";
 import { buildPopularSearchUrl, buildSearchQueryUrl } from "../utils/searchUrl";
 
 const LOADING_SKELETON_KEYS = [
@@ -50,7 +51,12 @@ function hasAnyKeywords(keywordsByPeriod) {
   );
 }
 
-function PeriodToggle({ period, onPeriodChange, disabled, showPriceIncreases }) {
+function PeriodToggle({
+  period,
+  onPeriodChange,
+  disabled,
+  showPriceIncreases,
+}) {
   return (
     <fieldset className="popular-search-period-toggle border-0 p-0 m-0">
       <legend className="visually-hidden">Trending search time range</legend>
@@ -154,18 +160,28 @@ function CKPriceIncreasesContent({
     <div className="popular-searches-pills">
       {priceIncreases.map((item) => {
         const isActive = isMatchingTrendingSearch(item.cardName, searchQuery);
+        const changeLabel = formatPriceChangePercent(item.priceChangePercent);
+        const ariaLabel = changeLabel
+          ? `Search for ${item.cardName}, up ${changeLabel}`
+          : `Search for ${item.cardName}`;
 
         return (
           <a
             key={item.cardName}
             href={buildSearchQueryUrl(BASE_URL, item.cardName)}
-            className={`btn btn-sm popular-search-pill text-decoration-none${
+            className={`btn btn-sm popular-search-pill popular-search-pill--riser text-decoration-none${
               isActive ? " is-active" : ""
             }`}
-            aria-label={`Search for ${item.cardName}`}
+            aria-label={ariaLabel}
             aria-current={isActive ? "page" : undefined}
           >
-            {item.cardName}
+            {changeLabel ? (
+              <span className="popular-search-pill-change" aria-hidden="true">
+                <ArrowUp size={11} strokeWidth={2.5} />
+                <span>{changeLabel}</span>
+              </span>
+            ) : null}
+            <span className="popular-search-pill-name">{item.cardName}</span>
           </a>
         );
       })}

--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -329,11 +329,11 @@ export default function TopSearchKeywords({
               }`}
               aria-pressed={showPriceIncreases}
               aria-controls={contentPanelId}
-              aria-label="Top risers in 24 hours"
+              aria-label="Top dollar risers in 24 hours"
               disabled={isLoadingPriceIncreases}
               onClick={handlePriceIncreasesSelect}
             >
-              Top risers (24h)
+              Top $ risers (24h)
             </button>
           </div>
 

--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -175,13 +175,13 @@ function CKPriceIncreasesContent({
             aria-label={ariaLabel}
             aria-current={isActive ? "page" : undefined}
           >
+            <span className="popular-search-pill-name">{item.cardName}</span>
             {changeLabel ? (
               <span className="popular-search-pill-change" aria-hidden="true">
                 <ArrowUp size={11} strokeWidth={2.5} />
                 <span>{changeLabel}</span>
               </span>
             ) : null}
-            <span className="popular-search-pill-name">{item.cardName}</span>
           </a>
         );
       })}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -627,6 +627,30 @@ ins.adsbygoogle.adsbygoogle-noablate {
   color: var(--bs-secondary-color);
 }
 
+.popular-search-pill--riser {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.popular-search-pill-change {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.125rem;
+  flex-shrink: 0;
+  font-weight: 600;
+  color: var(--bs-success);
+  line-height: 1;
+}
+
+.popular-search-pill-name {
+  min-width: 0;
+}
+
+.popular-search-pill.is-active .popular-search-pill-change {
+  color: color-mix(in srgb, var(--bs-success) 72%, var(--bs-white));
+}
+
 .popular-search-pill.is-active {
   background-color: var(--bs-primary);
   border-color: var(--bs-primary);

--- a/frontend/src/utils/ckPriceChanges.js
+++ b/frontend/src/utils/ckPriceChanges.js
@@ -1,3 +1,12 @@
+export function formatPriceChangePercent(percent) {
+  if (typeof percent !== "number" || !Number.isFinite(percent)) {
+    return null;
+  }
+
+  const rounded = Math.round(percent * 10) / 10;
+  return Number.isInteger(rounded) ? `${rounded}%` : `${rounded.toFixed(1)}%`;
+}
+
 export function parseCKPriceIncreases(payload, limit = 20) {
   if (!Array.isArray(payload?.top)) {
     return [];

--- a/frontend/src/utils/ckPriceChanges.test.js
+++ b/frontend/src/utils/ckPriceChanges.test.js
@@ -1,6 +1,16 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { parseCKPriceIncreases } from "./ckPriceChanges.js";
+import {
+  formatPriceChangePercent,
+  parseCKPriceIncreases,
+} from "./ckPriceChanges.js";
+
+test("formatPriceChangePercent formats whole and fractional percentages", () => {
+  assert.equal(formatPriceChangePercent(15), "15%");
+  assert.equal(formatPriceChangePercent(12.34), "12.3%");
+  assert.equal(formatPriceChangePercent(null), null);
+  assert.equal(formatPriceChangePercent(Number.NaN), null);
+});
 
 test("parseCKPriceIncreases returns top card names up to the display limit", () => {
   const payload = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Mock up the **Top risers (24h)** pill design so each item shows its CK price change percentage in green with an up-arrow prefix, placed to the **right of the card name**.

**Before:** pills showed only the card name (percentage was fetched but not rendered).

**After:** `Lightning Bolt ↑ 15%` — card name first, then green change badge on the right.

## Design details

- Card name on the left, then `ArrowUp` icon + formatted percent (`15%`, `12.3%`) in `--bs-success` green
- Active pill state lightens the green change indicator for contrast on the primary background
- Accessible `aria-label` includes the change (e.g. "Search for Lightning Bolt, up 15%")

## Screenshots

### Desktop

![Top risers pills with green percentage on the right of card name on desktop](https://cursor.com/artifacts/c/art-c089077f-0299-493f-88ca-9733d67fd1ca)

### Mobile

![Top risers pills with green percentage on the right of card name on mobile](https://cursor.com/artifacts/c/art-e3d07782-5274-4ed4-b695-cccf64c11f23)

## Testing

- `node --test frontend/src/utils/ckPriceChanges.test.js` — pass
- `npx biome check --write` on changed frontend files — pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f76db218-f7c2-4d50-8b4a-6da3c592b9b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f76db218-f7c2-4d50-8b4a-6da3c592b9b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

