### PR TITLE
Show only negative values in Top $ drops (and positive in Top $ risers)

### DIFF
--- a/api/store/ckprices/dynamodb.go
+++ b/api/store/ckprices/dynamodb.go
@@ -146,9 +146,12 @@ func (s *DynamoDBStore) GetTopBottomPriceChanges(ctx context.Context) (*TopBotto
 	if err != nil {
 		return nil, err
 	}
+	// Top must only contain price increases and Bottom only price drops. When
+	// fewer than PriceChangeRankingLimit listings moved in a direction, the raw
+	// rankings would otherwise spill over into the opposite sign.
 	return &TopBottomPriceChanges{
-		Top:    top,
-		Bottom: bottom,
+		Top:    filterPriceChangesByUsdSign(top, true),
+		Bottom: filterPriceChangesByUsdSign(bottom, false),
 	}, nil
 }
 

--- a/api/store/ckprices/price_change.go
+++ b/api/store/ckprices/price_change.go
@@ -126,6 +126,22 @@ func topBottomPriceChangesByUsd(listings []PriceChangeListing, limit int) TopBot
 	}
 }
 
+// filterPriceChangesByUsdSign keeps listings whose USD change matches the requested
+// direction: increases=true keeps price rises (> 0), increases=false keeps price
+// drops (< 0). Listings with a missing or zero change are always excluded.
+func filterPriceChangesByUsdSign(listings []PriceChangeListing, increases bool) []PriceChangeListing {
+	filtered := make([]PriceChangeListing, 0, len(listings))
+	for _, listing := range listings {
+		if listing.PriceChangeUsd == nil || *listing.PriceChangeUsd == 0 {
+			continue
+		}
+		if (*listing.PriceChangeUsd > 0) == increases {
+			filtered = append(filtered, listing)
+		}
+	}
+	return filtered
+}
+
 func priceChangesByPercentFromListings(listings []PriceChangeListing, ascending bool, limit int) []PriceChangeListing {
 	rankings := topBottomPriceChangesByPercent(listings, limit)
 	if ascending {

--- a/api/store/ckprices/price_change_test.go
+++ b/api/store/ckprices/price_change_test.go
@@ -206,6 +206,26 @@ func TestTopBottomPriceChangesByUsd(t *testing.T) {
 	require.InDelta(t, -8.00, *rankings.Bottom[0].PriceChangeUsd, 0.001)
 }
 
+func TestFilterPriceChangesByUsdSign(t *testing.T) {
+	usd := func(value float64) *float64 {
+		return &value
+	}
+	listings := []PriceChangeListing{
+		{NameKey: "riser", Listing: cardkingdom.Listing{PriceChangeUsd: usd(2.50)}},
+		{NameKey: "drop", Listing: cardkingdom.Listing{PriceChangeUsd: usd(-1.25)}},
+		{NameKey: "flat", Listing: cardkingdom.Listing{PriceChangeUsd: usd(0)}},
+		{NameKey: "missing", Listing: cardkingdom.Listing{}},
+	}
+
+	increases := filterPriceChangesByUsdSign(listings, true)
+	require.Len(t, increases, 1)
+	require.Equal(t, "riser", increases[0].NameKey)
+
+	drops := filterPriceChangesByUsdSign(listings, false)
+	require.Len(t, drops, 1)
+	require.Equal(t, "drop", drops[0].NameKey)
+}
+
 func TestPriceChangeListingFromRecord(t *testing.T) {
 	change := 15
 	listing, ok := priceChangeListingFromRecord(dynamoRecord{

--- a/frontend/src/utils/ckPriceChanges.js
+++ b/frontend/src/utils/ckPriceChanges.js
@@ -15,7 +15,7 @@ export function formatPriceChangeUsd(usd) {
   return `-$${amount}`;
 }
 
-function parseCKPriceChangeListings(listings, limit = 20) {
+function parseCKPriceChangeListings(listings, matchesDirection, limit = 20) {
   if (!Array.isArray(listings)) {
     return [];
   }
@@ -29,16 +29,29 @@ function parseCKPriceChangeListings(listings, limit = 20) {
           ? item.priceChangeUsd
           : null,
     }))
-    .filter((item) => item.cardName.length > 0)
+    .filter(
+      (item) =>
+        item.cardName.length > 0 &&
+        item.priceChangeUsd !== null &&
+        matchesDirection(item.priceChangeUsd),
+    )
     .slice(0, limit);
 }
 
 export function parseCKPriceIncreases(payload, limit = 20) {
-  return parseCKPriceChangeListings(payload?.top, limit);
+  return parseCKPriceChangeListings(
+    payload?.top,
+    (priceChangeUsd) => priceChangeUsd > 0,
+    limit,
+  );
 }
 
 export function parseCKPriceDrops(payload, limit = 20) {
-  return parseCKPriceChangeListings(payload?.bottom, limit);
+  return parseCKPriceChangeListings(
+    payload?.bottom,
+    (priceChangeUsd) => priceChangeUsd < 0,
+    limit,
+  );
 }
 
 export function hasNonZeroUsdPriceChanges(increases, drops) {

--- a/frontend/src/utils/ckPriceChanges.test.js
+++ b/frontend/src/utils/ckPriceChanges.test.js
@@ -17,25 +17,25 @@ test("formatPriceChangeUsd formats signed dollar amounts", () => {
   assert.equal(formatPriceChangeUsd(Number.NaN), null);
 });
 
-test("parseCKPriceIncreases returns top card names with USD changes when present", () => {
+test("parseCKPriceIncreases returns top card names with positive USD changes only", () => {
   const payload = {
     top: [
       { cardName: "Lightning Bolt", priceChangeUsd: 0.5 },
       { cardName: " Counterspell ", priceChangeUsd: 0.1 },
       { cardName: "", priceChangeUsd: 0.05 },
       { cardName: "Sol Ring", priceChangePercent: 5 },
+      { cardName: "Brainstorm", priceChangeUsd: 0 },
+      { cardName: "Dark Ritual", priceChangeUsd: -0.25 },
     ],
   };
 
   const increases = parseCKPriceIncreases(payload);
 
-  assert.equal(increases.length, 3);
+  assert.equal(increases.length, 2);
   assert.equal(increases[0].cardName, "Lightning Bolt");
   assert.equal(increases[0].priceChangeUsd, 0.5);
   assert.equal(increases[1].cardName, "Counterspell");
   assert.equal(increases[1].priceChangeUsd, 0.1);
-  assert.equal(increases[2].cardName, "Sol Ring");
-  assert.equal(increases[2].priceChangeUsd, null);
 });
 
 test("parseCKPriceIncreases returns an empty list for invalid payloads", () => {
@@ -44,25 +44,25 @@ test("parseCKPriceIncreases returns an empty list for invalid payloads", () => {
   assert.deepEqual(parseCKPriceIncreases({ top: "invalid" }), []);
 });
 
-test("parseCKPriceDrops returns bottom card names with USD changes when present", () => {
+test("parseCKPriceDrops returns bottom card names with negative USD changes only", () => {
   const payload = {
     bottom: [
       { cardName: "Counterspell", priceChangeUsd: -1.5 },
       { cardName: " Sol Ring ", priceChangeUsd: -0.1 },
       { cardName: "", priceChangeUsd: -0.05 },
       { cardName: "Lightning Bolt", priceChangePercent: -5 },
+      { cardName: "Brainstorm", priceChangeUsd: 0 },
+      { cardName: "Dark Ritual", priceChangeUsd: 0.75 },
     ],
   };
 
   const drops = parseCKPriceDrops(payload);
 
-  assert.equal(drops.length, 3);
+  assert.equal(drops.length, 2);
   assert.equal(drops[0].cardName, "Counterspell");
   assert.equal(drops[0].priceChangeUsd, -1.5);
   assert.equal(drops[1].cardName, "Sol Ring");
   assert.equal(drops[1].priceChangeUsd, -0.1);
-  assert.equal(drops[2].cardName, "Lightning Bolt");
-  assert.equal(drops[2].priceChangeUsd, null);
 });
 
 test("parseCKPriceDrops returns an empty list for invalid payloads", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Top $ drops (24 Hrs)** could show a card with a **+** value: the `bottom` ranking is just the 20 lowest USD changes, so when fewer than 20 cards dropped in price, positive/zero changes spilled into the drops list (and vice versa for risers). This PR enforces the sign in both the backend report and the frontend display.

## Changes

- **Backend** (`api/store/ckprices`): `GetTopBottomPriceChanges` now filters the exported rankings with a new `filterPriceChangesByUsdSign` helper — `top` keeps only positive USD changes, `bottom` only negative; zero/missing changes are excluded from both.
- **Frontend** (`frontend/src/utils/ckPriceChanges.js`): `parseCKPriceDrops` keeps only negative `priceChangeUsd` and `parseCKPriceIncreases` only positive, so stale/older `latest.json` reports can never render a `+` pill in drops (or `-` in risers).
- Unit tests added/updated on both sides.

## Screenshots

Tested against a mocked `latest.json` containing a positive entry in `bottom` and a negative entry in `top` (Vite `/analytics` proxy temporarily disabled during testing; reverted).

### Before (bug reproduced on pre-fix code, desktop)
"Bogus Riser In Drops +$12.50" rendered in the drops view:

![Top $ drops before fix showing +$12.50 pill](https://cursor.com/artifacts/c/art-375a9c43-db26-4ed2-b972-f1186b5967c4)

### After (desktop)
Only negative pills remain in Top $ drops:

![Top $ drops after fix desktop](https://cursor.com/artifacts/c/art-60bd32da-e6ec-4555-bb18-83316cffb31a)

Top $ risers shows only positive pills (negative test entry filtered out):

![Top $ risers after fix desktop](https://cursor.com/artifacts/c/art-206cdda2-21cd-4570-8c66-42910aed8817)

### After (mobile, 390px)

![Top $ drops after fix mobile](https://cursor.com/artifacts/c/art-d35d9d04-ca7a-4cb1-a6fc-8549ed976a4d)

### Demo video

<a href="https://cursor.com/agents/bc-eb738d55-671a-46b9-9cec-f9467b988b8b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftop_dollar_drops_negative_only_after_fix.mp4"><img src="https://cursor.com/artifacts/c/art-c5ebd991-5941-436b-b884-24f8e4f86868" alt="top_dollar_drops_negative_only_after_fix.mp4" /></a>

## Testing

- `cd frontend && node --test src/utils/ckPriceChanges.test.js` — pass
- `make test` — pass except one transient live-gateway timeout (`gateway/duellerpoint` `Test_Search`, upstream `Client.Timeout`); passed on immediate retry
- `cd api && go test -mod=vendor ./store/... ./handler/...` — pass
- `cd api && go fix ./...` — no changes
- `npm run lint` — pre-existing failures only (identical output on `master`); no new issues in touched files
- Manual GUI test: reproduced the `+` pill in Top $ drops on pre-fix code, then verified the fix filters it out (desktop + mobile, see screenshots/video)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb738d55-671a-46b9-9cec-f9467b988b8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb738d55-671a-46b9-9cec-f9467b988b8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

