### PR TITLE
Add CK_PRICELIST_PROXY for Card Kingdom pricelist downloads

### DIFF
--- a/api/gateway/cardkingdom/pricelist_fetch.go
+++ b/api/gateway/cardkingdom/pricelist_fetch.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"mtg-price-checker-sg/gateway"
+	"mtg-price-checker-sg/gateway/util"
 	"mtg-price-checker-sg/pkg/config"
 )
 
@@ -187,11 +188,19 @@ func ckPricelistURL() string {
 	return defaultCKPricelistURL
 }
 
-func downloadCKPricelist(ctx context.Context, downloadURL string) (*ckPricelistPayload, error) {
-	resp, err := gateway.DoOutboundGET(ctx, downloadURL, gateway.OutboundRequestOptions{
+func ckPricelistOutboundOptions() gateway.OutboundRequestOptions {
+	opts := gateway.OutboundRequestOptions{
 		Accept:         "application/json",
 		SkipWebBotAuth: true,
-	}, ckPricelistHTTPTimeout)
+	}
+	if proxyURL, ok := util.GetCKPricelistProxyURL(); ok {
+		opts.OnlyProxyURL = proxyURL
+	}
+	return opts
+}
+
+func downloadCKPricelist(ctx context.Context, downloadURL string) (*ckPricelistPayload, error) {
+	resp, err := gateway.DoOutboundGET(ctx, downloadURL, ckPricelistOutboundOptions(), ckPricelistHTTPTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("%s: download: %w", ckPricelistErrorPrefix, err)
 	}

--- a/api/gateway/cardkingdom/pricelist_fetch_test.go
+++ b/api/gateway/cardkingdom/pricelist_fetch_test.go
@@ -162,6 +162,22 @@ func TestCheapestListingsFromPricelist(t *testing.T) {
 	require.InDelta(t, 7.49, cheapest["the invincible iron man"].PriceUsd, 0.001)
 }
 
+func TestCKPricelistOutboundOptions_UsesConfiguredProxy(t *testing.T) {
+	t.Setenv("CK_PRICELIST_PROXY", "res.proxy|8080|user|pass")
+
+	opts := ckPricelistOutboundOptions()
+	require.Equal(t, "http://user:pass@res.proxy:8080", opts.OnlyProxyURL)
+	require.Equal(t, "application/json", opts.Accept)
+	require.True(t, opts.SkipWebBotAuth)
+}
+
+func TestCKPricelistOutboundOptions_NoProxyWhenUnset(t *testing.T) {
+	t.Setenv("CK_PRICELIST_PROXY", "")
+
+	opts := ckPricelistOutboundOptions()
+	require.Empty(t, opts.OnlyProxyURL)
+}
+
 func TestFetchCheapestFromCKPricelist_FromTestServer(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/api/gateway/collector.go
+++ b/api/gateway/collector.go
@@ -490,6 +490,11 @@ func resolveProxyLabel(mode, proxyURL string) string {
 			return label
 		}
 		return "dedicated-configured"
+	case "ck-pricelist":
+		if configuredURL, ok := util.GetCKPricelistProxyURL(); ok && configuredURL == proxyURL {
+			return config.CKPricelistProxyEnv
+		}
+		return "ck-pricelist-configured"
 	default:
 		return "configured"
 	}

--- a/api/gateway/outbound_get.go
+++ b/api/gateway/outbound_get.go
@@ -43,7 +43,7 @@ func DoOutboundRoundTrip(
 	buildReq func() (*http.Request, error),
 ) (*http.Response, error) {
 	var failures []string
-	for _, attempt := range buildOutboundGETAttempts(timeout, opts.SkipDirect) {
+	for _, attempt := range buildOutboundGETAttempts(timeout, opts.SkipDirect, opts.OnlyProxyURL) {
 		req, err := buildReq()
 		if err != nil {
 			return nil, err
@@ -78,7 +78,19 @@ func DoOutboundRoundTrip(
 	return nil, fmt.Errorf("outbound request failed: %s", strings.Join(failures, "; "))
 }
 
-func buildOutboundGETAttempts(timeout time.Duration, skipDirect bool) []outboundAttempt {
+func buildOutboundGETAttempts(timeout time.Duration, skipDirect bool, onlyProxyURL string) []outboundAttempt {
+	if onlyProxyURL != "" {
+		client, err := newProxyHTTPClient(onlyProxyURL, timeout)
+		if err != nil {
+			return nil
+		}
+		return []outboundAttempt{{
+			strategy: "ck-pricelist-proxy",
+			proxyURL: onlyProxyURL,
+			client:   client,
+		}}
+	}
+
 	var attempts []outboundAttempt
 	if !skipDirect {
 		attempts = append(attempts, outboundAttempt{
@@ -160,6 +172,8 @@ func outboundProxyMode(strategy string) string {
 		return "dynamic"
 	case strings.HasPrefix(strategy, "dedicated-"):
 		return "dedicated"
+	case strategy == "ck-pricelist-proxy":
+		return "ck-pricelist"
 	default:
 		return strategy
 	}

--- a/api/gateway/outbound_get_test.go
+++ b/api/gateway/outbound_get_test.go
@@ -64,7 +64,7 @@ func TestBuildOutboundGETAttempts_TriesEachDedicatedProxy(t *testing.T) {
 	t.Setenv("DEDICATED_PROXY_1", "1.2.3.4|8080|user|pass")
 	t.Setenv("DEDICATED_PROXY_2", "5.6.7.8|8080|user|pass")
 
-	attempts := buildOutboundGETAttempts(2*time.Second, false)
+	attempts := buildOutboundGETAttempts(2*time.Second, false, "")
 	require.GreaterOrEqual(t, len(attempts), 3)
 	require.Equal(t, "direct", attempts[0].strategy)
 	require.Equal(t, "dedicated-1", attempts[1].strategy)
@@ -75,16 +75,49 @@ func TestBuildOutboundGETAttempts_SkipDirect(t *testing.T) {
 	clearProxyEnv(t)
 	t.Setenv("DEDICATED_PROXY_1", "1.2.3.4|8080|user|pass")
 
-	attempts := buildOutboundGETAttempts(2*time.Second, true)
+	attempts := buildOutboundGETAttempts(2*time.Second, true, "")
 	require.Len(t, attempts, 1)
 	require.Equal(t, "dedicated-1", attempts[0].strategy)
+}
+
+func TestBuildOutboundGETAttempts_OnlyProxyURL(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("DEDICATED_PROXY_1", "1.2.3.4|8080|user|pass")
+
+	attempts := buildOutboundGETAttempts(2*time.Second, false, "http://user:pass@res.proxy:8080")
+	require.Len(t, attempts, 1)
+	require.Equal(t, "ck-pricelist-proxy", attempts[0].strategy)
+	require.Equal(t, "http://user:pass@res.proxy:8080", attempts[0].proxyURL)
+}
+
+func TestDoOutboundGET_OnlyProxyURLSkipsDirect(t *testing.T) {
+	clearProxyEnv(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	_, err := DoOutboundGET(
+		context.Background(),
+		server.URL,
+		OutboundRequestOptions{
+			Accept:         "application/json",
+			SkipWebBotAuth: true,
+			OnlyProxyURL:   "http://user:pass@127.0.0.1:9",
+		},
+		50*time.Millisecond,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ck-pricelist-proxy:")
+	require.NotContains(t, err.Error(), "direct:")
 }
 
 func TestOutboundProxyDescription(t *testing.T) {
 	clearProxyEnv(t)
 	t.Setenv("DEDICATED_PROXY_1", "1.2.3.4|8080|user|pass")
 
-	attempts := buildOutboundGETAttempts(2*time.Second, false)
+	attempts := buildOutboundGETAttempts(2*time.Second, false, "")
 	require.GreaterOrEqual(t, len(attempts), 2)
 
 	require.Equal(t, "proxy_mode=direct proxy=none", outboundProxyDescription(attempts[0]))

--- a/api/gateway/outbound_request.go
+++ b/api/gateway/outbound_request.go
@@ -24,6 +24,9 @@ type OutboundRequestOptions struct {
 	Accept string
 	// SkipDirect omits the direct transport from DoOutboundGET fallback chains.
 	SkipDirect bool
+	// OnlyProxyURL restricts DoOutboundGET to a single proxy transport when set.
+	// Direct, dedicated, and dynamic fallbacks are skipped.
+	OnlyProxyURL string
 	// SkipWebBotAuth uses a browser User-Agent and omits Web Bot Auth signing.
 	SkipWebBotAuth bool
 	// ShopifySGDCurrency sets cart_currency/localization cookies for Shopify storefronts.

--- a/api/gateway/util/dedicated_proxy.go
+++ b/api/gateway/util/dedicated_proxy.go
@@ -69,6 +69,12 @@ func BuildProxyURL(raw string) (string, bool) {
 	return BuildDedicatedProxyURL(parseDedicatedProxy(raw))
 }
 
+// GetCKPricelistProxyURL returns the optional CK pricelist-only proxy URL from
+// CK_PRICELIST_PROXY when configured.
+func GetCKPricelistProxyURL() (string, bool) {
+	return BuildProxyURL(os.Getenv("CK_PRICELIST_PROXY"))
+}
+
 func GetDedicatedProxyURLs() []string {
 	proxies := GetDedicatedProxy()
 	proxyURLs := make([]string, 0, len(proxies))

--- a/api/gateway/util/dedicated_proxy_test.go
+++ b/api/gateway/util/dedicated_proxy_test.go
@@ -91,6 +91,13 @@ func TestGetDedicatedProxyRejectsPartialSegments(t *testing.T) {
 	}
 }
 
+func TestGetCKPricelistProxyURL(t *testing.T) {
+	t.Setenv("CK_PRICELIST_PROXY", "res.proxy|8080|user|pass")
+	got, ok := GetCKPricelistProxyURL()
+	require.True(t, ok)
+	require.Equal(t, "http://user:pass@res.proxy:8080", got)
+}
+
 func TestBuildProxyURL(t *testing.T) {
 	t.Run("builds url from pipe separated proxy config", func(t *testing.T) {
 		got, ok := BuildProxyURL("dc.com|10000|user-spsykhacft-country-sg|F+password")

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -53,6 +53,10 @@ const (
 	CKPriceMaxAge = 48 * time.Hour
 	// CKPricelistURLEnv overrides the Card Kingdom singles pricelist download URL.
 	CKPricelistURLEnv = "CK_PRICELIST_URL"
+	// CKPricelistProxyEnv is an optional residential/ISP proxy used only for the
+	// Card Kingdom pricelist API download. Format matches DEDICATED_PROXY_*:
+	// host|port|username|password (full proxy URLs are also accepted).
+	CKPricelistProxyEnv = "CK_PRICELIST_PROXY"
 	// MTGJSONAllPricesTodayURLEnv overrides the MTGJSON AllPricesToday download URL.
 	MTGJSONAllPricesTodayURLEnv = "MTGJSON_ALL_PRICES_TODAY_URL"
 	// MTGJSONAllPrintingsURLEnv overrides the MTGJSON AllPrintings download URL.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds optional `CK_PRICELIST_PROXY` support so the daily Card Kingdom pricelist download can route through a dedicated residential/ISP proxy without affecting other outbound scrapers.

## Changes

- New env var `CK_PRICELIST_PROXY` (same `host|port|username|password` format as `DEDICATED_PROXY_*`; full proxy URLs also accepted)
- CK pricelist fetch uses **only** this proxy when configured (no direct/dedicated/dynamic fallback for that request)
- When unset, CK pricelist behavior is unchanged (existing outbound fallback chain)
- Logging identifies the transport as `CK_PRICELIST_PROXY`

## Usage

```bash
CK_PRICELIST_PROXY=res.proxy.example|8080|user|pass
```

## Testing

- `make test`
- Added unit tests for proxy option wiring, outbound-only-proxy attempts, and env parsing
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d59925e-bcee-4382-ab24-3d1fea76e5da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d59925e-bcee-4382-ab24-3d1fea76e5da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

