### PR TITLE
Reduce proxy rate limits: disable dynamic proxy, cap dedicated concurrency

### DIFF
--- a/api/controller/search.go
+++ b/api/controller/search.go
@@ -254,6 +254,13 @@ func searchShop(
 
 	if config.UseProxy {
 		if proxyURLs := util.GetDedicatedProxyURLs(); len(proxyURLs) > 0 {
+			releaseSearchSlot, slotErr := gateway.AcquireDedicatedProxySearchSlot(shopCtx)
+			if slotErr != nil {
+				recordShopSearchError(searchString, shopName, slotErr, aggregator)
+				return
+			}
+			defer releaseSearchSlot()
+
 			if proxyURL, release, err := gateway.LeaseDedicatedProxyURL(shopCtx, proxyURLs); err == nil {
 				defer release()
 				shopCtx = gateway.WithRequestDedicatedProxy(shopCtx, proxyURL)

--- a/api/controller/search_test.go
+++ b/api/controller/search_test.go
@@ -405,14 +405,14 @@ func TestFetchCardsConcurrently_ConcurrentStoresGetDistinctDedicatedProxies(t *t
 	for i := 1; i <= 7; i++ {
 		t.Setenv(fmt.Sprintf("DEDICATED_PROXY_%d", i), "")
 	}
-	for i := 1; i <= 6; i++ {
+	for i := 1; i <= 3; i++ {
 		t.Setenv(fmt.Sprintf("DEDICATED_PROXY_%d", i), fmt.Sprintf("10.0.0.%d|8080|user|pass", i))
 	}
 
-	started := make(chan struct{}, 6)
+	started := make(chan struct{}, gateway.DedicatedProxySearchMaxConcurrent)
 	release := make(chan struct{})
 	var mu sync.Mutex
-	pinned := make(map[string]string, 6)
+	pinned := make(map[string]string, gateway.DedicatedProxySearchMaxConcurrent)
 
 	makeShop := func(name string) gateway.LGS {
 		return &MockLGS{
@@ -435,9 +435,6 @@ func TestFetchCardsConcurrently_ConcurrentStoresGetDistinctDedicatedProxies(t *t
 		"Shop1": makeShop("Shop1"),
 		"Shop2": makeShop("Shop2"),
 		"Shop3": makeShop("Shop3"),
-		"Shop4": makeShop("Shop4"),
-		"Shop5": makeShop("Shop5"),
-		"Shop6": makeShop("Shop6"),
 	}
 
 	done := make(chan struct{})
@@ -449,7 +446,7 @@ func TestFetchCardsConcurrently_ConcurrentStoresGetDistinctDedicatedProxies(t *t
 		}
 	}()
 
-	for range 6 {
+	for range gateway.DedicatedProxySearchMaxConcurrent {
 		select {
 		case <-started:
 		case <-time.After(2 * time.Second):
@@ -461,10 +458,10 @@ func TestFetchCardsConcurrently_ConcurrentStoresGetDistinctDedicatedProxies(t *t
 
 	mu.Lock()
 	defer mu.Unlock()
-	if len(pinned) != 6 {
-		t.Fatalf("expected 6 pinned proxies, got %d (%v)", len(pinned), pinned)
+	if len(pinned) != gateway.DedicatedProxySearchMaxConcurrent {
+		t.Fatalf("expected %d pinned proxies, got %d (%v)", gateway.DedicatedProxySearchMaxConcurrent, len(pinned), pinned)
 	}
-	seen := make(map[string]struct{}, 6)
+	seen := make(map[string]struct{}, gateway.DedicatedProxySearchMaxConcurrent)
 	for shop, proxyURL := range pinned {
 		if proxyURL == "" {
 			t.Fatalf("shop %s pinned empty proxy", shop)
@@ -710,6 +707,10 @@ func TestFetchCardsConcurrently_SkipsCanceledForDiscord(t *testing.T) {
 }
 
 func TestFetchCardsConcurrently_LimitsConcurrentWorkers(t *testing.T) {
+	for i := 1; i <= 7; i++ {
+		t.Setenv(fmt.Sprintf("DEDICATED_PROXY_%d", i), "")
+	}
+
 	const shopCount = 10
 	started := make(chan struct{}, shopCount)
 	release := make(chan struct{})

--- a/api/gateway/binderpos/scrap.go
+++ b/api/gateway/binderpos/scrap.go
@@ -20,10 +20,6 @@ func (i impl) Scrap(ctx context.Context, scrapVariant int, storeName, baseUrl, s
 	return i.scrapWithCollectorFactory(ctx, scrapVariant, storeName, baseUrl, searchUrl, searchStr, newBinderposCollector)
 }
 
-func (i impl) scrapDynamic(ctx context.Context, scrapVariant int, storeName, baseUrl, searchUrl, searchStr string) ([]gateway.Card, error) {
-	return i.scrapWithCollectorFactory(ctx, scrapVariant, storeName, baseUrl, searchUrl, searchStr, newDynamicNoRetryCollector)
-}
-
 func (i impl) scrapDirect(ctx context.Context, scrapVariant int, storeName, baseUrl, searchUrl, searchStr string) ([]gateway.Card, error) {
 	return i.scrapWithCollectorFactory(ctx, scrapVariant, storeName, baseUrl, searchUrl, searchStr, newDirectNoRetryCollector)
 }

--- a/api/gateway/binderpos/scrap_dynamic.go
+++ b/api/gateway/binderpos/scrap_dynamic.go
@@ -1,0 +1,60 @@
+package binderpos
+
+import (
+	"context"
+
+	"mtg-price-checker-sg/gateway"
+)
+
+const (
+	// scrapDynamicMaxAttempts bounds how many times a single scrap-dynamic call
+	// is sent when the upstream responds with 429. Each retry uses a fresh
+	// collector so the rotating proxy egresses from a new IP.
+	scrapDynamicMaxAttempts = 3
+)
+
+func (i impl) scrapDynamic(ctx context.Context, scrapVariant int, storeName, baseUrl, searchUrl, searchStr string) ([]gateway.Card, error) {
+	releaseDynamicProxy, err := gateway.AcquireDynamicProxySlot(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer releaseDynamicProxy()
+
+	return scrapDynamicWithRetry(ctx, func() ([]gateway.Card, error) {
+		return i.scrapWithCollectorFactory(
+			ctx,
+			scrapVariant,
+			storeName,
+			baseUrl,
+			searchUrl,
+			searchStr,
+			newDynamicNoRetryCollector,
+		)
+	})
+}
+
+func scrapDynamicWithRetry(ctx context.Context, run func() ([]gateway.Card, error)) ([]gateway.Card, error) {
+	var (
+		cards   []gateway.Card
+		lastErr error
+	)
+
+	for attempt := range scrapDynamicMaxAttempts {
+		cards, lastErr = run()
+		if lastErr == nil {
+			return cards, nil
+		}
+		if !gateway.IsHTTPTooManyRequests(lastErr) || isLastScrapDynamicAttempt(attempt) {
+			return cards, lastErr
+		}
+		if !waitBeforeDecklistRetry(ctx, decklistBackoffDelay(attempt)) {
+			return cards, lastErr
+		}
+	}
+
+	return cards, lastErr
+}
+
+func isLastScrapDynamicAttempt(attempt int) bool {
+	return attempt >= scrapDynamicMaxAttempts-1
+}

--- a/api/gateway/binderpos/scrap_dynamic_test.go
+++ b/api/gateway/binderpos/scrap_dynamic_test.go
@@ -1,0 +1,50 @@
+package binderpos
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"mtg-price-checker-sg/gateway"
+)
+
+func TestScrapDynamicWithRetryRetriesOn429(t *testing.T) {
+	attempts := 0
+	cards, err := scrapDynamicWithRetry(context.Background(), func() ([]gateway.Card, error) {
+		attempts++
+		if attempts < 2 {
+			return nil, errors.New("429 Too Many Requests")
+		}
+		return []gateway.Card{{Name: "ok"}}, nil
+	})
+	if err != nil {
+		t.Fatalf("expected success on second attempt, got %v", err)
+	}
+	if len(cards) != 1 || cards[0].Name != "ok" {
+		t.Fatalf("unexpected cards: %+v", cards)
+	}
+	if attempts != 2 {
+		t.Fatalf("expected 2 attempts, got %d", attempts)
+	}
+}
+
+func TestScrapDynamicWithRetryDoesNotRetryOnNon429(t *testing.T) {
+	attempts := 0
+	_, err := scrapDynamicWithRetry(context.Background(), func() ([]gateway.Card, error) {
+		attempts++
+		return nil, errors.New("403 Forbidden")
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if attempts != 1 {
+		t.Fatalf("expected 1 attempt, got %d", attempts)
+	}
+}
+
+func TestIsHTTPTooManyRequestsRecognizesWrappedScrapError(t *testing.T) {
+	err := errors.New("attempt 4 (scrap-dynamic): 429 Too Many Requests (proxy_mode=dynamic proxy=DYNAMIC_PROXY)")
+	if !gateway.IsHTTPTooManyRequests(err) {
+		t.Fatalf("expected 429 to be detected in %q", err)
+	}
+}

--- a/api/gateway/binderpos/storefront_client.go
+++ b/api/gateway/binderpos/storefront_client.go
@@ -57,6 +57,12 @@ func searchByStorefrontAPIDynamic(ctx context.Context, scrapVariant int, storeNa
 		return nil, fmt.Errorf("no dynamic proxy configured for binderpos storefront api")
 	}
 
+	releaseDynamicProxy, err := gateway.AcquireDynamicProxySlot(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer releaseDynamicProxy()
+
 	client, err := newHTTPClientWithProxyURL(proxyURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid dynamic proxy configured for binderpos storefront api: %w", err)

--- a/api/gateway/dedicated_proxy_search_gate.go
+++ b/api/gateway/dedicated_proxy_search_gate.go
@@ -1,0 +1,29 @@
+package gateway
+
+import "context"
+
+// DedicatedProxySearchMaxConcurrent caps how many store searches may hold a
+// dedicated-proxy lease at once. The controller runs more workers than this,
+// but proxy-backed searches queue here so datacenter egress does not burst
+// every configured DEDICATED_PROXY_* slot at once.
+const DedicatedProxySearchMaxConcurrent = 3
+
+// dedicatedProxySearchGate bounds in-flight store searches that use dedicated proxies.
+var dedicatedProxySearchGate = make(chan struct{}, DedicatedProxySearchMaxConcurrent)
+
+// AcquireDedicatedProxySearchSlot blocks until a dedicated-proxy search slot is
+// free or ctx is done. The returned release must be called exactly once.
+func AcquireDedicatedProxySearchSlot(ctx context.Context) (func(), error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	select {
+	case dedicatedProxySearchGate <- struct{}{}:
+		return func() { <-dedicatedProxySearchGate }, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}

--- a/api/gateway/dedicated_proxy_search_gate_test.go
+++ b/api/gateway/dedicated_proxy_search_gate_test.go
@@ -1,0 +1,43 @@
+package gateway
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestAcquireDedicatedProxySearchSlotLimitsConcurrency(t *testing.T) {
+	releases := make([]func(), 0, DedicatedProxySearchMaxConcurrent)
+	for i := range DedicatedProxySearchMaxConcurrent {
+		release, err := AcquireDedicatedProxySearchSlot(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error acquiring slot %d: %v", i, err)
+		}
+		releases = append(releases, release)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	if _, err := AcquireDedicatedProxySearchSlot(ctx); err == nil {
+		t.Fatalf("expected acquire to block until ctx deadline when gate is full")
+	}
+
+	releases[0]()
+	release, err := AcquireDedicatedProxySearchSlot(context.Background())
+	if err != nil {
+		t.Fatalf("expected to acquire a freed slot, got error: %v", err)
+	}
+	release()
+
+	for _, r := range releases[1:] {
+		r()
+	}
+}
+
+func TestAcquireDedicatedProxySearchSlotRespectsCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := AcquireDedicatedProxySearchSlot(ctx); err == nil {
+		t.Fatalf("expected cancelled context to return an error")
+	}
+}

--- a/api/gateway/dynamic_proxy_gate.go
+++ b/api/gateway/dynamic_proxy_gate.go
@@ -1,0 +1,30 @@
+package gateway
+
+import "context"
+
+// dynamicProxyMaxConcurrent caps how many outbound requests may use DYNAMIC_PROXY
+// at once across all stores and strategies. BinderPOS reserves dynamic proxy for
+// the final scrap/decklist fallbacks, so many stores can reach those steps
+// together after earlier strategies fail; without a shared gate the proxy
+// endpoint is burst with concurrent traffic and often returns 429.
+const dynamicProxyMaxConcurrent = 3
+
+// dynamicProxyGate bounds in-flight requests routed through DYNAMIC_PROXY.
+var dynamicProxyGate = make(chan struct{}, dynamicProxyMaxConcurrent)
+
+// AcquireDynamicProxySlot blocks until a dynamic-proxy slot is free or ctx is
+// done. The returned release must be called exactly once.
+func AcquireDynamicProxySlot(ctx context.Context) (func(), error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	select {
+	case dynamicProxyGate <- struct{}{}:
+		return func() { <-dynamicProxyGate }, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}

--- a/api/gateway/dynamic_proxy_gate_test.go
+++ b/api/gateway/dynamic_proxy_gate_test.go
@@ -1,0 +1,43 @@
+package gateway
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestAcquireDynamicProxySlotLimitsConcurrency(t *testing.T) {
+	releases := make([]func(), 0, dynamicProxyMaxConcurrent)
+	for i := range dynamicProxyMaxConcurrent {
+		release, err := AcquireDynamicProxySlot(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error acquiring slot %d: %v", i, err)
+		}
+		releases = append(releases, release)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	if _, err := AcquireDynamicProxySlot(ctx); err == nil {
+		t.Fatalf("expected acquire to block until ctx deadline when gate is full")
+	}
+
+	releases[0]()
+	release, err := AcquireDynamicProxySlot(context.Background())
+	if err != nil {
+		t.Fatalf("expected to acquire a freed slot, got error: %v", err)
+	}
+	release()
+
+	for _, r := range releases[1:] {
+		r()
+	}
+}
+
+func TestAcquireDynamicProxySlotRespectsCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := AcquireDynamicProxySlot(ctx); err == nil {
+		t.Fatalf("expected cancelled context to return an error")
+	}
+}

--- a/api/gateway/http_status.go
+++ b/api/gateway/http_status.go
@@ -71,6 +71,19 @@ func ExtractHTTPStatusCode(msg string) int {
 	return 0
 }
 
+// IsHTTPTooManyRequests reports whether err (or any error in its chain) represents
+// an HTTP 429 Too Many Requests response.
+func IsHTTPTooManyRequests(err error) bool {
+	for err != nil {
+		code := ExtractHTTPStatusCode(err.Error())
+		if code == http.StatusTooManyRequests {
+			return true
+		}
+		err = errors.Unwrap(err)
+	}
+	return false
+}
+
 // EnrichErrorWithHTTPStatus prefixes err with code and status text when statusCode
 // is known and the message does not already include a status code.
 func EnrichErrorWithHTTPStatus(err error, statusCode int) error {

--- a/api/gateway/http_status_test.go
+++ b/api/gateway/http_status_test.go
@@ -55,6 +55,27 @@ func TestIsHTTPServerError(t *testing.T) {
 	}
 }
 
+func TestIsHTTPTooManyRequests(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "429 label", err: errors.New("429 Too Many Requests"), want: true},
+		{name: "unexpected status", err: errors.New("unexpected status 429"), want: true},
+		{name: "wrapped attempt", err: errors.New("attempt 4 (scrap-dynamic): 429 Too Many Requests (proxy_mode=dynamic)"), want: true},
+		{name: "403", err: errors.New("403 Forbidden"), want: false},
+		{name: "503", err: errors.New("503 Service Unavailable"), want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsHTTPTooManyRequests(tc.err); got != tc.want {
+				t.Fatalf("IsHTTPTooManyRequests(%q) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestEnrichErrorWithHTTPStatus(t *testing.T) {
 	err := EnrichErrorWithHTTPStatus(errors.New(http.StatusText(http.StatusForbidden)), http.StatusForbidden)
 	if got := err.Error(); got != "403 Forbidden" {

--- a/api/gateway/outbound_get.go
+++ b/api/gateway/outbound_get.go
@@ -72,6 +72,18 @@ func doOutboundAttempt(
 ) (*http.Response, string, bool, error) {
 	proxyDesc := outboundProxyDescription(attempt)
 
+	var releaseDynamicProxy func()
+	if attempt.strategy == "dynamic" {
+		release, err := AcquireDynamicProxySlot(ctx)
+		if err != nil {
+			return nil, "", false, err
+		}
+		releaseDynamicProxy = release
+	}
+	if releaseDynamicProxy != nil {
+		defer releaseDynamicProxy()
+	}
+
 	req, err := buildReq()
 	if err != nil {
 		return nil, "", false, err

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -31,6 +31,7 @@ const (
 	DynamicProxyEnv = "DYNAMIC_PROXY"
 	// UseDynamicProxyEnv toggles whether DYNAMIC_PROXY may be used for fallback
 	// attempts. When false, dynamic proxy is skipped even if configured.
+	// Defaults to disabled when unset or invalid.
 	UseDynamicProxyEnv = "USE_DYNAMIC_PROXY"
 	// WebBotAuthEnabledEnv toggles RFC 9421 Web Bot Auth signing on outbound gateway requests.
 	WebBotAuthEnabledEnv = "WEB_BOT_AUTH_ENABLED"
@@ -104,12 +105,12 @@ const UseLeasedDedicatedProxy = false
 func UseDynamicProxy() bool {
 	rawValue := strings.TrimSpace(os.Getenv(UseDynamicProxyEnv))
 	if rawValue == "" {
-		return true
+		return false
 	}
 
 	enabled, err := strconv.ParseBool(rawValue)
 	if err != nil {
-		return true
+		return false
 	}
 
 	return enabled

--- a/api/pkg/config/config_test.go
+++ b/api/pkg/config/config_test.go
@@ -5,10 +5,10 @@ import (
 )
 
 func TestUseDynamicProxy(t *testing.T) {
-	t.Run("defaults to enabled when unset", func(t *testing.T) {
+	t.Run("defaults to disabled when unset", func(t *testing.T) {
 		t.Setenv(UseDynamicProxyEnv, "")
-		if !UseDynamicProxy() {
-			t.Fatalf("expected dynamic proxy to be enabled by default")
+		if UseDynamicProxy() {
+			t.Fatalf("expected dynamic proxy to be disabled by default")
 		}
 	})
 
@@ -26,10 +26,10 @@ func TestUseDynamicProxy(t *testing.T) {
 		}
 	})
 
-	t.Run("defaults to enabled for invalid value", func(t *testing.T) {
+	t.Run("defaults to disabled for invalid value", func(t *testing.T) {
 		t.Setenv(UseDynamicProxyEnv, "not-a-bool")
-		if !UseDynamicProxy() {
-			t.Fatalf("expected invalid toggle to default to enabled")
+		if UseDynamicProxy() {
+			t.Fatalf("expected invalid toggle to default to disabled")
 		}
 	})
 }

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -30,6 +30,7 @@ This document records **where** the app configures search behavior, **timeouts**
 |------|--------|--------|
 | Configured slots | **`DEDICATED_PROXY_1`** … **`DEDICATED_PROXY_7`** | Each value is `host\|port\|username\|password` (pipe-separated). Empty or incomplete entries are ignored when building URLs. |
 | Dynamic fallback proxy | **`DYNAMIC_PROXY`** | Uses the same `host\|port\|username\|password` format as `DEDICATED_PROXY_*` (full proxy URLs are also accepted). BinderPOS reserves it for the final two fallback attempts (`scrap-dynamic` and `decklist-dynamic`) after dedicated and direct/no-proxy scrap and decklist tries. |
+| Dynamic proxy concurrency | 3 in-flight | `dynamicProxyMaxConcurrent` in `api/gateway/dynamic_proxy_gate.go` | Caps concurrent requests through `DYNAMIC_PROXY` across all stores and strategies so the final BinderPOS fallbacks do not burst the proxy endpoint and trigger 429. |
 | Residential proxy | **`RESIDENTIAL_PROXY_1`** | Optional residential proxy for stores that rate-limit datacenter IPs (currently 5 Mana). Uses the same `host\|port\|username\|password` format. |
 | Dynamic proxy toggle | **`USE_DYNAMIC_PROXY`** | When `false`, dynamic proxy fallback is disabled even if `DYNAMIC_PROXY` is set. Defaults to enabled when unset or invalid. |
 
@@ -56,6 +57,7 @@ Some tests in `api/gateway/binderpos/*_test.go` hit real stores and proxies. The
 | Decklist portal concurrency | 4 in-flight | `binderposPortalMaxConcurrent` in `api/gateway/binderpos/storefront_portal_gate.go` | Caps concurrent requests to `portal.binderpos.com` across stores in one search. |
 | Decklist transient retries | Up to 3 sends | `binderposDecklistMaxAttempts` in `api/gateway/binderpos/storefront.go`; `doDecklistRequestWithRetry` in `storefront_decklist_retry.go` | Retries 429/5xx and network errors with equal-jitter backoff (300ms base, 2.5s cap) and honors `Retry-After`. |
 | “Retries” | N/A (sequential fallbacks) | `runFallbackAttempts` in `storefront_fallback.go` | Stops on the first attempt that returns **cards**. An empty **scrape** attempt without error is **final** and decklist is not tried. An empty **decklist** attempt skips remaining decklist strategies. HTTP **5xx** on scrape is **final**. Returns the last annotated error if all attempts fail. This is **not** exponential backoff retry of a single scrape request. |
+| scrap-dynamic 429 retries | Up to 3 sends | `scrapDynamicMaxAttempts` in `api/gateway/binderpos/scrap_dynamic.go` | Retries 429 responses with equal-jitter backoff (reuses decklist backoff constants) and a fresh collector so the rotating proxy egresses from a new IP. Honors the per-attempt timeout budget. |
 
 ---
 

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -14,7 +14,7 @@ This document records **where** the app configures search behavior, **timeouts**
 | Colly request timeout (default scrapers) | 5s | `applyCollectorDefaults` → `c.SetRequestTimeout(config.SearchAttemptTimeout)` in `api/gateway/collector.go` | Overrides gocolly’s default 10s for optimized collectors. |
 | Minimum end-to-end response time | 1s | `responseThreshold` in `searchShops` in `api/controller/search.go` | If all stores finish in under 1s, the handler **sleeps** the remainder so the API “feels” less instant. |
 | Colly HTTP retries | None | `api/gateway/collector.go` (`configureRequestOptimizations`, `registerNoRetryErrorHandler`) | **Single HTTP attempt** per colly request path; no automatic colly/gateway retry of failed visits. |
-| Dedicated proxy per store search | 1 lease | `searchShop` in `api/controller/search.go` + `WithRequestDedicatedProxy` in `api/gateway/request_dedicated_proxy.go` | When dedicated proxies are configured, each store search acquires **one** dedicated-proxy lease for its own goroutine. Up to six concurrent store searches (see `maxConcurrentStoreSearches`) each take a distinct slot from the shared pool (up to seven). Additional stores in the same search wait for a slot to be released before starting. |
+| Dedicated proxy per store search | 1 lease | `searchShop` in `api/controller/search.go` + `WithRequestDedicatedProxy` in `api/gateway/request_dedicated_proxy.go` | When dedicated proxies are configured, each store search acquires **one** dedicated-proxy lease for its own goroutine. Up to six concurrent store searches (see `maxConcurrentStoreSearches`) share the worker pool, but at most **three** proxy-backed searches may hold a dedicated lease at once (`DedicatedProxySearchMaxConcurrent` in `api/gateway/dedicated_proxy_search_gate.go`). Additional proxy-backed stores wait for a slot before leasing. |
 
 ---
 
@@ -29,10 +29,11 @@ This document records **where** the app configures search behavior, **timeouts**
 | Item | Value | Notes |
 |------|--------|--------|
 | Configured slots | **`DEDICATED_PROXY_1`** … **`DEDICATED_PROXY_7`** | Each value is `host\|port\|username\|password` (pipe-separated). Empty or incomplete entries are ignored when building URLs. |
-| Dynamic fallback proxy | **`DYNAMIC_PROXY`** | Uses the same `host\|port\|username\|password` format as `DEDICATED_PROXY_*` (full proxy URLs are also accepted). BinderPOS reserves it for the final two fallback attempts (`scrap-dynamic` and `decklist-dynamic`) after dedicated and direct/no-proxy scrap and decklist tries. |
+| Dedicated proxy search concurrency | 3 in-flight | `DedicatedProxySearchMaxConcurrent` in `api/gateway/dedicated_proxy_search_gate.go` | Caps how many store searches may hold a dedicated-proxy lease at once so datacenter egress does not burst every configured slot. |
+| Dynamic fallback proxy | **`DYNAMIC_PROXY`** | Uses the same `host\|port\|username\|password` format as `DEDICATED_PROXY_*` (full proxy URLs are also accepted). BinderPOS reserves it for the final two fallback attempts (`scrap-dynamic` and `decklist-dynamic`) after dedicated and direct/no-proxy scrap and decklist tries. Disabled by default via `USE_DYNAMIC_PROXY`. |
 | Dynamic proxy concurrency | 3 in-flight | `dynamicProxyMaxConcurrent` in `api/gateway/dynamic_proxy_gate.go` | Caps concurrent requests through `DYNAMIC_PROXY` across all stores and strategies so the final BinderPOS fallbacks do not burst the proxy endpoint and trigger 429. |
 | Residential proxy | **`RESIDENTIAL_PROXY_1`** | Optional residential proxy for stores that rate-limit datacenter IPs (currently 5 Mana). Uses the same `host\|port\|username\|password` format. |
-| Dynamic proxy toggle | **`USE_DYNAMIC_PROXY`** | When `false`, dynamic proxy fallback is disabled even if `DYNAMIC_PROXY` is set. Defaults to enabled when unset or invalid. |
+| Dynamic proxy toggle | **`USE_DYNAMIC_PROXY`** | When `true`, dynamic proxy fallback is enabled if `DYNAMIC_PROXY` is set. Defaults to **disabled** when unset or invalid. |
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the burst of BinderPOS `429 Too Many Requests` errors on `scrap-dynamic` by reducing proxy pressure in two ways:

1. **Disable dynamic proxy by default** — `USE_DYNAMIC_PROXY` now defaults to `false` when unset or invalid. Set `USE_DYNAMIC_PROXY=true` explicitly to re-enable `DYNAMIC_PROXY` fallbacks.
2. **Cap dedicated-proxy store searches at 3** — a new gate (`DedicatedProxySearchMaxConcurrent`) limits how many store searches may hold a dedicated-proxy lease at once. The controller still runs up to 6 workers, but proxy-backed stores queue here instead of bursting all configured `DEDICATED_PROXY_*` slots.

Also includes earlier work from this branch:
- Dynamic-proxy concurrency gate (3 in-flight) for when dynamic proxy is re-enabled
- `scrap-dynamic` 429 retries with jittered backoff

## Changes

| Area | Change |
|------|--------|
| `api/pkg/config/config.go` | `UseDynamicProxy()` defaults to `false` |
| `api/gateway/dedicated_proxy_search_gate.go` | New gate: max 3 concurrent dedicated-proxy searches |
| `api/controller/search.go` | Acquire gate slot before `LeaseDedicatedProxyURL` |
| `docs/search-strategies-retries-timeouts.md` | Document new defaults and limits |

## Deploy note

No Lambda env change required for disabling dynamic proxy — it is now off by default. To turn it back on later, set `USE_DYNAMIC_PROXY=true`.

## Testing

- `go test ./controller/... ./gateway/... ./pkg/config/...` — pass
- `make test` — Agora live probe returned upstream 500 (transient/flaky)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da1f275f-31e1-4d0c-8d5a-b3fd03075365"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da1f275f-31e1-4d0c-8d5a-b3fd03075365"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

