### PR TITLE
CK pricelist MTGJSON fallback and outbound proxy logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,18 +143,19 @@ Example report shape:
 
 ### CK price refresh flow
 
-CK prices come from Card Kingdom's public pricelist API
-(`https://api.cardkingdom.com/api/v2/pricelist`). The refresh Lambda downloads
-the singles pricelist, picks the cheapest listed retail price per card name
-(using NM/EX/VG/G condition prices), and batch-writes the index. Search
-verifies the query against Scryfall before looking up DynamoDB and omits stale
-entries older than 48 hours.
+CK prices prefer Card Kingdom's public pricelist API
+(`https://api.cardkingdom.com/api/v2/pricelist`) and fall back to MTGJSON when
+Cloudflare blocks the pricelist download (common from AWS Lambda). The refresh
+Lambda picks the cheapest listed retail price per card name and batch-writes the
+index. Search verifies the query against Scryfall before looking up DynamoDB and
+omits stale entries older than 48 hours.
 
 ```mermaid
 sequenceDiagram
     participant EB as EventBridge
     participant R as mtg-price-ck-refresh
     participant CK as Card Kingdom API
+    participant M as MTGJSON
     participant D as DynamoDB
     participant S3 as S3 gishathfetch.com
     participant S as mtg-price-scrapper
@@ -163,6 +164,9 @@ sequenceDiagram
 
     EB->>R: daily ck-price-refresh-run
     R->>CK: download api/v2/pricelist
+    alt Cloudflare blocks CK API
+        R->>M: download AllPricesToday + AllPrintings
+    end
     R->>D: PutAll cheapest CK retail by name
     R->>D: query top/bottom 20 price changes
     R->>S3: analytics/ck-price-changes/latest.json

--- a/api/gateway/cardkingdom/mtgjson_fetch.go
+++ b/api/gateway/cardkingdom/mtgjson_fetch.go
@@ -1,0 +1,402 @@
+package cardkingdom
+
+import (
+	"bytes"
+	"compress/bzip2"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"mtg-price-checker-sg/pkg/config"
+)
+
+const (
+	defaultAllPricesTodayURL = "https://mtgjson.com/api/v5/AllPricesToday.json.bz2"
+	defaultAllPrintingsURL   = "https://mtgjson.com/api/v5/AllPrintings.json.bz2"
+	// mtgjsonFetchTimeout bounds the full MTGJSON download + parse path. AllPrintings
+	// alone can take several minutes on Lambda; keep Lambda timeout at 600s.
+	mtgjsonFetchTimeout            = 8 * time.Minute
+	mtgjsonAllPricesTodayHTTPTimeout = 2 * time.Minute
+	mtgjsonAllPrintingsHTTPTimeout  = 7 * time.Minute
+)
+
+type ckUUIDPrice struct {
+	normal float64
+	foil   float64
+}
+
+type mtgjsonCard struct {
+	UUID         string `json:"uuid"`
+	Name         string `json:"name"`
+	FaceName     string `json:"faceName"`
+	Number       string `json:"number"`
+	Side         string `json:"side"`
+	PurchaseUrls struct {
+		CardKingdom     string `json:"cardKingdom"`
+		CardKingdomFoil string `json:"cardKingdomFoil"`
+	} `json:"purchaseUrls"`
+}
+
+type printingKey struct {
+	number string
+	name   string
+	isDFC  bool
+}
+
+type printingAggregate struct {
+	cardName        string
+	cardKingdom     string
+	cardKingdomFoil string
+	price           ckUUIDPrice
+}
+
+func fetchCheapestFromMTGJSON(ctx context.Context) (map[string]Listing, error) {
+	ctx, cancel := context.WithTimeout(ctx, mtgjsonFetchTimeout)
+	defer cancel()
+
+	log.Printf("ck price refresh: downloading AllPricesToday from %s", allPricesTodayURL())
+	pricesStarted := time.Now()
+	pricesRaw, err := downloadMTGJSONBzip2(ctx, allPricesTodayURL(), mtgjsonAllPricesTodayHTTPTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("all prices today: %w", err)
+	}
+	log.Printf("ck price refresh: downloaded AllPricesToday bytes=%d duration=%s", len(pricesRaw), time.Since(pricesStarted).Round(time.Millisecond))
+
+	pricesByUUID, updatedAt, err := parseCKPricesByUUID(pricesRaw)
+	if err != nil {
+		return nil, fmt.Errorf("parse all prices today: %w", err)
+	}
+	if len(pricesByUUID) == 0 {
+		return nil, fmt.Errorf("parse all prices today: no card kingdom prices found")
+	}
+	log.Printf("ck price refresh: parsed AllPricesToday uuid_prices=%d price_date=%s", len(pricesByUUID), updatedAt.Format("2006-01-02"))
+
+	log.Printf("ck price refresh: streaming AllPrintings from %s", allPrintingsURL())
+	printingsStarted := time.Now()
+	listings, err := streamAllPrintingsSets(ctx, allPrintingsURL(), pricesByUUID, updatedAt)
+	if err != nil {
+		return nil, err
+	}
+	log.Printf("ck price refresh: streamed AllPrintings listings=%d duration=%s", len(listings), time.Since(printingsStarted).Round(time.Millisecond))
+
+	return listings, nil
+}
+
+func allPricesTodayURL() string {
+	if url := strings.TrimSpace(os.Getenv(config.MTGJSONAllPricesTodayURLEnv)); url != "" {
+		return url
+	}
+	return defaultAllPricesTodayURL
+}
+
+func allPrintingsURL() string {
+	if url := strings.TrimSpace(os.Getenv(config.MTGJSONAllPrintingsURLEnv)); url != "" {
+		return url
+	}
+	return defaultAllPrintingsURL
+}
+
+func downloadMTGJSONBzip2(ctx context.Context, downloadURL string, timeout time.Duration) ([]byte, error) {
+	client := &http.Client{Timeout: timeout}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/octet-stream")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	compressed, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %d", resp.StatusCode)
+	}
+
+	decompressed, err := io.ReadAll(bzip2.NewReader(bytes.NewReader(compressed)))
+	if err != nil {
+		return nil, fmt.Errorf("bzip2 decompress: %w", err)
+	}
+	return decompressed, nil
+}
+
+func parseCKPricesByUUID(raw []byte) (map[string]ckUUIDPrice, time.Time, error) {
+	var payload struct {
+		Meta struct {
+			Date string `json:"date"`
+		} `json:"meta"`
+		Data map[string]struct {
+			Paper *struct {
+				CardKingdom *struct {
+					Retail map[string]map[string]float64 `json:"retail"`
+				} `json:"cardkingdom"`
+			} `json:"paper"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		return nil, time.Time{}, err
+	}
+
+	updatedAt, err := time.Parse("2006-01-02", payload.Meta.Date)
+	if err != nil {
+		return nil, time.Time{}, fmt.Errorf("meta date: %w", err)
+	}
+
+	pricesByUUID := make(map[string]ckUUIDPrice)
+	for uuid, entry := range payload.Data {
+		if entry.Paper == nil || entry.Paper.CardKingdom == nil {
+			continue
+		}
+		price := ckUUIDPrice{
+			normal: latestRetailPrice(entry.Paper.CardKingdom.Retail["normal"]),
+			foil:   latestRetailPrice(entry.Paper.CardKingdom.Retail["foil"]),
+		}
+		if price.normal <= 0 && price.foil <= 0 {
+			continue
+		}
+		pricesByUUID[uuid] = price
+	}
+
+	return pricesByUUID, updatedAt.UTC(), nil
+}
+
+func latestRetailPrice(byDate map[string]float64) float64 {
+	var latest float64
+	for _, price := range byDate {
+		if price > latest {
+			latest = price
+		}
+	}
+	return latest
+}
+
+func streamAllPrintingsSets(
+	ctx context.Context,
+	downloadURL string,
+	pricesByUUID map[string]ckUUIDPrice,
+	updatedAt time.Time,
+) (map[string]Listing, error) {
+	client := &http.Client{Timeout: mtgjsonAllPrintingsHTTPTimeout}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/octet-stream")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %d", resp.StatusCode)
+	}
+
+	decoder := json.NewDecoder(bzip2.NewReader(resp.Body))
+	return decodeAllPrintingsSets(decoder, pricesByUUID, updatedAt)
+}
+
+func decodeAllPrintingsSets(
+	decoder *json.Decoder,
+	pricesByUUID map[string]ckUUIDPrice,
+	updatedAt time.Time,
+) (map[string]Listing, error) {
+	token, err := decoder.Token()
+	if err != nil {
+		return nil, err
+	}
+	if delim, ok := token.(json.Delim); !ok || delim != '{' {
+		return nil, fmt.Errorf("expected top-level object")
+	}
+
+	cheapest := make(map[string]Listing)
+	for decoder.More() {
+		keyToken, err := decoder.Token()
+		if err != nil {
+			return nil, err
+		}
+		key, ok := keyToken.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected object key")
+		}
+
+		switch key {
+		case "meta":
+			if err := skipJSONValue(decoder); err != nil {
+				return nil, err
+			}
+		case "data":
+			if err := decodeSetCatalog(decoder, pricesByUUID, updatedAt, cheapest); err != nil {
+				return nil, err
+			}
+		default:
+			if err := skipJSONValue(decoder); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if _, err := decoder.Token(); err != nil {
+		return nil, err
+	}
+	return cheapest, nil
+}
+
+func decodeSetCatalog(
+	decoder *json.Decoder,
+	pricesByUUID map[string]ckUUIDPrice,
+	updatedAt time.Time,
+	cheapest map[string]Listing,
+) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	if delim, ok := token.(json.Delim); !ok || delim != '{' {
+		return fmt.Errorf("expected data object")
+	}
+
+	for decoder.More() {
+		if _, err := decoder.Token(); err != nil {
+			return err
+		}
+
+		var set struct {
+			Name  string        `json:"name"`
+			Cards []mtgjsonCard `json:"cards"`
+		}
+		if err := decoder.Decode(&set); err != nil {
+			return err
+		}
+		if excludedCKPriceEdition(set.Name) {
+			continue
+		}
+
+		aggregates := make(map[printingKey]printingAggregate)
+		for _, card := range set.Cards {
+			mergePrintingAggregate(aggregates, card, pricesByUUID)
+		}
+		for _, aggregate := range aggregates {
+			applyPrintingAggregate(cheapest, aggregate.cardName, set.Name, aggregate, updatedAt)
+		}
+	}
+
+	_, err = decoder.Token()
+	return err
+}
+
+func mergePrintingAggregate(
+	aggregates map[printingKey]printingAggregate,
+	card mtgjsonCard,
+	pricesByUUID map[string]ckUUIDPrice,
+) {
+	name := strings.TrimSpace(card.Name)
+	if name == "" {
+		return
+	}
+
+	key := printingKeyFor(card)
+	aggregate := aggregates[key]
+	aggregate.cardName = preferCardName(aggregate.cardName, name)
+
+	if card.PurchaseUrls.CardKingdom != "" {
+		aggregate.cardKingdom = card.PurchaseUrls.CardKingdom
+	}
+	if card.PurchaseUrls.CardKingdomFoil != "" {
+		aggregate.cardKingdomFoil = card.PurchaseUrls.CardKingdomFoil
+	}
+	if price, ok := pricesByUUID[card.UUID]; ok {
+		if price.normal > 0 && (aggregate.price.normal <= 0 || price.normal < aggregate.price.normal) {
+			aggregate.price.normal = price.normal
+		}
+		if price.foil > 0 && (aggregate.price.foil <= 0 || price.foil < aggregate.price.foil) {
+			aggregate.price.foil = price.foil
+		}
+	}
+
+	aggregates[key] = aggregate
+}
+
+func printingKeyFor(card mtgjsonCard) printingKey {
+	number := strings.TrimSpace(card.Number)
+	side := strings.TrimSpace(card.Side)
+	if side == "a" || side == "b" {
+		return printingKey{number: number, isDFC: true}
+	}
+	return printingKey{number: number, name: strings.TrimSpace(card.Name)}
+}
+
+func preferCardName(current string, candidate string) string {
+	current = strings.TrimSpace(current)
+	candidate = strings.TrimSpace(candidate)
+	if candidate == "" {
+		return current
+	}
+	if current == "" {
+		return candidate
+	}
+	if strings.Contains(candidate, doubleFacedNameSeparator) {
+		return candidate
+	}
+	if strings.Contains(current, doubleFacedNameSeparator) {
+		return current
+	}
+	return candidate
+}
+
+func applyPrintingAggregate(
+	cheapest map[string]Listing,
+	cardName string,
+	setName string,
+	aggregate printingAggregate,
+	updatedAt time.Time,
+) {
+	updatedAtValue := updatedAt.Format(time.RFC3339)
+	if aggregate.price.normal > 0 && aggregate.cardKingdom != "" {
+		considerCheapestListing(cheapest, Listing{
+			CardName:  cardName,
+			Edition:   setName,
+			PriceUsd:  aggregate.price.normal,
+			URL:       aggregate.cardKingdom,
+			IsFoil:    false,
+			UpdatedAt: updatedAtValue,
+		})
+	}
+
+	if aggregate.price.foil <= 0 {
+		return
+	}
+
+	foilURL := aggregate.cardKingdomFoil
+	if foilURL == "" {
+		foilURL = aggregate.cardKingdom
+	}
+	if foilURL == "" {
+		return
+	}
+
+	considerCheapestListing(cheapest, Listing{
+		CardName:  cardName,
+		Edition:   setName,
+		PriceUsd:  aggregate.price.foil,
+		URL:       foilURL,
+		IsFoil:    true,
+		UpdatedAt: updatedAtValue,
+	})
+}
+
+func skipJSONValue(decoder *json.Decoder) error {
+	var discard json.RawMessage
+	return decoder.Decode(&discard)
+}

--- a/api/gateway/cardkingdom/mtgjson_fetch_test.go
+++ b/api/gateway/cardkingdom/mtgjson_fetch_test.go
@@ -1,0 +1,405 @@
+package cardkingdom
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const sampleAllPricesToday = `{
+  "meta": {"date": "2026-06-28"},
+  "data": {
+    "uuid-bolt-4ed": {
+      "paper": {
+        "cardkingdom": {
+          "retail": {
+            "normal": {"2026-06-28": 1.49}
+          }
+        }
+      }
+    },
+    "uuid-bolt-mm-foil": {
+      "paper": {
+        "cardkingdom": {
+          "retail": {
+            "foil": {"2026-06-28": 3.99}
+          }
+        }
+      }
+    },
+    "uuid-tony-80-price": {
+      "paper": {
+        "cardkingdom": {
+          "retail": {
+            "normal": {"2026-06-28": 7.49},
+            "foil": {"2026-06-28": 8.99}
+          }
+        }
+      }
+    },
+    "uuid-tony-363-price": {
+      "paper": {
+        "cardkingdom": {
+          "retail": {
+            "foil": {"2026-06-28": 44.99}
+          }
+        }
+      }
+    },
+    "uuid-no-ck": {
+      "paper": {
+        "tcgplayer": {
+          "retail": {
+            "normal": {"2026-06-28": 0.15}
+          }
+        }
+      }
+    }
+  }
+}`
+
+const sampleAllPrintings = `{
+  "meta": {"date": "2026-06-28"},
+  "data": {
+    "4ED": {
+      "name": "Fourth Edition",
+      "cards": [
+        {
+          "uuid": "uuid-bolt-4ed",
+          "name": "Lightning Bolt",
+          "number": "162",
+          "purchaseUrls": {
+            "cardKingdom": "https://www.cardkingdom.com/mtg/fourth-edition/lightning-bolt"
+          }
+        }
+      ]
+    },
+    "MM2": {
+      "name": "Modern Masters 2015",
+      "cards": [
+        {
+          "uuid": "uuid-bolt-mm-foil",
+          "name": "Lightning Bolt",
+          "number": "141",
+          "purchaseUrls": {
+            "cardKingdom": "https://www.cardkingdom.com/mtg/modern-masters-2015/lightning-bolt",
+            "cardKingdomFoil": "https://www.cardkingdom.com/mtg/modern-masters-2015/lightning-bolt-foil"
+          }
+        }
+      ]
+    }
+  }
+}`
+
+const sampleAllPrintingsSplitUUID = `{
+  "meta": {"date": "2026-06-28"},
+  "data": {
+    "MSH": {
+      "name": "Marvel Super Heroes",
+      "cards": [
+        {
+          "uuid": "uuid-tony-80-url",
+          "name": "Tony Stark // The Invincible Iron Man",
+          "number": "80",
+          "side": "a",
+          "purchaseUrls": {
+            "cardKingdom": "https://www.cardkingdom.com/mtg/marvel-super-heroes/tony-stark",
+            "cardKingdomFoil": "https://www.cardkingdom.com/mtg/marvel-super-heroes/tony-stark-foil"
+          }
+        },
+        {
+          "uuid": "uuid-tony-80-price",
+          "name": "Tony Stark // The Invincible Iron Man",
+          "number": "80",
+          "side": "b",
+          "purchaseUrls": {}
+        },
+        {
+          "uuid": "uuid-tony-363-url",
+          "name": "Tony Stark // The Invincible Iron Man",
+          "number": "363",
+          "side": "a",
+          "purchaseUrls": {
+            "cardKingdom": "https://www.cardkingdom.com/mtg/marvel-super-heroes-variants/tony-stark-0363-borderless",
+            "cardKingdomFoil": "https://www.cardkingdom.com/mtg/marvel-super-heroes-variants/tony-stark-0363-borderless-foil"
+          }
+        },
+        {
+          "uuid": "uuid-tony-363-price",
+          "name": "Tony Stark // The Invincible Iron Man",
+          "number": "363",
+          "side": "b",
+          "purchaseUrls": {}
+        }
+      ]
+    }
+  }
+}`
+
+const sampleAllPrintingsJenniferWalters = `{
+  "meta": {"date": "2026-07-02"},
+  "data": {
+    "MSH": {
+      "name": "Marvel Super Heroes",
+      "cards": [
+        {
+          "uuid": "uuid-jw-18-url",
+          "name": "Jennifer Walters // The Sensational She-Hulk",
+          "faceName": "Jennifer Walters",
+          "number": "18",
+          "side": "a",
+          "purchaseUrls": {
+            "cardKingdom": "https://www.cardkingdom.com/mtg/marvel-super-heroes/jennifer-walters"
+          }
+        },
+        {
+          "uuid": "uuid-jw-18-price",
+          "name": "Jennifer Walters // The Sensational She-Hulk",
+          "faceName": "The Sensational She-Hulk",
+          "number": "18",
+          "side": "b",
+          "purchaseUrls": {}
+        }
+      ]
+    }
+  }
+}`
+
+const sampleAllPrintingsWorldChampionshipDecks = `{
+  "meta": {"date": "2026-06-28"},
+  "data": {
+    "WC04": {
+      "name": "World Championship Decks 2004",
+      "cards": [
+        {
+          "uuid": "uuid-wcd-bolt",
+          "name": "Lightning Bolt",
+          "number": "1",
+          "purchaseUrls": {
+            "cardKingdom": "https://www.cardkingdom.com/mtg/world-championships/lightning-bolt"
+          }
+        }
+      ]
+    },
+    "4ED": {
+      "name": "Fourth Edition",
+      "cards": [
+        {
+          "uuid": "uuid-bolt-4ed",
+          "name": "Lightning Bolt",
+          "number": "162",
+          "purchaseUrls": {
+            "cardKingdom": "https://www.cardkingdom.com/mtg/fourth-edition/lightning-bolt"
+          }
+        }
+      ]
+    }
+  }
+}`
+
+func TestParseCKPricesByUUID(t *testing.T) {
+	prices, updatedAt, err := parseCKPricesByUUID([]byte(sampleAllPricesToday))
+	require.NoError(t, err)
+	require.Equal(t, time.Date(2026, 6, 28, 0, 0, 0, 0, time.UTC), updatedAt)
+	require.InDelta(t, 1.49, prices["uuid-bolt-4ed"].normal, 0.001)
+	require.InDelta(t, 3.99, prices["uuid-bolt-mm-foil"].foil, 0.001)
+	_, ok := prices["uuid-no-ck"]
+	require.False(t, ok)
+}
+
+func TestDecodeAllPrintingsSets(t *testing.T) {
+	prices := map[string]ckUUIDPrice{
+		"uuid-bolt-4ed":     {normal: 1.49},
+		"uuid-bolt-mm-foil": {foil: 3.99},
+	}
+	updatedAt := time.Date(2026, 6, 28, 0, 0, 0, 0, time.UTC)
+
+	cheapest, err := decodeAllPrintingsSets(
+		json.NewDecoder(strings.NewReader(sampleAllPrintings)),
+		prices,
+		updatedAt,
+	)
+	require.NoError(t, err)
+
+	listing := cheapest["lightning bolt"]
+	require.Equal(t, "Lightning Bolt", listing.CardName)
+	require.Equal(t, "Fourth Edition", listing.Edition)
+	require.InDelta(t, 1.49, listing.PriceUsd, 0.001)
+	require.False(t, listing.IsFoil)
+	require.Equal(t, "https://www.cardkingdom.com/mtg/fourth-edition/lightning-bolt", listing.URL)
+	require.Equal(t, updatedAt.Format(time.RFC3339), listing.UpdatedAt)
+}
+
+func TestDecodeAllPrintingsSets_ExcludesWorldChampionshipDecks(t *testing.T) {
+	prices := map[string]ckUUIDPrice{
+		"uuid-wcd-bolt": {normal: 0.99},
+		"uuid-bolt-4ed": {normal: 1.49},
+	}
+	updatedAt := time.Date(2026, 6, 28, 0, 0, 0, 0, time.UTC)
+
+	cheapest, err := decodeAllPrintingsSets(
+		json.NewDecoder(strings.NewReader(sampleAllPrintingsWorldChampionshipDecks)),
+		prices,
+		updatedAt,
+	)
+	require.NoError(t, err)
+
+	listing := cheapest["lightning bolt"]
+	require.Equal(t, "Fourth Edition", listing.Edition)
+	require.InDelta(t, 1.49, listing.PriceUsd, 0.001)
+}
+
+func TestDecodeAllPrintingsSets_MergesSplitUUIDPrintings(t *testing.T) {
+	prices := map[string]ckUUIDPrice{
+		"uuid-tony-80-price":  {normal: 7.49, foil: 8.99},
+		"uuid-tony-363-price": {foil: 44.99},
+	}
+	updatedAt := time.Date(2026, 6, 28, 0, 0, 0, 0, time.UTC)
+
+	cheapest, err := decodeAllPrintingsSets(
+		json.NewDecoder(strings.NewReader(sampleAllPrintingsSplitUUID)),
+		prices,
+		updatedAt,
+	)
+	require.NoError(t, err)
+
+	listing := cheapest["tony stark // the invincible iron man"]
+	require.Equal(t, "Tony Stark // The Invincible Iron Man", listing.CardName)
+	require.Equal(t, "Marvel Super Heroes", listing.Edition)
+	require.InDelta(t, 7.49, listing.PriceUsd, 0.001)
+	require.False(t, listing.IsFoil)
+	require.Equal(t, "https://www.cardkingdom.com/mtg/marvel-super-heroes/tony-stark", listing.URL)
+
+	faceListing := cheapest["tony stark"]
+	require.InDelta(t, 7.49, faceListing.PriceUsd, 0.001)
+}
+
+func TestDecodeAllPrintingsSets_MergesDoubleFacedFacesByNumber(t *testing.T) {
+	prices := map[string]ckUUIDPrice{
+		"uuid-jw-18-price": {normal: 10.99},
+	}
+	updatedAt := time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC)
+
+	cheapest, err := decodeAllPrintingsSets(
+		json.NewDecoder(strings.NewReader(sampleAllPrintingsJenniferWalters)),
+		prices,
+		updatedAt,
+	)
+	require.NoError(t, err)
+
+	listing := cheapest["jennifer walters // the sensational she-hulk"]
+	require.Equal(t, "Jennifer Walters // The Sensational She-Hulk", listing.CardName)
+	require.InDelta(t, 10.99, listing.PriceUsd, 0.001)
+	require.Equal(t, "https://www.cardkingdom.com/mtg/marvel-super-heroes/jennifer-walters", listing.URL)
+
+	faceListing := cheapest["jennifer walters"]
+	require.InDelta(t, 10.99, faceListing.PriceUsd, 0.001)
+}
+
+func TestDecodeAllPrintingsSets_MergesDoubleFacedFacesUsingCheapestSidePrice(t *testing.T) {
+	prices := map[string]ckUUIDPrice{
+		"uuid-jw-18-url":   {normal: 14.99},
+		"uuid-jw-18-price": {normal: 10.99},
+	}
+	updatedAt := time.Date(2026, 7, 3, 0, 0, 0, 0, time.UTC)
+
+	const sample = `{
+  "meta": {"date": "2026-07-03"},
+  "data": {
+    "MSH": {
+      "name": "Marvel Super Heroes",
+      "cards": [
+        {
+          "uuid": "uuid-jw-18-url",
+          "name": "Jennifer Walters // The Sensational She-Hulk",
+          "faceName": "Jennifer Walters",
+          "number": "18",
+          "side": "a",
+          "purchaseUrls": {
+            "cardKingdom": "https://www.cardkingdom.com/mtg/marvel-super-heroes/jennifer-walters"
+          }
+        },
+        {
+          "uuid": "uuid-jw-18-price",
+          "name": "Jennifer Walters // The Sensational She-Hulk",
+          "faceName": "The Sensational She-Hulk",
+          "number": "18",
+          "side": "b",
+          "purchaseUrls": {}
+        }
+      ]
+    }
+  }
+}`
+
+	cheapest, err := decodeAllPrintingsSets(
+		json.NewDecoder(strings.NewReader(sample)),
+		prices,
+		updatedAt,
+	)
+	require.NoError(t, err)
+
+	listing := cheapest["jennifer walters // the sensational she-hulk"]
+	require.InDelta(t, 10.99, listing.PriceUsd, 0.001)
+	require.False(t, listing.IsFoil)
+}
+
+func TestFetchCheapestFromMTGJSON_FromTestServers(t *testing.T) {
+	pricesServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = writeBzip2(w, []byte(sampleAllPricesToday))
+	}))
+	defer pricesServer.Close()
+
+	printingsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = writeBzip2(w, []byte(sampleAllPrintings))
+	}))
+	defer printingsServer.Close()
+
+	t.Setenv("MTGJSON_ALL_PRICES_TODAY_URL", pricesServer.URL)
+	t.Setenv("MTGJSON_ALL_PRINTINGS_URL", printingsServer.URL)
+
+	cheapest, err := fetchCheapestFromMTGJSON(context.Background())
+	require.NoError(t, err)
+	require.Len(t, cheapest, 1)
+	require.InDelta(t, 1.49, cheapest["lightning bolt"].PriceUsd, 0.001)
+}
+
+func writeBzip2(w http.ResponseWriter, raw []byte) (int, error) {
+	cmd := exec.Command("bzip2", "-c")
+	cmd.Stdin = bytes.NewReader(raw)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return 0, err
+	}
+	return w.Write(out.Bytes())
+}
+
+func TestConsiderCheapestListing_FoilDoubleFacedDoesNotPolluteFaceAlias(t *testing.T) {
+	updatedAt := time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
+	listings := make(map[string]Listing)
+	considerCheapestListing(listings, Listing{
+		CardName:  "Jennifer Walters // The Sensational She-Hulk",
+		Edition:   "Marvel Super Heroes",
+		PriceUsd:  69.99,
+		URL:       "https://mtgjson.com/links/d8187fd1eef32412",
+		IsFoil:    true,
+		UpdatedAt: updatedAt,
+	})
+
+	require.InDelta(t, 69.99, listings["jennifer walters // the sensational she-hulk"].PriceUsd, 0.001)
+	_, hasFrontFace := listings["jennifer walters"]
+	require.False(t, hasFrontFace)
+	_, hasBackFace := listings["the sensational she-hulk"]
+	require.False(t, hasBackFace)
+}

--- a/api/gateway/cardkingdom/pricelist.go
+++ b/api/gateway/cardkingdom/pricelist.go
@@ -3,16 +3,28 @@ package cardkingdom
 import (
 	"context"
 	"fmt"
+	"log"
 )
 
-const ckPricelistErrorPrefixPublic = "ck price pricelist"
+const (
+	ckPricelistErrorPrefixPublic = "ck price pricelist"
+	mtgjsonErrorPrefix           = "ck price mtgjson"
+)
 
-// FetchCheapestByName downloads Card Kingdom's public pricelist and indexes the
-// cheapest listed retail price per card name.
+// FetchCheapestByName downloads Card Kingdom retail prices and indexes the
+// cheapest listed price per card name. It prefers the official CK pricelist API
+// and falls back to MTGJSON when Cloudflare blocks the pricelist download.
 func FetchCheapestByName(ctx context.Context) (map[string]Listing, error) {
 	listings, err := fetchCheapestFromCKPricelist(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("%s: %w", ckPricelistErrorPrefixPublic, err)
+	if err == nil {
+		return listings, nil
+	}
+
+	log.Printf("ck price refresh: card kingdom pricelist unavailable, falling back to mtgjson: %v", err)
+
+	listings, fallbackErr := fetchCheapestFromMTGJSON(ctx)
+	if fallbackErr != nil {
+		return nil, fmt.Errorf("%s: %w; %s: %v", ckPricelistErrorPrefixPublic, err, mtgjsonErrorPrefix, fallbackErr)
 	}
 	return listings, nil
 }

--- a/api/gateway/cardkingdom/pricelist_fetch.go
+++ b/api/gateway/cardkingdom/pricelist_fetch.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -189,14 +188,7 @@ func ckPricelistURL() string {
 }
 
 func downloadCKPricelist(ctx context.Context, downloadURL string) (*ckPricelistPayload, error) {
-	storeBase, err := url.Parse("https://www.cardkingdom.com/")
-	if err != nil {
-		return nil, fmt.Errorf("%s: store base url: %w", ckPricelistErrorPrefix, err)
-	}
-
 	resp, err := gateway.DoOutboundGET(ctx, downloadURL, gateway.OutboundRequestOptions{
-		Style:          gateway.OutboundStyleJSON,
-		StoreBase:      storeBase,
 		Accept:         "application/json",
 		SkipWebBotAuth: true,
 	}, ckPricelistHTTPTimeout)

--- a/api/gateway/cardkingdom/pricelist_fetch_test.go
+++ b/api/gateway/cardkingdom/pricelist_fetch_test.go
@@ -176,22 +176,3 @@ func TestFetchCheapestFromCKPricelist_FromTestServer(t *testing.T) {
 	require.InDelta(t, 1.19, cheapest["lightning bolt"].PriceUsd, 0.001)
 	require.InDelta(t, 7.49, cheapest["spectacular spider-man"].PriceUsd, 0.001)
 }
-
-func TestConsiderCheapestListing_FoilDoubleFacedDoesNotPolluteFaceAlias(t *testing.T) {
-	updatedAt := time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
-	listings := make(map[string]Listing)
-	considerCheapestListing(listings, Listing{
-		CardName:  "Jennifer Walters // The Sensational She-Hulk",
-		Edition:   "Marvel Super Heroes",
-		PriceUsd:  69.99,
-		URL:       "https://www.cardkingdom.com/mtg/marvel-super-heroes/jennifer-walters-foil",
-		IsFoil:    true,
-		UpdatedAt: updatedAt,
-	})
-
-	require.InDelta(t, 69.99, listings["jennifer walters // the sensational she-hulk"].PriceUsd, 0.001)
-	_, hasFrontFace := listings["jennifer walters"]
-	require.False(t, hasFrontFace)
-	_, hasBackFace := listings["the sensational she-hulk"]
-	require.False(t, hasBackFace)
-}

--- a/api/gateway/cardkingdom/pricelist_test.go
+++ b/api/gateway/cardkingdom/pricelist_test.go
@@ -1,0 +1,37 @@
+package cardkingdom
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchCheapestByName_FallsBackToMTGJSONWhenPricelistBlocked(t *testing.T) {
+	pricelistServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "blocked", http.StatusForbidden)
+	}))
+	defer pricelistServer.Close()
+
+	pricesServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = writeBzip2(w, []byte(sampleAllPricesToday))
+	}))
+	defer pricesServer.Close()
+
+	printingsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = writeBzip2(w, []byte(sampleAllPrintings))
+	}))
+	defer printingsServer.Close()
+
+	t.Setenv("CK_PRICELIST_URL", pricelistServer.URL)
+	t.Setenv("MTGJSON_ALL_PRICES_TODAY_URL", pricesServer.URL)
+	t.Setenv("MTGJSON_ALL_PRINTINGS_URL", printingsServer.URL)
+
+	cheapest, err := FetchCheapestByName(context.Background())
+	require.NoError(t, err)
+	require.InDelta(t, 1.49, cheapest["lightning bolt"].PriceUsd, 0.001)
+}

--- a/api/gateway/outbound_get.go
+++ b/api/gateway/outbound_get.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"strings"
@@ -14,6 +15,7 @@ import (
 
 type outboundAttempt struct {
 	strategy string
+	proxyURL string
 	client   *http.Client
 }
 
@@ -50,15 +52,24 @@ func DoOutboundRoundTrip(
 			return nil, err
 		}
 
+		proxyDesc := outboundProxyDescription(attempt)
+		log.Printf("outbound request: trying %s url=%s", proxyDesc, outboundRequestURL(req))
+
 		resp, err := attempt.client.Do(req)
 		if err != nil {
-			failures = append(failures, fmt.Sprintf("%s: %v", attempt.strategy, err))
+			failure := fmt.Sprintf("%s: %v", attempt.strategy, err)
+			log.Printf("outbound request: failed %s: %v", proxyDesc, err)
+			failures = append(failures, failure)
 			continue
 		}
 		if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests {
-			failures = append(failures, outboundStatusFailure(attempt.strategy, resp))
+			failure := outboundStatusFailure(attempt.strategy, resp)
+			log.Printf("outbound request: failed %s: status %d", proxyDesc, resp.StatusCode)
+			failures = append(failures, failure)
 			continue
 		}
+
+		log.Printf("outbound request: succeeded %s status=%d url=%s", proxyDesc, resp.StatusCode, outboundRequestURL(req))
 		return resp, nil
 	}
 	if len(failures) == 0 {
@@ -86,12 +97,17 @@ func buildOutboundGETAttempts(timeout time.Duration, skipDirect bool) []outbound
 		}
 		attempts = append(attempts, outboundAttempt{
 			strategy: fmt.Sprintf("dedicated-%d", idx+1),
+			proxyURL: proxyURL,
 			client:   client,
 		})
 	}
 
 	if client, ok := dynamicProxyHTTPClient(timeout); ok {
-		attempts = append(attempts, outboundAttempt{strategy: "dynamic", client: client})
+		attempts = append(attempts, outboundAttempt{
+			strategy: "dynamic",
+			proxyURL: DynamicProxyURL(),
+			client:   client,
+		})
 	}
 
 	return attempts
@@ -130,6 +146,30 @@ func outboundStatusFailure(strategy string, resp *http.Response) string {
 		trimmed = trimmed[:120] + "..."
 	}
 	return msg + " (" + trimmed + ")"
+}
+
+func outboundProxyDescription(attempt outboundAttempt) string {
+	return formatProxyContext(outboundProxyMode(attempt.strategy), attempt.proxyURL)
+}
+
+func outboundProxyMode(strategy string) string {
+	switch {
+	case strategy == "direct":
+		return "direct"
+	case strategy == "dynamic":
+		return "dynamic"
+	case strings.HasPrefix(strategy, "dedicated-"):
+		return "dedicated"
+	default:
+		return strategy
+	}
+}
+
+func outboundRequestURL(req *http.Request) string {
+	if req == nil || req.URL == nil {
+		return ""
+	}
+	return req.URL.Redacted()
 }
 
 // NewOutboundHTTPClient returns an HTTP client that routes through a random dedicated

--- a/api/gateway/outbound_get_test.go
+++ b/api/gateway/outbound_get_test.go
@@ -80,6 +80,17 @@ func TestBuildOutboundGETAttempts_SkipDirect(t *testing.T) {
 	require.Equal(t, "dedicated-1", attempts[0].strategy)
 }
 
+func TestOutboundProxyDescription(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("DEDICATED_PROXY_1", "1.2.3.4|8080|user|pass")
+
+	attempts := buildOutboundGETAttempts(2*time.Second, false)
+	require.GreaterOrEqual(t, len(attempts), 2)
+
+	require.Equal(t, "proxy_mode=direct proxy=none", outboundProxyDescription(attempts[0]))
+	require.Equal(t, "proxy_mode=dedicated proxy=DEDICATED_PROXY_1", outboundProxyDescription(attempts[1]))
+}
+
 func TestDoOutboundGET_DirectForbiddenWithoutProxy(t *testing.T) {
 	clearProxyEnv(t)
 

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -53,6 +53,10 @@ const (
 	CKPriceMaxAge = 48 * time.Hour
 	// CKPricelistURLEnv overrides the Card Kingdom singles pricelist download URL.
 	CKPricelistURLEnv = "CK_PRICELIST_URL"
+	// MTGJSONAllPricesTodayURLEnv overrides the MTGJSON AllPricesToday download URL.
+	MTGJSONAllPricesTodayURLEnv = "MTGJSON_ALL_PRICES_TODAY_URL"
+	// MTGJSONAllPrintingsURLEnv overrides the MTGJSON AllPrintings download URL.
+	MTGJSONAllPrintingsURLEnv = "MTGJSON_ALL_PRINTINGS_URL"
 	// GA4PropertyIDEnv is the numeric GA4 property ID used by the Data API.
 	GA4PropertyIDEnv = "GA4_PROPERTY_ID"
 	// GA4CredentialsJSONEnv holds a Google service account JSON key with Analytics read access.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Builds on merged #283 (CK pricelist API swap). Adds:

1. **MTGJSON fallback** when Cloudflare blocks the CK pricelist download from Lambda/proxies
2. **Minimal CK API headers** (no cross-origin Origin/Referer)
3. **Outbound proxy logging** — each attempt logs `proxy_mode` and `DEDICATED_PROXY_N`

## Behaviour

1. Try CK pricelist API
2. On failure (403 from direct + dedicated + dynamic), fall back to MTGJSON
3. Index cheapest listed price per card name (including OOS)

## Testing

- `go test ./gateway/... ./controller/ckprice/... ./handler/...` — pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5720a8b3-c4f4-4906-b6e4-d7cf4604183f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5720a8b3-c4f4-4906-b6e4-d7cf4604183f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

