### PR TITLE
Hide empty extraInfo brackets in search results

### DIFF
--- a/api/controller/search.go
+++ b/api/controller/search.go
@@ -502,6 +502,27 @@ func isJapanese(s string) bool {
 	return strings.Contains(strings.ToLower(s), "japanese")
 }
 
+func extraInfoInnerText(info string) string {
+	info = strings.TrimSpace(info)
+	if len(info) >= 2 {
+		switch info[0] {
+		case '[':
+			if info[len(info)-1] == ']' {
+				return strings.TrimSpace(info[1 : len(info)-1])
+			}
+		case '(':
+			if info[len(info)-1] == ')' {
+				return strings.TrimSpace(info[1 : len(info)-1])
+			}
+		}
+	}
+	return info
+}
+
+func isNonemptyExtraInfo(info string) bool {
+	return extraInfoInnerText(info) != ""
+}
+
 func cleanName(name, quality string, extraInfo []string) (string, []string) {
 	cleanCardName := name
 
@@ -533,6 +554,10 @@ func cleanName(name, quality string, extraInfo []string) (string, []string) {
 	var extraInfoWithBrackets []string
 	if len(extraInfo) > 0 {
 		for _, info := range extraInfo {
+			info = strings.TrimSpace(info)
+			if !isNonemptyExtraInfo(info) {
+				continue
+			}
 			if !strings.HasPrefix(info, "[") && !strings.HasPrefix(info, "(") {
 				extraInfoWithBrackets = append(extraInfoWithBrackets, "["+info+"]")
 			} else {

--- a/api/controller/search_test.go
+++ b/api/controller/search_test.go
@@ -110,11 +110,21 @@ func TestCleanName(t *testing.T) {
 			expectedName:      "Name",
 			expectedExtraInfo: nil,
 		},
+		"Empty bracket extra info": {
+			name:              "Kratos, God of War",
+			quality:           "",
+			expectedName:      "Kratos, God of War",
+			expectedExtraInfo: nil,
+		},
 	}
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			gotName, gotExtra := cleanName(tt.name, tt.quality, nil)
+			var initialExtra []string
+			if name == "Empty bracket extra info" {
+				initialExtra = []string{"[]"}
+			}
+			gotName, gotExtra := cleanName(tt.name, tt.quality, initialExtra)
 			if gotName != tt.expectedName {
 				t.Errorf("cleanName() gotName = %v, want %v", gotName, tt.expectedName)
 			}

--- a/frontend/src/components/Card.jsx
+++ b/frontend/src/components/Card.jsx
@@ -5,6 +5,7 @@ import {
   Trash2,
 } from "react-feather";
 import { formatSavedAt } from "../hooks/useCart";
+import { normalizeExtraInfo } from "../utils/cardIdentity";
 
 const Card = ({
   card,
@@ -19,6 +20,7 @@ const Card = ({
   hasFavourites = false,
   baseUrl,
 }) => {
+  const extraInfo = normalizeExtraInfo(card.extraInfo);
   const qualityFoil = [];
   if (card.quality) qualityFoil.push(`≪ ${card.quality} ≫`);
   if (card.isFoil)
@@ -47,8 +49,8 @@ const Card = ({
       </div>
       <div className="text-center">
         <div className="fs-6 lh-sm fw-bold mb-1">{card.name}</div>
-        {card.extraInfo && (
-          <div className="fs-6 lh-sm fw-bold mb-1">{card.extraInfo}</div>
+        {extraInfo && (
+          <div className="fs-6 lh-sm fw-bold mb-1">{extraInfo}</div>
         )}
         {qualityFoil.length > 0 && (
           <div className="d-flex flex-wrap justify-content-center gap-1 fs-6 lh-sm fw-bold mb-1">

--- a/frontend/src/utils/cardIdentity.js
+++ b/frontend/src/utils/cardIdentity.js
@@ -13,7 +13,7 @@ export const normalizeExtraInfo = (extraInfo) => {
     ? extraInfo.join(" ")
     : String(extraInfo);
   const trimmed = normalizeText(text);
-  if (!trimmed) {
+  if (!trimmed || /^\[\s*\]$/.test(trimmed) || /^\(\s*\)$/.test(trimmed)) {
     return "";
   }
 

--- a/frontend/src/utils/cardIdentity.test.js
+++ b/frontend/src/utils/cardIdentity.test.js
@@ -21,6 +21,9 @@ assert.equal(
   "[Marvel Super Heroes Commander]",
 );
 assert.equal(normalizeExtraInfo([]), "");
+assert.equal(normalizeExtraInfo("[]"), "");
+assert.equal(normalizeExtraInfo("()"), "");
+assert.equal(normalizeExtraInfo("[ ]"), "");
 assert.equal(normalizeExtraInfo(undefined), "");
 assert.equal(normalizeExtraInfo("[Set B] [Set A]"), "[Set A] [Set B]");
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Searching for cards like **Kratos, God of War** could show a stray `[]` line under the card name when a store returned an empty set/extra-info field (e.g. `fmt.Sprintf("[%s]", "")`).

This change filters out meaningless bracket-only extra info in the backend and normalizes it away in the frontend before rendering.

## Changes

- **Backend (`cleanName`)**: Skip extra info entries whose bracket/paren content is empty (e.g. `[]`, `()`, `[ ]`).
- **Frontend (`normalizeExtraInfo`)**: Treat bracket-only empty values as empty strings.
- **Frontend (`Card.jsx`)**: Render extra info via `normalizeExtraInfo` so empty values are not shown.

## Screenshots

### Desktop
![Desktop search results without empty \[\] extraInfo](https://cursor.com/artifacts/c/art-67f0b203-e32f-437e-9f3a-29f77d9f1a0f)

### Mobile
![Mobile search results without empty \[\] extraInfo](https://cursor.com/artifacts/c/art-f7f6a49f-1cf7-49cc-998e-94074f9bcbdd)

## Testing

- `go test -mod=vendor ./controller/...`
- `node frontend/src/utils/cardIdentity.test.js`
- `make test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83f3c914-3cee-4103-a813-73cf0101b260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83f3c914-3cee-4103-a813-73cf0101b260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

