### PR TITLE
Document DynamoDB Query IAM for CK priceChangeUsd-index

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,27 @@ Example report shape:
 
 #### IAM permissions for `mtg-price-ck-refresh`
 
-The shared `lambda-mtg` role must allow `s3:PutObject` on the export prefix (`arn:aws:s3:::gishathfetch.com/analytics/ck-price-changes/*`).
+The shared `lambda-mtg` role must allow:
+
+- `s3:PutObject` on the export prefix (`arn:aws:s3:::gishathfetch.com/analytics/ck-price-changes/*`)
+- `dynamodb:Query` on both CK price-change GSIs:
+  - `arn:aws:dynamodb:ap-southeast-1:206363131200:table/gishathfetch-ck-prices/index/priceChangePercent-index`
+  - `arn:aws:dynamodb:ap-southeast-1:206363131200:table/gishathfetch-ck-prices/index/priceChangeUsd-index`
+
+The daily export ranks top/bottom price changes by USD (`priceChangeUsd-index`). If that GSI is missing from the role policy, the Lambda fails after the DynamoDB refresh with `AccessDeniedException` on `dynamodb:Query`.
+
+Example inline policy statement to add (merge with existing DynamoDB permissions on the role):
+
+```json
+{
+  "Effect": "Allow",
+  "Action": "dynamodb:Query",
+  "Resource": [
+    "arn:aws:dynamodb:ap-southeast-1:206363131200:table/gishathfetch-ck-prices/index/priceChangePercent-index",
+    "arn:aws:dynamodb:ap-southeast-1:206363131200:table/gishathfetch-ck-prices/index/priceChangeUsd-index"
+  ]
+}
+```
 
 ## 🔎 Search flow
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents the missing IAM permission behind `mtg-price-ck-refresh` failures after #268 switched daily CK price-change rankings to the `priceChangeUsd-index` GSI.

## Problem

The Lambda role `lambda-mtg` can refresh CK prices in DynamoDB, but the post-refresh export calls `GetTopBottomPriceChanges`, which queries:

`arn:aws:dynamodb:ap-southeast-1:206363131200:table/gishathfetch-ck-prices/index/priceChangeUsd-index`

Without `dynamodb:Query` on that index ARN, the job fails with:

```
AccessDeniedException: User: arn:aws:sts::206363131200:assumed-role/lambda-mtg/mtg-price-ck-refresh is not authorized to perform: dynamodb:Query on resource: .../index/priceChangeUsd-index
```

## Required AWS fix (manual)

Add `dynamodb:Query` on both CK price-change GSIs to the `lambda-mtg` role policy (see README for the exact statement).

## Repo change

- Expand the `mtg-price-ck-refresh` IAM section in README with both GSI ARNs and an example policy statement.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-460b73d7-e1fe-46ad-be14-1201d816ca73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-460b73d7-e1fe-46ad-be14-1201d816ca73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

