### PR TITLE
Limit store search concurrency to 6 workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ before being returned.
 1. The handler parses `s` (the search string, minimum 3 characters) and an
    optional `lgs` filter (comma-separated store names; empty means all stores).
 2. The controller instantiates each selected store and runs **one goroutine per
-   store**, each bounded by a 16s per-site timeout (`config.PerSiteTimeout`).
+   store**, each bounded by a 20s per-site timeout (`config.PerSiteTimeout`).
 3. Each store's results are merged into a shared aggregator. A per-store failure
    is recorded but never blocks the others, so a search returns whatever
    succeeded (partial success).

--- a/api/controller/search.go
+++ b/api/controller/search.go
@@ -129,6 +129,13 @@ func searchShops(ctx context.Context, input SearchInput, shopNameToLGSMap map[st
 	return inStockCards, buildStoreErrors(siteErrors), nil
 }
 
+const maxConcurrentStoreSearches = 6
+
+type shopSearchJob struct {
+	name string
+	lgs  gateway.LGS
+}
+
 func fetchCardsConcurrently(ctx context.Context, searchString string, shops map[string]gateway.LGS) ([]gateway.Card, map[string]error) {
 	var wg sync.WaitGroup
 	aggregator := newFetchResultAggregator(len(shops))
@@ -143,9 +150,22 @@ func fetchCardsConcurrently(ctx context.Context, searchString string, shops map[
 
 	start := time.Now()
 
+	jobs := make(chan shopSearchJob, len(shops))
 	for shopName, lgs := range shops {
+		jobs <- shopSearchJob{name: shopName, lgs: lgs}
+	}
+	close(jobs)
+
+	workerCount := len(shops)
+	if workerCount > maxConcurrentStoreSearches {
+		workerCount = maxConcurrentStoreSearches
+	}
+
+	for range workerCount {
 		wg.Go(func() {
-			searchShop(searchCtx, searchString, shopName, lgs, aggregator)
+			for job := range jobs {
+				searchShop(searchCtx, searchString, job.name, job.lgs, aggregator)
+			}
 		})
 	}
 

--- a/api/controller/search.go
+++ b/api/controller/search.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"maps"
 	"mtg-price-checker-sg/gateway"
-	"mtg-price-checker-sg/gateway/util"
 	"mtg-price-checker-sg/gateway/agora"
 	"mtg-price-checker-sg/gateway/cardaffinity"
 	"mtg-price-checker-sg/gateway/cardsandcollection"
@@ -26,6 +25,7 @@ import (
 	"mtg-price-checker-sg/gateway/mtgasia"
 	"mtg-price-checker-sg/gateway/onemtg"
 	"mtg-price-checker-sg/gateway/tcgmarketplace"
+	"mtg-price-checker-sg/gateway/util"
 	"mtg-price-checker-sg/pkg/alert"
 	"mtg-price-checker-sg/pkg/config"
 	"sort"
@@ -156,10 +156,7 @@ func fetchCardsConcurrently(ctx context.Context, searchString string, shops map[
 	}
 	close(jobs)
 
-	workerCount := len(shops)
-	if workerCount > maxConcurrentStoreSearches {
-		workerCount = maxConcurrentStoreSearches
-	}
+	workerCount := min(len(shops), maxConcurrentStoreSearches)
 
 	for range workerCount {
 		wg.Go(func() {

--- a/api/controller/search_test.go
+++ b/api/controller/search_test.go
@@ -12,6 +12,7 @@ import (
 	"mtg-price-checker-sg/gateway/hideout"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -547,6 +548,65 @@ func TestFetchCardsConcurrently_SkipsCanceledForDiscord(t *testing.T) {
 	case <-alertSent:
 		t.Fatal("did not expect discord alert for canceled search")
 	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func TestFetchCardsConcurrently_LimitsConcurrentWorkers(t *testing.T) {
+	const shopCount = 10
+	started := make(chan struct{}, shopCount)
+	release := make(chan struct{})
+	var inFlight atomic.Int32
+	var maxInFlight atomic.Int32
+
+	shops := make(map[string]gateway.LGS, shopCount)
+	for i := range shopCount {
+		shops[fmt.Sprintf("Shop%d", i)] = &MockLGS{
+			SearchFunc: func(ctx context.Context, searchStr string) ([]gateway.Card, error) {
+				cur := inFlight.Add(1)
+				for {
+					prev := maxInFlight.Load()
+					if cur <= prev || maxInFlight.CompareAndSwap(prev, cur) {
+						break
+					}
+				}
+				started <- struct{}{}
+				<-release
+				inFlight.Add(-1)
+				return nil, nil
+			},
+		}
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, siteErrors := fetchCardsConcurrently(context.Background(), "Abrade", shops)
+		if len(siteErrors) != 0 {
+			t.Errorf("unexpected site errors: %v", siteErrors)
+		}
+	}()
+
+	for i := range 6 {
+		select {
+		case <-started:
+		case <-done:
+			t.Fatal("fetch finished before 6 shops started")
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for shop %d to start; max in flight was %d", i, maxInFlight.Load())
+		}
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	if got := maxInFlight.Load(); got > maxConcurrentStoreSearches {
+		t.Fatalf("expected at most %d concurrent searches, got %d", maxConcurrentStoreSearches, got)
+	}
+
+	close(release)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for fetch to complete")
 	}
 }
 

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -19,7 +19,7 @@ const (
 	EnvProd  = "prod"
 	EnvLocal = "local"
 	UseProxy         = true
-	PerSiteTimeout   = 16 * time.Second
+	PerSiteTimeout   = 20 * time.Second
 	// SearchAttemptTimeout bounds a single search strategy attempt (BinderPOS step
 	// or default colly scrape).
 	SearchAttemptTimeout = 5 * time.Second

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -8,7 +8,7 @@ This document records **where** the app configures search behavior, **timeouts**
 
 | Item | Value | Source | Notes |
 |------|--------|--------|--------|
-| Per-store deadline | 16s | `config.PerSiteTimeout` in `api/pkg/config/config.go`; used in `searchShop` as `context.WithTimeout` in `api/controller/search.go` | One goroutine per selected store; each `LGS.Search` runs under this cap. |
+| Per-store deadline | 20s | `config.PerSiteTimeout` in `api/pkg/config/config.go`; used in `searchShop` as `context.WithTimeout` in `api/controller/search.go` | One goroutine per selected store; each `LGS.Search` runs under this cap. |
 | Per-attempt timeout (default) | 5s | `config.SearchAttemptTimeout` in `api/pkg/config/config.go` | Bounds each BinderPOS strategy step and default colly scrape request. |
 | Agora per-attempt timeout | 10s | `config.AgoraSearchAttemptTimeout` in `api/pkg/config/config.go`; applied in `api/gateway/agora/search.go` | Agora keeps a longer single-scrape cap. |
 | Colly request timeout (default scrapers) | 5s | `applyCollectorDefaults` → `c.SetRequestTimeout(config.SearchAttemptTimeout)` in `api/gateway/collector.go` | Overrides gocolly’s default 10s for optimized collectors. |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Caps concurrent store searches at six when a request targets more than six shops. Instead of launching one goroutine per store immediately, a worker pool keeps at most six goroutines in flight and assigns the next store only after a worker finishes.

Also restores `PerSiteTimeout` from 16s back to 20s.

## Changes

- Add `maxConcurrentStoreSearches = 6` and a `shopSearchJob` queue in `fetchCardsConcurrently`.
- Spawn `min(len(shops), 6)` workers that drain the job channel.
- Add `TestFetchCardsConcurrently_LimitsConcurrentWorkers` to verify the cap with ten blocking mock stores.
- Restore `config.PerSiteTimeout` to 20s and update related docs.

## Testing

- `go test -mod=vendor -failfast -timeout 5m ./controller/... -run TestFetchCardsConcurrently`
- `make test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1883ab26-9706-4cff-9f33-3c074e5a26be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1883ab26-9706-4cff-9f33-3c074e5a26be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

