### PR TITLE
Show CK price change pills in USD after refresh export

### DIFF
--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -165,9 +165,7 @@ function CKPriceChangeContent({
     <div className="popular-searches-pills">
       {items.map((item) => {
         const isActive = isMatchingTrendingSearch(item.cardName, searchQuery);
-        const changeLabel = formatPriceChangeUsd(item.priceChangeUsd, {
-          absolute: !isRiser,
-        });
+        const changeLabel = formatPriceChangeUsd(item.priceChangeUsd);
         const ariaLabel = changeLabel
           ? `Search for ${item.cardName}, ${directionWord} ${changeLabel}`
           : `Search for ${item.cardName}`;

--- a/frontend/src/utils/ckPriceChanges.js
+++ b/frontend/src/utils/ckPriceChanges.js
@@ -1,15 +1,11 @@
-export function formatPriceChangeUsd(usd, { absolute = false } = {}) {
+export function formatPriceChangeUsd(usd) {
   if (typeof usd !== "number" || !Number.isFinite(usd)) {
     return null;
   }
 
-  const value = absolute ? Math.abs(usd) : usd;
-  const rounded = Math.round(value * 100) / 100;
+  const rounded = Math.round(usd * 100) / 100;
   const amount = Math.abs(rounded).toFixed(2);
 
-  if (absolute) {
-    return `$${amount}`;
-  }
   if (rounded > 0) {
     return `+$${amount}`;
   }

--- a/frontend/src/utils/ckPriceChanges.test.js
+++ b/frontend/src/utils/ckPriceChanges.test.js
@@ -6,11 +6,11 @@ import {
   parseCKPriceIncreases,
 } from "./ckPriceChanges.js";
 
-test("formatPriceChangeUsd formats signed and absolute dollar amounts", () => {
+test("formatPriceChangeUsd formats signed dollar amounts", () => {
   assert.equal(formatPriceChangeUsd(0.5), "+$0.50");
   assert.equal(formatPriceChangeUsd(10), "+$10.00");
   assert.equal(formatPriceChangeUsd(-0.25), "-$0.25");
-  assert.equal(formatPriceChangeUsd(-10, { absolute: true }), "$10.00");
+  assert.equal(formatPriceChangeUsd(-10), "-$10.00");
   assert.equal(formatPriceChangeUsd(0), "$0.00");
   assert.equal(formatPriceChangeUsd(null), null);
   assert.equal(formatPriceChangeUsd(Number.NaN), null);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the Top $ risers / Top $ drops pills to display dollar amounts from `priceChangeUsd` instead of percentages.

The change badge only appears when `priceChangeUsd` is present in `latest.json`. Until the next scheduled CK refresh job writes USD-ranked data, pills show card names without a change label — there is no percent fallback.

## Display format

- **Risers:** `+$0.50`
- **Drops:** `-$1.25` (negative sign shown)

## Behaviour

| Timing | What users see |
|--------|----------------|
| Before next CK refresh | Card names only (no change badge) |
| After next CK refresh | Signed dollar amounts on each pill |

## Testing

- `node --test src/utils/ckPriceChanges.test.js` — pass
- `biome check` on changed files — pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50fc9be5-04ba-41d3-9b4b-b533a5eb2014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50fc9be5-04ba-41d3-9b4b-b533a5eb2014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

