### PR TITLE
Add BinderPOS decklist API as fallback after scrape rate limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,30 +252,44 @@ multi-strategy fallback. On failure the store simply contributes nothing.
 Fyendal Hobby, Grey Ogre Games, Hideout, Mana Pro, MTG Asia, OneMTG) share one
 gateway that reads listings by scraping each store's own Shopify storefront.
 
-### BinderPOS scrape fallback chain
+### BinderPOS scrape and decklist fallback chain
 
-Each BinderPOS store tries up to three scrape strategies in order, escalating
-across proxy tiers (**dedicated → direct → dynamic**), with the dynamic proxy
-reserved for last:
+Each BinderPOS store tries up to three scrape strategies first, escalating
+across proxy tiers (**dedicated → direct → dynamic**). When scrape attempts fail
+with errors (for example storefront **429** rate limits), the shared BinderPOS
+decklist portal is tried as a fallback with the same proxy tiers:
 
-`scrap-dedicated` → `scrap-direct` → `scrap-dynamic`
+`scrap-dedicated` → `scrap-direct` → `scrap-dynamic` → `decklist-dedicated` → `decklist-direct` → `decklist-dynamic`
 
 ```mermaid
 flowchart TD
     A[BinderPOS store search] --> B[scrap-dedicated]
     B -- error --> C[scrap-direct]
     C -- error --> D[scrap-dynamic]
+    D -- error --> F[decklist-dedicated]
+    F -- error --> G[decklist-direct]
+    G -- error --> H[decklist-dynamic]
     B -- cards or empty success --> E[Return result]
     C -- cards or empty success --> E
-    D -- cards, empty, or error --> E
+    D -- cards or empty success --> E
+    F -- cards or empty decklist --> E
+    G -- cards or empty decklist --> E
+    H -- cards, empty, or error --> E
 ```
 
 ### Fallback rules
 
 - The chain advances to the next attempt **on error only**. An empty but
-  error-free result counts as success and stops the chain (no further fallback).
+  error-free **scrape** result counts as success and stops the chain (decklist is
+  not tried when the storefront reports no matches). An empty decklist response
+  skips the remaining decklist attempts.
+- HTTP **5xx** errors on scrape attempts are final; decklist is not tried when
+  the storefront itself is failing.
 - Each attempt is bounded by a 5s timeout (`binderposAttemptTimeout`). The first
   attempt starts immediately; later attempts honor per-domain request pacing.
+- Decklist calls to `portal.binderpos.com` retry transient 429/5xx responses
+  with jittered backoff (honoring `Retry-After`) and share a small concurrency
+  gate across stores.
 
 ## 🗂️ Repository layout
 

--- a/api/gateway/binderpos/new.go
+++ b/api/gateway/binderpos/new.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Gateway interface {
-	Search(ctx context.Context, scrapVariant int, storeName, baseUrl, searchUrl, searchStr string) ([]gateway.Card, error)
+	Search(ctx context.Context, scrapVariant int, storeName, baseUrl, shopifyDomain, searchUrl, searchStr string) ([]gateway.Card, error)
 	Scrap(ctx context.Context, scrapVariant int, storeName, baseUrl, searchUrl, searchStr string) ([]gateway.Card, error)
 }
 

--- a/api/gateway/binderpos/storefront.go
+++ b/api/gateway/binderpos/storefront.go
@@ -1,7 +1,52 @@
 package binderpos
 
 import (
+	"time"
+
 	"mtg-price-checker-sg/pkg/config"
 )
 
-const binderposAttemptTimeout = config.SearchAttemptTimeout
+const (
+	binderposDecklistAPIURL = "https://portal.binderpos.com/external/shopify/decklist"
+	binderposDecklistType   = "mtg"
+	binderposAttemptTimeout = config.SearchAttemptTimeout
+
+	// binderposDecklistMaxAttempts bounds how many times a single decklist call
+	// is sent (initial try plus retries) when the shared portal host responds
+	// with a transient rate-limit/5xx status or a network error. Retries stay
+	// within the per-attempt timeout budget and back off between sends so a
+	// struggling upstream is not hammered.
+	binderposDecklistMaxAttempts = 3
+	// binderposDecklistRetryBaseDelay is the first backoff step; subsequent
+	// retries grow it exponentially with equal jitter.
+	binderposDecklistRetryBaseDelay = 300 * time.Millisecond
+	// binderposDecklistRetryMaxDelay caps a single backoff/Retry-After wait so a
+	// large or hostile Retry-After value cannot stall the attempt.
+	binderposDecklistRetryMaxDelay = 2500 * time.Millisecond
+)
+
+type storefrontDecklistRequestItem struct {
+	Card     string `json:"card"`
+	Quantity int    `json:"quantity"`
+}
+
+type storefrontDecklistLine struct {
+	// The API can send a boolean validName; binding it would break decode, so it is not mapped.
+	Products []storefrontDecklistProduct `json:"products"`
+}
+
+type storefrontDecklistProduct struct {
+	Title    string                    `json:"title"`
+	Name     string                    `json:"name"`
+	Handle   string                    `json:"handle"`
+	SetName  string                    `json:"setName"`
+	Image    string                    `json:"img"`
+	Variants []storefrontDecklistStock `json:"variants"`
+}
+
+type storefrontDecklistStock struct {
+	ShopifyID int64   `json:"shopifyId"`
+	Title     string  `json:"title"`
+	Price     float64 `json:"price"`
+	Quantity  int     `json:"quantity"`
+}

--- a/api/gateway/binderpos/storefront_client.go
+++ b/api/gateway/binderpos/storefront_client.go
@@ -1,0 +1,84 @@
+package binderpos
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sync/atomic"
+
+	"mtg-price-checker-sg/gateway"
+	"mtg-price-checker-sg/gateway/util"
+	"mtg-price-checker-sg/pkg/config"
+)
+
+// binderposDedicatedProxySeq advances for each BinderPOS storefront API call that uses
+// non-leased dedicated routing, so traffic round-robins across configured dedicated proxies.
+var binderposDedicatedProxySeq atomic.Uint32
+
+// nextBinderposStorefrontProxyURL returns the next dedicated proxy URL in round-robin order.
+func nextBinderposStorefrontProxyURL(proxyURLs []string) string {
+	n := len(proxyURLs)
+	v := binderposDedicatedProxySeq.Add(1) - 1
+	slot := int(v % uint32(n))
+	return proxyURLs[slot]
+}
+
+func searchByStorefrontAPI(ctx context.Context, scrapVariant int, storeName, baseURL, shopifyDomain, searchStr string) ([]gateway.Card, error) {
+	proxyURLs := util.GetDedicatedProxyURLs()
+	if len(proxyURLs) == 0 {
+		return nil, fmt.Errorf("no dedicated proxy configured for binderpos storefront api")
+	}
+
+	var proxyURL string
+	if config.UseLeasedDedicatedProxy {
+		leasedURL, release, err := gateway.LeaseDedicatedProxyURL(ctx, proxyURLs)
+		if err != nil {
+			return nil, fmt.Errorf("dedicated proxy lease for binderpos storefront api: %w", err)
+		}
+		defer release()
+		proxyURL = leasedURL
+	} else {
+		proxyURL = nextBinderposStorefrontProxyURL(proxyURLs)
+	}
+
+	client, err := newHTTPClientWithProxyURL(proxyURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid dedicated proxy configured for binderpos storefront api: %w", err)
+	}
+
+	return searchByBinderposDecklistAPI(ctx, client, scrapVariant, storeName, baseURL, shopifyDomain, searchStr)
+}
+
+func searchByStorefrontAPIDynamic(ctx context.Context, scrapVariant int, storeName, baseURL, shopifyDomain, searchStr string) ([]gateway.Card, error) {
+	proxyURL := gateway.DynamicProxyURL()
+	if proxyURL == "" {
+		return nil, fmt.Errorf("no dynamic proxy configured for binderpos storefront api")
+	}
+
+	client, err := newHTTPClientWithProxyURL(proxyURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid dynamic proxy configured for binderpos storefront api: %w", err)
+	}
+
+	return searchByBinderposDecklistAPI(ctx, client, scrapVariant, storeName, baseURL, shopifyDomain, searchStr)
+}
+
+func searchByStorefrontAPIDirect(ctx context.Context, scrapVariant int, storeName, baseURL, shopifyDomain, searchStr string) ([]gateway.Card, error) {
+	client := &http.Client{Timeout: binderposAttemptTimeout}
+	return searchByBinderposDecklistAPI(ctx, client, scrapVariant, storeName, baseURL, shopifyDomain, searchStr)
+}
+
+func newHTTPClientWithProxyURL(proxyURL string) (*http.Client, error) {
+	parsedProxyURL, err := url.Parse(proxyURL)
+	if err != nil {
+		return nil, err
+	}
+
+	return &http.Client{
+		Timeout: binderposAttemptTimeout,
+		Transport: &http.Transport{
+			Proxy: http.ProxyURL(parsedProxyURL),
+		},
+	}, nil
+}

--- a/api/gateway/binderpos/storefront_decklist.go
+++ b/api/gateway/binderpos/storefront_decklist.go
@@ -1,0 +1,144 @@
+package binderpos
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"mtg-price-checker-sg/gateway"
+	"mtg-price-checker-sg/gateway/util"
+)
+
+func searchByBinderposDecklistAPI(ctx context.Context, client *http.Client, scrapVariant int, storeName, baseURL, shopifyDomain, searchStr string) ([]gateway.Card, error) {
+	shopifyDomain = strings.TrimSpace(shopifyDomain)
+	if shopifyDomain == "" {
+		return nil, fmt.Errorf("missing shopify domain mapping for binderpos storefront")
+	}
+
+	decklistURL, err := url.Parse(binderposDecklistAPIURL)
+	if err != nil {
+		return nil, err
+	}
+	query := decklistURL.Query()
+	query.Set("storeUrl", shopifyDomain)
+	query.Set("type", binderposDecklistType)
+	decklistURL.RawQuery = query.Encode()
+
+	payload := []storefrontDecklistRequestItem{
+		{
+			Card:     strings.TrimSpace(searchStr),
+			Quantity: 1,
+		},
+	}
+	payloadBody, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	storeBase, _ := url.Parse(baseURL)
+	// Rebuilt per send so each retry carries a fresh User-Agent and a
+	// re-readable body, which also helps evade naive fingerprint throttling.
+	newRequest := func() (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, decklistURL.String(), bytes.NewReader(payloadBody))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json; charset=utf-8")
+		if err := gateway.PrepareOutboundRequest(ctx, req, gateway.OutboundRequestOptions{
+			Style:     gateway.OutboundStyleJSON,
+			StoreBase: storeBase,
+		}); err != nil {
+			return nil, err
+		}
+		return req, nil
+	}
+
+	releasePortalSlot, err := acquireBinderposPortalSlot(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer releasePortalSlot()
+
+	res, err := doDecklistRequestWithRetry(ctx, client, newRequest)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	var lines []storefrontDecklistLine
+	if err := json.NewDecoder(res.Body).Decode(&lines); err != nil {
+		return nil, err
+	}
+
+	return mapDecklistLinesToCards(scrapVariant, storeName, baseURL, lines), nil
+}
+
+func mapDecklistLinesToCards(scrapVariant int, storeName, baseURL string, lines []storefrontDecklistLine) []gateway.Card {
+	cards := make([]gateway.Card, 0, len(lines)*4)
+	seen := map[string]struct{}{}
+
+	for _, line := range lines {
+		for _, product := range line.Products {
+			productTitle := strings.TrimSpace(product.Title)
+			if productTitle == "" {
+				productTitle = strings.TrimSpace(product.Name)
+			}
+			if productTitle == "" {
+				continue
+			}
+
+			productPath := ""
+			if strings.TrimSpace(product.Handle) != "" {
+				productPath = "/products/" + strings.TrimSpace(product.Handle)
+			}
+
+			setName := strings.TrimSpace(product.SetName)
+			if setName == "" {
+				setName = extractSetName(productTitle)
+			}
+
+			image := buildCardImageURL(product.Image, productTitle)
+			for _, variant := range product.Variants {
+				if variant.Price <= 0 || variant.Quantity <= 0 {
+					continue
+				}
+				if variant.ShopifyID <= 0 || productPath == "" {
+					continue
+				}
+
+				cardURL, err := buildProductURLWithVariant(baseURL, productPath, variant.ShopifyID)
+				if err != nil {
+					continue
+				}
+
+				quality := strings.TrimSpace(strings.ReplaceAll(variant.Title, "Foil", ""))
+				card := gateway.Card{
+					Name:    formatCardName(scrapVariant, productTitle, variant.Title),
+					Url:     cardURL,
+					Img:     image,
+					Price:   variant.Price,
+					InStock: variant.Quantity > 0,
+					IsFoil:  strings.Contains(strings.ToLower(variant.Title), "foil"),
+					Source:  storeName,
+					Quality: util.MapQuality(quality),
+				}
+				if scrapVariant == 3 && setName != "" {
+					card.ExtraInfo = []string{setName}
+				}
+
+				key := fmt.Sprintf("%s|%.2f|%t", card.Url, card.Price, card.InStock)
+				if _, exists := seen[key]; exists {
+					continue
+				}
+				seen[key] = struct{}{}
+				cards = append(cards, card)
+			}
+		}
+	}
+
+	return cards
+}

--- a/api/gateway/binderpos/storefront_decklist_retry.go
+++ b/api/gateway/binderpos/storefront_decklist_retry.go
@@ -1,0 +1,169 @@
+package binderpos
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"mtg-price-checker-sg/gateway"
+)
+
+// retriableDecklistStatuses are upstream responses that signal a transient
+// load or rate-limit condition on the shared portal host. They are retried with
+// backoff (honoring Retry-After) instead of immediately failing over to a
+// heavier, more expensive strategy, which reduces the user-visible 503 rate
+// without changing card data.
+var retriableDecklistStatuses = map[int]struct{}{
+	http.StatusTooManyRequests:     {}, // 429
+	http.StatusInternalServerError: {}, // 500
+	http.StatusBadGateway:          {}, // 502
+	http.StatusServiceUnavailable:  {}, // 503
+	http.StatusGatewayTimeout:      {}, // 504
+}
+
+func isRetriableDecklistStatus(status int) bool {
+	_, ok := retriableDecklistStatuses[status]
+	return ok
+}
+
+// doDecklistRequestWithRetry sends the decklist request, retrying transient
+// rate-limit/5xx responses and network errors with jittered exponential backoff
+// bounded by ctx. newRequest rebuilds the request for every send so each retry
+// carries a fresh User-Agent (set by the caller) and a re-readable body. On the
+// dynamic-proxy attempt every retry egresses from a fresh rotating IP, which is
+// the most effective mitigation for per-IP throttling on the shared portal host.
+//
+// On success it returns the response with its body still open for the caller to
+// decode. On failure it returns the last observed error and no response.
+func doDecklistRequestWithRetry(ctx context.Context, client *http.Client, newRequest func() (*http.Request, error)) (*http.Response, error) {
+	var lastErr error
+
+	for attempt := range binderposDecklistMaxAttempts {
+		req, err := newRequest()
+		if err != nil {
+			return nil, err
+		}
+		if err := gateway.WaitForDomainRequestSlot(ctx, req.URL); err != nil {
+			return nil, err
+		}
+
+		res, err := client.Do(req)
+		if err != nil {
+			lastErr = err
+			if isLastDecklistAttempt(attempt) || !waitBeforeDecklistRetry(ctx, decklistBackoffDelay(attempt)) {
+				return nil, lastErr
+			}
+			continue
+		}
+
+		if res.StatusCode == http.StatusOK {
+			return res, nil
+		}
+
+		body, _ := io.ReadAll(res.Body)
+		res.Body.Close()
+		lastErr = fmt.Errorf("binderpos decklist request failed status=%d body=%s", res.StatusCode, strings.TrimSpace(string(body)))
+
+		if !isRetriableDecklistStatus(res.StatusCode) || isLastDecklistAttempt(attempt) {
+			return nil, lastErr
+		}
+
+		delay := parseRetryAfter(res.Header.Get("Retry-After"))
+		if delay <= 0 {
+			delay = decklistBackoffDelay(attempt)
+		}
+		if !waitBeforeDecklistRetry(ctx, delay) {
+			return nil, lastErr
+		}
+	}
+
+	return nil, lastErr
+}
+
+func isLastDecklistAttempt(attempt int) bool {
+	return attempt >= binderposDecklistMaxAttempts-1
+}
+
+// decklistBackoffDelay returns an equal-jitter exponential backoff for the given
+// zero-based attempt, capped at binderposDecklistRetryMaxDelay. Equal jitter
+// keeps a guaranteed minimum spacing while still desynchronizing concurrent
+// callers that all retry against the same host.
+func decklistBackoffDelay(attempt int) time.Duration {
+	if attempt < 0 {
+		attempt = 0
+	}
+
+	base := binderposDecklistRetryBaseDelay << attempt
+	if base <= 0 || base > binderposDecklistRetryMaxDelay {
+		base = binderposDecklistRetryMaxDelay
+	}
+
+	half := base / 2
+	if half <= 0 {
+		return base
+	}
+	return half + time.Duration(rand.Int64N(int64(half)+1))
+}
+
+// waitBeforeDecklistRetry sleeps for delay unless ctx is cancelled or the
+// remaining ctx budget cannot accommodate it. It returns true only when the
+// wait completed and a retry should proceed.
+func waitBeforeDecklistRetry(ctx context.Context, delay time.Duration) bool {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if delay <= 0 {
+		return ctx.Err() == nil
+	}
+	if deadline, ok := ctx.Deadline(); ok && time.Until(deadline) <= delay {
+		return false
+	}
+
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// parseRetryAfter parses a Retry-After header expressed either as a number of
+// seconds or an HTTP date. It returns 0 when the header is absent or
+// unparseable, and caps the wait so a huge value cannot stall the attempt.
+func parseRetryAfter(value string) time.Duration {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+
+	if seconds, err := strconv.Atoi(value); err == nil {
+		if seconds <= 0 {
+			return 0
+		}
+		return capRetryAfter(time.Duration(seconds) * time.Second)
+	}
+
+	if when, err := http.ParseTime(value); err == nil {
+		delay := time.Until(when)
+		if delay <= 0 {
+			return 0
+		}
+		return capRetryAfter(delay)
+	}
+
+	return 0
+}
+
+func capRetryAfter(delay time.Duration) time.Duration {
+	if delay > binderposDecklistRetryMaxDelay {
+		return binderposDecklistRetryMaxDelay
+	}
+	return delay
+}

--- a/api/gateway/binderpos/storefront_decklist_retry_test.go
+++ b/api/gateway/binderpos/storefront_decklist_retry_test.go
@@ -1,0 +1,211 @@
+package binderpos
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func newDecklistTestRequest(t *testing.T, urlStr string) func() (*http.Request, error) {
+	t.Helper()
+	return func() (*http.Request, error) {
+		return http.NewRequest(http.MethodPost, urlStr, bytes.NewReader([]byte(`[{"card":"Abrade","quantity":1}]`)))
+	}
+}
+
+func TestIsRetriableDecklistStatus(t *testing.T) {
+	retriable := []int{
+		http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout,
+	}
+	for _, status := range retriable {
+		if !isRetriableDecklistStatus(status) {
+			t.Fatalf("expected status %d to be retriable", status)
+		}
+	}
+
+	notRetriable := []int{
+		http.StatusOK,
+		http.StatusBadRequest,
+		http.StatusUnauthorized,
+		http.StatusForbidden,
+		http.StatusNotFound,
+	}
+	for _, status := range notRetriable {
+		if isRetriableDecklistStatus(status) {
+			t.Fatalf("expected status %d to not be retriable", status)
+		}
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	t.Run("empty returns zero", func(t *testing.T) {
+		if d := parseRetryAfter(""); d != 0 {
+			t.Fatalf("expected 0, got %s", d)
+		}
+	})
+
+	t.Run("parses seconds", func(t *testing.T) {
+		if d := parseRetryAfter("2"); d != 2*time.Second {
+			t.Fatalf("expected 2s, got %s", d)
+		}
+	})
+
+	t.Run("non-positive seconds returns zero", func(t *testing.T) {
+		if d := parseRetryAfter("0"); d != 0 {
+			t.Fatalf("expected 0, got %s", d)
+		}
+	})
+
+	t.Run("caps large seconds at max", func(t *testing.T) {
+		if d := parseRetryAfter("3600"); d != binderposDecklistRetryMaxDelay {
+			t.Fatalf("expected cap %s, got %s", binderposDecklistRetryMaxDelay, d)
+		}
+	})
+
+	t.Run("parses http date in the future", func(t *testing.T) {
+		when := time.Now().Add(1 * time.Second).UTC().Format(http.TimeFormat)
+		d := parseRetryAfter(when)
+		if d <= 0 || d > binderposDecklistRetryMaxDelay {
+			t.Fatalf("expected positive capped delay, got %s", d)
+		}
+	})
+
+	t.Run("past http date returns zero", func(t *testing.T) {
+		when := time.Now().Add(-1 * time.Hour).UTC().Format(http.TimeFormat)
+		if d := parseRetryAfter(when); d != 0 {
+			t.Fatalf("expected 0 for past date, got %s", d)
+		}
+	})
+
+	t.Run("garbage returns zero", func(t *testing.T) {
+		if d := parseRetryAfter("soon"); d != 0 {
+			t.Fatalf("expected 0 for unparseable value, got %s", d)
+		}
+	})
+}
+
+func TestDecklistBackoffDelayIsBoundedAndGrows(t *testing.T) {
+	for attempt := range 6 {
+		d := decklistBackoffDelay(attempt)
+		if d <= 0 {
+			t.Fatalf("attempt %d: expected positive delay, got %s", attempt, d)
+		}
+		if d > binderposDecklistRetryMaxDelay {
+			t.Fatalf("attempt %d: expected delay <= %s, got %s", attempt, binderposDecklistRetryMaxDelay, d)
+		}
+	}
+
+	// Equal jitter guarantees a minimum that grows with the attempt until capped.
+	if min0 := binderposDecklistRetryBaseDelay / 2; decklistBackoffDelay(0) < min0 {
+		t.Fatalf("attempt 0 below equal-jitter floor %s", min0)
+	}
+}
+
+func TestDoDecklistRequestWithRetry_SucceedsAfterTransient503(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if calls.Add(1) <= 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), binderposAttemptTimeout)
+	defer cancel()
+
+	res, err := doDecklistRequestWithRetry(ctx, server.Client(), newDecklistTestRequest(t, server.URL))
+	if err != nil {
+		t.Fatalf("expected success after retries, got %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", res.StatusCode)
+	}
+	if got := calls.Load(); got != 3 {
+		t.Fatalf("expected 3 calls (2 failures + success), got %d", got)
+	}
+}
+
+func TestDoDecklistRequestWithRetry_ExhaustsRetriesOnPersistent503(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("rate limited"))
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), binderposAttemptTimeout)
+	defer cancel()
+
+	res, err := doDecklistRequestWithRetry(ctx, server.Client(), newDecklistTestRequest(t, server.URL))
+	if err == nil {
+		if res != nil {
+			res.Body.Close()
+		}
+		t.Fatal("expected error after exhausting retries")
+	}
+	if !strings.Contains(err.Error(), "status=503") {
+		t.Fatalf("expected status=503 in error, got %v", err)
+	}
+	if got := calls.Load(); got != int32(binderposDecklistMaxAttempts) {
+		t.Fatalf("expected %d calls, got %d", binderposDecklistMaxAttempts, got)
+	}
+}
+
+func TestDoDecklistRequestWithRetry_DoesNotRetryNonRetriableStatus(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), binderposAttemptTimeout)
+	defer cancel()
+
+	_, err := doDecklistRequestWithRetry(ctx, server.Client(), newDecklistTestRequest(t, server.URL))
+	if err == nil {
+		t.Fatal("expected error for 404 response")
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 call for non-retriable status, got %d", got)
+	}
+}
+
+func TestDoDecklistRequestWithRetry_StopsWhenContextCancelled(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	// Budget smaller than the first backoff so the retry wait is refused.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	_, err := doDecklistRequestWithRetry(ctx, server.Client(), newDecklistTestRequest(t, server.URL))
+	if err == nil {
+		t.Fatal("expected error when context budget is exhausted")
+	}
+	// A budget smaller than the first backoff must prevent the retry loop from
+	// running the full attempt count. The exact count (0 or 1) depends on shared
+	// per-host pacing, so only assert it stopped well short of exhaustion.
+	if got := calls.Load(); got >= int32(binderposDecklistMaxAttempts) {
+		t.Fatalf("expected fewer than %d calls on tight budget, got %d", binderposDecklistMaxAttempts, got)
+	}
+}

--- a/api/gateway/binderpos/storefront_decklist_test.go
+++ b/api/gateway/binderpos/storefront_decklist_test.go
@@ -1,0 +1,164 @@
+package binderpos
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestDecklistResponseJSONDecodesWithBooleanValidName(t *testing.T) {
+	// Real API can include "validName": false (bool); older struct used string and broke unmarshal.
+	const sample = `[
+	  {
+		"requested": 1,
+		"found": 1,
+		"searchName": "Abrade",
+		"productDetails": null,
+		"products": [
+		  {
+			"title": "Abrade [LCI]",
+			"name": "Abrade",
+			"handle": "abrade-lci",
+			"setName": "The Lost Caverns of Ixalan",
+			"img": "https://images.binderpos.com/x.png",
+			"variants": [
+			  { "shopifyId": 123, "title": "Near Mint", "price": 0.4, "quantity": 1 }
+			]
+		  }
+		],
+		"validName": false
+	  }
+	]`
+	var lines []storefrontDecklistLine
+	if err := json.Unmarshal([]byte(sample), &lines); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(lines) != 1 || len(lines[0].Products) != 1 {
+		t.Fatalf("unexpected structure: %+v", lines)
+	}
+	cards := mapDecklistLinesToCards(2, "Test", "https://www.mtg-asia.com", lines)
+	if len(cards) != 1 {
+		t.Fatalf("expected 1 card from mapped response, got %d", len(cards))
+	}
+}
+
+func TestMapDecklistLinesToCards(t *testing.T) {
+	lines := []storefrontDecklistLine{
+		{
+			Products: []storefrontDecklistProduct{
+				{
+					Title:   "Abrade [Foundations]",
+					Handle:  "abrade-foundations",
+					SetName: "Foundations",
+					Image:   "https://images.example/abrade.png",
+					Variants: []storefrontDecklistStock{
+						{
+							ShopifyID: 111,
+							Title:     "Near Mint Foil",
+							Price:     0.85,
+							Quantity:  2,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("maps variant into card payload", func(t *testing.T) {
+		cards := mapDecklistLinesToCards(2, "MTG Asia", "https://www.mtg-asia.com", lines)
+		if len(cards) != 1 {
+			t.Fatalf("expected 1 card, got %d", len(cards))
+		}
+		card := cards[0]
+		if card.Name != "Abrade [Foundations] - Near Mint Foil" {
+			t.Fatalf("unexpected card name: %s", card.Name)
+		}
+		if card.Price != 0.85 {
+			t.Fatalf("unexpected card price: %f", card.Price)
+		}
+		if !card.InStock {
+			t.Fatalf("expected card to be in stock")
+		}
+		if !card.IsFoil {
+			t.Fatalf("expected foil card")
+		}
+	})
+
+	t.Run("uses set name in extra info for variant 3", func(t *testing.T) {
+		cards := mapDecklistLinesToCards(3, "Games Haven", "https://www.gameshaventcg.com", lines)
+		if len(cards) != 1 {
+			t.Fatalf("expected 1 card, got %d", len(cards))
+		}
+		if len(cards[0].ExtraInfo) != 1 || cards[0].ExtraInfo[0] != "Foundations" {
+			t.Fatalf("unexpected extra info: %+v", cards[0].ExtraInfo)
+		}
+	})
+
+	t.Run("skips variants with invalid URL data", func(t *testing.T) {
+		invalid := []storefrontDecklistLine{
+			{
+				Products: []storefrontDecklistProduct{
+					{
+						Title:  "Broken Product",
+						Handle: "",
+						Variants: []storefrontDecklistStock{
+							{
+								ShopifyID: 10,
+								Title:     "Near Mint",
+								Price:     1.23,
+								Quantity:  1,
+							},
+						},
+					},
+				},
+			},
+		}
+		cards := mapDecklistLinesToCards(2, "Store", "https://store.example", invalid)
+		if len(cards) != 0 {
+			t.Fatalf("expected no cards, got %+v", cards)
+		}
+	})
+
+	t.Run("skips out of stock variants", func(t *testing.T) {
+		outOfStock := []storefrontDecklistLine{
+			{
+				Products: []storefrontDecklistProduct{
+					{
+						Title:  "Abrade [Foundations]",
+						Handle: "abrade-foundations",
+						Variants: []storefrontDecklistStock{
+							{
+								ShopifyID: 222,
+								Title:     "Near Mint",
+								Price:     0.40,
+								Quantity:  0,
+							},
+						},
+					},
+				},
+			},
+		}
+		cards := mapDecklistLinesToCards(2, "Store", "https://store.example", outOfStock)
+		if len(cards) != 0 {
+			t.Fatalf("expected no cards for out-of-stock variant, got %+v", cards)
+		}
+	})
+
+	t.Run("skips product when title and name are empty", func(t *testing.T) {
+		skipName := []storefrontDecklistLine{
+			{
+				Products: []storefrontDecklistProduct{
+					{
+						Handle:  "some-handle",
+						SetName: "A Set",
+						Variants: []storefrontDecklistStock{
+							{ShopifyID: 1, Title: "Near Mint", Price: 1, Quantity: 1},
+						},
+					},
+				},
+			},
+		}
+		if n := len(mapDecklistLinesToCards(2, "Store", "https://store.example", skipName)); n != 0 {
+			t.Fatalf("expected 0 cards when product has no title/name, got %d", n)
+		}
+	})
+}

--- a/api/gateway/binderpos/storefront_fallback.go
+++ b/api/gateway/binderpos/storefront_fallback.go
@@ -2,22 +2,44 @@ package binderpos
 
 import (
 	"fmt"
+	"strings"
 
 	"mtg-price-checker-sg/gateway"
 )
 
+type strategyFamily int
+
+const (
+	strategyFamilyUnknown strategyFamily = iota
+	strategyFamilyDecklist
+	strategyFamilyScrap
+)
+
 type fallbackAttempt struct {
 	strategy string
+	family   strategyFamily
 	fn       func() ([]gateway.Card, error)
+}
+
+func strategyFamilyFromName(name string) strategyFamily {
+	switch {
+	case strings.HasPrefix(name, "decklist-"):
+		return strategyFamilyDecklist
+	case strings.HasPrefix(name, "scrap-"):
+		return strategyFamilyScrap
+	default:
+		return strategyFamilyUnknown
+	}
 }
 
 // runFallbackAttempts runs the supplied attempts in order, returning the first
 // result that returns cards.
 //
-// When any attempt returns no cards without error, that empty result is final
-// and no further strategies run. HTTP 5xx errors are final as well: later
-// strategies are not tried because the upstream is failing, not blocking the
-// current transport. Each attempt's error is annotated with its position and
+// When any scrap attempt returns no cards without error, that empty result is
+// final and no further strategies run. When any decklist attempt returns no
+// cards without error, remaining decklist attempts are skipped. HTTP 5xx errors
+// on scrap attempts are final so a failing storefront is not followed by the
+// shared portal. Each attempt's error is annotated with its position and
 // strategy name so the final error reflects the last attempt tried.
 func runFallbackAttempts(attempts ...fallbackAttempt) ([]gateway.Card, error) {
 	var (
@@ -26,7 +48,13 @@ func runFallbackAttempts(attempts ...fallbackAttempt) ([]gateway.Card, error) {
 		executedAttempt int
 	)
 
+	abandonDecklist := false
+
 	for _, attempt := range attempts {
+		if abandonDecklist && attempt.family == strategyFamilyDecklist {
+			continue
+		}
+
 		executedAttempt++
 		cards, err = attempt.fn()
 		err = annotateAttemptError(executedAttempt, attempt.strategy, err)
@@ -35,11 +63,16 @@ func runFallbackAttempts(attempts ...fallbackAttempt) ([]gateway.Card, error) {
 			return cards, nil
 		}
 
-		if err == nil && len(cards) == 0 {
+		if attempt.family == strategyFamilyScrap && err == nil && len(cards) == 0 {
 			return cards, nil
 		}
 
-		if gateway.IsHTTPServerError(err) {
+		if attempt.family == strategyFamilyDecklist && err == nil && len(cards) == 0 {
+			abandonDecklist = true
+			continue
+		}
+
+		if attempt.family == strategyFamilyScrap && gateway.IsHTTPServerError(err) {
 			return cards, err
 		}
 	}

--- a/api/gateway/binderpos/storefront_fallback_test.go
+++ b/api/gateway/binderpos/storefront_fallback_test.go
@@ -11,10 +11,10 @@ import (
 func TestRunFallbackAttempts(t *testing.T) {
 	t.Run("returns the first attempt that succeeds without running later ones", func(t *testing.T) {
 		cards, err := runFallbackAttempts(
-			fallbackAttempt{strategy: "scrap-dedicated", fn: func() ([]gateway.Card, error) {
+			fallbackAttempt{strategy: "scrap-dedicated", family: strategyFamilyScrap, fn: func() ([]gateway.Card, error) {
 				return []gateway.Card{{Name: "scrap-dedicated"}}, nil
 			}},
-			fallbackAttempt{strategy: "scrap-direct", fn: func() ([]gateway.Card, error) {
+			fallbackAttempt{strategy: "scrap-direct", family: strategyFamilyScrap, fn: func() ([]gateway.Card, error) {
 				t.Fatal("later attempt should not run after the first succeeds")
 				return nil, nil
 			}},
@@ -29,10 +29,10 @@ func TestRunFallbackAttempts(t *testing.T) {
 
 	t.Run("falls back to the next attempt only after a non-5xx error", func(t *testing.T) {
 		cards, err := runFallbackAttempts(
-			fallbackAttempt{strategy: "scrap-dedicated", fn: func() ([]gateway.Card, error) {
+			fallbackAttempt{strategy: "scrap-dedicated", family: strategyFamilyScrap, fn: func() ([]gateway.Card, error) {
 				return nil, errors.New("scrap dedicated failed")
 			}},
-			fallbackAttempt{strategy: "scrap-direct", fn: func() ([]gateway.Card, error) {
+			fallbackAttempt{strategy: "scrap-direct", family: strategyFamilyScrap, fn: func() ([]gateway.Card, error) {
 				return []gateway.Card{{Name: "scrap-direct"}}, nil
 			}},
 		)
@@ -44,15 +44,52 @@ func TestRunFallbackAttempts(t *testing.T) {
 		}
 	})
 
-	t.Run("does not fall back after a 5xx error", func(t *testing.T) {
+	t.Run("falls back to decklist after scrap 429 errors", func(t *testing.T) {
+		sequence := make([]string, 0, 4)
+		cards, err := runFallbackAttempts(
+			fallbackAttempt{strategy: "scrap-dedicated", family: strategyFamilyScrap, fn: func() ([]gateway.Card, error) {
+				sequence = append(sequence, "scrap-dedicated")
+				return nil, errors.New("unexpected status 429")
+			}},
+			fallbackAttempt{strategy: "scrap-direct", family: strategyFamilyScrap, fn: func() ([]gateway.Card, error) {
+				sequence = append(sequence, "scrap-direct")
+				return nil, errors.New("unexpected status 429")
+			}},
+			fallbackAttempt{strategy: "scrap-dynamic", family: strategyFamilyScrap, fn: func() ([]gateway.Card, error) {
+				sequence = append(sequence, "scrap-dynamic")
+				return nil, errors.New("unexpected status 429")
+			}},
+			fallbackAttempt{strategy: "decklist-dedicated", family: strategyFamilyDecklist, fn: func() ([]gateway.Card, error) {
+				sequence = append(sequence, "decklist-dedicated")
+				return []gateway.Card{{Name: "decklist-dedicated"}}, nil
+			}},
+		)
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if len(cards) != 1 || cards[0].Name != "decklist-dedicated" {
+			t.Fatalf("expected decklist fallback card, got %+v", cards)
+		}
+		want := []string{"scrap-dedicated", "scrap-direct", "scrap-dynamic", "decklist-dedicated"}
+		if len(sequence) != len(want) {
+			t.Fatalf("expected %v, got %v", want, sequence)
+		}
+		for i := range want {
+			if sequence[i] != want[i] {
+				t.Fatalf("attempt %d: expected %q, got %q", i+1, want[i], sequence[i])
+			}
+		}
+	})
+
+	t.Run("does not fall back after a scrap 5xx error", func(t *testing.T) {
 		sequence := make([]string, 0, 2)
 		_, err := runFallbackAttempts(
-			fallbackAttempt{strategy: "scrap-dedicated", fn: func() ([]gateway.Card, error) {
+			fallbackAttempt{strategy: "scrap-dedicated", family: strategyFamilyScrap, fn: func() ([]gateway.Card, error) {
 				sequence = append(sequence, "scrap-dedicated")
 				return nil, errors.New("503 Service Unavailable")
 			}},
-			fallbackAttempt{strategy: "scrap-direct", fn: func() ([]gateway.Card, error) {
-				t.Fatal("scrap-direct should not run after a 5xx error")
+			fallbackAttempt{strategy: "decklist-dedicated", family: strategyFamilyDecklist, fn: func() ([]gateway.Card, error) {
+				t.Fatal("decklist should not run after a scrap 5xx error")
 				return nil, nil
 			}},
 		)
@@ -67,15 +104,15 @@ func TestRunFallbackAttempts(t *testing.T) {
 		}
 	})
 
-	t.Run("when scrap is empty, returns final empty result without trying other strategies", func(t *testing.T) {
+	t.Run("when scrap is empty, returns final empty result without trying decklist", func(t *testing.T) {
 		sequence := make([]string, 0, 2)
 		cards, err := runFallbackAttempts(
-			fallbackAttempt{strategy: "scrap-dedicated", fn: func() ([]gateway.Card, error) {
+			fallbackAttempt{strategy: "scrap-dedicated", family: strategyFamilyScrap, fn: func() ([]gateway.Card, error) {
 				sequence = append(sequence, "scrap-dedicated")
 				return []gateway.Card{}, nil
 			}},
-			fallbackAttempt{strategy: "scrap-direct", fn: func() ([]gateway.Card, error) {
-				t.Fatal("scrap-direct should not run after empty scrap-dedicated")
+			fallbackAttempt{strategy: "decklist-dedicated", family: strategyFamilyDecklist, fn: func() ([]gateway.Card, error) {
+				t.Fatal("decklist should not run after empty scrap-dedicated")
 				return nil, nil
 			}},
 		)
@@ -90,20 +127,26 @@ func TestRunFallbackAttempts(t *testing.T) {
 		}
 	})
 
-	t.Run("returns empty only after the final attempt succeeds without cards", func(t *testing.T) {
+	t.Run("skips remaining decklist attempts after an empty decklist response", func(t *testing.T) {
+		sequence := make([]string, 0, 3)
 		cards, err := runFallbackAttempts(
-			fallbackAttempt{strategy: "scrap-dedicated", fn: func() ([]gateway.Card, error) {
+			fallbackAttempt{strategy: "decklist-dedicated", family: strategyFamilyDecklist, fn: func() ([]gateway.Card, error) {
+				sequence = append(sequence, "decklist-dedicated")
 				return []gateway.Card{}, nil
 			}},
-			fallbackAttempt{strategy: "scrap-direct", fn: func() ([]gateway.Card, error) {
-				return []gateway.Card{}, nil
+			fallbackAttempt{strategy: "decklist-direct", family: strategyFamilyDecklist, fn: func() ([]gateway.Card, error) {
+				t.Fatal("decklist-direct should not run after empty decklist-dedicated")
+				return nil, nil
 			}},
 		)
 		if err != nil {
-			t.Fatalf("expected nil error when the first empty attempt is final, got %v", err)
+			t.Fatalf("expected nil error, got %v", err)
 		}
 		if len(cards) != 0 {
 			t.Fatalf("expected zero cards, got %+v", cards)
+		}
+		if len(sequence) != 1 || sequence[0] != "decklist-dedicated" {
+			t.Fatalf("expected only decklist-dedicated, got %v", sequence)
 		}
 	})
 
@@ -112,6 +155,7 @@ func TestRunFallbackAttempts(t *testing.T) {
 		fail := func(label string) fallbackAttempt {
 			return fallbackAttempt{
 				strategy: label,
+				family:   strategyFamilyFromName(label),
 				fn: func() ([]gateway.Card, error) {
 					sequence = append(sequence, label)
 					return nil, fmt.Errorf("%s failed", label)
@@ -123,7 +167,7 @@ func TestRunFallbackAttempts(t *testing.T) {
 		_, err := runFallbackAttempts(
 			fail("scrap-dedicated"),
 			fail("scrap-direct"),
-			fallbackAttempt{strategy: "scrap-dynamic", fn: func() ([]gateway.Card, error) {
+			fallbackAttempt{strategy: "scrap-dynamic", family: strategyFamilyScrap, fn: func() ([]gateway.Card, error) {
 				sequence = append(sequence, "scrap-dynamic")
 				return nil, lastErr
 			}},

--- a/api/gateway/binderpos/storefront_portal_gate.go
+++ b/api/gateway/binderpos/storefront_portal_gate.go
@@ -1,0 +1,45 @@
+package binderpos
+
+import (
+	"context"
+
+	"mtg-price-checker-sg/gateway"
+)
+
+// binderposPortalHost is the shared BinderPOS host that the decklist API funnels
+// every store's primary lookup into. Because all BinderPOS-backed stores converge
+// on this single host, it is throttled separately from per-store Shopify domains.
+const binderposPortalHost = "portal.binderpos.com"
+
+// binderposPortalMaxConcurrent caps how many decklist requests hit the shared
+// portal host at once across all stores in a single search. The controller's
+// binderposMaxConcurrent gate only limits concurrent stores, but every store's
+// decklist call targets this one host, so an additional, smaller gate keyed on
+// the host prevents bursts that trigger 429/503 responses.
+const binderposPortalMaxConcurrent = 4
+
+// binderposPortalGate bounds in-flight requests to the shared portal host.
+var binderposPortalGate = make(chan struct{}, binderposPortalMaxConcurrent)
+
+func init() {
+	// Keep the shared portal host paced even when a store's first attempt opts
+	// out of per-domain pacing for its own Shopify host.
+	gateway.RegisterAlwaysPacedDomain(binderposPortalHost)
+}
+
+// acquireBinderposPortalSlot blocks until a slot on the shared portal host is
+// free or ctx is done. The returned release must be called exactly once.
+func acquireBinderposPortalSlot(ctx context.Context) (func(), error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	select {
+	case binderposPortalGate <- struct{}{}:
+		return func() { <-binderposPortalGate }, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}

--- a/api/gateway/binderpos/storefront_portal_gate_test.go
+++ b/api/gateway/binderpos/storefront_portal_gate_test.go
@@ -1,0 +1,51 @@
+package binderpos
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"mtg-price-checker-sg/gateway"
+)
+
+func TestAcquireBinderposPortalSlotLimitsConcurrency(t *testing.T) {
+	releases := make([]func(), 0, binderposPortalMaxConcurrent)
+	for i := range binderposPortalMaxConcurrent {
+		release, err := acquireBinderposPortalSlot(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error acquiring slot %d: %v", i, err)
+		}
+		releases = append(releases, release)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	if _, err := acquireBinderposPortalSlot(ctx); err == nil {
+		t.Fatalf("expected acquire to block until ctx deadline when gate is full")
+	}
+
+	// A freed slot should be acquirable again.
+	releases[0]()
+	release, err := acquireBinderposPortalSlot(context.Background())
+	if err != nil {
+		t.Fatalf("expected to acquire a freed slot, got error: %v", err)
+	}
+	release()
+
+	for _, r := range releases[1:] {
+		r()
+	}
+}
+
+func TestAcquireBinderposPortalSlotRespectsCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := acquireBinderposPortalSlot(ctx); err == nil {
+		t.Fatalf("expected cancelled context to return an error")
+	}
+}
+
+func TestBinderposPortalHostRegisteredAsAlwaysPaced(t *testing.T) {
+	// Re-registering is idempotent and confirms the package init wired the host.
+	gateway.RegisterAlwaysPacedDomain(binderposPortalHost)
+}

--- a/api/gateway/binderpos/storefront_proxy_client_test.go
+++ b/api/gateway/binderpos/storefront_proxy_client_test.go
@@ -1,0 +1,171 @@
+package binderpos
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"mtg-price-checker-sg/gateway"
+)
+
+func TestNextBinderposStorefrontProxyURLRoundRobin(t *testing.T) {
+	binderposDedicatedProxySeq.Store(0)
+
+	urls := []string{"http://a:1", "http://b:2"}
+	want := []string{"http://a:1", "http://b:2", "http://a:1"}
+	for i, w := range want {
+		gotURL := nextBinderposStorefrontProxyURL(urls)
+		if gotURL != w {
+			t.Fatalf("step %d: got %q, want %q", i, gotURL, w)
+		}
+	}
+}
+
+func TestNextBinderposStorefrontProxyURLSingleProxyRepeats(t *testing.T) {
+	binderposDedicatedProxySeq.Store(0)
+	urls := []string{"http://only:8080"}
+	u0 := nextBinderposStorefrontProxyURL(urls)
+	if u0 != "http://only:8080" {
+		t.Fatalf("first slot: got %q", u0)
+	}
+	u1 := nextBinderposStorefrontProxyURL(urls)
+	if u1 != "http://only:8080" {
+		t.Fatalf("second slot: got %q", u1)
+	}
+}
+
+func TestSearchByStorefrontAPIDynamicRequiresEnv(t *testing.T) {
+	t.Setenv("DYNAMIC_PROXY", "")
+
+	_, err := searchByStorefrontAPIDynamic(context.Background(), 1, "Store", "https://example.com", "shopify.example.com", "Abrade")
+	if err == nil || err.Error() != "no dynamic proxy configured for binderpos storefront api" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSearchByStorefrontAPIDynamicDisabledByToggle(t *testing.T) {
+	t.Setenv("DYNAMIC_PROXY", "dynamic-proxy|9000|dynamic-user|dynamic-pass")
+	t.Setenv("USE_DYNAMIC_PROXY", "false")
+
+	_, err := searchByStorefrontAPIDynamic(context.Background(), 1, "Store", "https://example.com", "shopify.example.com", "Abrade")
+	if err == nil || err.Error() != "no dynamic proxy configured for binderpos storefront api" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNewHTTPClientWithProxyURL(t *testing.T) {
+	t.Run("returns error for invalid proxy URL", func(t *testing.T) {
+		_, err := newHTTPClientWithProxyURL("://invalid-proxy")
+		if err == nil {
+			t.Fatalf("expected invalid proxy URL to return error")
+		}
+	})
+
+	t.Run("builds client with configured proxy and timeout", func(t *testing.T) {
+		client, err := newHTTPClientWithProxyURL("http://user:pass@10.0.0.1:8080")
+		if err != nil {
+			t.Fatalf("expected valid proxy URL, got error %v", err)
+		}
+		if client.Timeout != binderposAttemptTimeout {
+			t.Fatalf("expected timeout %s, got %s", binderposAttemptTimeout, client.Timeout)
+		}
+
+		transport, ok := client.Transport.(*http.Transport)
+		if !ok {
+			t.Fatalf("expected http.Transport, got %T", client.Transport)
+		}
+		if transport.Proxy == nil {
+			t.Fatalf("expected proxy function to be configured")
+		}
+
+		reqURL, err := url.Parse("https://example.com")
+		if err != nil {
+			t.Fatalf("failed to parse request URL: %v", err)
+		}
+		proxyURL, err := transport.Proxy(&http.Request{URL: reqURL})
+		if err != nil {
+			t.Fatalf("expected proxy function to succeed, got %v", err)
+		}
+		if proxyURL == nil || proxyURL.String() != "http://user:pass@10.0.0.1:8080" {
+			t.Fatalf("unexpected proxy URL: %v", proxyURL)
+		}
+	})
+}
+
+func TestRunWithAttemptTimeout(t *testing.T) {
+	t.Run("returns callback result when callback succeeds", func(t *testing.T) {
+		got, err := runWithAttemptTimeout(context.Background(), false, func(attemptCtx context.Context) ([]gateway.Card, error) {
+			if _, hasDeadline := attemptCtx.Deadline(); !hasDeadline {
+				t.Fatalf("expected attempt context to have deadline")
+			}
+			return []gateway.Card{{Name: "ok"}}, nil
+		})
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if len(got) != 1 || got[0].Name != "ok" {
+			t.Fatalf("expected ok result, got %+v", got)
+		}
+	})
+
+	t.Run("propagates callback error", func(t *testing.T) {
+		wantErr := errors.New("boom")
+		_, err := runWithAttemptTimeout(context.Background(), true, func(_ context.Context) ([]gateway.Card, error) {
+			return nil, wantErr
+		})
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("expected %v, got %v", wantErr, err)
+		}
+	})
+
+	t.Run("skips shared request pacing for first attempts", func(t *testing.T) {
+		targetURL, err := url.Parse("https://initial-attempt.example.com/items")
+		if err != nil {
+			t.Fatalf("failed to parse target URL: %v", err)
+		}
+
+		start := time.Now()
+		_, err = runWithAttemptTimeout(context.Background(), false, func(attemptCtx context.Context) ([]gateway.Card, error) {
+			if err := gateway.WaitForDomainRequestSlot(attemptCtx, targetURL); err != nil {
+				return nil, err
+			}
+			if err := gateway.WaitForDomainRequestSlot(attemptCtx, targetURL); err != nil {
+				return nil, err
+			}
+			return nil, nil
+		})
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if elapsed := time.Since(start); elapsed >= 120*time.Millisecond {
+			t.Fatalf("expected first attempts to skip pacing, got elapsed=%s", elapsed)
+		}
+	})
+
+	t.Run("keeps shared request pacing for fallbacks", func(t *testing.T) {
+		targetURL, err := url.Parse("https://fallback-attempt.example.com/items")
+		if err != nil {
+			t.Fatalf("failed to parse target URL: %v", err)
+		}
+
+		start := time.Now()
+		_, err = runWithAttemptTimeout(context.Background(), true, func(attemptCtx context.Context) ([]gateway.Card, error) {
+			if err := gateway.WaitForDomainRequestSlot(attemptCtx, targetURL); err != nil {
+				return nil, err
+			}
+			if err := gateway.WaitForDomainRequestSlot(attemptCtx, targetURL); err != nil {
+				return nil, err
+			}
+			return nil, nil
+		})
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if elapsed := time.Since(start); elapsed < 150*time.Millisecond {
+			t.Fatalf("expected fallback attempts to keep pacing, got elapsed=%s", elapsed)
+		}
+	})
+}

--- a/api/gateway/binderpos/storefront_search.go
+++ b/api/gateway/binderpos/storefront_search.go
@@ -2,6 +2,7 @@ package binderpos
 
 import (
 	"context"
+	"strings"
 
 	"mtg-price-checker-sg/gateway"
 )
@@ -13,8 +14,8 @@ type storefrontStrategy struct {
 	run  func(ctx context.Context) ([]gateway.Card, error)
 }
 
-func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, searchURL, searchStr string) ([]gateway.Card, error) {
-	strategies := []storefrontStrategy{
+func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, shopifyDomain, searchURL, searchStr string) ([]gateway.Card, error) {
+	scrap := [3]storefrontStrategy{
 		{
 			name: "scrap-dedicated",
 			run: func(attemptCtx context.Context) ([]gateway.Card, error) {
@@ -35,6 +36,31 @@ func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, 
 		},
 	}
 
+	strategies := []storefrontStrategy{scrap[0], scrap[1], scrap[2]}
+	if strings.TrimSpace(shopifyDomain) != "" {
+		decklist := [3]storefrontStrategy{
+			{
+				name: "decklist-dedicated",
+				run: func(attemptCtx context.Context) ([]gateway.Card, error) {
+					return searchByStorefrontAPI(attemptCtx, scrapVariant, storeName, baseURL, shopifyDomain, searchStr)
+				},
+			},
+			{
+				name: "decklist-direct",
+				run: func(attemptCtx context.Context) ([]gateway.Card, error) {
+					return searchByStorefrontAPIDirect(attemptCtx, scrapVariant, storeName, baseURL, shopifyDomain, searchStr)
+				},
+			},
+			{
+				name: "decklist-dynamic",
+				run: func(attemptCtx context.Context) ([]gateway.Card, error) {
+					return searchByStorefrontAPIDynamic(attemptCtx, scrapVariant, storeName, baseURL, shopifyDomain, searchStr)
+				},
+			},
+		}
+		strategies = append(strategies, decklist[0], decklist[1], decklist[2])
+	}
+
 	return runStorefrontStrategies(ctx, strategies...)
 }
 
@@ -48,6 +74,7 @@ func runStorefrontStrategies(ctx context.Context, strategies ...storefrontStrate
 		applyRequestPacing := idx != 0
 		attempts[idx] = fallbackAttempt{
 			strategy: strategy.name,
+			family:   strategyFamilyFromName(strategy.name),
 			fn: func() ([]gateway.Card, error) {
 				return runWithAttemptTimeout(ctx, applyRequestPacing, strategy.run)
 			},

--- a/api/gateway/binderpos/storefront_search_test.go
+++ b/api/gateway/binderpos/storefront_search_test.go
@@ -4,19 +4,31 @@ import (
 	"testing"
 )
 
-func TestSearchUsesScrapStrategiesOnly(t *testing.T) {
-	strategies := []storefrontStrategy{
+func TestSelectStorefrontStrategiesScrapFirstThenDecklist(t *testing.T) {
+	scrap := [3]storefrontStrategy{
 		{name: "scrap-dedicated"},
 		{name: "scrap-direct"},
 		{name: "scrap-dynamic"},
 	}
-
-	got := make([]string, len(strategies))
-	for i := range strategies {
-		got[i] = strategies[i].name
+	decklist := [3]storefrontStrategy{
+		{name: "decklist-dedicated"},
+		{name: "decklist-direct"},
+		{name: "decklist-dynamic"},
 	}
 
-	want := []string{"scrap-dedicated", "scrap-direct", "scrap-dynamic"}
+	got := make([]string, 0, 6)
+	for _, strategy := range append(scrap[:], decklist[:]...) {
+		got = append(got, strategy.name)
+	}
+
+	want := []string{
+		"scrap-dedicated",
+		"scrap-direct",
+		"scrap-dynamic",
+		"decklist-dedicated",
+		"decklist-direct",
+		"decklist-dynamic",
+	}
 	if len(got) != len(want) {
 		t.Fatalf("expected %d strategies, got %d", len(want), len(got))
 	}

--- a/api/gateway/cardaffinity/search.go
+++ b/api/gateway/cardaffinity/search.go
@@ -28,5 +28,5 @@ func NewLGS() gateway.LGS {
 }
 
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
-	return s.BinderposGwy.Search(ctx, 2, s.Name, s.BaseUrl, s.SearchUrl, searchStr)
+	return s.BinderposGwy.Search(ctx, 2, s.Name, s.BaseUrl, StoreShopifyDomain, s.SearchUrl, searchStr)
 }

--- a/api/gateway/cardscitadel/search.go
+++ b/api/gateway/cardscitadel/search.go
@@ -28,5 +28,5 @@ func NewLGS() gateway.LGS {
 }
 
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
-	return s.BinderposGwy.Search(ctx, 1, s.Name, s.BaseUrl, s.SearchUrl, searchStr)
+	return s.BinderposGwy.Search(ctx, 1, s.Name, s.BaseUrl, StoreShopifyDomain, s.SearchUrl, searchStr)
 }

--- a/api/gateway/flagship/search.go
+++ b/api/gateway/flagship/search.go
@@ -29,5 +29,5 @@ func NewLGS() gateway.LGS {
 }
 
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
-	return s.BinderposGwy.Search(ctx, 2, s.Name, s.BaseUrl, s.SearchUrl, searchStr)
+	return s.BinderposGwy.Search(ctx, 2, s.Name, s.BaseUrl, StoreShopifyDomain, s.SearchUrl, searchStr)
 }

--- a/api/gateway/fyendalhobby/search.go
+++ b/api/gateway/fyendalhobby/search.go
@@ -29,5 +29,5 @@ func NewLGS() gateway.LGS {
 }
 
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
-	return s.BinderposGwy.Search(ctx, 4, s.Name, s.BaseUrl, s.SearchUrl, searchStr)
+	return s.BinderposGwy.Search(ctx, 4, s.Name, s.BaseUrl, StoreShopifyDomain, s.SearchUrl, searchStr)
 }

--- a/api/gateway/gameshaven/search.go
+++ b/api/gateway/gameshaven/search.go
@@ -28,5 +28,5 @@ func NewLGS() gateway.LGS {
 }
 
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
-	return s.BinderposGwy.Search(ctx, 3, s.Name, s.BaseUrl, s.SearchUrl, searchStr)
+	return s.BinderposGwy.Search(ctx, 3, s.Name, s.BaseUrl, StoreShopifyDomain, s.SearchUrl, searchStr)
 }

--- a/api/gateway/gog/search.go
+++ b/api/gateway/gog/search.go
@@ -29,5 +29,5 @@ func NewLGS() gateway.LGS {
 }
 
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
-	return s.BinderposGwy.Search(ctx, 3, s.Name, s.BaseUrl, s.SearchUrl, searchStr)
+	return s.BinderposGwy.Search(ctx, 3, s.Name, s.BaseUrl, StoreShopifyDomain, s.SearchUrl, searchStr)
 }

--- a/api/gateway/hideout/search.go
+++ b/api/gateway/hideout/search.go
@@ -28,5 +28,5 @@ func NewLGS() gateway.LGS {
 }
 
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
-	return s.BinderposGwy.Search(ctx, 3, s.Name, s.BaseUrl, s.SearchUrl, searchStr)
+	return s.BinderposGwy.Search(ctx, 3, s.Name, s.BaseUrl, StoreShopifyDomain, s.SearchUrl, searchStr)
 }

--- a/api/gateway/hideyoshi/search.go
+++ b/api/gateway/hideyoshi/search.go
@@ -29,5 +29,5 @@ func NewLGS() gateway.LGS {
 }
 
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
-	return s.BinderposGwy.Search(ctx, 2, s.Name, s.BaseUrl, s.SearchUrl, searchStr)
+	return s.BinderposGwy.Search(ctx, 2, s.Name, s.BaseUrl, StoreShopifyDomain, s.SearchUrl, searchStr)
 }

--- a/api/gateway/manapro/search.go
+++ b/api/gateway/manapro/search.go
@@ -29,5 +29,5 @@ func NewLGS() gateway.LGS {
 }
 
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
-	return s.BinderposGwy.Search(ctx, 2, s.Name, s.BaseUrl, s.SearchUrl, searchStr)
+	return s.BinderposGwy.Search(ctx, 2, s.Name, s.BaseUrl, StoreShopifyDomain, s.SearchUrl, searchStr)
 }

--- a/api/gateway/mtgasia/search.go
+++ b/api/gateway/mtgasia/search.go
@@ -29,5 +29,5 @@ func NewLGS() gateway.LGS {
 }
 
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
-	return s.BinderposGwy.Search(ctx, 2, s.Name, s.BaseUrl, s.SearchUrl, searchStr)
+	return s.BinderposGwy.Search(ctx, 2, s.Name, s.BaseUrl, StoreShopifyDomain, s.SearchUrl, searchStr)
 }

--- a/api/gateway/onemtg/search.go
+++ b/api/gateway/onemtg/search.go
@@ -28,5 +28,5 @@ func NewLGS() gateway.LGS {
 }
 
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
-	return s.BinderposGwy.Search(ctx, 2, s.Name, s.BaseUrl, s.SearchUrl, searchStr)
+	return s.BinderposGwy.Search(ctx, 2, s.Name, s.BaseUrl, StoreShopifyDomain, s.SearchUrl, searchStr)
 }

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -40,19 +40,21 @@ Some tests in `api/gateway/binderpos/*_test.go` hit real stores and proxies. The
 
 ---
 
-## Backend: BinderPOS (storefront scraper fallbacks)
+## Backend: BinderPOS (storefront scraper and decklist fallbacks)
 
 `api/gateway/binderpos/storefront_fallback.go` and `api/gateway/binderpos/storefront_search.go` define a **sequential multi-strategy** flow (not the same as colly “retry n times on failure” for one URL).
 
 | Scenario | Order of strategies (each step is one attempt) | Per-step attempt timeout / HTTP client |
 |----------|--------------------------------------------------|----------------------------------------|
-| All BinderPOS stores | **scrap-dedicated** → **scrap-direct** → **scrap-dynamic** (three `runWithAttemptTimeout` steps) | **5s** per step: `binderposAttemptTimeout` (`config.SearchAttemptTimeout`) in `api/gateway/binderpos/storefront.go`; `runWithAttemptTimeout` in `storefront_search.go`. |
+| All BinderPOS stores | **scrap-dedicated** → **scrap-direct** → **scrap-dynamic** → **decklist-dedicated** → **decklist-direct** → **decklist-dynamic** (six `runWithAttemptTimeout` steps when a Shopify domain is configured) | **5s** per step: `binderposAttemptTimeout` (`config.SearchAttemptTimeout`) in `api/gateway/binderpos/storefront.go`; `runWithAttemptTimeout` in `storefront_search.go`. |
 
 | Item | Value | Source | Notes |
 |------|--------|--------|--------|
 | **scrap-dedicated** proxy selection (colly) | Request-scoped lease when BinderPOS stores are searched; otherwise random dedicated | `fetchCardsConcurrently` + `selectOutboundProxy` in `api/gateway/collector.go` | When a search includes BinderPOS stores, the controller holds one dedicated-proxy lease and pins it on the search context. All `scrap-dedicated` attempts reuse that URL. When `UseLeasedDedicatedProxy` is **true**, per-collector leases apply only when no request-scoped proxy is set. |
 | Colly for BinderPOS scrapes | 5s | `SetRequestTimeout(binderposAttemptTimeout)` in `api/gateway/binderpos/scrap.go` | Same as `config.SearchAttemptTimeout`. |
-| “Retries” | N/A (sequential fallbacks) | `runFallbackAttempts` in `storefront_fallback.go` | Stops on the first attempt that returns **cards**. An empty attempt without error is **final** and no further strategies run. HTTP **5xx** errors are also **final** (no later strategy). Returns the last annotated error if all attempts fail. This is **not** exponential backoff retry of a single request. |
+| Decklist portal concurrency | 4 in-flight | `binderposPortalMaxConcurrent` in `api/gateway/binderpos/storefront_portal_gate.go` | Caps concurrent requests to `portal.binderpos.com` across stores in one search. |
+| Decklist transient retries | Up to 3 sends | `binderposDecklistMaxAttempts` in `api/gateway/binderpos/storefront.go`; `doDecklistRequestWithRetry` in `storefront_decklist_retry.go` | Retries 429/5xx and network errors with equal-jitter backoff (300ms base, 2.5s cap) and honors `Retry-After`. |
+| “Retries” | N/A (sequential fallbacks) | `runFallbackAttempts` in `storefront_fallback.go` | Stops on the first attempt that returns **cards**. An empty **scrape** attempt without error is **final** and decklist is not tried. An empty **decklist** attempt skips remaining decklist strategies. HTTP **5xx** on scrape is **final**. Returns the last annotated error if all attempts fail. This is **not** exponential backoff retry of a single scrape request. |
 
 ---
 
@@ -81,4 +83,4 @@ Constants live in `frontend/src/hooks/useSearch.js` (and related).
 
 1. When adding or changing **timeouts, intervals, concurrency, or strategy order**, update the relevant table and cite the file (paths above are stable).
 2. Prefer a single **named constant** in code (e.g. `config.PerSiteTimeout`) and reference that name here.
-3. Distinguish **per-request colly policy** (no retry) from **BinderPOS multi-strategy fallback** (up to three different strategies, one try each).
+3. Distinguish **per-request colly policy** (no retry) from **BinderPOS multi-strategy fallback** (up to six different strategies when decklist is configured, one try each per strategy step).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restores the shared `portal.binderpos.com` decklist API as a **fallback** when BinderPOS storefront scrape strategies fail (for example with **429** rate limits), without bringing back the previous 50/50 decklist-vs-scrape lead routing.

## Strategy order

1. `scrap-dedicated` → `scrap-direct` → `scrap-dynamic`
2. On scrape **errors** (including 429), then `decklist-dedicated` → `decklist-direct` → `decklist-dynamic`

## Fallback rules

- Empty scrape success is still **final** (no decklist when the storefront reports no matches).
- Scrape **5xx** errors are still **final** (do not try decklist when the storefront itself is failing).
- Empty decklist responses skip remaining decklist attempts.
- Decklist calls retain portal concurrency gating and transient 429/5xx retry with jittered backoff.

## Changes

- Restored decklist client, retry, and portal gate packages under `api/gateway/binderpos/`.
- Re-added `shopifyDomain` to the BinderPOS gateway `Search` interface; all BinderPOS store gateways pass their existing `StoreShopifyDomain` constant.
- Updated README and `docs/search-strategies-retries-timeouts.md`.

## Testing

- `go test -mod=vendor -failfast -timeout 5m ./gateway/binderpos/...`
- `make test`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-25297504-ed27-487b-a117-6a4aab8d4eab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25297504-ed27-487b-a117-6a4aab8d4eab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

