### PR TITLE
Stop BinderPOS search fallback on HTTP 5xx errors

### DIFF
--- a/api/gateway/binderpos/storefront_fallback.go
+++ b/api/gateway/binderpos/storefront_fallback.go
@@ -15,8 +15,10 @@ type fallbackAttempt struct {
 // result that returns cards.
 //
 // When any attempt returns no cards without error, that empty result is final
-// and no further strategies run. Each attempt's error is annotated with its
-// position and strategy name so the final error reflects the last attempt tried.
+// and no further strategies run. HTTP 5xx errors are final as well: later
+// strategies are not tried because the upstream is failing, not blocking the
+// current transport. Each attempt's error is annotated with its position and
+// strategy name so the final error reflects the last attempt tried.
 func runFallbackAttempts(attempts ...fallbackAttempt) ([]gateway.Card, error) {
 	var (
 		cards           []gateway.Card
@@ -35,6 +37,10 @@ func runFallbackAttempts(attempts ...fallbackAttempt) ([]gateway.Card, error) {
 
 		if err == nil && len(cards) == 0 {
 			return cards, nil
+		}
+
+		if gateway.IsHTTPServerError(err) {
+			return cards, err
 		}
 	}
 

--- a/api/gateway/binderpos/storefront_fallback_test.go
+++ b/api/gateway/binderpos/storefront_fallback_test.go
@@ -27,7 +27,7 @@ func TestRunFallbackAttempts(t *testing.T) {
 		}
 	})
 
-	t.Run("falls back to the next attempt only after an error", func(t *testing.T) {
+	t.Run("falls back to the next attempt only after a non-5xx error", func(t *testing.T) {
 		cards, err := runFallbackAttempts(
 			fallbackAttempt{strategy: "scrap-dedicated", fn: func() ([]gateway.Card, error) {
 				return nil, errors.New("scrap dedicated failed")
@@ -41,6 +41,29 @@ func TestRunFallbackAttempts(t *testing.T) {
 		}
 		if len(cards) != 1 || cards[0].Name != "scrap-direct" {
 			t.Fatalf("expected fallback card, got %+v", cards)
+		}
+	})
+
+	t.Run("does not fall back after a 5xx error", func(t *testing.T) {
+		sequence := make([]string, 0, 2)
+		_, err := runFallbackAttempts(
+			fallbackAttempt{strategy: "scrap-dedicated", fn: func() ([]gateway.Card, error) {
+				sequence = append(sequence, "scrap-dedicated")
+				return nil, errors.New("503 Service Unavailable")
+			}},
+			fallbackAttempt{strategy: "scrap-direct", fn: func() ([]gateway.Card, error) {
+				t.Fatal("scrap-direct should not run after a 5xx error")
+				return nil, nil
+			}},
+		)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !gateway.IsHTTPServerError(err) {
+			t.Fatalf("expected 5xx error, got %v", err)
+		}
+		if len(sequence) != 1 || sequence[0] != "scrap-dedicated" {
+			t.Fatalf("expected only scrap-dedicated, got %v", sequence)
 		}
 	})
 

--- a/api/gateway/http_status.go
+++ b/api/gateway/http_status.go
@@ -34,6 +34,24 @@ func ErrorMessageHasHTTPStatus(msg string) bool {
 	return ExtractHTTPStatusCode(msg) > 0
 }
 
+// IsHTTPServerError reports whether err (or any error in its chain) represents an
+// HTTP 5xx response. Bare status phrases such as "Service Unavailable" are
+// recognized when they map to a 5xx code.
+func IsHTTPServerError(err error) bool {
+	for err != nil {
+		msg := err.Error()
+		code := ExtractHTTPStatusCode(msg)
+		if code == 0 {
+			code = ExtractHTTPStatusCode(EnsureHTTPStatusInErrorMessage(msg))
+		}
+		if code >= http.StatusInternalServerError && code < 600 {
+			return true
+		}
+		err = errors.Unwrap(err)
+	}
+	return false
+}
+
 // ExtractHTTPStatusCode returns the first HTTP status code found in msg, or 0.
 func ExtractHTTPStatusCode(msg string) int {
 	for _, pattern := range httpStatusPatterns {

--- a/api/gateway/http_status_test.go
+++ b/api/gateway/http_status_test.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"testing"
 )
@@ -29,6 +30,28 @@ func TestExtractHTTPStatusCode(t *testing.T) {
 		if got := ExtractHTTPStatusCode(msg); got != want {
 			t.Fatalf("ExtractHTTPStatusCode(%q) = %d, want %d", msg, got, want)
 		}
+	}
+}
+
+func TestIsHTTPServerError(t *testing.T) {
+	tests := map[string]bool{
+		"503 Service Unavailable":                                                      true,
+		"attempt 1 (scrap-dedicated): 503 Service Unavailable (proxy_mode=direct)":     true,
+		"attempt 2 (scrap-direct): Service Unavailable (proxy_mode=direct proxy=none)": true,
+		"403 Forbidden":           false,
+		"unexpected status 429":   false,
+		"connection reset by peer": false,
+	}
+
+	for msg, want := range tests {
+		if got := IsHTTPServerError(errors.New(msg)); got != want {
+			t.Fatalf("IsHTTPServerError(%q) = %v, want %v", msg, got, want)
+		}
+	}
+
+	wrapped := fmt.Errorf("attempt 1 (scrap-dedicated): %w", errors.New("503 Service Unavailable"))
+	if !IsHTTPServerError(wrapped) {
+		t.Fatalf("IsHTTPServerError() should detect wrapped 5xx errors")
 	}
 }
 

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -52,7 +52,7 @@ Some tests in `api/gateway/binderpos/*_test.go` hit real stores and proxies. The
 |------|--------|--------|--------|
 | **scrap-dedicated** proxy selection (colly) | Request-scoped lease when BinderPOS stores are searched; otherwise random dedicated | `fetchCardsConcurrently` + `selectOutboundProxy` in `api/gateway/collector.go` | When a search includes BinderPOS stores, the controller holds one dedicated-proxy lease and pins it on the search context. All `scrap-dedicated` attempts reuse that URL. When `UseLeasedDedicatedProxy` is **true**, per-collector leases apply only when no request-scoped proxy is set. |
 | Colly for BinderPOS scrapes | 5s | `SetRequestTimeout(binderposAttemptTimeout)` in `api/gateway/binderpos/scrap.go` | Same as `config.SearchAttemptTimeout`. |
-| “Retries” | N/A (sequential fallbacks) | `runFallbackAttempts` in `storefront_fallback.go` | Stops on the first attempt that returns **cards**. An empty attempt without error is **final** and no further strategies run. Returns the last annotated error if all attempts fail. This is **not** exponential backoff retry of a single request. |
+| “Retries” | N/A (sequential fallbacks) | `runFallbackAttempts` in `storefront_fallback.go` | Stops on the first attempt that returns **cards**. An empty attempt without error is **final** and no further strategies run. HTTP **5xx** errors are also **final** (no later strategy). Returns the last annotated error if all attempts fail. This is **not** exponential backoff retry of a single request. |
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When a BinderPOS scrape strategy fails with an HTTP 5xx response, the search now stops immediately instead of trying later strategies (direct / dynamic proxy).

A 5xx indicates the upstream store is failing, not that the current transport was blocked, so falling back to another proxy strategy is unlikely to help and adds unnecessary load/latency.

## Changes

- Add `gateway.IsHTTPServerError` to detect 5xx status codes in error messages and wrapped error chains (including bare phrases like `Service Unavailable`).
- Update `runFallbackAttempts` to return on the first 5xx error without running later BinderPOS strategies.
- Document the new behavior in `docs/search-strategies-retries-timeouts.md`.

## Testing

- `go test -mod=vendor ./gateway/... ./gateway/binderpos/... -run 'TestIsHTTPServerError|TestRunFallbackAttempts'`
- `make test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-18dc938c-d309-4481-a94a-8a6042272fa4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18dc938c-d309-4481-a94a-8a6042272fa4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

