### PR TITLE
Use NM-only prices for Card Kingdom CK price lookup

### DIFF
--- a/api/gateway/cardkingdom/pricelist_fetch.go
+++ b/api/gateway/cardkingdom/pricelist_fetch.go
@@ -273,26 +273,8 @@ func listingFromPricelistItem(item ckPricelistItem, baseURL string, updatedAt st
 }
 
 func cheapestListedUSD(values ckConditionValues, priceRetail float64) (float64, bool) {
-	best := 0.0
-	found := false
-
-	for _, price := range []float64{
-		float64(values.NmPrice),
-		float64(values.ExPrice),
-		float64(values.VgPrice),
-		float64(values.GPrice),
-	} {
-		if price <= 0 {
-			continue
-		}
-		if !found || price < best {
-			best = price
-			found = true
-		}
-	}
-
-	if found {
-		return best, true
+	if values.NmPrice > 0 {
+		return float64(values.NmPrice), true
 	}
 	if priceRetail > 0 {
 		return priceRetail, true

--- a/api/gateway/cardkingdom/pricelist_fetch_test.go
+++ b/api/gateway/cardkingdom/pricelist_fetch_test.go
@@ -113,7 +113,7 @@ const sampleCKPricelist = `{
   ]
 }`
 
-func TestCheapestListedUSD_UsesLowestListedCondition(t *testing.T) {
+func TestCheapestListedUSD_UsesNMOnly(t *testing.T) {
 	price, ok := cheapestListedUSD(ckConditionValues{
 		NmPrice: 1.49,
 		NmQty:   0,
@@ -123,7 +123,7 @@ func TestCheapestListedUSD_UsesLowestListedCondition(t *testing.T) {
 		VgQty:   1,
 	}, 1.49)
 	require.True(t, ok)
-	require.InDelta(t, 0.99, price, 0.001)
+	require.InDelta(t, 1.49, price, 0.001)
 }
 
 func TestCheapestListedUSD_IncludesOutOfStock(t *testing.T) {
@@ -145,7 +145,7 @@ func TestCheapestListingsFromPricelist(t *testing.T) {
 	listing := cheapest["lightning bolt"]
 	require.Equal(t, "Lightning Bolt", listing.CardName)
 	require.Equal(t, "4th Edition", listing.Edition)
-	require.InDelta(t, 1.19, listing.PriceUsd, 0.001)
+	require.InDelta(t, 1.49, listing.PriceUsd, 0.001)
 	require.False(t, listing.IsFoil)
 	require.Equal(t, "https://www.cardkingdom.com/mtg/fourth-edition/lightning-bolt", listing.URL)
 	require.Equal(t, updatedAt.Format(time.RFC3339), listing.UpdatedAt)
@@ -186,9 +186,10 @@ func TestFetchCheapestFromCKPricelist_FromTestServer(t *testing.T) {
 	defer server.Close()
 
 	t.Setenv("CK_PRICELIST_URL", server.URL)
+	t.Setenv("CK_PRICELIST_PROXY", "")
 
 	cheapest, err := fetchCheapestFromCKPricelist(context.Background())
 	require.NoError(t, err)
-	require.InDelta(t, 1.19, cheapest["lightning bolt"].PriceUsd, 0.001)
+	require.InDelta(t, 1.49, cheapest["lightning bolt"].PriceUsd, 0.001)
 	require.InDelta(t, 7.49, cheapest["spectacular spider-man"].PriceUsd, 0.001)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Card Kingdom price indexing now uses **Near Mint (`nm_price`) only** when building cheapest listings from the CK pricelist API.

Previously, the indexer took the minimum across NM/EX/VG/G condition prices. That could surface misleading "lowest" prices from out-of-stock lower conditions — for example, **Delney, Streetwise Lookout** showed **$22** from foil Good (`g_qty: 0`) while the actual lowest NM in-stock prices are **$47.99** (non-foil) and **$54.99** (foil).

## Changes

- `cheapestListedUSD` now returns `nm_price`, falling back to `price_retail` when NM is absent
- Updated cardkingdom pricelist tests to expect NM pricing
- Cleared `CK_PRICELIST_PROXY` in the pricelist fetch integration test so it runs correctly when the proxy env var is set globally

## Expected impact

After the next CK price refresh, Delney should index at **$47.99** (cheapest NM across foil/non-foil variants) instead of $22.

## Testing

- `make test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d84d121-6650-46c2-b740-31fbed9ef3a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d84d121-6650-46c2-b740-31fbed9ef3a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

