### PR TITLE
Hide CK price change controls when all USD changes are zero

### DIFF
--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -9,7 +9,10 @@ import {
 } from "../constants";
 import useCKPriceChanges from "../hooks/useCKPriceChanges";
 import useMediaQuery from "../hooks/useMediaQuery";
-import { formatPriceChangeUsd } from "../utils/ckPriceChanges";
+import {
+  formatPriceChangeUsd,
+  hasNonZeroUsdPriceChanges,
+} from "../utils/ckPriceChanges";
 import { buildPopularSearchUrl, buildSearchQueryUrl } from "../utils/searchUrl";
 
 const LOADING_SKELETON_KEYS = [
@@ -260,6 +263,23 @@ export default function TopSearchKeywords({
     }
   }, [collapseOnSearch]);
 
+  useEffect(() => {
+    if (!hasLoadedPriceChanges && !isLoadingPriceChanges) {
+      void loadPriceChanges();
+    }
+  }, [hasLoadedPriceChanges, isLoadingPriceChanges, loadPriceChanges]);
+
+  const showPriceChangeControls =
+    hasLoadedPriceChanges &&
+    !priceChangesError &&
+    hasNonZeroUsdPriceChanges(priceIncreases, priceDrops);
+
+  useEffect(() => {
+    if (!showPriceChangeControls && priceChangeView) {
+      setPriceChangeView(null);
+    }
+  }, [showPriceChangeControls, priceChangeView]);
+
   const handlePeriodChange = (nextPeriod) => {
     if (!priceChangeView && nextPeriod === period) {
       return;
@@ -296,7 +316,7 @@ export default function TopSearchKeywords({
   };
 
   const handlePriceChangeSelect = async (view) => {
-    if (priceChangeView === view) {
+    if (!showPriceChangeControls || priceChangeView === view) {
       return;
     }
 
@@ -331,36 +351,40 @@ export default function TopSearchKeywords({
               disabled={isLoading}
               priceChangeView={priceChangeView}
             />
-            <button
-              type="button"
-              className={`btn btn-sm popular-search-period-btn${
-                priceChangeView === "risers" ? " is-active" : ""
-              }`}
-              aria-pressed={priceChangeView === "risers"}
-              aria-controls={contentPanelId}
-              aria-label="Top dollar risers in 24 hours"
-              disabled={isLoadingPriceChanges}
-              onClick={() => handlePriceChangeSelect("risers")}
-            >
-              Top $ risers (24h)
-            </button>
-            <button
-              type="button"
-              className={`btn btn-sm popular-search-period-btn${
-                priceChangeView === "drops" ? " is-active" : ""
-              }`}
-              aria-pressed={priceChangeView === "drops"}
-              aria-controls={contentPanelId}
-              aria-label="Top dollar drops in 24 hours"
-              disabled={isLoadingPriceChanges}
-              onClick={() => handlePriceChangeSelect("drops")}
-            >
-              Top $ drops (24 Hrs)
-            </button>
+            {showPriceChangeControls ? (
+              <>
+                <button
+                  type="button"
+                  className={`btn btn-sm popular-search-period-btn${
+                    priceChangeView === "risers" ? " is-active" : ""
+                  }`}
+                  aria-pressed={priceChangeView === "risers"}
+                  aria-controls={contentPanelId}
+                  aria-label="Top dollar risers in 24 hours"
+                  disabled={isLoadingPriceChanges}
+                  onClick={() => handlePriceChangeSelect("risers")}
+                >
+                  Top $ risers (24h)
+                </button>
+                <button
+                  type="button"
+                  className={`btn btn-sm popular-search-period-btn${
+                    priceChangeView === "drops" ? " is-active" : ""
+                  }`}
+                  aria-pressed={priceChangeView === "drops"}
+                  aria-controls={contentPanelId}
+                  aria-label="Top dollar drops in 24 hours"
+                  disabled={isLoadingPriceChanges}
+                  onClick={() => handlePriceChangeSelect("drops")}
+                >
+                  Top $ drops (24 Hrs)
+                </button>
+              </>
+            ) : null}
           </div>
 
           <div id={contentPanelId}>
-            {priceChangeView === "risers" ? (
+            {showPriceChangeControls && priceChangeView === "risers" ? (
               <CKPriceChangeContent
                 variant="riser"
                 isLoading={isLoadingPriceChanges}
@@ -369,7 +393,7 @@ export default function TopSearchKeywords({
                 searchQuery={searchQuery}
                 emptyMessage="No CK price increases available."
               />
-            ) : priceChangeView === "drops" ? (
+            ) : showPriceChangeControls && priceChangeView === "drops" ? (
               <CKPriceChangeContent
                 variant="drop"
                 isLoading={isLoadingPriceChanges}

--- a/frontend/src/utils/ckPriceChanges.js
+++ b/frontend/src/utils/ckPriceChanges.js
@@ -40,3 +40,12 @@ export function parseCKPriceIncreases(payload, limit = 20) {
 export function parseCKPriceDrops(payload, limit = 20) {
   return parseCKPriceChangeListings(payload?.bottom, limit);
 }
+
+export function hasNonZeroUsdPriceChanges(increases, drops) {
+  return [...increases, ...drops].some(
+    (item) =>
+      typeof item?.priceChangeUsd === "number" &&
+      Number.isFinite(item.priceChangeUsd) &&
+      item.priceChangeUsd !== 0,
+  );
+}

--- a/frontend/src/utils/ckPriceChanges.test.js
+++ b/frontend/src/utils/ckPriceChanges.test.js
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   formatPriceChangeUsd,
+  hasNonZeroUsdPriceChanges,
   parseCKPriceDrops,
   parseCKPriceIncreases,
 } from "./ckPriceChanges.js";
@@ -68,4 +69,39 @@ test("parseCKPriceDrops returns an empty list for invalid payloads", () => {
   assert.deepEqual(parseCKPriceDrops(null), []);
   assert.deepEqual(parseCKPriceDrops({}), []);
   assert.deepEqual(parseCKPriceDrops({ bottom: "invalid" }), []);
+});
+
+test("hasNonZeroUsdPriceChanges is false when all changes are zero, missing, or absent", () => {
+  assert.equal(hasNonZeroUsdPriceChanges([], []), false);
+  assert.equal(
+    hasNonZeroUsdPriceChanges(
+      [{ cardName: "Bolt", priceChangeUsd: 0 }],
+      [{ cardName: "Ring", priceChangeUsd: 0 }],
+    ),
+    false,
+  );
+  assert.equal(
+    hasNonZeroUsdPriceChanges(
+      [{ cardName: "Bolt", priceChangeUsd: null }],
+      [{ cardName: "Ring", priceChangeUsd: null }],
+    ),
+    false,
+  );
+});
+
+test("hasNonZeroUsdPriceChanges is true when any listing has a non-zero USD change", () => {
+  assert.equal(
+    hasNonZeroUsdPriceChanges(
+      [{ cardName: "Bolt", priceChangeUsd: 0.5 }],
+      [{ cardName: "Ring", priceChangeUsd: 0 }],
+    ),
+    true,
+  );
+  assert.equal(
+    hasNonZeroUsdPriceChanges(
+      [{ cardName: "Bolt", priceChangeUsd: 0 }],
+      [{ cardName: "Ring", priceChangeUsd: -0.25 }],
+    ),
+    true,
+  );
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hides the **Top $ risers (24h)** and **Top $ drops (24 Hrs)** buttons (and their content) when CK price-change data has no non-zero USD movements.

## Changes

- Added `hasNonZeroUsdPriceChanges()` in `ckPriceChanges.js` to detect whether any riser/drop listing has a finite, non-zero `priceChangeUsd`.
- Load CK price changes when the trending section mounts so visibility can be decided without requiring a button click first.
- Render risers/drops controls only after data loads successfully and at least one non-zero USD change exists.
- Reset the active price-change view back to trending keywords when controls are hidden.

## Testing

- `node --test frontend/src/utils/ckPriceChanges.test.js`
- `make test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2ee4161-0ac9-4e20-a1a6-ef5174e46701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2ee4161-0ac9-4e20-a1a6-ef5174e46701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

