### PR TITLE
Show CK price change pills in USD after refresh export

### DIFF
--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -9,7 +9,7 @@ import {
 } from "../constants";
 import useCKPriceChanges from "../hooks/useCKPriceChanges";
 import useMediaQuery from "../hooks/useMediaQuery";
-import { formatPriceChangePercent } from "../utils/ckPriceChanges";
+import { formatPriceChangeUsd } from "../utils/ckPriceChanges";
 import { buildPopularSearchUrl, buildSearchQueryUrl } from "../utils/searchUrl";
 
 const LOADING_SKELETON_KEYS = [
@@ -165,7 +165,7 @@ function CKPriceChangeContent({
     <div className="popular-searches-pills">
       {items.map((item) => {
         const isActive = isMatchingTrendingSearch(item.cardName, searchQuery);
-        const changeLabel = formatPriceChangePercent(item.priceChangePercent, {
+        const changeLabel = formatPriceChangeUsd(item.priceChangeUsd, {
           absolute: !isRiser,
         });
         const ariaLabel = changeLabel

--- a/frontend/src/utils/ckPriceChanges.js
+++ b/frontend/src/utils/ckPriceChanges.js
@@ -1,11 +1,22 @@
-export function formatPriceChangePercent(percent, { absolute = false } = {}) {
-  if (typeof percent !== "number" || !Number.isFinite(percent)) {
+export function formatPriceChangeUsd(usd, { absolute = false } = {}) {
+  if (typeof usd !== "number" || !Number.isFinite(usd)) {
     return null;
   }
 
-  const rounded = Math.round(percent * 10) / 10;
-  const value = absolute ? Math.abs(rounded) : rounded;
-  return Number.isInteger(value) ? `${value}%` : `${value.toFixed(1)}%`;
+  const value = absolute ? Math.abs(usd) : usd;
+  const rounded = Math.round(value * 100) / 100;
+  const amount = Math.abs(rounded).toFixed(2);
+
+  if (absolute) {
+    return `$${amount}`;
+  }
+  if (rounded > 0) {
+    return `+$${amount}`;
+  }
+  if (rounded < 0) {
+    return `-$${amount}`;
+  }
+  return `$${amount}`;
 }
 
 function parseCKPriceChangeListings(listings, limit = 20) {
@@ -16,9 +27,10 @@ function parseCKPriceChangeListings(listings, limit = 20) {
   return listings
     .map((item) => ({
       cardName: typeof item?.cardName === "string" ? item.cardName.trim() : "",
-      priceChangePercent:
-        typeof item?.priceChangePercent === "number"
-          ? item.priceChangePercent
+      priceChangeUsd:
+        typeof item?.priceChangeUsd === "number" &&
+        Number.isFinite(item.priceChangeUsd)
+          ? item.priceChangeUsd
           : null,
     }))
     .filter((item) => item.cardName.length > 0)

--- a/frontend/src/utils/ckPriceChanges.test.js
+++ b/frontend/src/utils/ckPriceChanges.test.js
@@ -1,26 +1,27 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
-  formatPriceChangePercent,
+  formatPriceChangeUsd,
   parseCKPriceDrops,
   parseCKPriceIncreases,
 } from "./ckPriceChanges.js";
 
-test("formatPriceChangePercent formats whole and fractional percentages", () => {
-  assert.equal(formatPriceChangePercent(15), "15%");
-  assert.equal(formatPriceChangePercent(12.34), "12.3%");
-  assert.equal(formatPriceChangePercent(-10), "-10%");
-  assert.equal(formatPriceChangePercent(-10, { absolute: true }), "10%");
-  assert.equal(formatPriceChangePercent(null), null);
-  assert.equal(formatPriceChangePercent(Number.NaN), null);
+test("formatPriceChangeUsd formats signed and absolute dollar amounts", () => {
+  assert.equal(formatPriceChangeUsd(0.5), "+$0.50");
+  assert.equal(formatPriceChangeUsd(10), "+$10.00");
+  assert.equal(formatPriceChangeUsd(-0.25), "-$0.25");
+  assert.equal(formatPriceChangeUsd(-10, { absolute: true }), "$10.00");
+  assert.equal(formatPriceChangeUsd(0), "$0.00");
+  assert.equal(formatPriceChangeUsd(null), null);
+  assert.equal(formatPriceChangeUsd(Number.NaN), null);
 });
 
-test("parseCKPriceIncreases returns top card names up to the display limit", () => {
+test("parseCKPriceIncreases returns top card names with USD changes when present", () => {
   const payload = {
     top: [
-      { cardName: "Lightning Bolt", priceChangePercent: 15 },
-      { cardName: " Counterspell ", priceChangePercent: 10 },
-      { cardName: "", priceChangePercent: 5 },
+      { cardName: "Lightning Bolt", priceChangeUsd: 0.5 },
+      { cardName: " Counterspell ", priceChangeUsd: 0.1 },
+      { cardName: "", priceChangeUsd: 0.05 },
       { cardName: "Sol Ring", priceChangePercent: 5 },
     ],
   };
@@ -29,9 +30,11 @@ test("parseCKPriceIncreases returns top card names up to the display limit", () 
 
   assert.equal(increases.length, 3);
   assert.equal(increases[0].cardName, "Lightning Bolt");
-  assert.equal(increases[0].priceChangePercent, 15);
+  assert.equal(increases[0].priceChangeUsd, 0.5);
   assert.equal(increases[1].cardName, "Counterspell");
-  assert.equal(increases[1].priceChangePercent, 10);
+  assert.equal(increases[1].priceChangeUsd, 0.1);
+  assert.equal(increases[2].cardName, "Sol Ring");
+  assert.equal(increases[2].priceChangeUsd, null);
 });
 
 test("parseCKPriceIncreases returns an empty list for invalid payloads", () => {
@@ -40,12 +43,12 @@ test("parseCKPriceIncreases returns an empty list for invalid payloads", () => {
   assert.deepEqual(parseCKPriceIncreases({ top: "invalid" }), []);
 });
 
-test("parseCKPriceDrops returns bottom card names up to the display limit", () => {
+test("parseCKPriceDrops returns bottom card names with USD changes when present", () => {
   const payload = {
     bottom: [
-      { cardName: "Counterspell", priceChangePercent: -15 },
-      { cardName: " Sol Ring ", priceChangePercent: -10 },
-      { cardName: "", priceChangePercent: -5 },
+      { cardName: "Counterspell", priceChangeUsd: -1.5 },
+      { cardName: " Sol Ring ", priceChangeUsd: -0.1 },
+      { cardName: "", priceChangeUsd: -0.05 },
       { cardName: "Lightning Bolt", priceChangePercent: -5 },
     ],
   };
@@ -54,9 +57,11 @@ test("parseCKPriceDrops returns bottom card names up to the display limit", () =
 
   assert.equal(drops.length, 3);
   assert.equal(drops[0].cardName, "Counterspell");
-  assert.equal(drops[0].priceChangePercent, -15);
+  assert.equal(drops[0].priceChangeUsd, -1.5);
   assert.equal(drops[1].cardName, "Sol Ring");
-  assert.equal(drops[1].priceChangePercent, -10);
+  assert.equal(drops[1].priceChangeUsd, -0.1);
+  assert.equal(drops[2].cardName, "Lightning Bolt");
+  assert.equal(drops[2].priceChangeUsd, null);
 });
 
 test("parseCKPriceDrops returns an empty list for invalid payloads", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the Top $ risers / Top $ drops pills to display dollar amounts from `priceChangeUsd` instead of percentages.

The change badge only appears when `priceChangeUsd` is present in `latest.json`. Until the next scheduled CK refresh job writes USD-ranked data, pills show card names without a change label — there is no percent fallback.

## Behaviour

| Timing | What users see |
|--------|----------------|
| Before next CK refresh | Card names only (no change badge) |
| After next CK refresh | e.g. `+$0.50` on risers, `$1.25` on drops |

## Changes

- `formatPriceChangeUsd` replaces percent formatting
- Parser reads `priceChangeUsd` from the S3 export
- `TopSearchKeywords` renders dollar labels when available

## Testing

- `node --test src/utils/ckPriceChanges.test.js` — pass
- `biome check` on changed files — pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50fc9be5-04ba-41d3-9b4b-b533a5eb2014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50fc9be5-04ba-41d3-9b4b-b533a5eb2014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

