### PR TITLE
Hide USD price change label when value is zero

### DIFF
--- a/frontend/src/utils/ckPriceChanges.js
+++ b/frontend/src/utils/ckPriceChanges.js
@@ -6,13 +6,13 @@ export function formatPriceChangeUsd(usd) {
   const rounded = Math.round(usd * 100) / 100;
   const amount = Math.abs(rounded).toFixed(2);
 
+  if (rounded === 0) {
+    return null;
+  }
   if (rounded > 0) {
     return `+$${amount}`;
   }
-  if (rounded < 0) {
-    return `-$${amount}`;
-  }
-  return `$${amount}`;
+  return `-$${amount}`;
 }
 
 function parseCKPriceChangeListings(listings, limit = 20) {

--- a/frontend/src/utils/ckPriceChanges.test.js
+++ b/frontend/src/utils/ckPriceChanges.test.js
@@ -11,7 +11,7 @@ test("formatPriceChangeUsd formats signed dollar amounts", () => {
   assert.equal(formatPriceChangeUsd(10), "+$10.00");
   assert.equal(formatPriceChangeUsd(-0.25), "-$0.25");
   assert.equal(formatPriceChangeUsd(-10), "-$10.00");
-  assert.equal(formatPriceChangeUsd(0), "$0.00");
+  assert.equal(formatPriceChangeUsd(0), null);
   assert.equal(formatPriceChangeUsd(null), null);
   assert.equal(formatPriceChangeUsd(Number.NaN), null);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hides the USD price change badge on popular-search pills when the change is exactly $0.00.

`formatPriceChangeUsd` now returns `null` for a zero change instead of `"$0.00"`. `TopSearchKeywords` already omits the change pill when the formatter returns `null`, so cards with no dollar movement show only the card name.

## Test plan

- [x] `node --test src/utils/ckPriceChanges.test.js`
- [ ] `make test` (failed on unrelated transient `gateway/agora` live search timeout)

## Screenshots

### Desktop

![Trending risers section on desktop](https://cursor.com/artifacts/c/art-5bf37ea6-cf92-4a1e-a281-e31f909c9fc1)

### Mobile

![Trending risers section on mobile](https://cursor.com/artifacts/c/art-ad02211e-4930-4ec3-8a6e-8fbfd4cf9495)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5cf00819-3298-42ee-b317-74a893119811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5cf00819-3298-42ee-b317-74a893119811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

