### PR TITLE
Fix 5 Mana 429 rate limits by reducing outbound proxy fan-out

### DIFF
--- a/api/gateway/outbound_get.go
+++ b/api/gateway/outbound_get.go
@@ -5,12 +5,23 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math/rand/v2"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
 	"mtg-price-checker-sg/gateway/util"
+)
+
+const (
+	// outboundGETMaxAttemptsPerTransport bounds how many times a single transport
+	// is tried when the upstream responds with 429 Too Many Requests. Retries
+	// back off between sends so a rate-limited host is not hammered.
+	outboundGETMaxAttemptsPerTransport = 3
+	outboundGETRetryBaseDelay          = 300 * time.Millisecond
+	outboundGETRetryMaxDelay           = 2500 * time.Millisecond
 )
 
 type outboundAttempt struct {
@@ -20,7 +31,8 @@ type outboundAttempt struct {
 }
 
 // DoOutboundGET performs a GET with direct, dedicated-proxy, and dynamic-proxy
-// fallback. Transient errors and 403/429 responses advance to the next transport.
+// fallback. 403 responses advance to the next transport; 429 responses retry
+// with backoff on the same transport before failing over.
 func DoOutboundGET(
 	ctx context.Context,
 	requestURL string,
@@ -33,9 +45,10 @@ func DoOutboundGET(
 }
 
 // DoOutboundRoundTrip performs an HTTP round trip with direct, dedicated-proxy,
-// and dynamic-proxy fallback. Transient errors and 403/429 responses advance to
-// the next transport. buildReq is called for each attempt so callers can supply
-// a fresh request body when needed.
+// and dynamic-proxy fallback. 403 responses advance to the next transport; 429
+// responses retry with backoff on the same transport before failing over.
+// buildReq is called for each send so callers can supply a fresh request body
+// when needed.
 func DoOutboundRoundTrip(
 	ctx context.Context,
 	opts OutboundRequestOptions,
@@ -44,38 +57,74 @@ func DoOutboundRoundTrip(
 ) (*http.Response, error) {
 	var failures []string
 	for _, attempt := range buildOutboundGETAttempts(timeout, opts.SkipDirect, opts.OnlyProxyURL) {
-		req, err := buildReq()
+		resp, failure, ok, err := doOutboundAttempt(ctx, attempt, opts, buildReq)
 		if err != nil {
 			return nil, err
 		}
-		if err := PrepareOutboundRequest(ctx, req, opts); err != nil {
-			return nil, err
+		if ok {
+			return resp, nil
 		}
-
-		proxyDesc := outboundProxyDescription(attempt)
-		log.Printf("outbound request: trying %s url=%s", proxyDesc, outboundRequestURL(req))
-
-		resp, err := attempt.client.Do(req)
-		if err != nil {
-			failure := fmt.Sprintf("%s: %v", attempt.strategy, err)
-			log.Printf("outbound request: failed %s: %v", proxyDesc, err)
+		if failure != "" {
 			failures = append(failures, failure)
-			continue
 		}
-		if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests {
-			failure := outboundStatusFailure(attempt.strategy, resp)
-			log.Printf("outbound request: failed %s: status %d", proxyDesc, resp.StatusCode)
-			failures = append(failures, failure)
-			continue
-		}
-
-		log.Printf("outbound request: succeeded %s status=%d url=%s", proxyDesc, resp.StatusCode, outboundRequestURL(req))
-		return resp, nil
 	}
 	if len(failures) == 0 {
 		return nil, fmt.Errorf("outbound request failed")
 	}
 	return nil, fmt.Errorf("outbound request failed: %s", strings.Join(failures, "; "))
+}
+
+func doOutboundAttempt(
+	ctx context.Context,
+	attempt outboundAttempt,
+	opts OutboundRequestOptions,
+	buildReq func() (*http.Request, error),
+) (*http.Response, string, bool, error) {
+	proxyDesc := outboundProxyDescription(attempt)
+	var lastFailure string
+
+	for retry := range outboundGETMaxAttemptsPerTransport {
+		req, err := buildReq()
+		if err != nil {
+			return nil, "", false, err
+		}
+		if err := PrepareOutboundRequest(ctx, req, opts); err != nil {
+			return nil, "", false, err
+		}
+
+		if retry == 0 {
+			log.Printf("outbound request: trying %s url=%s", proxyDesc, outboundRequestURL(req))
+		} else {
+			log.Printf("outbound request: retrying %s attempt=%d url=%s", proxyDesc, retry+1, outboundRequestURL(req))
+		}
+
+		resp, err := attempt.client.Do(req)
+		if err != nil {
+			lastFailure = fmt.Sprintf("%s: %v", attempt.strategy, err)
+			log.Printf("outbound request: failed %s: %v", proxyDesc, err)
+			return nil, lastFailure, false, nil
+		}
+
+		if resp.StatusCode == http.StatusForbidden {
+			lastFailure = outboundStatusFailure(attempt.strategy, resp)
+			log.Printf("outbound request: failed %s: status %d", proxyDesc, resp.StatusCode)
+			return nil, lastFailure, false, nil
+		}
+
+		if resp.StatusCode == http.StatusTooManyRequests {
+			lastFailure = outboundStatusFailure(attempt.strategy, resp)
+			log.Printf("outbound request: failed %s: status %d", proxyDesc, resp.StatusCode)
+			if isLastOutboundGETRetry(retry) || !waitBeforeOutboundGETRetry(ctx, outboundGETRetryDelay(retry, resp.Header.Get("Retry-After"))) {
+				return nil, lastFailure, false, nil
+			}
+			continue
+		}
+
+		log.Printf("outbound request: succeeded %s status=%d url=%s", proxyDesc, resp.StatusCode, outboundRequestURL(req))
+		return resp, "", true, nil
+	}
+
+	return nil, lastFailure, false, nil
 }
 
 func buildOutboundGETAttempts(timeout time.Duration, skipDirect bool, onlyProxyURL string) []outboundAttempt {
@@ -99,19 +148,18 @@ func buildOutboundGETAttempts(timeout time.Duration, skipDirect bool, onlyProxyU
 		})
 	}
 
-	for idx, proxyURL := range util.GetDedicatedProxyURLs() {
-		if proxyURL == "" {
-			continue
-		}
+	// Match colly's selectOutboundProxy policy: one randomly chosen dedicated
+	// proxy per search, not every configured slot. Cycling all dedicated proxies
+	// on 429/403 bursts the upstream and triggers proxy-side local_rate_limited.
+	if proxyURL, ok := RandomDedicatedProxyURL(); ok {
 		client, err := newProxyHTTPClient(proxyURL, timeout)
-		if err != nil {
-			continue
+		if err == nil {
+			attempts = append(attempts, outboundAttempt{
+				strategy: dedicatedProxyStrategyName(proxyURL),
+				proxyURL: proxyURL,
+				client:   client,
+			})
 		}
-		attempts = append(attempts, outboundAttempt{
-			strategy: fmt.Sprintf("dedicated-%d", idx+1),
-			proxyURL: proxyURL,
-			client:   client,
-		})
 	}
 
 	if client, ok := dynamicProxyHTTPClient(timeout); ok {
@@ -125,6 +173,15 @@ func buildOutboundGETAttempts(timeout time.Duration, skipDirect bool, onlyProxyU
 	return attempts
 }
 
+func dedicatedProxyStrategyName(proxyURL string) string {
+	for idx, configuredURL := range util.GetDedicatedProxyURLs() {
+		if configuredURL == proxyURL {
+			return fmt.Sprintf("dedicated-%d", idx+1)
+		}
+	}
+	return "dedicated"
+}
+
 func dynamicProxyHTTPClient(timeout time.Duration) (*http.Client, bool) {
 	proxyURL := DynamicProxyURL()
 	if proxyURL == "" {
@@ -136,6 +193,86 @@ func dynamicProxyHTTPClient(timeout time.Duration) (*http.Client, bool) {
 		return nil, false
 	}
 	return client, true
+}
+
+func isLastOutboundGETRetry(retry int) bool {
+	return retry >= outboundGETMaxAttemptsPerTransport-1
+}
+
+func outboundGETRetryDelay(retry int, retryAfter string) time.Duration {
+	if delay := parseOutboundRetryAfter(retryAfter); delay > 0 {
+		return delay
+	}
+	return outboundGETBackoffDelay(retry)
+}
+
+func outboundGETBackoffDelay(retry int) time.Duration {
+	if retry < 0 {
+		retry = 0
+	}
+
+	base := outboundGETRetryBaseDelay << retry
+	if base <= 0 || base > outboundGETRetryMaxDelay {
+		base = outboundGETRetryMaxDelay
+	}
+
+	half := base / 2
+	if half <= 0 {
+		return base
+	}
+	return half + time.Duration(rand.Int64N(int64(half)+1))
+}
+
+func waitBeforeOutboundGETRetry(ctx context.Context, delay time.Duration) bool {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if delay <= 0 {
+		return ctx.Err() == nil
+	}
+	if deadline, ok := ctx.Deadline(); ok && time.Until(deadline) <= delay {
+		return false
+	}
+
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func parseOutboundRetryAfter(value string) time.Duration {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+
+	if seconds, err := strconv.Atoi(value); err == nil {
+		if seconds <= 0 {
+			return 0
+		}
+		return capOutboundRetryAfter(time.Duration(seconds) * time.Second)
+	}
+
+	if when, err := http.ParseTime(value); err == nil {
+		delay := time.Until(when)
+		if delay <= 0 {
+			return 0
+		}
+		return capOutboundRetryAfter(delay)
+	}
+
+	return 0
+}
+
+func capOutboundRetryAfter(delay time.Duration) time.Duration {
+	if delay > outboundGETRetryMaxDelay {
+		return outboundGETRetryMaxDelay
+	}
+	return delay
 }
 
 func outboundStatusFailure(strategy string, resp *http.Response) string {
@@ -190,7 +327,7 @@ func outboundRequestURL(req *http.Request) string {
 // proxy when configured, otherwise dynamic proxy, otherwise direct. The policy matches
 // optimized colly collectors used by non-BinderPOS scrapers.
 func NewOutboundHTTPClient(timeout time.Duration) (*http.Client, error) {
-		_, proxyURL := selectOutboundProxy("", "")
+	_, proxyURL := selectOutboundProxy("", "")
 	if proxyURL == "" {
 		return &http.Client{Timeout: timeout}, nil
 	}

--- a/api/gateway/outbound_get_test.go
+++ b/api/gateway/outbound_get_test.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -59,16 +61,16 @@ func TestDoOutboundGET_DirectSuccess(t *testing.T) {
 	require.NoError(t, resp.Body.Close())
 }
 
-func TestBuildOutboundGETAttempts_TriesEachDedicatedProxy(t *testing.T) {
+func TestBuildOutboundGETAttempts_TriesOneRandomDedicatedProxy(t *testing.T) {
 	clearProxyEnv(t)
 	t.Setenv("DEDICATED_PROXY_1", "1.2.3.4|8080|user|pass")
 	t.Setenv("DEDICATED_PROXY_2", "5.6.7.8|8080|user|pass")
 
 	attempts := buildOutboundGETAttempts(2*time.Second, false, "")
-	require.GreaterOrEqual(t, len(attempts), 3)
+	require.GreaterOrEqual(t, len(attempts), 2)
 	require.Equal(t, "direct", attempts[0].strategy)
-	require.Equal(t, "dedicated-1", attempts[1].strategy)
-	require.Equal(t, "dedicated-2", attempts[2].strategy)
+	require.True(t, strings.HasPrefix(attempts[1].strategy, "dedicated-"))
+	require.Len(t, attempts, 2)
 }
 
 func TestBuildOutboundGETAttempts_SkipDirect(t *testing.T) {
@@ -77,7 +79,7 @@ func TestBuildOutboundGETAttempts_SkipDirect(t *testing.T) {
 
 	attempts := buildOutboundGETAttempts(2*time.Second, true, "")
 	require.Len(t, attempts, 1)
-	require.Equal(t, "dedicated-1", attempts[0].strategy)
+	require.True(t, strings.HasPrefix(attempts[0].strategy, "dedicated-"))
 }
 
 func TestBuildOutboundGETAttempts_OnlyProxyURL(t *testing.T) {
@@ -121,7 +123,7 @@ func TestOutboundProxyDescription(t *testing.T) {
 	require.GreaterOrEqual(t, len(attempts), 2)
 
 	require.Equal(t, "proxy_mode=direct proxy=none", outboundProxyDescription(attempts[0]))
-	require.Equal(t, "proxy_mode=dedicated proxy=DEDICATED_PROXY_1", outboundProxyDescription(attempts[1]))
+	require.Contains(t, outboundProxyDescription(attempts[1]), "proxy_mode=dedicated proxy=DEDICATED_PROXY_")
 }
 
 func TestDoOutboundGET_DirectForbiddenWithoutProxy(t *testing.T) {
@@ -161,6 +163,53 @@ func TestDoOutboundGET_ContinuesAfterDirectTimeout(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "direct:")
 	require.Contains(t, err.Error(), "dedicated-1:")
+}
+
+func TestDoOutboundGET_Retries429BeforeFailingOver(t *testing.T) {
+	clearProxyEnv(t)
+
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) == 1 {
+			w.Header().Set("Retry-After", "0")
+			http.Error(w, "rate limited", http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	resp, err := DoOutboundGET(
+		context.Background(),
+		server.URL,
+		OutboundRequestOptions{SkipWebBotAuth: true},
+		2*time.Second,
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.GreaterOrEqual(t, int(calls.Load()), 2)
+	require.NoError(t, resp.Body.Close())
+}
+
+func TestDoOutboundGET_FailsOverAfter429RetriesExhausted(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("DEDICATED_PROXY_1", "127.0.0.1|9|u|p")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "rate limited", http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	_, err := DoOutboundGET(
+		context.Background(),
+		server.URL,
+		OutboundRequestOptions{SkipWebBotAuth: true},
+		2*time.Second,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "direct: status 429")
+	require.Contains(t, err.Error(), "dedicated-1:")
+	require.NotContains(t, err.Error(), "dedicated-2:")
 }
 
 func TestDoOutboundRoundTrip_RebuildsPOSTBodyPerAttempt(t *testing.T) {

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -63,7 +63,7 @@ Some tests in `api/gateway/binderpos/*_test.go` hit real stores and proxies. The
 | Item | Value | Source | Notes |
 |------|--------|--------|--------|
 | Outbound proxy policy | Random dedicated → dynamic → direct | `selectOutboundProxy` in `api/gateway/collector.go` | Same single-attempt policy as default optimized colly collectors. When `DEDICATED_PROXY_*` is configured, each search picks one dedicated proxy uniformly at random. |
-| `net/http` scrapers / APIs | Direct → dedicated proxies → dynamic fallback | `DoOutboundGET` / `DoOutboundRoundTrip` in `api/gateway/outbound_get.go` | Used by Agora, Dueller's Point, 5 Mana, Mox & Lotus, Cards & Collections, and TCG Marketplace. Each transport is tried once per search; timeouts, connection errors, 403, and 429 advance to the next transport. |
+| `net/http` scrapers / APIs | Direct → one random dedicated proxy → dynamic fallback | `DoOutboundGET` / `DoOutboundRoundTrip` in `api/gateway/outbound_get.go` | Used by Agora, Dueller's Point, 5 Mana, Mox & Lotus, Cards & Collections, and TCG Marketplace. Each transport is tried once per search (one dedicated slot, not every configured proxy). 429 responses retry with backoff on the same transport before failing over; 403 and connection errors advance immediately. |
 | Cards Central API | Direct only | `http.Client` in `api/gateway/cardscentral/search.go` | Always uses a direct client; does not route through dedicated or dynamic proxies. |
 
 ---


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

5 Mana searches (e.g. Snow-Covered Island) were failing with 429 errors across every outbound transport:

```
direct: status 429 (Cloudflare)
dedicated-1 … dedicated-7: status 429 (local_rate_limited)
dynamic: status 429 (local_rate_limited)
```

`DoOutboundGET` was cycling through **all** configured dedicated proxies on a 403/429, firing up to nine rapid requests per search. That burst triggers Cloudflare rate limits and proxy-provider `local_rate_limited` responses — making the failure worse, not better.

## Fix

1. **One random dedicated proxy per search** — matches the colly `selectOutboundProxy` policy used by other scrapers (direct → one dedicated → dynamic), instead of hammering every `DEDICATED_PROXY_*` slot.
2. **429 backoff retries** — on `429 Too Many Requests`, retry the same transport up to 3 times with equal-jitter exponential backoff (honoring `Retry-After`) before failing over to the next transport. `403` still fails over immediately.

This affects all `DoOutboundGET` consumers (5 Mana, Agora, Dueller's Point, Mox & Lotus, etc.).

## Testing

- Added unit tests for single-proxy selection and 429 retry/failover behavior
- `make test` passes
- Verified 5 Mana live search for Snow-Covered Island succeeds locally
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68b78a3a-d42f-435b-a46d-95fd3498f4e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68b78a3a-d42f-435b-a46d-95fd3498f4e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

