### PR TITLE
Move BinderPOS dynamic proxy fallbacks to final two attempts

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,26 +254,25 @@ gateway that reads listings by scraping each store's own Shopify storefront.
 
 ### BinderPOS scrape and decklist fallback chain
 
-Each BinderPOS store tries up to three scrape strategies first, escalating
-across proxy tiers (**dedicated → direct → dynamic**). When scrape attempts fail
-with errors (for example storefront **429** rate limits), the shared BinderPOS
-decklist portal is tried as a fallback with the same proxy tiers:
+Each BinderPOS store tries scrape and decklist strategies across dedicated and
+direct proxy tiers first. When those fail with errors (for example storefront
+**429** rate limits), dynamic proxy is reserved for the final two attempts:
 
-`scrap-dedicated` → `scrap-direct` → `scrap-dynamic` → `decklist-dedicated` → `decklist-direct` → `decklist-dynamic`
+`scrap-dedicated` → `scrap-direct` → `decklist-dedicated` → `decklist-direct` → `scrap-dynamic` → `decklist-dynamic`
 
 ```mermaid
 flowchart TD
     A[BinderPOS store search] --> B[scrap-dedicated]
     B -- error --> C[scrap-direct]
-    C -- error --> D[scrap-dynamic]
-    D -- error --> F[decklist-dedicated]
+    C -- error --> F[decklist-dedicated]
     F -- error --> G[decklist-direct]
-    G -- error --> H[decklist-dynamic]
+    G -- error --> D[scrap-dynamic]
+    D -- error --> H[decklist-dynamic]
     B -- cards or empty success --> E[Return result]
     C -- cards or empty success --> E
-    D -- cards or empty success --> E
     F -- cards or empty decklist --> E
     G -- cards or empty decklist --> E
+    D -- cards or empty success --> E
     H -- cards, empty, or error --> E
 ```
 

--- a/api/gateway/binderpos/storefront_fallback_test.go
+++ b/api/gateway/binderpos/storefront_fallback_test.go
@@ -45,7 +45,7 @@ func TestRunFallbackAttempts(t *testing.T) {
 	})
 
 	t.Run("falls back to decklist after scrap 429 errors", func(t *testing.T) {
-		sequence := make([]string, 0, 4)
+		sequence := make([]string, 0, 3)
 		cards, err := runFallbackAttempts(
 			fallbackAttempt{strategy: "scrap-dedicated", family: strategyFamilyScrap, fn: func() ([]gateway.Card, error) {
 				sequence = append(sequence, "scrap-dedicated")
@@ -55,13 +55,13 @@ func TestRunFallbackAttempts(t *testing.T) {
 				sequence = append(sequence, "scrap-direct")
 				return nil, errors.New("unexpected status 429")
 			}},
-			fallbackAttempt{strategy: "scrap-dynamic", family: strategyFamilyScrap, fn: func() ([]gateway.Card, error) {
-				sequence = append(sequence, "scrap-dynamic")
-				return nil, errors.New("unexpected status 429")
-			}},
 			fallbackAttempt{strategy: "decklist-dedicated", family: strategyFamilyDecklist, fn: func() ([]gateway.Card, error) {
 				sequence = append(sequence, "decklist-dedicated")
 				return []gateway.Card{{Name: "decklist-dedicated"}}, nil
+			}},
+			fallbackAttempt{strategy: "scrap-dynamic", family: strategyFamilyScrap, fn: func() ([]gateway.Card, error) {
+				t.Fatal("scrap-dynamic should not run before decklist after scrap 429 errors")
+				return nil, nil
 			}},
 		)
 		if err != nil {
@@ -70,7 +70,7 @@ func TestRunFallbackAttempts(t *testing.T) {
 		if len(cards) != 1 || cards[0].Name != "decklist-dedicated" {
 			t.Fatalf("expected decklist fallback card, got %+v", cards)
 		}
-		want := []string{"scrap-dedicated", "scrap-direct", "scrap-dynamic", "decklist-dedicated"}
+		want := []string{"scrap-dedicated", "scrap-direct", "decklist-dedicated"}
 		if len(sequence) != len(want) {
 			t.Fatalf("expected %v, got %v", want, sequence)
 		}

--- a/api/gateway/binderpos/storefront_search.go
+++ b/api/gateway/binderpos/storefront_search.go
@@ -36,7 +36,8 @@ func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, 
 		},
 	}
 
-	strategies := []storefrontStrategy{scrap[0], scrap[1], scrap[2]}
+	strategies := []storefrontStrategy{scrap[0], scrap[1]}
+	var decklistDynamic storefrontStrategy
 	if strings.TrimSpace(shopifyDomain) != "" {
 		decklist := [3]storefrontStrategy{
 			{
@@ -58,7 +59,12 @@ func (i impl) Search(ctx context.Context, scrapVariant int, storeName, baseURL, 
 				},
 			},
 		}
-		strategies = append(strategies, decklist[0], decklist[1], decklist[2])
+		strategies = append(strategies, decklist[0], decklist[1])
+		decklistDynamic = decklist[2]
+	}
+	strategies = append(strategies, scrap[2])
+	if strings.TrimSpace(shopifyDomain) != "" {
+		strategies = append(strategies, decklistDynamic)
 	}
 
 	return runStorefrontStrategies(ctx, strategies...)

--- a/api/gateway/binderpos/storefront_search_test.go
+++ b/api/gateway/binderpos/storefront_search_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestSelectStorefrontStrategiesScrapFirstThenDecklist(t *testing.T) {
+func TestStorefrontStrategyOrder(t *testing.T) {
 	scrap := [3]storefrontStrategy{
 		{name: "scrap-dedicated"},
 		{name: "scrap-direct"},
@@ -16,17 +16,21 @@ func TestSelectStorefrontStrategiesScrapFirstThenDecklist(t *testing.T) {
 		{name: "decklist-dynamic"},
 	}
 
-	got := make([]string, 0, 6)
-	for _, strategy := range append(scrap[:], decklist[:]...) {
-		got = append(got, strategy.name)
+	got := []string{
+		scrap[0].name,
+		scrap[1].name,
+		decklist[0].name,
+		decklist[1].name,
+		scrap[2].name,
+		decklist[2].name,
 	}
 
 	want := []string{
 		"scrap-dedicated",
 		"scrap-direct",
-		"scrap-dynamic",
 		"decklist-dedicated",
 		"decklist-direct",
+		"scrap-dynamic",
 		"decklist-dynamic",
 	}
 	if len(got) != len(want) {

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -26,8 +26,8 @@ const (
 	// AgoraSearchAttemptTimeout is the per-attempt cap for Agora Hobby only.
 	AgoraSearchAttemptTimeout = 10 * time.Second
 	// DynamicProxyEnv contains an authenticated proxy URL used for explicit
-	// dynamic-proxy fallback attempts, which BinderPOS now reserves for the
-	// final fallback after dedicated and direct/no-proxy attempts.
+	// dynamic-proxy fallback attempts, which BinderPOS reserves for the final
+	// two attempts after dedicated and direct/no-proxy scrap and decklist tries.
 	DynamicProxyEnv = "DYNAMIC_PROXY"
 	// UseDynamicProxyEnv toggles whether DYNAMIC_PROXY may be used for fallback
 	// attempts. When false, dynamic proxy is skipped even if configured.

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -29,7 +29,7 @@ This document records **where** the app configures search behavior, **timeouts**
 | Item | Value | Notes |
 |------|--------|--------|
 | Configured slots | **`DEDICATED_PROXY_1`** … **`DEDICATED_PROXY_7`** | Each value is `host\|port\|username\|password` (pipe-separated). Empty or incomplete entries are ignored when building URLs. |
-| Dynamic fallback proxy | **`DYNAMIC_PROXY`** | Uses the same `host\|port\|username\|password` format as `DEDICATED_PROXY_*` (full proxy URLs are also accepted). BinderPOS reserves it for the final fallback after dedicated and direct/no-proxy attempts. |
+| Dynamic fallback proxy | **`DYNAMIC_PROXY`** | Uses the same `host\|port\|username\|password` format as `DEDICATED_PROXY_*` (full proxy URLs are also accepted). BinderPOS reserves it for the final two fallback attempts (`scrap-dynamic` and `decklist-dynamic`) after dedicated and direct/no-proxy scrap and decklist tries. |
 | Residential proxy | **`RESIDENTIAL_PROXY_1`** | Optional residential proxy for stores that rate-limit datacenter IPs (currently 5 Mana). Uses the same `host\|port\|username\|password` format. |
 | Dynamic proxy toggle | **`USE_DYNAMIC_PROXY`** | When `false`, dynamic proxy fallback is disabled even if `DYNAMIC_PROXY` is set. Defaults to enabled when unset or invalid. |
 
@@ -47,7 +47,7 @@ Some tests in `api/gateway/binderpos/*_test.go` hit real stores and proxies. The
 
 | Scenario | Order of strategies (each step is one attempt) | Per-step attempt timeout / HTTP client |
 |----------|--------------------------------------------------|----------------------------------------|
-| All BinderPOS stores | **scrap-dedicated** → **scrap-direct** → **scrap-dynamic** → **decklist-dedicated** → **decklist-direct** → **decklist-dynamic** (six `runWithAttemptTimeout` steps when a Shopify domain is configured) | **5s** per step: `binderposAttemptTimeout` (`config.SearchAttemptTimeout`) in `api/gateway/binderpos/storefront.go`; `runWithAttemptTimeout` in `storefront_search.go`. |
+| All BinderPOS stores | **scrap-dedicated** → **scrap-direct** → **decklist-dedicated** → **decklist-direct** → **scrap-dynamic** → **decklist-dynamic** (six `runWithAttemptTimeout` steps when a Shopify domain is configured) | **5s** per step: `binderposAttemptTimeout` (`config.SearchAttemptTimeout`) in `api/gateway/binderpos/storefront.go`; `runWithAttemptTimeout` in `storefront_search.go`. Dynamic proxy is reserved for the final two attempts. |
 
 | Item | Value | Source | Notes |
 |------|--------|--------|--------|


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reorders the BinderPOS storefront fallback chain so dynamic proxy is reserved for the final two attempts instead of running `scrap-dynamic` before decklist strategies.

**Previous order:**
`scrap-dedicated` → `scrap-direct` → `scrap-dynamic` → `decklist-dedicated` → `decklist-direct` → `decklist-dynamic`

**New order:**
`scrap-dedicated` → `scrap-direct` → `decklist-dedicated` → `decklist-direct` → `scrap-dynamic` → `decklist-dynamic`

This defers the more expensive rotating dynamic proxy until dedicated and direct scrap/decklist attempts have been exhausted.

## Changes

- `api/gateway/binderpos/storefront_search.go` — build strategy list with dynamic attempts last
- Tests updated for the new ordering
- README and `docs/search-strategies-retries-timeouts.md` updated
- `api/pkg/config/config.go` comment clarified

## Testing

- `go test -mod=vendor -failfast -timeout 5m ./gateway/binderpos/...` — pass
- `make test` — BinderPOS and other unrelated packages pass; Agora and Dueller's Point live gateway tests timed out (known flaky upstream/network behaviour, unrelated to this change)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8669d7d8-e368-4ed5-be6d-a9d0491abb72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8669d7d8-e368-4ed5-be6d-a9d0491abb72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

