### PR TITLE
Fix 5 Mana 429 rate limits: reduce proxy fan-out and use suggest.json

### DIFF
--- a/api/gateway/fivemana/fixtures_test.go
+++ b/api/gateway/fivemana/fixtures_test.go
@@ -1,56 +1,51 @@
 package fivemana
 
-const soldOutProductHTML = `
-<ul class="grid product-grid">
-<li class="grid__item">
-<div class="card-wrapper product-card-wrapper">
-  <div class="card card--standard card--media">
-    <div class="card__inner">
-      <div class="card__media">
-        <img src="//5-mana.sg/cdn/shop/files/ten-rings.png" alt="The Ten Rings [Marvel Super Heroes]">
-      </div>
-      <div class="card__content">
-        <div class="card__badge bottom left"><span class="badge badge--bottom-left">Sold out</span></div>
-      </div>
-    </div>
-    <div class="card__content">
-      <h3 class="card__heading h5">
-        <a href="/products/the-ten-rings-marvel-super-heroes">The Ten Rings [Marvel Super Heroes]</a>
-      </h3>
-      <div class="price price--sold-out">
-        <div class="price__sale">
-          <span class="price-item price-item--sale price-item--last">$9.90 SGD</span>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-</li>
-</ul>
-`
+const unavailableSuggestJSON = `{
+  "resources": {
+    "results": {
+      "products": [
+        {
+          "available": false,
+          "title": "The Ten Rings [Marvel Super Heroes]",
+          "price": "9.90",
+          "image": "https://cdn.shopify.com/example.png",
+          "url": "/products/the-ten-rings-marvel-super-heroes"
+        }
+      ]
+    }
+  }
+}`
 
-const inStockProductHTML = `
-<ul class="grid product-grid">
-<li class="grid__item">
-<div class="card-wrapper product-card-wrapper">
-  <div class="card card--standard card--media">
-    <div class="card__inner">
-      <div class="card__media">
-        <img src="//5-mana.sg/cdn/shop/files/abrade.png" alt="Abrade [Foundations]">
-      </div>
-    </div>
-    <div class="card__content">
-      <h3 class="card__heading h5">
-        <a href="/products/abrade-foundations">Abrade [Foundations]</a>
-      </h3>
-      <div class="price">
-        <div class="price__sale">
-          <span class="price-item price-item--sale price-item--last">$0.40 SGD</span>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-</li>
-</ul>
-`
+const inStockSuggestJSON = `{
+  "resources": {
+    "results": {
+      "products": [
+        {
+          "available": true,
+          "title": "Abrade [Foundations]",
+          "price": "0.40",
+          "image": "https://cdn.shopify.com/abrade.png",
+          "url": "/products/abrade-foundations",
+          "tags": ["Foundations", "Foundations Non-Foil", "Red", "Uncommon"]
+        }
+      ]
+    }
+  }
+}`
+
+const foilSuggestJSON = `{
+  "resources": {
+    "results": {
+      "products": [
+        {
+          "available": true,
+          "title": "Rhystic Study [Foil]",
+          "price": "120.00",
+          "image": "https://cdn.shopify.com/foil.png",
+          "url": "/products/rhystic-study-foil",
+          "tags": ["Foil"]
+        }
+      ]
+    }
+  }
+}`

--- a/api/gateway/fivemana/search.go
+++ b/api/gateway/fivemana/search.go
@@ -2,19 +2,19 @@ package fivemana
 
 import (
 	"context"
+	"encoding/json"
 	"log"
 	"mtg-price-checker-sg/gateway"
-	"mtg-price-checker-sg/gateway/util"
 	"mtg-price-checker-sg/pkg/config"
 	"net/url"
+	"strconv"
 	"strings"
-
-	"github.com/PuerkitoBio/goquery"
 )
 
 const StoreName = "5 Mana"
 const StoreBaseURL = "https://5-mana.sg"
-const StoreSearchPath = "/search"
+const StoreSearchPath = "/search/suggest.json"
+const suggestProductLimit = "20"
 
 type Store struct {
 	Name       string
@@ -30,25 +30,49 @@ func NewLGS() gateway.LGS {
 	}
 }
 
+type suggestResponse struct {
+	Resources struct {
+		Results struct {
+			Products []suggestProduct `json:"products"`
+		} `json:"results"`
+	} `json:"resources"`
+}
+
+type suggestProduct struct {
+	Available bool     `json:"available"`
+	Title     string   `json:"title"`
+	Price     string   `json:"price"`
+	Image     string   `json:"image"`
+	URL       string   `json:"url"`
+	Tags      []string `json:"tags"`
+}
+
 func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
 	var cards []gateway.Card
 
-	// Build the request URL from constant components only;
-	// user input is placed exclusively into query parameters via url.Values.
+	storeBase, err := url.Parse(s.BaseUrl)
+	if err != nil {
+		return cards, err
+	}
+
 	apiURL := &url.URL{
 		Scheme: "https",
 		Host:   "5-mana.sg",
 		Path:   StoreSearchPath,
 		RawQuery: url.Values{
-			"q":                     {searchStr},
-			"filter.v.availability": {"1"},
+			"q":                  {searchStr},
+			"resources[type]":    {"product"},
+			"resources[limit]": {suggestProductLimit},
 		}.Encode(),
 	}
 
 	resp, err := gateway.DoOutboundGET(ctx, apiURL.String(), gateway.OutboundRequestOptions{
-		Style:              gateway.OutboundStyleHTML,
-		PageURL:            apiURL,
+		Style:              gateway.OutboundStyleJSON,
+		PageURL:            storeBase,
 		ShopifySGDCurrency: true,
+		// Shopify storefronts behind Cloudflare respond better to browser-like
+		// requests than signed bot traffic on the suggest API path.
+		SkipWebBotAuth: true,
 	}, config.SearchAttemptTimeout)
 	if err != nil {
 		return cards, err
@@ -60,56 +84,72 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 		return cards, err
 	}
 
-	doc, err := goquery.NewDocumentFromReader(strings.NewReader(string(body)))
-	if err != nil {
+	var payload suggestResponse
+	if err := json.Unmarshal(body, &payload); err != nil {
 		return cards, err
 	}
 
-	doc.Find("ul.product-grid li").Each(func(i int, se *goquery.Selection) {
-		card, ok := parseProductCard(se, s.Name)
+	for _, product := range payload.Resources.Results.Products {
+		card, ok := parseSuggestProduct(product, s.Name)
 		if ok {
 			cards = append(cards, card)
 		}
-	})
+	}
 
 	return cards, nil
 }
 
-func parseProductCard(se *goquery.Selection, storeName string) (gateway.Card, bool) {
-	// Shopify's availability filter can still surface sold-out listings; the theme
-	// marks them with price--sold-out and a "Sold out" badge.
-	if se.Find("div.price.price--sold-out").Length() > 0 {
+func parseSuggestProduct(product suggestProduct, storeName string) (gateway.Card, bool) {
+	if !product.Available {
 		return gateway.Card{}, false
 	}
 
-	c := gateway.Card{
-		Source: storeName,
+	title := strings.TrimSpace(product.Title)
+	if title == "" {
+		return gateway.Card{}, false
 	}
 
-	// name e.g. Rhystic Study (Anime Borderless) [Wilds of Eldraine: Enchanting Tales] [Foil]
-	heading := se.Find("h3.card__heading.h5 a")
-	c.Name = strings.TrimSpace(strings.Replace(heading.Text(), "[Foil]", "", -1))
-	c.IsFoil = strings.Contains(strings.ToLower(heading.Text()), "[foil]")
-
-	c.Url = StoreBaseURL + se.Find("h3.card__heading a").AttrOr("href", "")
-	c.Img = se.Find("div.card__media img").AttrOr("src", "")
-	c.InStock = true
-
-	price, err := util.ParsePrice(se.Find("span.price-item.price-item--sale.price-item--last").Text())
-	if err != nil {
-		c.InStock = false
+	price, err := strconv.ParseFloat(strings.TrimSpace(product.Price), 64)
+	if err != nil || price <= 0 {
+		return gateway.Card{}, false
 	}
-	c.Price = price
 
-	cleanPageURL, err := url.Parse(c.Url)
+	productURL := strings.TrimSpace(product.URL)
+	if productURL == "" {
+		return gateway.Card{}, false
+	}
+	if strings.HasPrefix(productURL, "/") {
+		productURL = StoreBaseURL + productURL
+	}
+
+	cleanPageURL, err := url.Parse(productURL)
 	if err != nil {
-		log.Printf("error parsing url for %s with value [%s]: %v", storeName, c.Url, err)
+		log.Printf("error parsing url for %s with value [%s]: %v", storeName, productURL, err)
 		return gateway.Card{}, false
 	}
 	cleanPageURL.RawQuery = url.Values{
 		"utm_source": []string{config.UtmSource},
 	}.Encode()
-	c.Url = cleanPageURL.String()
 
-	return c, c.Name != "" && c.InStock
+	return gateway.Card{
+		Name:      strings.TrimSpace(strings.Replace(title, "[Foil]", "", -1)),
+		Url:       cleanPageURL.String(),
+		Img:       strings.TrimSpace(product.Image),
+		InStock:   true,
+		IsFoil:    isFoilProduct(title, product.Tags),
+		Price:     price,
+		Source:    storeName,
+	}, true
+}
+
+func isFoilProduct(title string, tags []string) bool {
+	if strings.Contains(strings.ToLower(title), "[foil]") {
+		return true
+	}
+	for _, tag := range tags {
+		if strings.EqualFold(strings.TrimSpace(tag), "foil") {
+			return true
+		}
+	}
+	return false
 }

--- a/api/gateway/fivemana/search_test.go
+++ b/api/gateway/fivemana/search_test.go
@@ -2,33 +2,44 @@ package fivemana
 
 import (
 	"context"
-	"strings"
+	"encoding/json"
 	"testing"
 
 	"mtg-price-checker-sg/gateway/gatewaytest"
 
-	"github.com/PuerkitoBio/goquery"
 	"github.com/stretchr/testify/require"
 )
 
-func Test_ParseProductCardSkipsSoldOut(t *testing.T) {
-	doc, err := goquery.NewDocumentFromReader(strings.NewReader(soldOutProductHTML))
-	require.NoError(t, err)
+func Test_ParseSuggestProductSkipsUnavailable(t *testing.T) {
+	var payload suggestResponse
+	require.NoError(t, json.Unmarshal([]byte(unavailableSuggestJSON), &payload))
 
-	card, ok := parseProductCard(doc.Find("ul.product-grid li").First(), StoreName)
-	require.False(t, ok, "sold-out listing should be skipped")
+	card, ok := parseSuggestProduct(payload.Resources.Results.Products[0], StoreName)
+	require.False(t, ok, "unavailable listing should be skipped")
 	require.Empty(t, card.Name)
 }
 
-func Test_ParseProductCardKeepsInStock(t *testing.T) {
-	doc, err := goquery.NewDocumentFromReader(strings.NewReader(inStockProductHTML))
-	require.NoError(t, err)
+func Test_ParseSuggestProductKeepsInStock(t *testing.T) {
+	var payload suggestResponse
+	require.NoError(t, json.Unmarshal([]byte(inStockSuggestJSON), &payload))
 
-	card, ok := parseProductCard(doc.Find("ul.product-grid li").First(), StoreName)
+	card, ok := parseSuggestProduct(payload.Resources.Results.Products[0], StoreName)
 	require.True(t, ok)
 	require.Equal(t, "Abrade [Foundations]", card.Name)
+	require.False(t, card.IsFoil)
 	require.True(t, card.InStock)
 	require.Equal(t, 0.40, card.Price)
+	require.Contains(t, card.Url, StoreBaseURL+"/products/abrade-foundations")
+}
+
+func Test_ParseSuggestProductDetectsFoil(t *testing.T) {
+	var payload suggestResponse
+	require.NoError(t, json.Unmarshal([]byte(foilSuggestJSON), &payload))
+
+	card, ok := parseSuggestProduct(payload.Resources.Results.Products[0], StoreName)
+	require.True(t, ok)
+	require.Equal(t, "Rhystic Study", card.Name)
+	require.True(t, card.IsFoil)
 }
 
 func Test_Search(t *testing.T) {

--- a/api/gateway/gatewaytest/live_probes.go
+++ b/api/gateway/gatewaytest/live_probes.go
@@ -28,22 +28,36 @@ func RequireAgoraSearchStructure(t *testing.T, ctx context.Context, baseURL, sea
 	})
 }
 
-// RequireFiveManaSearchStructure verifies the 5 Mana Shopify search page markup.
+// RequireFiveManaSearchStructure verifies the 5 Mana Shopify suggest API shape.
 func RequireFiveManaSearchStructure(t *testing.T, ctx context.Context, baseURL, searchPath, query string) {
 	t.Helper()
 	host := strings.TrimPrefix(strings.TrimPrefix(baseURL, "https://"), "http://")
 	probeURL := BuildURL("https", host, searchPath, url.Values{
-		"q":                     {query},
-		"filter.v.availability": {"1"},
+		"q":                  {query},
+		"resources[type]":    {"product"},
+		"resources[limit]": {"20"},
 	})
-	pageURL, err := url.Parse(probeURL)
-	require.NoError(t, err)
-	RequireHTMLStructure(t, ctx, HTMLProbe{
-		URL:                probeURL,
-		PrimarySelector:    "ul.product-grid li",
-		FallbackSelector:   "ul.product-grid",
-		PageURL:            pageURL,
-		ShopifySGDCurrency: true,
+	RequireJSONStructure(t, ctx, JSONProbe{
+		URL: probeURL,
+		Headers: map[string]string{
+			"Accept": "application/json",
+		},
+		Validate: func(body []byte) error {
+			var payload struct {
+				Resources struct {
+					Results struct {
+						Products []json.RawMessage `json:"products"`
+					} `json:"results"`
+				} `json:"resources"`
+			}
+			if err := json.Unmarshal(body, &payload); err != nil {
+				return ValidateErrorf("decode suggest response: %w", err)
+			}
+			if payload.Resources.Results.Products == nil {
+				return ValidateErrorf("missing resources.results.products array")
+			}
+			return nil
+		},
 	})
 }
 

--- a/api/gateway/outbound_get.go
+++ b/api/gateway/outbound_get.go
@@ -5,12 +5,23 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math/rand/v2"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
 	"mtg-price-checker-sg/gateway/util"
+)
+
+const (
+	// outboundGETMaxAttemptsPerTransport bounds how many times a single transport
+	// is tried when the upstream responds with 429 Too Many Requests. Retries
+	// back off between sends so a rate-limited host is not hammered.
+	outboundGETMaxAttemptsPerTransport = 3
+	outboundGETRetryBaseDelay          = 300 * time.Millisecond
+	outboundGETRetryMaxDelay           = 2500 * time.Millisecond
 )
 
 type outboundAttempt struct {
@@ -20,7 +31,8 @@ type outboundAttempt struct {
 }
 
 // DoOutboundGET performs a GET with direct, dedicated-proxy, and dynamic-proxy
-// fallback. Transient errors and 403/429 responses advance to the next transport.
+// fallback. 403 responses advance to the next transport; 429 responses retry
+// with backoff on the same transport before failing over.
 func DoOutboundGET(
 	ctx context.Context,
 	requestURL string,
@@ -33,9 +45,10 @@ func DoOutboundGET(
 }
 
 // DoOutboundRoundTrip performs an HTTP round trip with direct, dedicated-proxy,
-// and dynamic-proxy fallback. Transient errors and 403/429 responses advance to
-// the next transport. buildReq is called for each attempt so callers can supply
-// a fresh request body when needed.
+// and dynamic-proxy fallback. 403 responses advance to the next transport; 429
+// responses retry with backoff on the same transport before failing over.
+// buildReq is called for each send so callers can supply a fresh request body
+// when needed.
 func DoOutboundRoundTrip(
 	ctx context.Context,
 	opts OutboundRequestOptions,
@@ -44,38 +57,74 @@ func DoOutboundRoundTrip(
 ) (*http.Response, error) {
 	var failures []string
 	for _, attempt := range buildOutboundGETAttempts(timeout, opts.SkipDirect, opts.OnlyProxyURL) {
-		req, err := buildReq()
+		resp, failure, ok, err := doOutboundAttempt(ctx, attempt, opts, buildReq)
 		if err != nil {
 			return nil, err
 		}
-		if err := PrepareOutboundRequest(ctx, req, opts); err != nil {
-			return nil, err
+		if ok {
+			return resp, nil
 		}
-
-		proxyDesc := outboundProxyDescription(attempt)
-		log.Printf("outbound request: trying %s url=%s", proxyDesc, outboundRequestURL(req))
-
-		resp, err := attempt.client.Do(req)
-		if err != nil {
-			failure := fmt.Sprintf("%s: %v", attempt.strategy, err)
-			log.Printf("outbound request: failed %s: %v", proxyDesc, err)
+		if failure != "" {
 			failures = append(failures, failure)
-			continue
 		}
-		if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests {
-			failure := outboundStatusFailure(attempt.strategy, resp)
-			log.Printf("outbound request: failed %s: status %d", proxyDesc, resp.StatusCode)
-			failures = append(failures, failure)
-			continue
-		}
-
-		log.Printf("outbound request: succeeded %s status=%d url=%s", proxyDesc, resp.StatusCode, outboundRequestURL(req))
-		return resp, nil
 	}
 	if len(failures) == 0 {
 		return nil, fmt.Errorf("outbound request failed")
 	}
 	return nil, fmt.Errorf("outbound request failed: %s", strings.Join(failures, "; "))
+}
+
+func doOutboundAttempt(
+	ctx context.Context,
+	attempt outboundAttempt,
+	opts OutboundRequestOptions,
+	buildReq func() (*http.Request, error),
+) (*http.Response, string, bool, error) {
+	proxyDesc := outboundProxyDescription(attempt)
+	var lastFailure string
+
+	for retry := range outboundGETMaxAttemptsPerTransport {
+		req, err := buildReq()
+		if err != nil {
+			return nil, "", false, err
+		}
+		if err := PrepareOutboundRequest(ctx, req, opts); err != nil {
+			return nil, "", false, err
+		}
+
+		if retry == 0 {
+			log.Printf("outbound request: trying %s url=%s", proxyDesc, outboundRequestURL(req))
+		} else {
+			log.Printf("outbound request: retrying %s attempt=%d url=%s", proxyDesc, retry+1, outboundRequestURL(req))
+		}
+
+		resp, err := attempt.client.Do(req)
+		if err != nil {
+			lastFailure = fmt.Sprintf("%s: %v", attempt.strategy, err)
+			log.Printf("outbound request: failed %s: %v", proxyDesc, err)
+			return nil, lastFailure, false, nil
+		}
+
+		if resp.StatusCode == http.StatusForbidden {
+			lastFailure = outboundStatusFailure(attempt.strategy, resp)
+			log.Printf("outbound request: failed %s: status %d", proxyDesc, resp.StatusCode)
+			return nil, lastFailure, false, nil
+		}
+
+		if resp.StatusCode == http.StatusTooManyRequests {
+			lastFailure = outboundStatusFailure(attempt.strategy, resp)
+			log.Printf("outbound request: failed %s: status %d", proxyDesc, resp.StatusCode)
+			if isLastOutboundGETRetry(retry) || !waitBeforeOutboundGETRetry(ctx, outboundGETRetryDelay(retry, resp.Header.Get("Retry-After"))) {
+				return nil, lastFailure, false, nil
+			}
+			continue
+		}
+
+		log.Printf("outbound request: succeeded %s status=%d url=%s", proxyDesc, resp.StatusCode, outboundRequestURL(req))
+		return resp, "", true, nil
+	}
+
+	return nil, lastFailure, false, nil
 }
 
 func buildOutboundGETAttempts(timeout time.Duration, skipDirect bool, onlyProxyURL string) []outboundAttempt {
@@ -99,19 +148,18 @@ func buildOutboundGETAttempts(timeout time.Duration, skipDirect bool, onlyProxyU
 		})
 	}
 
-	for idx, proxyURL := range util.GetDedicatedProxyURLs() {
-		if proxyURL == "" {
-			continue
-		}
+	// Match colly's selectOutboundProxy policy: one randomly chosen dedicated
+	// proxy per search, not every configured slot. Cycling all dedicated proxies
+	// on 429/403 bursts the upstream and triggers proxy-side local_rate_limited.
+	if proxyURL, ok := RandomDedicatedProxyURL(); ok {
 		client, err := newProxyHTTPClient(proxyURL, timeout)
-		if err != nil {
-			continue
+		if err == nil {
+			attempts = append(attempts, outboundAttempt{
+				strategy: dedicatedProxyStrategyName(proxyURL),
+				proxyURL: proxyURL,
+				client:   client,
+			})
 		}
-		attempts = append(attempts, outboundAttempt{
-			strategy: fmt.Sprintf("dedicated-%d", idx+1),
-			proxyURL: proxyURL,
-			client:   client,
-		})
 	}
 
 	if client, ok := dynamicProxyHTTPClient(timeout); ok {
@@ -125,6 +173,15 @@ func buildOutboundGETAttempts(timeout time.Duration, skipDirect bool, onlyProxyU
 	return attempts
 }
 
+func dedicatedProxyStrategyName(proxyURL string) string {
+	for idx, configuredURL := range util.GetDedicatedProxyURLs() {
+		if configuredURL == proxyURL {
+			return fmt.Sprintf("dedicated-%d", idx+1)
+		}
+	}
+	return "dedicated"
+}
+
 func dynamicProxyHTTPClient(timeout time.Duration) (*http.Client, bool) {
 	proxyURL := DynamicProxyURL()
 	if proxyURL == "" {
@@ -136,6 +193,86 @@ func dynamicProxyHTTPClient(timeout time.Duration) (*http.Client, bool) {
 		return nil, false
 	}
 	return client, true
+}
+
+func isLastOutboundGETRetry(retry int) bool {
+	return retry >= outboundGETMaxAttemptsPerTransport-1
+}
+
+func outboundGETRetryDelay(retry int, retryAfter string) time.Duration {
+	if delay := parseOutboundRetryAfter(retryAfter); delay > 0 {
+		return delay
+	}
+	return outboundGETBackoffDelay(retry)
+}
+
+func outboundGETBackoffDelay(retry int) time.Duration {
+	if retry < 0 {
+		retry = 0
+	}
+
+	base := outboundGETRetryBaseDelay << retry
+	if base <= 0 || base > outboundGETRetryMaxDelay {
+		base = outboundGETRetryMaxDelay
+	}
+
+	half := base / 2
+	if half <= 0 {
+		return base
+	}
+	return half + time.Duration(rand.Int64N(int64(half)+1))
+}
+
+func waitBeforeOutboundGETRetry(ctx context.Context, delay time.Duration) bool {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if delay <= 0 {
+		return ctx.Err() == nil
+	}
+	if deadline, ok := ctx.Deadline(); ok && time.Until(deadline) <= delay {
+		return false
+	}
+
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func parseOutboundRetryAfter(value string) time.Duration {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+
+	if seconds, err := strconv.Atoi(value); err == nil {
+		if seconds <= 0 {
+			return 0
+		}
+		return capOutboundRetryAfter(time.Duration(seconds) * time.Second)
+	}
+
+	if when, err := http.ParseTime(value); err == nil {
+		delay := time.Until(when)
+		if delay <= 0 {
+			return 0
+		}
+		return capOutboundRetryAfter(delay)
+	}
+
+	return 0
+}
+
+func capOutboundRetryAfter(delay time.Duration) time.Duration {
+	if delay > outboundGETRetryMaxDelay {
+		return outboundGETRetryMaxDelay
+	}
+	return delay
 }
 
 func outboundStatusFailure(strategy string, resp *http.Response) string {
@@ -190,7 +327,7 @@ func outboundRequestURL(req *http.Request) string {
 // proxy when configured, otherwise dynamic proxy, otherwise direct. The policy matches
 // optimized colly collectors used by non-BinderPOS scrapers.
 func NewOutboundHTTPClient(timeout time.Duration) (*http.Client, error) {
-		_, proxyURL := selectOutboundProxy("", "")
+	_, proxyURL := selectOutboundProxy("", "")
 	if proxyURL == "" {
 		return &http.Client{Timeout: timeout}, nil
 	}

--- a/api/gateway/outbound_get_test.go
+++ b/api/gateway/outbound_get_test.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -59,16 +61,16 @@ func TestDoOutboundGET_DirectSuccess(t *testing.T) {
 	require.NoError(t, resp.Body.Close())
 }
 
-func TestBuildOutboundGETAttempts_TriesEachDedicatedProxy(t *testing.T) {
+func TestBuildOutboundGETAttempts_TriesOneRandomDedicatedProxy(t *testing.T) {
 	clearProxyEnv(t)
 	t.Setenv("DEDICATED_PROXY_1", "1.2.3.4|8080|user|pass")
 	t.Setenv("DEDICATED_PROXY_2", "5.6.7.8|8080|user|pass")
 
 	attempts := buildOutboundGETAttempts(2*time.Second, false, "")
-	require.GreaterOrEqual(t, len(attempts), 3)
+	require.GreaterOrEqual(t, len(attempts), 2)
 	require.Equal(t, "direct", attempts[0].strategy)
-	require.Equal(t, "dedicated-1", attempts[1].strategy)
-	require.Equal(t, "dedicated-2", attempts[2].strategy)
+	require.True(t, strings.HasPrefix(attempts[1].strategy, "dedicated-"))
+	require.Len(t, attempts, 2)
 }
 
 func TestBuildOutboundGETAttempts_SkipDirect(t *testing.T) {
@@ -77,7 +79,7 @@ func TestBuildOutboundGETAttempts_SkipDirect(t *testing.T) {
 
 	attempts := buildOutboundGETAttempts(2*time.Second, true, "")
 	require.Len(t, attempts, 1)
-	require.Equal(t, "dedicated-1", attempts[0].strategy)
+	require.True(t, strings.HasPrefix(attempts[0].strategy, "dedicated-"))
 }
 
 func TestBuildOutboundGETAttempts_OnlyProxyURL(t *testing.T) {
@@ -121,7 +123,7 @@ func TestOutboundProxyDescription(t *testing.T) {
 	require.GreaterOrEqual(t, len(attempts), 2)
 
 	require.Equal(t, "proxy_mode=direct proxy=none", outboundProxyDescription(attempts[0]))
-	require.Equal(t, "proxy_mode=dedicated proxy=DEDICATED_PROXY_1", outboundProxyDescription(attempts[1]))
+	require.Contains(t, outboundProxyDescription(attempts[1]), "proxy_mode=dedicated proxy=DEDICATED_PROXY_")
 }
 
 func TestDoOutboundGET_DirectForbiddenWithoutProxy(t *testing.T) {
@@ -161,6 +163,53 @@ func TestDoOutboundGET_ContinuesAfterDirectTimeout(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "direct:")
 	require.Contains(t, err.Error(), "dedicated-1:")
+}
+
+func TestDoOutboundGET_Retries429BeforeFailingOver(t *testing.T) {
+	clearProxyEnv(t)
+
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) == 1 {
+			w.Header().Set("Retry-After", "0")
+			http.Error(w, "rate limited", http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	resp, err := DoOutboundGET(
+		context.Background(),
+		server.URL,
+		OutboundRequestOptions{SkipWebBotAuth: true},
+		2*time.Second,
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.GreaterOrEqual(t, int(calls.Load()), 2)
+	require.NoError(t, resp.Body.Close())
+}
+
+func TestDoOutboundGET_FailsOverAfter429RetriesExhausted(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("DEDICATED_PROXY_1", "127.0.0.1|9|u|p")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "rate limited", http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	_, err := DoOutboundGET(
+		context.Background(),
+		server.URL,
+		OutboundRequestOptions{SkipWebBotAuth: true},
+		2*time.Second,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "direct: status 429")
+	require.Contains(t, err.Error(), "dedicated-1:")
+	require.NotContains(t, err.Error(), "dedicated-2:")
 }
 
 func TestDoOutboundRoundTrip_RebuildsPOSTBodyPerAttempt(t *testing.T) {

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -63,7 +63,7 @@ Some tests in `api/gateway/binderpos/*_test.go` hit real stores and proxies. The
 | Item | Value | Source | Notes |
 |------|--------|--------|--------|
 | Outbound proxy policy | Random dedicated → dynamic → direct | `selectOutboundProxy` in `api/gateway/collector.go` | Same single-attempt policy as default optimized colly collectors. When `DEDICATED_PROXY_*` is configured, each search picks one dedicated proxy uniformly at random. |
-| `net/http` scrapers / APIs | Direct → dedicated proxies → dynamic fallback | `DoOutboundGET` / `DoOutboundRoundTrip` in `api/gateway/outbound_get.go` | Used by Agora, Dueller's Point, 5 Mana, Mox & Lotus, Cards & Collections, and TCG Marketplace. Each transport is tried once per search; timeouts, connection errors, 403, and 429 advance to the next transport. |
+| `net/http` scrapers / APIs | Direct → one random dedicated proxy → dynamic fallback | `DoOutboundGET` / `DoOutboundRoundTrip` in `api/gateway/outbound_get.go` | Used by Agora, Dueller's Point, 5 Mana, Mox & Lotus, Cards & Collections, and TCG Marketplace. Each transport is tried once per search (one dedicated slot, not every configured proxy). 429 responses retry with backoff on the same transport before failing over; 403 and connection errors advance immediately. |
 | Cards Central API | Direct only | `http.Client` in `api/gateway/cardscentral/search.go` | Always uses a direct client; does not route through dedicated or dynamic proxies. |
 
 ---


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

5 Mana searches (e.g. Snow-Covered Island) were failing with 429 errors across every outbound transport:

```
direct: status 429 (Cloudflare)
dedicated-1 … dedicated-7: status 429 (local_rate_limited)
dynamic: status 429 (local_rate_limited)
```

Two issues compounded:

1. `DoOutboundGET` cycled through **all** configured dedicated proxies on failure, firing up to nine rapid requests per search and triggering proxy-side `local_rate_limited`.
2. The **HTML search page** (`/search?q=…`) is aggressively rate-limited by Cloudflare on proxied traffic, even when the suggest API succeeds through the same proxy.

## Fix

### 1. Reduce outbound proxy fan-out (`outbound_get.go`)
- One random dedicated proxy per search (matches colly policy), not all 7 slots
- 429 backoff retries on the same transport before failing over

### 2. Switch 5 Mana to Shopify `search/suggest.json`
- Uses Shopify's lightweight JSON suggest endpoint instead of scraping the HTML search page
- Returns the same product fields (title, price, image, URL, availability)
- Verified: HTML page returns 429 through proxies; `suggest.json` returns 200 through the same dedicated proxy
- Uses browser User-Agent (`SkipWebBotAuth`) for Cloudflare compatibility

## Testing

- Unit tests for suggest JSON parsing (in-stock, unavailable, foil)
- Outbound retry/fan-out unit tests
- `gateway/fivemana` live search passes
- `make test` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68b78a3a-d42f-435b-a46d-95fd3498f4e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68b78a3a-d42f-435b-a46d-95fd3498f4e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

