### PR TITLE
Record previous CK price in DynamoDB during refresh job

### DIFF
--- a/api/gateway/cardkingdom/types.go
+++ b/api/gateway/cardkingdom/types.go
@@ -13,10 +13,11 @@ type Product struct {
 
 // Listing is the cheapest Card Kingdom retail offer for a card name.
 type Listing struct {
-	CardName           string  `json:"cardName"`
-	Edition            string  `json:"edition"`
-	PriceUsd           float64 `json:"priceUsd"`
-	PriceChangePercent *int    `json:"priceChangePercent,omitempty"`
+	CardName           string   `json:"cardName"`
+	Edition            string   `json:"edition"`
+	PriceUsd           float64  `json:"priceUsd"`
+	PreviousPriceUsd   *float64 `json:"previousPriceUsd,omitempty"`
+	PriceChangePercent *int     `json:"priceChangePercent,omitempty"`
 	URL                string  `json:"url"`
 	IsFoil             bool    `json:"isFoil"`
 	UpdatedAt          string  `json:"updatedAt,omitempty"`

--- a/api/store/ckprices/dynamodb.go
+++ b/api/store/ckprices/dynamodb.go
@@ -27,11 +27,12 @@ const (
 )
 
 type dynamoRecord struct {
-	NameKey            string  `dynamodbav:"nameKey"`
-	CardName           string  `dynamodbav:"cardName"`
-	Edition            string  `dynamodbav:"edition"`
-	PriceUsd           float64 `dynamodbav:"priceUsd"`
-	PriceChangePercent *int    `dynamodbav:"priceChangePercent,omitempty"`
+	NameKey            string   `dynamodbav:"nameKey"`
+	CardName           string   `dynamodbav:"cardName"`
+	Edition            string   `dynamodbav:"edition"`
+	PriceUsd           float64  `dynamodbav:"priceUsd"`
+	PreviousPriceUsd   *float64 `dynamodbav:"previousPriceUsd,omitempty"`
+	PriceChangePercent *int     `dynamodbav:"priceChangePercent,omitempty"`
 	PriceChangeIndexPK *string `dynamodbav:"priceChangeIndexPK,omitempty"`
 	URL                string  `dynamodbav:"url"`
 	IsFoil             bool    `dynamodbav:"isFoil"`
@@ -230,6 +231,7 @@ func dynamoRecordFromListing(nameKey string, listing cardkingdom.Listing, synced
 		CardName:           listing.CardName,
 		Edition:            listing.Edition,
 		PriceUsd:           listing.PriceUsd,
+		PreviousPriceUsd:   listing.PreviousPriceUsd,
 		PriceChangePercent: listing.PriceChangePercent,
 		URL:                listing.URL,
 		IsFoil:             listing.IsFoil,
@@ -251,6 +253,7 @@ func listingFromRecord(record dynamoRecord) (cardkingdom.Listing, bool) {
 		CardName:           record.CardName,
 		Edition:            record.Edition,
 		PriceUsd:           record.PriceUsd,
+		PreviousPriceUsd:   record.PreviousPriceUsd,
 		PriceChangePercent: record.PriceChangePercent,
 		URL:                record.URL,
 		IsFoil:             record.IsFoil,

--- a/api/store/ckprices/dynamodb_test.go
+++ b/api/store/ckprices/dynamodb_test.go
@@ -14,10 +14,12 @@ import (
 func TestDynamoRecordFromListing(t *testing.T) {
 	syncedAt := time.Date(2026, 6, 28, 15, 30, 0, 0, time.UTC).Format(time.RFC3339)
 	priceChangePercent := 12
+	previousPriceUsd := 1.33
 	record := dynamoRecordFromListing("lightning bolt", cardkingdom.Listing{
 		CardName:           "Lightning Bolt",
 		Edition:            "Fourth Edition",
 		PriceUsd:           1.49,
+		PreviousPriceUsd:   &previousPriceUsd,
 		PriceChangePercent: &priceChangePercent,
 		URL:                "https://www.cardkingdom.com/mtg/fourth-edition/lightning-bolt",
 		IsFoil:             false,
@@ -27,6 +29,8 @@ func TestDynamoRecordFromListing(t *testing.T) {
 	require.Equal(t, "lightning bolt", record.NameKey)
 	require.Equal(t, "2026-06-28T00:00:00Z", record.UpdatedAt)
 	require.Equal(t, syncedAt, record.SyncedAt)
+	require.NotNil(t, record.PreviousPriceUsd)
+	require.Equal(t, 1.33, *record.PreviousPriceUsd)
 	require.NotNil(t, record.PriceChangePercent)
 	require.Equal(t, 12, *record.PriceChangePercent)
 	require.NotNil(t, record.PriceChangeIndexPK)
@@ -67,8 +71,10 @@ func TestDynamoRecordMarshalIncludesSyncedAt(t *testing.T) {
 func TestDynamoRecordMarshalIncludesPriceChangePercent(t *testing.T) {
 	syncedAt := time.Date(2026, 6, 28, 15, 30, 0, 0, time.UTC).Format(time.RFC3339)
 	priceChangePercent := -8
+	previousPriceUsd := 1.62
 	record := dynamoRecordFromListing("lightning bolt", cardkingdom.Listing{
 		UpdatedAt:          "2026-06-28T00:00:00Z",
+		PreviousPriceUsd:   &previousPriceUsd,
 		PriceChangePercent: &priceChangePercent,
 	}, syncedAt)
 	item, err := attributevalue.MarshalMap(record)
@@ -77,6 +83,10 @@ func TestDynamoRecordMarshalIncludesPriceChangePercent(t *testing.T) {
 	av, ok := item["priceChangePercent"].(*types.AttributeValueMemberN)
 	require.True(t, ok)
 	require.Equal(t, "-8", av.Value)
+	require.Contains(t, item, "previousPriceUsd")
+	previousAV, ok := item["previousPriceUsd"].(*types.AttributeValueMemberN)
+	require.True(t, ok)
+	require.Equal(t, "1.62", previousAV.Value)
 }
 
 func TestSyncMetadataRecordMarshal(t *testing.T) {

--- a/api/store/ckprices/price_change.go
+++ b/api/store/ckprices/price_change.go
@@ -24,7 +24,9 @@ func listingsWithPriceChange(
 	enriched := make(map[string]cardkingdom.Listing, len(listings))
 	for nameKey, listing := range listings {
 		if previous, ok := existing[nameKey]; ok {
-			listing.PriceChangePercent = computePriceChangePercent(previous.PriceUsd, listing.PriceUsd)
+			previousPriceUsd := previous.PriceUsd
+			listing.PreviousPriceUsd = &previousPriceUsd
+			listing.PriceChangePercent = computePriceChangePercent(previousPriceUsd, listing.PriceUsd)
 		}
 		enriched[nameKey] = listing
 	}

--- a/api/store/ckprices/price_change_test.go
+++ b/api/store/ckprices/price_change_test.go
@@ -141,7 +141,12 @@ func TestListingsWithPriceChange(t *testing.T) {
 
 	require.NotNil(t, enriched["lightning bolt"].PriceChangePercent)
 	require.Equal(t, 10, *enriched["lightning bolt"].PriceChangePercent)
+	require.NotNil(t, enriched["lightning bolt"].PreviousPriceUsd)
+	require.Equal(t, 1.00, *enriched["lightning bolt"].PreviousPriceUsd)
 	require.NotNil(t, enriched["counterspell"].PriceChangePercent)
 	require.Equal(t, -10, *enriched["counterspell"].PriceChangePercent)
+	require.NotNil(t, enriched["counterspell"].PreviousPriceUsd)
+	require.Equal(t, 2.00, *enriched["counterspell"].PreviousPriceUsd)
 	require.Nil(t, enriched["new card"].PriceChangePercent)
+	require.Nil(t, enriched["new card"].PreviousPriceUsd)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When the CK price refresh job upserts listings into DynamoDB, it now persists the prior `priceUsd` from the existing record as `previousPriceUsd`, alongside the already-computed `priceChangePercent`.

- New listings (no prior DynamoDB row) continue to omit both `previousPriceUsd` and `priceChangePercent`.
- Existing listings always store `previousPriceUsd` from the last sync, even when the price is unchanged.
- The field is exposed on `cardkingdom.Listing`, so it flows through to price-change rankings and S3 exports automatically.

## Changes

- Add `PreviousPriceUsd` to `cardkingdom.Listing` and the DynamoDB `dynamoRecord` struct.
- Set `PreviousPriceUsd` in `listingsWithPriceChange` when a prior record exists.
- Map the field in `dynamoRecordFromListing` / `listingFromRecord`.
- Extend unit tests for enrichment and DynamoDB marshaling.

## Testing

- `go test -mod=vendor ./store/ckprices/... ./controller/ckprice/... ./handler/...`
- `go fix ./...`
- `make test` hit a transient `gateway/duellerpoint` timeout (unrelated to this change); CK-focused tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8319ab56-8486-483a-9862-b8de7bb6cd08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8319ab56-8486-483a-9862-b8de7bb6cd08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

