### PR TITLE
Record and rank CK price changes by USD

### DIFF
--- a/api/controller/ckprice/ckprice_test.go
+++ b/api/controller/ckprice/ckprice_test.go
@@ -29,6 +29,10 @@ func (m *mockStore) GetPriceChangesByPercent(_ context.Context, _ bool, _ int) (
 	return nil, nil
 }
 
+func (m *mockStore) GetPriceChangesByUsd(_ context.Context, _ bool, _ int) ([]ckprices.PriceChangeListing, error) {
+	return nil, nil
+}
+
 func (m *mockStore) GetTopBottomPriceChanges(_ context.Context) (*ckprices.TopBottomPriceChanges, error) {
 	return &ckprices.TopBottomPriceChanges{}, nil
 }

--- a/api/gateway/cardkingdom/types.go
+++ b/api/gateway/cardkingdom/types.go
@@ -18,6 +18,7 @@ type Listing struct {
 	PriceUsd           float64  `json:"priceUsd"`
 	PreviousPriceUsd   *float64 `json:"previousPriceUsd,omitempty"`
 	PriceChangePercent *int     `json:"priceChangePercent,omitempty"`
+	PriceChangeUsd     *float64 `json:"priceChangeUsd,omitempty"`
 	URL                string  `json:"url"`
 	IsFoil             bool    `json:"isFoil"`
 	UpdatedAt          string  `json:"updatedAt,omitempty"`

--- a/api/handler/ck_refresh_test.go
+++ b/api/handler/ck_refresh_test.go
@@ -107,6 +107,10 @@ func (m *mockCKRefreshStore) GetPriceChangesByPercent(_ context.Context, _ bool,
 	return nil, nil
 }
 
+func (m *mockCKRefreshStore) GetPriceChangesByUsd(_ context.Context, _ bool, _ int) ([]ckprices.PriceChangeListing, error) {
+	return nil, nil
+}
+
 func (m *mockCKRefreshStore) GetTopBottomPriceChanges(_ context.Context) (*ckprices.TopBottomPriceChanges, error) {
 	if m.changes != nil {
 		return m.changes, nil

--- a/api/store/ckprices/dynamodb.go
+++ b/api/store/ckprices/dynamodb.go
@@ -21,6 +21,7 @@ const (
 	batchGetLimit            = 100
 	batchWriteLimit          = 25
 	priceChangeIndexName     = "priceChangePercent-index"
+	priceChangeUsdIndexName  = "priceChangeUsd-index"
 	priceChangeIndexPKValue  = "CURRENT"
 	syncMetadataKey          = "__sync__"
 	syncMetadataLabel        = "CK price sync metadata"
@@ -116,12 +117,32 @@ func (s *DynamoDBStore) GetPriceChangesByPercent(ctx context.Context, ascending 
 	return priceChangesByPercentFromListings(scanned, ascending, limit), nil
 }
 
+func (s *DynamoDBStore) GetPriceChangesByUsd(ctx context.Context, ascending bool, limit int) ([]PriceChangeListing, error) {
+	if limit <= 0 {
+		limit = PriceChangeRankingLimit
+	}
+
+	listings, err := s.queryPriceChangesByUsd(ctx, ascending, limit)
+	if err == nil {
+		return listings, nil
+	}
+	if !isMissingPriceChangeIndex(err) {
+		return nil, err
+	}
+
+	scanned, scanErr := s.scanPriceChangeListingsByUsd(ctx)
+	if scanErr != nil {
+		return nil, scanErr
+	}
+	return priceChangesByUsdFromListings(scanned, ascending, limit), nil
+}
+
 func (s *DynamoDBStore) GetTopBottomPriceChanges(ctx context.Context) (*TopBottomPriceChanges, error) {
-	top, err := s.GetPriceChangesByPercent(ctx, false, PriceChangeRankingLimit)
+	top, err := s.GetPriceChangesByUsd(ctx, false, PriceChangeRankingLimit)
 	if err != nil {
 		return nil, err
 	}
-	bottom, err := s.GetPriceChangesByPercent(ctx, true, PriceChangeRankingLimit)
+	bottom, err := s.GetPriceChangesByUsd(ctx, true, PriceChangeRankingLimit)
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +170,36 @@ func (s *DynamoDBStore) queryPriceChangesByPercent(ctx context.Context, ascendin
 	return priceChangeListingsFromItems(output.Items)
 }
 
+func (s *DynamoDBStore) queryPriceChangesByUsd(ctx context.Context, ascending bool, limit int) ([]PriceChangeListing, error) {
+	output, err := s.client.Query(ctx, &dynamodb.QueryInput{
+		TableName:              aws.String(s.tableName),
+		IndexName:              aws.String(priceChangeUsdIndexName),
+		KeyConditionExpression: aws.String("priceChangeIndexPK = :pk"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":pk": &types.AttributeValueMemberS{Value: priceChangeIndexPKValue},
+		},
+		ScanIndexForward: aws.Bool(ascending),
+		Limit:            aws.Int32(int32(limit)),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return priceChangeListingsFromItemsByUsd(output.Items)
+}
+
 func (s *DynamoDBStore) scanPriceChangeListings(ctx context.Context) ([]PriceChangeListing, error) {
+	return s.scanPriceChangeListingsWithFilter(ctx, priceChangeListingFromRecord)
+}
+
+func (s *DynamoDBStore) scanPriceChangeListingsByUsd(ctx context.Context) ([]PriceChangeListing, error) {
+	return s.scanPriceChangeListingsWithFilter(ctx, priceChangeListingFromRecordByUsd)
+}
+
+func (s *DynamoDBStore) scanPriceChangeListingsWithFilter(
+	ctx context.Context,
+	fromRecord func(dynamoRecord) (PriceChangeListing, bool),
+) ([]PriceChangeListing, error) {
 	listings := make([]PriceChangeListing, 0)
 	var exclusiveStartKey map[string]types.AttributeValue
 
@@ -162,7 +212,7 @@ func (s *DynamoDBStore) scanPriceChangeListings(ctx context.Context) ([]PriceCha
 			return nil, err
 		}
 
-		batch, err := priceChangeListingsFromItems(output.Items)
+		batch, err := priceChangeListingsFromItemsWithFilter(output.Items, fromRecord)
 		if err != nil {
 			return nil, err
 		}
@@ -240,7 +290,7 @@ func dynamoRecordFromListing(nameKey string, listing cardkingdom.Listing, synced
 		UpdatedAt:          listing.UpdatedAt,
 		SyncedAt:           syncedAt,
 	}
-	if listing.PriceChangePercent != nil {
+	if listing.PriceChangeUsd != nil || listing.PriceChangePercent != nil {
 		indexPK := priceChangeIndexPKValue
 		record.PriceChangeIndexPK = &indexPK
 	}
@@ -279,14 +329,39 @@ func priceChangeListingFromRecord(record dynamoRecord) (PriceChangeListing, bool
 	}, true
 }
 
+func priceChangeListingFromRecordByUsd(record dynamoRecord) (PriceChangeListing, bool) {
+	if record.NameKey == syncMetadataKey || record.PriceChangeUsd == nil {
+		return PriceChangeListing{}, false
+	}
+	listing, ok := listingFromRecord(record)
+	if !ok {
+		return PriceChangeListing{}, false
+	}
+	return PriceChangeListing{
+		NameKey: record.NameKey,
+		Listing: listing,
+	}, true
+}
+
 func priceChangeListingsFromItems(items []map[string]types.AttributeValue) ([]PriceChangeListing, error) {
+	return priceChangeListingsFromItemsWithFilter(items, priceChangeListingFromRecord)
+}
+
+func priceChangeListingsFromItemsByUsd(items []map[string]types.AttributeValue) ([]PriceChangeListing, error) {
+	return priceChangeListingsFromItemsWithFilter(items, priceChangeListingFromRecordByUsd)
+}
+
+func priceChangeListingsFromItemsWithFilter(
+	items []map[string]types.AttributeValue,
+	fromRecord func(dynamoRecord) (PriceChangeListing, bool),
+) ([]PriceChangeListing, error) {
 	listings := make([]PriceChangeListing, 0, len(items))
 	for _, item := range items {
 		var record dynamoRecord
 		if err := attributevalue.UnmarshalMap(item, &record); err != nil {
 			return nil, err
 		}
-		if listing, ok := priceChangeListingFromRecord(record); ok {
+		if listing, ok := fromRecord(record); ok {
 			listings = append(listings, listing)
 		}
 	}

--- a/api/store/ckprices/dynamodb.go
+++ b/api/store/ckprices/dynamodb.go
@@ -33,6 +33,7 @@ type dynamoRecord struct {
 	PriceUsd           float64  `dynamodbav:"priceUsd"`
 	PreviousPriceUsd   *float64 `dynamodbav:"previousPriceUsd,omitempty"`
 	PriceChangePercent *int     `dynamodbav:"priceChangePercent,omitempty"`
+	PriceChangeUsd     *float64 `dynamodbav:"priceChangeUsd,omitempty"`
 	PriceChangeIndexPK *string `dynamodbav:"priceChangeIndexPK,omitempty"`
 	URL                string  `dynamodbav:"url"`
 	IsFoil             bool    `dynamodbav:"isFoil"`
@@ -233,6 +234,7 @@ func dynamoRecordFromListing(nameKey string, listing cardkingdom.Listing, synced
 		PriceUsd:           listing.PriceUsd,
 		PreviousPriceUsd:   listing.PreviousPriceUsd,
 		PriceChangePercent: listing.PriceChangePercent,
+		PriceChangeUsd:     listing.PriceChangeUsd,
 		URL:                listing.URL,
 		IsFoil:             listing.IsFoil,
 		UpdatedAt:          listing.UpdatedAt,
@@ -255,6 +257,7 @@ func listingFromRecord(record dynamoRecord) (cardkingdom.Listing, bool) {
 		PriceUsd:           record.PriceUsd,
 		PreviousPriceUsd:   record.PreviousPriceUsd,
 		PriceChangePercent: record.PriceChangePercent,
+		PriceChangeUsd:     record.PriceChangeUsd,
 		URL:                record.URL,
 		IsFoil:             record.IsFoil,
 		UpdatedAt:          record.UpdatedAt,

--- a/api/store/ckprices/dynamodb_test.go
+++ b/api/store/ckprices/dynamodb_test.go
@@ -14,6 +14,7 @@ import (
 func TestDynamoRecordFromListing(t *testing.T) {
 	syncedAt := time.Date(2026, 6, 28, 15, 30, 0, 0, time.UTC).Format(time.RFC3339)
 	priceChangePercent := 12
+	priceChangeUsd := 0.16
 	previousPriceUsd := 1.33
 	record := dynamoRecordFromListing("lightning bolt", cardkingdom.Listing{
 		CardName:           "Lightning Bolt",
@@ -21,6 +22,7 @@ func TestDynamoRecordFromListing(t *testing.T) {
 		PriceUsd:           1.49,
 		PreviousPriceUsd:   &previousPriceUsd,
 		PriceChangePercent: &priceChangePercent,
+		PriceChangeUsd:     &priceChangeUsd,
 		URL:                "https://www.cardkingdom.com/mtg/fourth-edition/lightning-bolt",
 		IsFoil:             false,
 		UpdatedAt:          "2026-06-28T00:00:00Z",
@@ -33,6 +35,8 @@ func TestDynamoRecordFromListing(t *testing.T) {
 	require.Equal(t, 1.33, *record.PreviousPriceUsd)
 	require.NotNil(t, record.PriceChangePercent)
 	require.Equal(t, 12, *record.PriceChangePercent)
+	require.NotNil(t, record.PriceChangeUsd)
+	require.InDelta(t, 0.16, *record.PriceChangeUsd, 0.001)
 	require.NotNil(t, record.PriceChangeIndexPK)
 	require.Equal(t, priceChangeIndexPKValue, *record.PriceChangeIndexPK)
 }
@@ -66,6 +70,23 @@ func TestDynamoRecordMarshalIncludesSyncedAt(t *testing.T) {
 	av, ok := item["syncedAt"].(*types.AttributeValueMemberS)
 	require.True(t, ok)
 	require.Equal(t, syncedAt, av.Value)
+}
+
+func TestDynamoRecordMarshalIncludesPriceChangeUsd(t *testing.T) {
+	syncedAt := time.Date(2026, 6, 28, 15, 30, 0, 0, time.UTC).Format(time.RFC3339)
+	priceChangeUsd := 0.25
+	previousPriceUsd := 1.00
+	record := dynamoRecordFromListing("lightning bolt", cardkingdom.Listing{
+		UpdatedAt:        "2026-06-28T00:00:00Z",
+		PreviousPriceUsd: &previousPriceUsd,
+		PriceChangeUsd:   &priceChangeUsd,
+	}, syncedAt)
+	item, err := attributevalue.MarshalMap(record)
+	require.NoError(t, err)
+	require.Contains(t, item, "priceChangeUsd")
+	av, ok := item["priceChangeUsd"].(*types.AttributeValueMemberN)
+	require.True(t, ok)
+	require.Equal(t, "0.25", av.Value)
 }
 
 func TestDynamoRecordMarshalIncludesPriceChangePercent(t *testing.T) {

--- a/api/store/ckprices/price_change.go
+++ b/api/store/ckprices/price_change.go
@@ -17,6 +17,15 @@ func computePriceChangePercent(previousPriceUsd, currentPriceUsd float64) *int {
 	return &changePercent
 }
 
+func computePriceChangeUsd(previousPriceUsd, currentPriceUsd float64) *float64 {
+	if previousPriceUsd <= 0 {
+		return nil
+	}
+
+	changeUsd := math.Round((currentPriceUsd-previousPriceUsd)*100) / 100
+	return &changeUsd
+}
+
 func listingsWithPriceChange(
 	existing map[string]dynamoRecord,
 	listings map[string]cardkingdom.Listing,
@@ -27,6 +36,7 @@ func listingsWithPriceChange(
 			previousPriceUsd := previous.PriceUsd
 			listing.PreviousPriceUsd = &previousPriceUsd
 			listing.PriceChangePercent = computePriceChangePercent(previousPriceUsd, listing.PriceUsd)
+			listing.PriceChangeUsd = computePriceChangeUsd(previousPriceUsd, listing.PriceUsd)
 		}
 		enriched[nameKey] = listing
 	}

--- a/api/store/ckprices/price_change.go
+++ b/api/store/ckprices/price_change.go
@@ -1,6 +1,7 @@
 package ckprices
 
 import (
+	"cmp"
 	"math"
 	"slices"
 	"strings"
@@ -43,7 +44,7 @@ func listingsWithPriceChange(
 	return enriched
 }
 
-func topBottomPriceChanges(listings []PriceChangeListing, limit int) TopBottomPriceChanges {
+func topBottomPriceChangesByPercent(listings []PriceChangeListing, limit int) TopBottomPriceChanges {
 	if limit <= 0 {
 		limit = PriceChangeRankingLimit
 	}
@@ -84,8 +85,57 @@ func topBottomPriceChanges(listings []PriceChangeListing, limit int) TopBottomPr
 	}
 }
 
+func topBottomPriceChangesByUsd(listings []PriceChangeListing, limit int) TopBottomPriceChanges {
+	if limit <= 0 {
+		limit = PriceChangeRankingLimit
+	}
+
+	changed := make([]PriceChangeListing, 0, len(listings))
+	for _, listing := range listings {
+		if listing.PriceChangeUsd == nil {
+			continue
+		}
+		changed = append(changed, listing)
+	}
+
+	top := append([]PriceChangeListing(nil), changed...)
+	slices.SortFunc(top, func(a, b PriceChangeListing) int {
+		if *a.PriceChangeUsd != *b.PriceChangeUsd {
+			return cmp.Compare(*b.PriceChangeUsd, *a.PriceChangeUsd)
+		}
+		return strings.Compare(a.NameKey, b.NameKey)
+	})
+	if len(top) > limit {
+		top = top[:limit]
+	}
+
+	bottom := append([]PriceChangeListing(nil), changed...)
+	slices.SortFunc(bottom, func(a, b PriceChangeListing) int {
+		if *a.PriceChangeUsd != *b.PriceChangeUsd {
+			return cmp.Compare(*a.PriceChangeUsd, *b.PriceChangeUsd)
+		}
+		return strings.Compare(a.NameKey, b.NameKey)
+	})
+	if len(bottom) > limit {
+		bottom = bottom[:limit]
+	}
+
+	return TopBottomPriceChanges{
+		Top:    top,
+		Bottom: bottom,
+	}
+}
+
 func priceChangesByPercentFromListings(listings []PriceChangeListing, ascending bool, limit int) []PriceChangeListing {
-	rankings := topBottomPriceChanges(listings, limit)
+	rankings := topBottomPriceChangesByPercent(listings, limit)
+	if ascending {
+		return rankings.Bottom
+	}
+	return rankings.Top
+}
+
+func priceChangesByUsdFromListings(listings []PriceChangeListing, ascending bool, limit int) []PriceChangeListing {
+	rankings := topBottomPriceChangesByUsd(listings, limit)
 	if ascending {
 		return rankings.Bottom
 	}

--- a/api/store/ckprices/price_change_test.go
+++ b/api/store/ckprices/price_change_test.go
@@ -127,7 +127,7 @@ func TestTopBottomPriceChanges(t *testing.T) {
 		Listing: cardkingdom.Listing{CardName: "No Change"},
 	})
 
-	rankings := topBottomPriceChanges(listings, PriceChangeRankingLimit)
+	rankings := topBottomPriceChangesByPercent(listings, PriceChangeRankingLimit)
 
 	require.Len(t, rankings.Top, PriceChangeRankingLimit)
 	require.Equal(t, 25, *rankings.Top[0].PriceChangePercent)
@@ -136,6 +136,74 @@ func TestTopBottomPriceChanges(t *testing.T) {
 	require.Len(t, rankings.Bottom, PriceChangeRankingLimit)
 	require.Equal(t, -25, *rankings.Bottom[0].PriceChangePercent)
 	require.Equal(t, -6, *rankings.Bottom[19].PriceChangePercent)
+}
+
+func TestPriceChangesByUsdFromListings(t *testing.T) {
+	usd := func(value float64) *float64 {
+		return &value
+	}
+	listing := func(nameKey string, change float64) PriceChangeListing {
+		return PriceChangeListing{
+			NameKey: nameKey,
+			Listing: cardkingdom.Listing{
+				CardName:       nameKey,
+				PriceChangeUsd: usd(change),
+			},
+		}
+	}
+
+	listings := []PriceChangeListing{
+		listing("a", 30),
+		listing("b", 10),
+		listing("c", -30),
+		listing("d", -10),
+	}
+
+	bottom := priceChangesByUsdFromListings(listings, true, 2)
+	require.Len(t, bottom, 2)
+	require.InDelta(t, -30, *bottom[0].PriceChangeUsd, 0.001)
+	require.InDelta(t, -10, *bottom[1].PriceChangeUsd, 0.001)
+
+	top := priceChangesByUsdFromListings(listings, false, 2)
+	require.Len(t, top, 2)
+	require.InDelta(t, 30, *top[0].PriceChangeUsd, 0.001)
+	require.InDelta(t, 10, *top[1].PriceChangeUsd, 0.001)
+}
+
+func TestTopBottomPriceChangesByUsd(t *testing.T) {
+	usd := func(value float64) *float64 {
+		return &value
+	}
+	percent := func(value int) *int {
+		return &value
+	}
+	listing := func(nameKey string, changeUsd float64, changePercent int) PriceChangeListing {
+		return PriceChangeListing{
+			NameKey: nameKey,
+			Listing: cardkingdom.Listing{
+				CardName:           nameKey,
+				PriceChangeUsd:     usd(changeUsd),
+				PriceChangePercent: percent(changePercent),
+			},
+		}
+	}
+
+	// USD ranking should prefer the larger absolute dollar move even when percent is lower.
+	listings := []PriceChangeListing{
+		listing("small-base-big-percent", 0.50, 50),
+		listing("big-base-small-percent", 10.00, 10),
+		listing("small-drop", -0.25, -25),
+		listing("big-drop", -8.00, -8),
+	}
+
+	rankings := topBottomPriceChangesByUsd(listings, 1)
+	require.Len(t, rankings.Top, 1)
+	require.Equal(t, "big-base-small-percent", rankings.Top[0].NameKey)
+	require.InDelta(t, 10.00, *rankings.Top[0].PriceChangeUsd, 0.001)
+
+	require.Len(t, rankings.Bottom, 1)
+	require.Equal(t, "big-drop", rankings.Bottom[0].NameKey)
+	require.InDelta(t, -8.00, *rankings.Bottom[0].PriceChangeUsd, 0.001)
 }
 
 func TestPriceChangeListingFromRecord(t *testing.T) {
@@ -154,6 +222,25 @@ func TestPriceChangeListingFromRecord(t *testing.T) {
 	require.False(t, ok)
 
 	_, ok = priceChangeListingFromRecord(dynamoRecord{NameKey: "new card", CardName: "New Card"})
+	require.False(t, ok)
+}
+
+func TestPriceChangeListingFromRecordByUsd(t *testing.T) {
+	change := 0.15
+	listing, ok := priceChangeListingFromRecordByUsd(dynamoRecord{
+		NameKey:        "lightning bolt",
+		CardName:       "Lightning Bolt",
+		PriceUsd:       1.49,
+		PriceChangeUsd: &change,
+	})
+	require.True(t, ok)
+	require.Equal(t, "lightning bolt", listing.NameKey)
+	require.InDelta(t, 0.15, *listing.PriceChangeUsd, 0.001)
+
+	_, ok = priceChangeListingFromRecordByUsd(dynamoRecord{NameKey: syncMetadataKey})
+	require.False(t, ok)
+
+	_, ok = priceChangeListingFromRecordByUsd(dynamoRecord{NameKey: "new card", CardName: "New Card"})
 	require.False(t, ok)
 }
 

--- a/api/store/ckprices/price_change_test.go
+++ b/api/store/ckprices/price_change_test.go
@@ -39,6 +39,36 @@ func TestComputePriceChangePercent(t *testing.T) {
 	})
 }
 
+func TestComputePriceChangeUsd(t *testing.T) {
+	t.Run("increase", func(t *testing.T) {
+		change := computePriceChangeUsd(10, 12)
+		require.NotNil(t, change)
+		require.InDelta(t, 2, *change, 0.001)
+	})
+
+	t.Run("decrease", func(t *testing.T) {
+		change := computePriceChangeUsd(10, 8)
+		require.NotNil(t, change)
+		require.InDelta(t, -2, *change, 0.001)
+	})
+
+	t.Run("rounds to cents", func(t *testing.T) {
+		change := computePriceChangeUsd(1.00, 1.10)
+		require.NotNil(t, change)
+		require.InDelta(t, 0.10, *change, 0.001)
+	})
+
+	t.Run("no change", func(t *testing.T) {
+		change := computePriceChangeUsd(4.99, 4.99)
+		require.NotNil(t, change)
+		require.InDelta(t, 0, *change, 0.001)
+	})
+
+	t.Run("missing previous price", func(t *testing.T) {
+		require.Nil(t, computePriceChangeUsd(0, 4.99))
+	})
+}
+
 func TestPriceChangesByPercentFromListings(t *testing.T) {
 	percent := func(value int) *int {
 		return &value
@@ -141,12 +171,17 @@ func TestListingsWithPriceChange(t *testing.T) {
 
 	require.NotNil(t, enriched["lightning bolt"].PriceChangePercent)
 	require.Equal(t, 10, *enriched["lightning bolt"].PriceChangePercent)
+	require.NotNil(t, enriched["lightning bolt"].PriceChangeUsd)
+	require.InDelta(t, 0.10, *enriched["lightning bolt"].PriceChangeUsd, 0.001)
 	require.NotNil(t, enriched["lightning bolt"].PreviousPriceUsd)
 	require.Equal(t, 1.00, *enriched["lightning bolt"].PreviousPriceUsd)
 	require.NotNil(t, enriched["counterspell"].PriceChangePercent)
 	require.Equal(t, -10, *enriched["counterspell"].PriceChangePercent)
+	require.NotNil(t, enriched["counterspell"].PriceChangeUsd)
+	require.InDelta(t, -0.20, *enriched["counterspell"].PriceChangeUsd, 0.001)
 	require.NotNil(t, enriched["counterspell"].PreviousPriceUsd)
 	require.Equal(t, 2.00, *enriched["counterspell"].PreviousPriceUsd)
 	require.Nil(t, enriched["new card"].PriceChangePercent)
+	require.Nil(t, enriched["new card"].PriceChangeUsd)
 	require.Nil(t, enriched["new card"].PreviousPriceUsd)
 }

--- a/api/store/ckprices/store.go
+++ b/api/store/ckprices/store.go
@@ -8,7 +8,7 @@ import (
 
 const PriceChangeRankingLimit = 20
 
-// PriceChangeListing ranks a Card Kingdom listing by its latest price change percent.
+// PriceChangeListing ranks a Card Kingdom listing by its latest price change.
 type PriceChangeListing struct {
 	NameKey string `json:"nameKey"`
 	cardkingdom.Listing
@@ -27,6 +27,9 @@ type Store interface {
 	// GetPriceChangesByPercent returns listings ordered by priceChangePercent.
 	// ascending=true is equivalent to SQL ORDER BY priceChangePercent ASC LIMIT n.
 	GetPriceChangesByPercent(ctx context.Context, ascending bool, limit int) ([]PriceChangeListing, error)
+	// GetPriceChangesByUsd returns listings ordered by priceChangeUsd.
+	// ascending=true is equivalent to SQL ORDER BY priceChangeUsd ASC LIMIT n.
+	GetPriceChangesByUsd(ctx context.Context, ascending bool, limit int) ([]PriceChangeListing, error)
 	GetTopBottomPriceChanges(ctx context.Context) (*TopBottomPriceChanges, error)
 	PutAll(ctx context.Context, listings map[string]cardkingdom.Listing) (syncedAt string, err error)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Records actual USD price differences on CK price refresh and uses them for the daily top/bottom 20 export.

Each listing with a prior price now stores:
- `previousPriceUsd`
- `priceChangePercent` (still recorded)
- `priceChangeUsd` (current minus previous, rounded to cents)

The CK refresh job now ranks and exports top/bottom 20 by `priceChangeUsd` instead of `priceChangePercent`.

## Changes

- `cardkingdom.Listing` and DynamoDB records persist `priceChangeUsd`
- `GetPriceChangesByUsd` queries the `priceChangeUsd-index` GSI (with scan fallback if the index is missing)
- `GetTopBottomPriceChanges` now uses USD ranking
- CK refresh handler already calls `GetTopBottomPriceChanges`, so the S3 export picks up USD rankings automatically

## AWS prerequisite

Create the `priceChangeUsd-index` GSI on the CK DynamoDB table before deploying:

- **Partition key:** `priceChangeIndexPK` (String)
- **Sort key:** `priceChangeUsd` (Number)
- **Index name:** `priceChangeUsd-index`

Without the GSI, the store falls back to a full table scan + in-memory sort.

## Testing

- `go test -mod=vendor ./store/ckprices/... ./handler/... ./controller/ckprice/... ./store/ckpricereport/...` — pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50fc9be5-04ba-41d3-9b4b-b533a5eb2014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50fc9be5-04ba-41d3-9b4b-b533a5eb2014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

