### PR TITLE
Fix BinderPOS silent misses when decklist API returns empty

### DIFF
--- a/api/gateway/binderpos/storefront_fallback.go
+++ b/api/gateway/binderpos/storefront_fallback.go
@@ -12,9 +12,11 @@ type fallbackAttempt struct {
 }
 
 // runFallbackAttempts runs the supplied attempts in order, returning the first
-// result that succeeds (a nil error, even with zero cards). Each attempt's error
-// is annotated with its position and strategy name so the final error reflects
-// the last attempt tried.
+// result that returns cards. An attempt that finishes without error but finds no
+// cards is treated as inconclusive and the next strategy is tried; only the
+// final attempt may return an empty result. Each attempt's error is annotated
+// with its position and strategy name so the final error reflects the last
+// attempt tried.
 func runFallbackAttempts(attempts ...fallbackAttempt) ([]gateway.Card, error) {
 	var (
 		cards []gateway.Card
@@ -24,7 +26,7 @@ func runFallbackAttempts(attempts ...fallbackAttempt) ([]gateway.Card, error) {
 	for idx, attempt := range attempts {
 		cards, err = attempt.fn()
 		err = annotateAttemptError(idx+1, attempt.strategy, err)
-		if err == nil {
+		if err == nil && (len(cards) > 0 || idx == len(attempts)-1) {
 			return cards, nil
 		}
 	}

--- a/api/gateway/binderpos/storefront_fallback_test.go
+++ b/api/gateway/binderpos/storefront_fallback_test.go
@@ -44,7 +44,7 @@ func TestRunFallbackAttempts(t *testing.T) {
 		}
 	})
 
-	t.Run("treats an empty but error-free attempt as success", func(t *testing.T) {
+	t.Run("continues after an empty but error-free attempt", func(t *testing.T) {
 		cards, err := runFallbackAttempts(
 			fallbackAttempt{strategy: "decklist-dedicated", fn: func() ([]gateway.Card, error) {
 				return nil, errors.New("decklist dedicated failed")
@@ -53,12 +53,28 @@ func TestRunFallbackAttempts(t *testing.T) {
 				return []gateway.Card{}, nil
 			}},
 			fallbackAttempt{strategy: "scrap-direct", fn: func() ([]gateway.Card, error) {
-				t.Fatal("later attempt should not run after an empty success")
-				return nil, nil
+				return []gateway.Card{{Name: "scrap-direct"}}, nil
 			}},
 		)
 		if err != nil {
-			t.Fatalf("expected nil error when an attempt succeeds with empty result, got %v", err)
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if len(cards) != 1 || cards[0].Name != "scrap-direct" {
+			t.Fatalf("expected scrap-direct card, got %+v", cards)
+		}
+	})
+
+	t.Run("returns empty only after the final attempt succeeds without cards", func(t *testing.T) {
+		cards, err := runFallbackAttempts(
+			fallbackAttempt{strategy: "decklist-dedicated", fn: func() ([]gateway.Card, error) {
+				return []gateway.Card{}, nil
+			}},
+			fallbackAttempt{strategy: "scrap-direct", fn: func() ([]gateway.Card, error) {
+				return []gateway.Card{}, nil
+			}},
+		)
+		if err != nil {
+			t.Fatalf("expected nil error when the final attempt is empty, got %v", err)
 		}
 		if len(cards) != 0 {
 			t.Fatalf("expected zero cards, got %+v", cards)

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -56,7 +56,7 @@ Some tests in `api/gateway/binderpos/*_test.go` hit real stores and proxies. The
 | **api-dedicated** proxy selection (storefront HTTP client) | Round-robin | `nextBinderposStorefrontProxyURL` + `binderposDedicatedProxySeq` in `api/gateway/binderpos/storefront_client.go` | When `UseLeasedDedicatedProxy` is **false** (default in `api/pkg/config/config.go`), each storefront API call cycles **proxy₁ → … → proxyₙ** then repeats, using all URLs from `GetDedicatedProxyURLs()`. When `UseLeasedDedicatedProxy` is **true**, selection is unchanged: `LeaseDedicatedProxyURL` from the dedicated pool. |
 | **api-dynamic** proxy selection (storefront HTTP client) | Fixed env URL | `searchByStorefrontAPIDynamic` in `api/gateway/binderpos/storefront_client.go` | Uses `DYNAMIC_PROXY` as the authenticated proxy URL for the final BinderPOS API fallback attempt. |
 | Colly for BinderPOS scrapes | 5s | `SetRequestTimeout(binderposAttemptTimeout)` in `api/gateway/binderpos/scrap.go` | Same as `config.SearchAttemptTimeout`. |
-| “Retries” | N/A (sequential fallbacks) | `searchWithFallback` | Stops on first **success**; returns last error if all attempts fail. This is **not** exponential backoff retry of a single request. |
+| “Retries” | N/A (sequential fallbacks) | `runFallbackAttempts` in `storefront_fallback.go` | Stops on the first attempt that returns **cards**; an error-free attempt with **zero cards** is treated as inconclusive and the next strategy runs. Only the final attempt may return an empty result. Returns the last annotated error if all attempts fail. This is **not** exponential backoff retry of a single request. |
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Searching for cards like **Delney, Streetwise Lookout** at **Mana Pro** could return different results on each try, with no store error shown in the UI.

This was not a frontend error-reporting bug. Store errors are only surfaced when a gateway returns a non-nil `error`. Mana Pro (BinderPOS) was often finishing "successfully" with **zero cards**, so the API returned `errors: []` even though the store had stock.

## Root cause

BinderPOS runs up to six strategies (decklist API + storefront scrape, each via dedicated/direct/dynamic). `runFallbackAttempts` treated any **error-free** attempt as final success — including attempts that returned **zero cards**.

For Delney at Mana Pro:

- `decklist-dedicated` / `decklist-direct` often return HTTP 200 with an empty product list (no error)
- `scrap-direct` finds the card in stock

When decklist led the strategy order (~50% of searches), the empty decklist response stopped the chain before scrape ran. When scrape led, results appeared. That produced intermittent missing Mana Pro rows with no error banner.

## Fix

Continue the BinderPOS fallback chain when an attempt returns zero cards without error. Only the **final** attempt may return an empty result. Hard failures (429, timeouts, etc.) still advance as before.

After the change, local Mana Pro searches for Delney returned cards on 8/8 runs (previously mixed 0/16).

## Testing

- `go test ./gateway/binderpos/...` — updated fallback unit tests pass
- `go test ./gateway/manapro/...` — live search passes
- `go test ./controller/...` — passes
- Full `make test` — Agora/Dueller's Point live probes failed intermittently due to upstream timeouts/500s (unrelated to this change)

## Notes for reviewers

- Genuinely out-of-stock cards still return empty with no store error after all strategies exhaust (expected).
- Worst-case BinderPOS latency may increase slightly when early strategies return empty, but correctness is prioritized per project guidelines.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d23310f-97bf-41ee-b69c-93c5bd03a306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d23310f-97bf-41ee-b69c-93c5bd03a306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

