### PR TITLE
Remove unused BinderPOS store concurrency gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,10 +237,6 @@ before being returned.
    and Japanese-language listings are excluded. A minimum response time (~1s) is
    enforced for a consistent UX.
 
-### Concurrency gates
-
-- At most **12** BinderPOS stores search concurrently (`binderposMaxConcurrent`).
-
 ### Two kinds of stores
 
 **Non-BinderPOS stores** (e.g. Agora, Cards Central, Cards & Collections,

--- a/api/controller/search.go
+++ b/api/controller/search.go
@@ -58,8 +58,6 @@ type StoreError struct {
 	StatusCode int    `json:"statusCode,omitempty"`
 }
 
-const binderposMaxConcurrent = 12
-
 var sendDiscordAlert = alert.SendDiscordAlert
 
 type shopSpec struct {
@@ -136,7 +134,6 @@ func searchShops(ctx context.Context, input SearchInput, shopNameToLGSMap map[st
 func fetchCardsConcurrently(ctx context.Context, searchString string, shops map[string]gateway.LGS) ([]gateway.Card, map[string]error) {
 	var wg sync.WaitGroup
 	aggregator := newFetchResultAggregator(len(shops))
-	binderposGate := make(chan struct{}, binderposMaxConcurrent)
 
 	searchCtx := ctx
 	if searchIncludesBinderposStore(shops) {
@@ -150,7 +147,7 @@ func fetchCardsConcurrently(ctx context.Context, searchString string, shops map[
 
 	for shopName, lgs := range shops {
 		wg.Go(func() {
-			searchShop(searchCtx, searchString, shopName, lgs, binderposGate, aggregator)
+			searchShop(searchCtx, searchString, shopName, lgs, aggregator)
 		})
 	}
 
@@ -237,7 +234,6 @@ func searchShop(
 	searchString string,
 	shopName string,
 	lgs gateway.LGS,
-	binderposGate chan struct{},
 	aggregator *fetchResultAggregator,
 ) {
 	defer recoverShopPanic(shopName, aggregator)
@@ -248,11 +244,6 @@ func searchShop(
 
 	shopCtx, cancel := context.WithTimeout(ctx, config.PerSiteTimeout)
 	defer cancel()
-
-	if isBinderposStore(shopName) {
-		binderposGate <- struct{}{}
-		defer func() { <-binderposGate }()
-	}
 
 	cards, err := lgs.Search(shopCtx, searchString)
 	if err != nil {

--- a/api/controller/search_test.go
+++ b/api/controller/search_test.go
@@ -9,7 +9,6 @@ import (
 	"mtg-price-checker-sg/gateway/agora"
 	"mtg-price-checker-sg/gateway/cardaffinity"
 	"mtg-price-checker-sg/gateway/cardscitadel"
-	"mtg-price-checker-sg/gateway/gameshaven"
 	"mtg-price-checker-sg/gateway/hideout"
 	"strings"
 	"sync"

--- a/api/controller/search_test.go
+++ b/api/controller/search_test.go
@@ -13,7 +13,6 @@ import (
 	"mtg-price-checker-sg/gateway/hideout"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -389,46 +388,6 @@ func TestIsBinderposStore(t *testing.T) {
 				t.Fatalf("isBinderposStore(%q) = %v, want %v", shop, got, expected)
 			}
 		})
-	}
-}
-
-func TestFetchCardsConcurrently_BinderposGate(t *testing.T) {
-	var activeBinderpos int32
-	var maxActiveBinderpos int32
-
-	binderposShops := []string{
-		cardscitadel.StoreName,
-		cardaffinity.StoreName,
-		hideout.StoreName,
-		gameshaven.StoreName,
-	}
-	shops := make(map[string]gateway.LGS, len(binderposShops)+1)
-	for _, name := range binderposShops {
-		shops[name] = &MockLGS{
-			SearchFunc: func(ctx context.Context, searchStr string) ([]gateway.Card, error) {
-				active := atomic.AddInt32(&activeBinderpos, 1)
-				for {
-					currentMax := atomic.LoadInt32(&maxActiveBinderpos)
-					if active <= currentMax || atomic.CompareAndSwapInt32(&maxActiveBinderpos, currentMax, active) {
-						break
-					}
-				}
-				time.Sleep(80 * time.Millisecond)
-				atomic.AddInt32(&activeBinderpos, -1)
-				return []gateway.Card{{Name: searchStr, InStock: true, Price: 1, Source: cardscitadel.StoreName}}, nil
-			},
-		}
-	}
-
-	shops[agora.StoreName] = &MockLGS{
-		SearchFunc: func(ctx context.Context, searchStr string) ([]gateway.Card, error) {
-			return []gateway.Card{{Name: searchStr, InStock: true, Price: 1, Source: agora.StoreName}}, nil
-		},
-	}
-
-	_, _ = fetchCardsConcurrently(context.Background(), "Abrade", shops)
-	if atomic.LoadInt32(&maxActiveBinderpos) > binderposMaxConcurrent {
-		t.Fatalf("expected at most %d concurrent binderpos searches, got %d", binderposMaxConcurrent, maxActiveBinderpos)
 	}
 }
 

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -14,7 +14,6 @@ This document records **where** the app configures search behavior, **timeouts**
 | Colly request timeout (default scrapers) | 5s | `applyCollectorDefaults` → `c.SetRequestTimeout(config.SearchAttemptTimeout)` in `api/gateway/collector.go` | Overrides gocolly’s default 10s for optimized collectors. |
 | Minimum end-to-end response time | 1s | `responseThreshold` in `searchShops` in `api/controller/search.go` | If all stores finish in under 1s, the handler **sleeps** the remainder so the API “feels” less instant. |
 | Colly HTTP retries | None | `api/gateway/collector.go` (`configureRequestOptimizations`, `registerNoRetryErrorHandler`) | **Single HTTP attempt** per colly request path; no automatic colly/gateway retry of failed visits. |
-| BinderPOS store concurrency | 12 | `binderposMaxConcurrent` in `api/controller/search.go` | Semaphore limits how many binderpos-backed shops run at once. Non-binderpos stores are not limited by this gate. |
 | BinderPOS dedicated proxy per search request | 1 lease | `fetchCardsConcurrently` in `api/controller/search.go` + `WithRequestDedicatedProxy` in `api/gateway/request_dedicated_proxy.go` | When the search includes any BinderPOS store and dedicated proxies are configured, the controller acquires **one** dedicated-proxy lease for the whole request. All BinderPOS `scrap-dedicated` attempts share that URL via context; the lease is released when the search finishes. |
 
 ---


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes `binderposMaxConcurrent` and the per-store BinderPOS semaphore in the controller.

Request-scoped dedicated proxy leasing already caps outbound proxy usage per search (one lease shared by all BinderPOS `scrap-dedicated` attempts). The concurrency gate was set to 12 while only 11 BinderPOS stores are active, so it never actually limited parallelism.

## Changes

- Drop `binderposMaxConcurrent`, `binderposGate`, and gate acquire/release in `searchShop`
- Remove `TestFetchCardsConcurrently_BinderposGate`
- Update README and `docs/search-strategies-retries-timeouts.md`

## Testing

- `make test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bffdd705-d141-4994-a2cc-abea3f7d6eab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bffdd705-d141-4994-a2cc-abea3f7d6eab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

