### PR TITLE
Skip direct outbound transport for 5 Mana

### DIFF
--- a/api/gateway/fivemana/search.go
+++ b/api/gateway/fivemana/search.go
@@ -49,6 +49,7 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 		Style:              gateway.OutboundStyleHTML,
 		PageURL:            apiURL,
 		ShopifySGDCurrency: true,
+		SkipDirect:         true,
 	}, config.SearchAttemptTimeout)
 	if err != nil {
 		return cards, err


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

5 Mana searches now set `SkipDirect: true` on `DoOutboundGET`, so outbound requests start on the per-store dedicated proxy lease (then dynamic fallback) instead of hitting `5-mana.sg` directly from the server IP first.

## Motivation

`5-mana.sg` is a Cloudflare-protected Shopify HTML search page. The previous `direct → dedicated → dynamic` order triggered Cloudflare 429s from the bare server/Lambda IP before the leased dedicated proxy was used. Other BinderPOS/colly stores already prefer dedicated when a lease is pinned; this aligns 5 Mana with that behavior for its `DoOutboundGET` path.

## Change

- `api/gateway/fivemana/search.go`: add `SkipDirect: true` to `OutboundRequestOptions`.

## Testing

- `go test -mod=vendor ./gateway/fivemana/...` — unit tests pass; live `Test_Search` fails in CI/cloud due to upstream 429 / proxy `local_rate_limited` against `5-mana.sg` (no `direct:` attempt in failure output, confirming skip-direct works).
- `make test` — all packages pass except live `gateway/fivemana` integration test (upstream rate limiting).
- `go fix ./...` — no changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-28274469-56ca-4630-b65b-1d9f012520ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-28274469-56ca-4630-b65b-1d9f012520ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

