### PR TITLE
Exclude World Championship Decks from CK price indexing

### DIFF
--- a/api/gateway/cardkingdom/excluded_editions.go
+++ b/api/gateway/cardkingdom/excluded_editions.go
@@ -1,0 +1,20 @@
+package cardkingdom
+
+import "strings"
+
+// excludedCKPriceEdition reports whether a set/edition should be omitted from CK
+// cheapest-price indexing. World Championship Deck printings use the same card
+// names as regular sets but are separate memorabilia products with distinct
+// pricing.
+func excludedCKPriceEdition(edition string) bool {
+	edition = strings.TrimSpace(edition)
+	if edition == "" {
+		return false
+	}
+
+	lower := strings.ToLower(edition)
+	if lower == "world championships" {
+		return true
+	}
+	return strings.HasPrefix(lower, "world championship decks")
+}

--- a/api/gateway/cardkingdom/excluded_editions.go
+++ b/api/gateway/cardkingdom/excluded_editions.go
@@ -13,8 +13,5 @@ func excludedCKPriceEdition(edition string) bool {
 	}
 
 	lower := strings.ToLower(edition)
-	if lower == "world championships" {
-		return true
-	}
-	return strings.HasPrefix(lower, "world championship decks")
+	return strings.Contains(lower, "world championship")
 }

--- a/api/gateway/cardkingdom/excluded_editions_test.go
+++ b/api/gateway/cardkingdom/excluded_editions_test.go
@@ -1,0 +1,18 @@
+package cardkingdom
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExcludedCKPriceEdition(t *testing.T) {
+	require.True(t, excludedCKPriceEdition("World Championship Decks 2004"))
+	require.True(t, excludedCKPriceEdition("World Championship Decks 1997"))
+	require.True(t, excludedCKPriceEdition("World Championships"))
+	require.True(t, excludedCKPriceEdition("  World Championships  "))
+
+	require.False(t, excludedCKPriceEdition("Fourth Edition"))
+	require.False(t, excludedCKPriceEdition("World Championship Promos"))
+	require.False(t, excludedCKPriceEdition(""))
+}

--- a/api/gateway/cardkingdom/excluded_editions_test.go
+++ b/api/gateway/cardkingdom/excluded_editions_test.go
@@ -11,8 +11,8 @@ func TestExcludedCKPriceEdition(t *testing.T) {
 	require.True(t, excludedCKPriceEdition("World Championship Decks 1997"))
 	require.True(t, excludedCKPriceEdition("World Championships"))
 	require.True(t, excludedCKPriceEdition("  World Championships  "))
+	require.True(t, excludedCKPriceEdition("World Championship Promos"))
 
 	require.False(t, excludedCKPriceEdition("Fourth Edition"))
-	require.False(t, excludedCKPriceEdition("World Championship Promos"))
 	require.False(t, excludedCKPriceEdition(""))
 }

--- a/api/gateway/cardkingdom/index.go
+++ b/api/gateway/cardkingdom/index.go
@@ -13,6 +13,10 @@ func BuildCheapestByName(products []Product, updatedAt time.Time) map[string]Lis
 	updatedAtValue := updatedAt.UTC().Format(time.RFC3339)
 
 	for _, product := range products {
+		if excludedCKPriceEdition(product.Edition) {
+			continue
+		}
+
 		priceUsd, err := product.PriceRetail.Float64()
 		if err != nil || priceUsd <= 0 {
 			continue

--- a/api/gateway/cardkingdom/index_test.go
+++ b/api/gateway/cardkingdom/index_test.go
@@ -52,6 +52,39 @@ func TestBuildCheapestByName(t *testing.T) {
 	require.Equal(t, updatedAt.Format(time.RFC3339), listing.UpdatedAt)
 }
 
+func TestBuildCheapestByName_ExcludesWorldChampionshipDecks(t *testing.T) {
+	updatedAt := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	products := []Product{
+		{
+			Name:        "Birds of Paradise",
+			Edition:     "World Championships",
+			PriceRetail: "12.99",
+			URL:         "mtg/world-championships/birds-of-paradise",
+			IsFoil:      "false",
+		},
+		{
+			Name:        "Birds of Paradise",
+			Edition:     "8th Edition",
+			PriceRetail: "16.99",
+			URL:         "mtg/8th-edition/birds-of-paradise",
+			IsFoil:      "false",
+		},
+		{
+			Name:        "Birds of Paradise",
+			Edition:     "Ravnica",
+			PriceRetail: "17.99",
+			URL:         "mtg/ravnica/birds-of-paradise",
+			IsFoil:      "false",
+		},
+	}
+
+	cheapest := BuildCheapestByName(products, updatedAt)
+
+	require.Len(t, cheapest, 1)
+	require.InDelta(t, 16.99, cheapest["birds of paradise"].PriceUsd, 0.001)
+	require.Equal(t, "8th Edition", cheapest["birds of paradise"].Edition)
+}
+
 func TestBuildCheapestByName_DoubleFacedCardIndexesFaceNames(t *testing.T) {
 	updatedAt := time.Date(2026, 7, 2, 12, 0, 0, 0, time.UTC)
 	products := []Product{

--- a/api/gateway/cardkingdom/mtgjson_fetch.go
+++ b/api/gateway/cardkingdom/mtgjson_fetch.go
@@ -279,6 +279,9 @@ func decodeSetCatalog(
 		if err := decoder.Decode(&set); err != nil {
 			return err
 		}
+		if excludedCKPriceEdition(set.Name) {
+			continue
+		}
 
 		aggregates := make(map[printingKey]printingAggregate)
 		for _, card := range set.Cards {

--- a/api/gateway/cardkingdom/mtgjson_fetch_test.go
+++ b/api/gateway/cardkingdom/mtgjson_fetch_test.go
@@ -173,6 +173,38 @@ const sampleAllPrintingsJenniferWalters = `{
   }
 }`
 
+const sampleAllPrintingsWorldChampionshipDecks = `{
+  "meta": {"date": "2026-06-28"},
+  "data": {
+    "WC04": {
+      "name": "World Championship Decks 2004",
+      "cards": [
+        {
+          "uuid": "uuid-wcd-bolt",
+          "name": "Lightning Bolt",
+          "number": "1",
+          "purchaseUrls": {
+            "cardKingdom": "https://www.cardkingdom.com/mtg/world-championships/lightning-bolt"
+          }
+        }
+      ]
+    },
+    "4ED": {
+      "name": "Fourth Edition",
+      "cards": [
+        {
+          "uuid": "uuid-bolt-4ed",
+          "name": "Lightning Bolt",
+          "number": "162",
+          "purchaseUrls": {
+            "cardKingdom": "https://www.cardkingdom.com/mtg/fourth-edition/lightning-bolt"
+          }
+        }
+      ]
+    }
+  }
+}`
+
 func TestParseCKPricesByUUID(t *testing.T) {
 	prices, updatedAt, err := parseCKPricesByUUID([]byte(sampleAllPricesToday))
 	require.NoError(t, err)
@@ -204,6 +236,25 @@ func TestDecodeAllPrintingsSets(t *testing.T) {
 	require.False(t, listing.IsFoil)
 	require.Equal(t, "https://www.cardkingdom.com/mtg/fourth-edition/lightning-bolt", listing.URL)
 	require.Equal(t, updatedAt.Format(time.RFC3339), listing.UpdatedAt)
+}
+
+func TestDecodeAllPrintingsSets_ExcludesWorldChampionshipDecks(t *testing.T) {
+	prices := map[string]ckUUIDPrice{
+		"uuid-wcd-bolt": {normal: 0.99},
+		"uuid-bolt-4ed": {normal: 1.49},
+	}
+	updatedAt := time.Date(2026, 6, 28, 0, 0, 0, 0, time.UTC)
+
+	cheapest, err := decodeAllPrintingsSets(
+		json.NewDecoder(strings.NewReader(sampleAllPrintingsWorldChampionshipDecks)),
+		prices,
+		updatedAt,
+	)
+	require.NoError(t, err)
+
+	listing := cheapest["lightning bolt"]
+	require.Equal(t, "Fourth Edition", listing.Edition)
+	require.InDelta(t, 1.49, listing.PriceUsd, 0.001)
 }
 
 func TestDecodeAllPrintingsSets_MergesSplitUUIDPrintings(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

World Championship Deck (WCD) printings share card names with regular sets but are separate memorabilia products with distinct pricing. They were being included when building cheapest-by-name CK price indexes, which could skew search reference prices.

This change excludes WCD-related sets from both CK price ingestion paths using a case-insensitive substring match on `world championship`.

## Implementation

Added `excludedCKPriceEdition()` and applied it in:

- `decodeSetCatalog()` (MTGJSON stream)
- `BuildCheapestByName()` (CK pricelist API)

Matching now uses `strings.Contains(strings.ToLower(edition), "world championship")`, which covers variants such as:

- `World Championship Decks 2004` (MTGJSON)
- `World Championships` (CK pricelist)
- `World Championship Promos`

## Testing

- Added unit tests for the exclusion helper and both ingestion paths
- `go test ./gateway/cardkingdom/...` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db430cc9-9113-4bcb-a358-ab256c959cdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db430cc9-9113-4bcb-a358-ab256c959cdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

