### PR TITLE
Add Top $ Drops toggle for CK price decreases

### DIFF
--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -357,7 +357,7 @@ export default function TopSearchKeywords({
               disabled={isLoadingPriceChanges}
               onClick={() => handlePriceChangeSelect("drops")}
             >
-              Top $ Drops (24 Hrs)
+              Top $ drops (24 Hrs)
             </button>
           </div>
 

--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -357,7 +357,7 @@ export default function TopSearchKeywords({
               disabled={isLoadingPriceChanges}
               onClick={() => handlePriceChangeSelect("drops")}
             >
-              Top $ Drops
+              Top $ Drops (24 Hrs)
             </button>
           </div>
 

--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useId, useState } from "react";
-import { ArrowUp, ChevronDown, TrendingUp } from "react-feather";
+import { ArrowDown, ArrowUp, ChevronDown, TrendingUp } from "react-feather";
 import {
   BASE_URL,
   CK_PRICE_CHANGES_DISPLAY_LIMIT,
@@ -7,7 +7,7 @@ import {
   TOP_SEARCH_KEYWORDS_DISPLAY_LIMIT,
   TOP_SEARCH_KEYWORDS_MOBILE_DISPLAY_LIMIT,
 } from "../constants";
-import useCKPriceIncreases from "../hooks/useCKPriceIncreases";
+import useCKPriceChanges from "../hooks/useCKPriceChanges";
 import useMediaQuery from "../hooks/useMediaQuery";
 import { formatPriceChangePercent } from "../utils/ckPriceChanges";
 import { buildPopularSearchUrl, buildSearchQueryUrl } from "../utils/searchUrl";
@@ -51,17 +51,12 @@ function hasAnyKeywords(keywordsByPeriod) {
   );
 }
 
-function PeriodToggle({
-  period,
-  onPeriodChange,
-  disabled,
-  showPriceIncreases,
-}) {
+function PeriodToggle({ period, onPeriodChange, disabled, priceChangeView }) {
   return (
     <fieldset className="popular-search-period-toggle border-0 p-0 m-0">
       <legend className="visually-hidden">Trending search time range</legend>
       {PERIOD_OPTIONS.map((option) => {
-        const isActive = !showPriceIncreases && period === option.id;
+        const isActive = !priceChangeView && period === option.id;
 
         return (
           <button
@@ -121,12 +116,22 @@ function TrendingSectionToggle({ isExpanded, collapsible, panelId, onToggle }) {
   );
 }
 
-function CKPriceIncreasesContent({
+function CKPriceChangeContent({
+  variant,
   isLoading,
   error,
-  priceIncreases,
+  items,
   searchQuery,
+  emptyMessage,
 }) {
+  const isRiser = variant === "riser";
+  const ChangeIcon = isRiser ? ArrowUp : ArrowDown;
+  const pillModifier = isRiser
+    ? "popular-search-pill--riser"
+    : "popular-search-pill--drop";
+  const changeModifier = isRiser ? "" : " popular-search-pill-change--drop";
+  const directionWord = isRiser ? "up" : "down";
+
   if (isLoading) {
     return (
       <div className="popular-searches-pills">
@@ -148,28 +153,30 @@ function CKPriceIncreasesContent({
     );
   }
 
-  if (priceIncreases.length === 0) {
+  if (items.length === 0) {
     return (
       <p className="popular-searches-empty small text-muted mb-0">
-        No CK price increases available.
+        {emptyMessage}
       </p>
     );
   }
 
   return (
     <div className="popular-searches-pills">
-      {priceIncreases.map((item) => {
+      {items.map((item) => {
         const isActive = isMatchingTrendingSearch(item.cardName, searchQuery);
-        const changeLabel = formatPriceChangePercent(item.priceChangePercent);
+        const changeLabel = formatPriceChangePercent(item.priceChangePercent, {
+          absolute: !isRiser,
+        });
         const ariaLabel = changeLabel
-          ? `Search for ${item.cardName}, up ${changeLabel}`
+          ? `Search for ${item.cardName}, ${directionWord} ${changeLabel}`
           : `Search for ${item.cardName}`;
 
         return (
           <a
             key={item.cardName}
             href={buildSearchQueryUrl(BASE_URL, item.cardName)}
-            className={`btn btn-sm popular-search-pill popular-search-pill--riser text-decoration-none${
+            className={`btn btn-sm popular-search-pill ${pillModifier} text-decoration-none${
               isActive ? " is-active" : ""
             }`}
             aria-label={ariaLabel}
@@ -177,8 +184,11 @@ function CKPriceIncreasesContent({
           >
             <span className="popular-search-pill-name">{item.cardName}</span>
             {changeLabel ? (
-              <span className="popular-search-pill-change" aria-hidden="true">
-                <ArrowUp size={11} strokeWidth={2.5} />
+              <span
+                className={`popular-search-pill-change${changeModifier}`}
+                aria-hidden="true"
+              >
+                <ChangeIcon size={11} strokeWidth={2.5} />
                 <span>{changeLabel}</span>
               </span>
             ) : null}
@@ -227,14 +237,15 @@ export default function TopSearchKeywords({
     () => !collapsible || defaultExpanded,
   );
   const [showAllKeywords, setShowAllKeywords] = useState(false);
-  const [showPriceIncreases, setShowPriceIncreases] = useState(false);
+  const [priceChangeView, setPriceChangeView] = useState(null);
   const {
     priceIncreases,
-    isLoading: isLoadingPriceIncreases,
-    error: priceIncreasesError,
-    hasLoaded: hasLoadedPriceIncreases,
-    loadPriceIncreases,
-  } = useCKPriceIncreases();
+    priceDrops,
+    isLoading: isLoadingPriceChanges,
+    error: priceChangesError,
+    hasLoaded: hasLoadedPriceChanges,
+    loadPriceChanges,
+  } = useCKPriceChanges();
   const isDesktop = useMediaQuery(DESKTOP_MIN_WIDTH_MEDIA_QUERY);
   const displayLimit = getDisplayLimit(isDesktop, showAllKeywords);
   const panelId = useId();
@@ -252,13 +263,13 @@ export default function TopSearchKeywords({
   }, [collapseOnSearch]);
 
   const handlePeriodChange = (nextPeriod) => {
-    if (!showPriceIncreases && nextPeriod === period) {
+    if (!priceChangeView && nextPeriod === period) {
       return;
     }
 
     setPeriod(nextPeriod);
     setShowAllKeywords(false);
-    setShowPriceIncreases(false);
+    setPriceChangeView(null);
   };
 
   if (!isLoading && !hasAnyKeywords(keywordsByPeriod)) {
@@ -286,15 +297,15 @@ export default function TopSearchKeywords({
     }
   };
 
-  const handlePriceIncreasesSelect = async () => {
-    if (showPriceIncreases) {
+  const handlePriceChangeSelect = async (view) => {
+    if (priceChangeView === view) {
       return;
     }
 
-    setShowPriceIncreases(true);
+    setPriceChangeView(view);
 
-    if (!hasLoadedPriceIncreases && !isLoadingPriceIncreases) {
-      await loadPriceIncreases();
+    if (!hasLoadedPriceChanges && !isLoadingPriceChanges) {
+      await loadPriceChanges();
     }
   };
 
@@ -320,30 +331,54 @@ export default function TopSearchKeywords({
               period={period}
               onPeriodChange={handlePeriodChange}
               disabled={isLoading}
-              showPriceIncreases={showPriceIncreases}
+              priceChangeView={priceChangeView}
             />
             <button
               type="button"
               className={`btn btn-sm popular-search-period-btn${
-                showPriceIncreases ? " is-active" : ""
+                priceChangeView === "risers" ? " is-active" : ""
               }`}
-              aria-pressed={showPriceIncreases}
+              aria-pressed={priceChangeView === "risers"}
               aria-controls={contentPanelId}
               aria-label="Top dollar risers in 24 hours"
-              disabled={isLoadingPriceIncreases}
-              onClick={handlePriceIncreasesSelect}
+              disabled={isLoadingPriceChanges}
+              onClick={() => handlePriceChangeSelect("risers")}
             >
               Top $ risers (24h)
+            </button>
+            <button
+              type="button"
+              className={`btn btn-sm popular-search-period-btn${
+                priceChangeView === "drops" ? " is-active" : ""
+              }`}
+              aria-pressed={priceChangeView === "drops"}
+              aria-controls={contentPanelId}
+              aria-label="Top dollar drops in 24 hours"
+              disabled={isLoadingPriceChanges}
+              onClick={() => handlePriceChangeSelect("drops")}
+            >
+              Top $ Drops
             </button>
           </div>
 
           <div id={contentPanelId}>
-            {showPriceIncreases ? (
-              <CKPriceIncreasesContent
-                isLoading={isLoadingPriceIncreases}
-                error={priceIncreasesError}
-                priceIncreases={priceIncreases}
+            {priceChangeView === "risers" ? (
+              <CKPriceChangeContent
+                variant="riser"
+                isLoading={isLoadingPriceChanges}
+                error={priceChangesError}
+                items={priceIncreases}
                 searchQuery={searchQuery}
+                emptyMessage="No CK price increases available."
+              />
+            ) : priceChangeView === "drops" ? (
+              <CKPriceChangeContent
+                variant="drop"
+                isLoading={isLoadingPriceChanges}
+                error={priceChangesError}
+                items={priceDrops}
+                searchQuery={searchQuery}
+                emptyMessage="No CK price drops available."
               />
             ) : isLoading ? (
               <div className="popular-searches-pills">

--- a/frontend/src/hooks/useCKPriceChanges.js
+++ b/frontend/src/hooks/useCKPriceChanges.js
@@ -1,15 +1,22 @@
 import { useCallback, useRef, useState } from "react";
-import { CK_PRICE_CHANGES_DISPLAY_LIMIT, CK_PRICE_CHANGES_URL } from "../constants";
-import { parseCKPriceIncreases } from "../utils/ckPriceChanges";
+import {
+  CK_PRICE_CHANGES_DISPLAY_LIMIT,
+  CK_PRICE_CHANGES_URL,
+} from "../constants";
+import {
+  parseCKPriceDrops,
+  parseCKPriceIncreases,
+} from "../utils/ckPriceChanges";
 
-export default function useCKPriceIncreases() {
+export default function useCKPriceChanges() {
   const [priceIncreases, setPriceIncreases] = useState([]);
+  const [priceDrops, setPriceDrops] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
   const [hasLoaded, setHasLoaded] = useState(false);
   const requestIdRef = useRef(0);
 
-  const loadPriceIncreases = useCallback(async () => {
+  const loadPriceChanges = useCallback(async () => {
     const requestId = requestIdRef.current + 1;
     requestIdRef.current = requestId;
     setIsLoading(true);
@@ -29,15 +36,17 @@ export default function useCKPriceIncreases() {
       setPriceIncreases(
         parseCKPriceIncreases(payload, CK_PRICE_CHANGES_DISPLAY_LIMIT),
       );
+      setPriceDrops(parseCKPriceDrops(payload, CK_PRICE_CHANGES_DISPLAY_LIMIT));
       setHasLoaded(true);
     } catch (loadError) {
       if (requestId !== requestIdRef.current) {
         return;
       }
 
-      console.error("Failed to load CK price increases:", loadError);
+      console.error("Failed to load CK price changes:", loadError);
       setPriceIncreases([]);
-      setError("Could not load CK price increases.");
+      setPriceDrops([]);
+      setError("Could not load CK price changes.");
       setHasLoaded(true);
     } finally {
       if (requestId === requestIdRef.current) {
@@ -48,9 +57,10 @@ export default function useCKPriceIncreases() {
 
   return {
     priceIncreases,
+    priceDrops,
     isLoading,
     error,
     hasLoaded,
-    loadPriceIncreases,
+    loadPriceChanges,
   };
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -627,7 +627,8 @@ ins.adsbygoogle.adsbygoogle-noablate {
   color: var(--bs-secondary-color);
 }
 
-.popular-search-pill--riser {
+.popular-search-pill--riser,
+.popular-search-pill--drop {
   display: inline-flex;
   align-items: center;
   gap: 0.375rem;
@@ -643,12 +644,20 @@ ins.adsbygoogle.adsbygoogle-noablate {
   line-height: 1;
 }
 
+.popular-search-pill-change--drop {
+  color: var(--bs-danger);
+}
+
 .popular-search-pill-name {
   min-width: 0;
 }
 
 .popular-search-pill.is-active .popular-search-pill-change {
   color: color-mix(in srgb, var(--bs-success) 72%, var(--bs-white));
+}
+
+.popular-search-pill.is-active .popular-search-pill-change--drop {
+  color: color-mix(in srgb, var(--bs-danger) 72%, var(--bs-white));
 }
 
 .popular-search-pill.is-active {

--- a/frontend/src/utils/ckPriceChanges.js
+++ b/frontend/src/utils/ckPriceChanges.js
@@ -1,18 +1,19 @@
-export function formatPriceChangePercent(percent) {
+export function formatPriceChangePercent(percent, { absolute = false } = {}) {
   if (typeof percent !== "number" || !Number.isFinite(percent)) {
     return null;
   }
 
   const rounded = Math.round(percent * 10) / 10;
-  return Number.isInteger(rounded) ? `${rounded}%` : `${rounded.toFixed(1)}%`;
+  const value = absolute ? Math.abs(rounded) : rounded;
+  return Number.isInteger(value) ? `${value}%` : `${value.toFixed(1)}%`;
 }
 
-export function parseCKPriceIncreases(payload, limit = 20) {
-  if (!Array.isArray(payload?.top)) {
+function parseCKPriceChangeListings(listings, limit = 20) {
+  if (!Array.isArray(listings)) {
     return [];
   }
 
-  return payload.top
+  return listings
     .map((item) => ({
       cardName: typeof item?.cardName === "string" ? item.cardName.trim() : "",
       priceChangePercent:
@@ -22,4 +23,12 @@ export function parseCKPriceIncreases(payload, limit = 20) {
     }))
     .filter((item) => item.cardName.length > 0)
     .slice(0, limit);
+}
+
+export function parseCKPriceIncreases(payload, limit = 20) {
+  return parseCKPriceChangeListings(payload?.top, limit);
+}
+
+export function parseCKPriceDrops(payload, limit = 20) {
+  return parseCKPriceChangeListings(payload?.bottom, limit);
 }

--- a/frontend/src/utils/ckPriceChanges.test.js
+++ b/frontend/src/utils/ckPriceChanges.test.js
@@ -2,12 +2,15 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   formatPriceChangePercent,
+  parseCKPriceDrops,
   parseCKPriceIncreases,
 } from "./ckPriceChanges.js";
 
 test("formatPriceChangePercent formats whole and fractional percentages", () => {
   assert.equal(formatPriceChangePercent(15), "15%");
   assert.equal(formatPriceChangePercent(12.34), "12.3%");
+  assert.equal(formatPriceChangePercent(-10), "-10%");
+  assert.equal(formatPriceChangePercent(-10, { absolute: true }), "10%");
   assert.equal(formatPriceChangePercent(null), null);
   assert.equal(formatPriceChangePercent(Number.NaN), null);
 });
@@ -35,4 +38,29 @@ test("parseCKPriceIncreases returns an empty list for invalid payloads", () => {
   assert.deepEqual(parseCKPriceIncreases(null), []);
   assert.deepEqual(parseCKPriceIncreases({}), []);
   assert.deepEqual(parseCKPriceIncreases({ top: "invalid" }), []);
+});
+
+test("parseCKPriceDrops returns bottom card names up to the display limit", () => {
+  const payload = {
+    bottom: [
+      { cardName: "Counterspell", priceChangePercent: -15 },
+      { cardName: " Sol Ring ", priceChangePercent: -10 },
+      { cardName: "", priceChangePercent: -5 },
+      { cardName: "Lightning Bolt", priceChangePercent: -5 },
+    ],
+  };
+
+  const drops = parseCKPriceDrops(payload);
+
+  assert.equal(drops.length, 3);
+  assert.equal(drops[0].cardName, "Counterspell");
+  assert.equal(drops[0].priceChangePercent, -15);
+  assert.equal(drops[1].cardName, "Sol Ring");
+  assert.equal(drops[1].priceChangePercent, -10);
+});
+
+test("parseCKPriceDrops returns an empty list for invalid payloads", () => {
+  assert.deepEqual(parseCKPriceDrops(null), []);
+  assert.deepEqual(parseCKPriceDrops({}), []);
+  assert.deepEqual(parseCKPriceDrops({ bottom: "invalid" }), []);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Top $ drops (24 Hrs)** toggle to the Trending section, showing the top 20 Card Kingdom cards with the largest price decreases (from the existing `bottom` array in `latest.json`).

## Changes

- Parse `bottom` listings via new `parseCKPriceDrops` helper
- Refactor `useCKPriceIncreases` → `useCKPriceChanges` to fetch both risers and drops in one request
- Add **Top $ drops (24 Hrs)** button alongside **Top $ risers (24h)**
- Share pill rendering between risers (green ↑) and drops (red ↓), showing absolute percent for drops

## Screenshots

### Desktop
![Top $ drops desktop](https://cursor.com/artifacts/c/art-1ef96650-b155-4a84-8303-140b97831175)

### Mobile
![Top $ drops mobile](https://cursor.com/artifacts/c/art-ccbef011-63f4-4afa-971d-d333a77fba56)

## Testing

- `node --test src/utils/ckPriceChanges.test.js` — pass
- `make test` — unrelated live gateway failure in `gateway/agora` (upstream 500)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c7d7c673-62df-4feb-98ec-39c463a01a7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7d7c673-62df-4feb-98ec-39c463a01a7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

