### PR TITLE
Restore Agora search via dedicated proxy and browser TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ before being returned.
 
 ### Two kinds of stores
 
-**Non-BinderPOS stores** (e.g. Cards Central, Cards & Collections,
+**Non-BinderPOS stores** (e.g. Agora, Cards Central, Cards & Collections,
 Dueller's Point, Mox & Lotus, TCG Marketplace) each implement a single bespoke
 `Search` — a custom JSON API call or one HTML scrape — with no multi-strategy
 fallback. On failure the store simply contributes nothing.

--- a/api/controller/search.go
+++ b/api/controller/search.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"maps"
 	"mtg-price-checker-sg/gateway"
+	"mtg-price-checker-sg/gateway/agora"
 	"mtg-price-checker-sg/gateway/cardaffinity"
 	"mtg-price-checker-sg/gateway/cardsandcollection"
 	"mtg-price-checker-sg/gateway/cardscentral"
@@ -65,6 +66,7 @@ type shopSpec struct {
 }
 
 var shopRegistry = []shopSpec{
+	{name: agora.StoreName, newLGS: agora.NewLGS},
 	{name: cardaffinity.StoreName, newLGS: cardaffinity.NewLGS, isBinderpos: true},
 	{name: cardscentral.StoreName, newLGS: cardscentral.NewLGS},
 	{name: cardscitadel.StoreName, newLGS: cardscitadel.NewLGS, isBinderpos: true},

--- a/api/controller/search_test.go
+++ b/api/controller/search_test.go
@@ -8,7 +8,6 @@ import (
 	"mtg-price-checker-sg/gateway"
 	"mtg-price-checker-sg/gateway/agora"
 	"mtg-price-checker-sg/gateway/cardaffinity"
-	"mtg-price-checker-sg/gateway/cardscentral"
 	"mtg-price-checker-sg/gateway/cardscitadel"
 	"mtg-price-checker-sg/gateway/hideout"
 	"strings"

--- a/api/controller/search_test.go
+++ b/api/controller/search_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"mtg-price-checker-sg/gateway"
+	"mtg-price-checker-sg/gateway/agora"
 	"mtg-price-checker-sg/gateway/cardaffinity"
 	"mtg-price-checker-sg/gateway/cardscentral"
 	"mtg-price-checker-sg/gateway/cardscitadel"
@@ -18,13 +19,13 @@ import (
 )
 
 func TestInitAndMapShops_FiltersByRequestedLGS(t *testing.T) {
-	shops := initAndMapShops([]string{cardscentral.StoreName, hideout.StoreName})
+	shops := initAndMapShops([]string{agora.StoreName, hideout.StoreName})
 
 	if len(shops) != 2 {
 		t.Fatalf("expected 2 shops after filtering, got %d", len(shops))
 	}
-	if _, ok := shops[cardscentral.StoreName]; !ok {
-		t.Fatalf("expected %q to be included", cardscentral.StoreName)
+	if _, ok := shops[agora.StoreName]; !ok {
+		t.Fatalf("expected %q to be included", agora.StoreName)
 	}
 	if _, ok := shops[hideout.StoreName]; !ok {
 		t.Fatalf("expected %q to be included", hideout.StoreName)
@@ -388,7 +389,7 @@ func TestIsBinderposStore(t *testing.T) {
 	tests := map[string]bool{
 		cardscitadel.StoreName: true,
 		hideout.StoreName:      true,
-		cardscentral.StoreName: false,
+		agora.StoreName:        false,
 		"Unknown Shop":         false,
 	}
 
@@ -771,7 +772,7 @@ func TestFetchCardsConcurrently_LimitsConcurrentWorkers(t *testing.T) {
 
 func TestFormatShopSearchSummary(t *testing.T) {
 	got := formatShopSearchSummary("Orthion, Hero of Lavabrink", 8*time.Second+240*time.Millisecond, []shopSearchDuration{
-		{name: "5 Mana", duration: 8*time.Second + 240*time.Millisecond},
+		{name: "Agora Hobby", duration: 8*time.Second + 240*time.Millisecond},
 		{name: "Fyendal Hobby", duration: 222 * time.Millisecond},
 		{name: "Cards & Collections", duration: 341 * time.Millisecond},
 	})
@@ -779,8 +780,8 @@ func TestFormatShopSearchSummary(t *testing.T) {
 	if !strings.Contains(got, "Checked 3 shops for [Orthion, Hero of Lavabrink] in 8.24s:") {
 		t.Fatalf("expected summary header, got: %s", got)
 	}
-	if !strings.Contains(got, "[5 Mana] 8.24s") {
-		t.Fatalf("expected 5 Mana duration, got: %s", got)
+	if !strings.Contains(got, "[Agora Hobby] 8.24s") {
+		t.Fatalf("expected Agora Hobby duration, got: %s", got)
 	}
 	if !strings.Contains(got, "[Cards & Collections] 341ms") {
 		t.Fatalf("expected Cards & Collections duration, got: %s", got)
@@ -788,7 +789,7 @@ func TestFormatShopSearchSummary(t *testing.T) {
 	if !strings.Contains(got, "[Fyendal Hobby] 222ms") {
 		t.Fatalf("expected Fyendal Hobby duration, got: %s", got)
 	}
-	if strings.Index(got, "[5 Mana]") > strings.Index(got, "[Cards & Collections]") {
+	if strings.Index(got, "[Agora Hobby]") > strings.Index(got, "[Cards & Collections]") {
 		t.Fatalf("expected shops to be sorted alphabetically, got: %s", got)
 	}
 }

--- a/api/gateway/agora/fixtures_test.go
+++ b/api/gateway/agora/fixtures_test.go
@@ -1,0 +1,25 @@
+package agora
+
+const outOfStockStoreItemHTML = `
+<div id="store_listingcontainer">
+  <div class="store-item">
+    <div class="store-item-stock">Stock: 0</div>
+    <div class="store-item-price">$1.50</div>
+    <div class="store-item-cat">[DMU] Dominaria United - Near Mint</div>
+    <div class="store-item-title">Abrade</div>
+    <div class="store-item-img" data-img="https://agorahobby.com/img/abrade.jpg"></div>
+  </div>
+</div>
+`
+
+const inStockStoreItemHTML = `
+<div id="store_listingcontainer">
+  <div class="store-item">
+    <div class="store-item-stock">Stock: 3</div>
+    <div class="store-item-price">$2.00</div>
+    <div class="store-item-cat">[DMU] Dominaria United - Near Mint</div>
+    <div class="store-item-title">Abrade FOIL</div>
+    <div class="store-item-img" data-img="https://agorahobby.com/img/abrade-foil.jpg"></div>
+  </div>
+</div>
+`

--- a/api/gateway/agora/search.go
+++ b/api/gateway/agora/search.go
@@ -1,0 +1,155 @@
+package agora
+
+import (
+	"context"
+	"log"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"mtg-price-checker-sg/gateway"
+	"mtg-price-checker-sg/gateway/util"
+	"mtg-price-checker-sg/pkg/config"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+const StoreName = "Agora Hobby"
+const StoreBaseURL = "https://agorahobby.com"
+const StoreSearchPath = "/store/search"
+const storeCategoryMTG = "mtg"
+
+type Store struct {
+	Name       string
+	BaseUrl    string
+	SearchPath string
+}
+
+func NewLGS() gateway.LGS {
+	return Store{
+		Name:       StoreName,
+		BaseUrl:    StoreBaseURL,
+		SearchPath: StoreSearchPath,
+	}
+}
+
+func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
+	var cards []gateway.Card
+
+	baseURL, err := url.Parse(s.BaseUrl)
+	if err != nil {
+		return cards, err
+	}
+
+	apiURL := &url.URL{
+		Scheme: baseURL.Scheme,
+		Host:   baseURL.Host,
+		Path:   s.SearchPath,
+		RawQuery: url.Values{
+			"category":    {storeCategoryMTG},
+			"searchfield": {searchStr},
+		}.Encode(),
+	}
+
+	resp, err := gateway.DoOutboundGET(ctx, apiURL.String(), agoraOutboundOpts(apiURL), config.AgoraSearchAttemptTimeout)
+	if err != nil {
+		return cards, err
+	}
+	defer resp.Body.Close()
+
+	body, err := gateway.ReadResponseBody(resp)
+	if err != nil {
+		return cards, err
+	}
+
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(string(body)))
+	if err != nil {
+		return cards, err
+	}
+
+	doc.Find("div#store_listingcontainer div.store-item").Each(func(_ int, se *goquery.Selection) {
+		card, ok := parseStoreItem(se, s.Name, apiURL, searchStr)
+		if ok {
+			cards = append(cards, card)
+		}
+	})
+
+	return cards, nil
+}
+
+func agoraOutboundOpts(pageURL *url.URL) gateway.OutboundRequestOptions {
+	opts := gateway.OutboundRequestOptions{
+		Style:          gateway.OutboundStyleHTML,
+		PageURL:        pageURL,
+		SkipWebBotAuth: true,
+		SkipDirect:     true,
+	}
+	// Non-production hosts (httptest unit tests) must use the direct transport.
+	if pageURL == nil || pageURL.Host != "agorahobby.com" {
+		opts.SkipDirect = false
+	}
+	return opts
+}
+
+func parseStoreItem(se *goquery.Selection, storeName string, apiURL *url.URL, searchStr string) (gateway.Card, bool) {
+	if se.Find("div.store-item-stock").Text() == "Stock: 0" {
+		return gateway.Card{}, false
+	}
+
+	priceStr := strings.TrimSpace(se.Find("div.store-item-price").Text())
+	priceStr = strings.Replace(priceStr, "$", "", -1)
+	priceStr = strings.Replace(priceStr, ",", "", -1)
+	price, err := strconv.ParseFloat(strings.TrimSpace(priceStr), 64)
+	if err != nil || price <= 0 {
+		return gateway.Card{}, false
+	}
+
+	categoryText := se.Find("div.store-item-cat").Text()
+	quality := ""
+	qualityParts := strings.Split(categoryText, " - ")
+	if len(qualityParts) == 2 {
+		quality = strings.TrimSpace(qualityParts[1])
+	}
+
+	var extraInfo []string
+	if strings.Contains(categoryText, "]") {
+		set := categoryText[:strings.Index(categoryText, "]")+1]
+		extraInfo = append(extraInfo, set)
+	}
+
+	name := strings.TrimSpace(se.Find("div.store-item-title").Text())
+	if name == "" {
+		return gateway.Card{}, false
+	}
+
+	cardURL, err := buildCardURL(apiURL, searchStr)
+	if err != nil {
+		log.Printf("error parsing url for %s with value [%s]: %v", storeName, apiURL.String(), err)
+		return gateway.Card{}, false
+	}
+
+	return gateway.Card{
+		Name:      name,
+		Url:       cardURL,
+		InStock:   true,
+		IsFoil:    strings.Contains(name, "FOIL"),
+		Price:     price,
+		Source:    storeName,
+		Img:       strings.TrimSpace(se.Find("div.store-item-img").AttrOr("data-img", "")),
+		Quality:   util.MapQuality(quality),
+		ExtraInfo: extraInfo,
+	}, true
+}
+
+func buildCardURL(apiURL *url.URL, searchStr string) (string, error) {
+	cleanPageURL, err := url.Parse(apiURL.String())
+	if err != nil {
+		return "", err
+	}
+	cleanPageURL.RawQuery = url.Values{
+		"category":    []string{storeCategoryMTG},
+		"searchfield": []string{searchStr},
+		"utm_source":  []string{config.UtmSource},
+	}.Encode()
+	return cleanPageURL.String(), nil
+}

--- a/api/gateway/agora/search_opts_test.go
+++ b/api/gateway/agora/search_opts_test.go
@@ -1,0 +1,28 @@
+package agora
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgoraOutboundOpts_ProductionHost(t *testing.T) {
+	pageURL, err := url.Parse(StoreBaseURL + StoreSearchPath)
+	require.NoError(t, err)
+
+	opts := agoraOutboundOpts(pageURL)
+	require.True(t, opts.SkipWebBotAuth)
+	require.True(t, opts.SkipDirect)
+	require.False(t, opts.PreferResidentialProxy)
+}
+
+func TestAgoraOutboundOpts_NonProductionHostAllowsDirect(t *testing.T) {
+	pageURL, err := url.Parse("http://127.0.0.1:0/store/search")
+	require.NoError(t, err)
+
+	opts := agoraOutboundOpts(pageURL)
+	require.True(t, opts.SkipWebBotAuth)
+	require.False(t, opts.SkipDirect)
+	require.False(t, opts.PreferResidentialProxy)
+}

--- a/api/gateway/agora/search_test.go
+++ b/api/gateway/agora/search_test.go
@@ -1,0 +1,83 @@
+package agora
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"testing"
+
+	"mtg-price-checker-sg/gateway/gatewaytest"
+	"mtg-price-checker-sg/gateway/util"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ParseStoreItemSkipsOutOfStock(t *testing.T) {
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(outOfStockStoreItemHTML))
+	require.NoError(t, err)
+
+	apiURL, err := url.Parse(StoreBaseURL + StoreSearchPath + "?category=mtg&searchfield=Abrade")
+	require.NoError(t, err)
+
+	card, ok := parseStoreItem(doc.Find("div.store-item").First(), StoreName, apiURL, "Abrade")
+	require.False(t, ok)
+	require.Empty(t, card.Name)
+}
+
+func Test_ParseStoreItemKeepsInStock(t *testing.T) {
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(inStockStoreItemHTML))
+	require.NoError(t, err)
+
+	apiURL, err := url.Parse(StoreBaseURL + StoreSearchPath + "?category=mtg&searchfield=Abrade")
+	require.NoError(t, err)
+
+	card, ok := parseStoreItem(doc.Find("div.store-item").First(), StoreName, apiURL, "Abrade")
+	require.True(t, ok)
+	require.Equal(t, "Abrade FOIL", card.Name)
+	require.True(t, card.InStock)
+	require.True(t, card.IsFoil)
+	require.Equal(t, 2.0, card.Price)
+	require.Equal(t, "[DMU]", card.ExtraInfo[0])
+	require.Contains(t, card.Url, "utm_source=")
+}
+
+func Test_Search(t *testing.T) {
+	skipLiveAgoraSearchUnlessDedicatedProxy(t)
+
+	s := NewLGS()
+	result, err := s.Search(context.Background(), "Abrade")
+	gatewaytest.RequireSearchOrProbe(t, err, result, gatewaytest.CardExpect{
+		URLContains:    StoreBaseURL + "/store/search?category=" + storeCategoryMTG + "&searchfield=",
+		RequireInStock: true,
+	}, func(t *testing.T, ctx context.Context) {
+		gatewaytest.RequireAgoraSearchStructure(t, ctx, StoreBaseURL, StoreSearchPath, storeCategoryMTG, "Abrade")
+	})
+}
+
+func Test_Search_FiltersMTGCategory(t *testing.T) {
+	skipLiveAgoraSearchUnlessDedicatedProxy(t)
+
+	s := NewLGS()
+	result, err := s.Search(context.Background(), "Bulbasaur")
+	require.NoError(t, err)
+
+	for _, card := range result {
+		require.True(t, card.InStock, "gateway should only return in-stock listings")
+		require.Contains(t, card.Url, "category="+storeCategoryMTG,
+			"Agora product links should stay scoped to the MTG category")
+		lower := strings.ToLower(card.Name)
+		require.NotContains(t, lower, "pokemon",
+			"Pokemon inventory should not appear when category=mtg is set")
+		require.NotContains(t, lower, "holofoil",
+			"Pokemon condition labels should not appear when category=mtg is set")
+	}
+}
+
+func skipLiveAgoraSearchUnlessDedicatedProxy(t *testing.T) {
+	t.Helper()
+	if len(util.GetDedicatedProxyURLs()) > 0 {
+		return
+	}
+	t.Skipf("set DEDICATED_PROXY_* to run live Agora search checks (direct egress is blocked by Cloudflare)")
+}

--- a/api/gateway/gatewaytest/live_probes.go
+++ b/api/gateway/gatewaytest/live_probes.go
@@ -11,6 +11,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// RequireAgoraSearchStructure verifies the Agora MTG search page markup.
+func RequireAgoraSearchStructure(t *testing.T, ctx context.Context, baseURL, searchPath, category, query string) {
+	t.Helper()
+	probeURL := BuildURL("https", strings.TrimPrefix(strings.TrimPrefix(baseURL, "https://"), "http://"), searchPath, url.Values{
+		"category":    {category},
+		"searchfield": {query},
+	})
+	pageURL, err := url.Parse(probeURL)
+	require.NoError(t, err)
+	RequireHTMLStructure(t, ctx, HTMLProbe{
+		URL:              probeURL,
+		PrimarySelector:  "div#store_listingcontainer",
+		FallbackSelector: "div.store-item",
+		PageURL:          pageURL,
+		SkipDirect:       true,
+		SkipWebBotAuth:   true,
+	})
+}
+
 // RequireFiveManaSearchStructure verifies the 5 Mana Shopify search page markup.
 func RequireFiveManaSearchStructure(t *testing.T, ctx context.Context, baseURL, searchPath, query string) {
 	t.Helper()

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -23,6 +23,8 @@ const (
 	// SearchAttemptTimeout bounds a single search strategy attempt (BinderPOS step
 	// or default colly scrape).
 	SearchAttemptTimeout = 5 * time.Second
+	// AgoraSearchAttemptTimeout is the per-attempt cap for Agora Hobby only.
+	AgoraSearchAttemptTimeout = 10 * time.Second
 	// DynamicProxyEnv contains an authenticated proxy URL used for explicit
 	// dynamic-proxy fallback attempts, which BinderPOS reserves for the final
 	// two attempts after dedicated and direct/no-proxy scrap and decklist tries.

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -10,6 +10,7 @@ This document records **where** the app configures search behavior, **timeouts**
 |------|--------|--------|--------|
 | Per-store deadline | 20s | `config.PerSiteTimeout` in `api/pkg/config/config.go`; used in `searchShop` as `context.WithTimeout` in `api/controller/search.go` | One goroutine per selected store; each `LGS.Search` runs under this cap. |
 | Per-attempt timeout (default) | 5s | `config.SearchAttemptTimeout` in `api/pkg/config/config.go` | Bounds each BinderPOS strategy step and default colly scrape request. |
+| Agora per-attempt timeout | 10s | `config.AgoraSearchAttemptTimeout` in `api/pkg/config/config.go`; applied in `api/gateway/agora/search.go` | Agora keeps a longer single-scrape cap. |
 | Colly request timeout (default scrapers) | 5s | `applyCollectorDefaults` → `c.SetRequestTimeout(config.SearchAttemptTimeout)` in `api/gateway/collector.go` | Overrides gocolly’s default 10s for optimized collectors. |
 | Minimum end-to-end response time | 1s | `responseThreshold` in `searchShops` in `api/controller/search.go` | If all stores finish in under 1s, the handler **sleeps** the remainder so the API “feels” less instant. |
 | Colly HTTP retries | None | `api/gateway/collector.go` (`configureRequestOptimizations`, `registerNoRetryErrorHandler`) | **Single HTTP attempt** per colly request path; no automatic colly/gateway retry of failed visits. |
@@ -63,12 +64,13 @@ Some tests in `api/gateway/binderpos/*_test.go` hit real stores and proxies. The
 
 ---
 
-## Backend: non-BinderPOS stores (Cards Central, Dueller's Point, 5 Mana, Mox & Lotus, Cards & Collections, TCG Marketplace)
+## Backend: non-BinderPOS stores (Agora, Cards Central, Dueller's Point, 5 Mana, Mox & Lotus, Cards & Collections, TCG Marketplace)
 
 | Item | Value | Source | Notes |
 |------|--------|--------|--------|
 | Outbound proxy policy | Random dedicated → dynamic → direct | `selectOutboundProxy` in `api/gateway/collector.go` | Same single-attempt policy as default optimized colly collectors. When a store search holds a request-scoped dedicated lease, colly and `DoOutboundGET` reuse that URL. When no lease is pinned and `DEDICATED_PROXY_*` is configured, each outbound store falls back to one random dedicated proxy. |
 | `net/http` scrapers / APIs | Direct → one random dedicated proxy → dynamic fallback | `DoOutboundGET` / `DoOutboundRoundTrip` in `api/gateway/outbound_get.go` | Used by Dueller's Point, Mox & Lotus, Cards & Collections, and TCG Marketplace. Reuses the per-store dedicated lease when set. Each transport is tried once per store (one dedicated slot, not every configured proxy). Client errors (4xx) and connection errors advance immediately to the next transport. |
+| Agora Hobby HTML search | dedicated → dynamic; browser TLS | `api/gateway/agora/search.go` | Agora sits behind Cloudflare that blocks direct/datacenter egress. Skips direct transport, uses browser TLS fingerprinting via `SkipWebBotAuth` + `BROWSER_TLS_EMULATION_ENABLED`, and routes through the per-store dedicated-proxy lease (then dynamic fallback). |
 | 5 Mana Shopify search | **graphql** → **html** (section scrape); dedicated → dynamic | `api/gateway/fivemana/search.go`, `graphql.go` | Primary: Storefront GraphQL `search` with public access token (variants include condition/price). Fallback: Dawn `main-search` HTML section scrape on GraphQL error (except HTTP 5xx, which is final). Both paths skip direct requests and use dedicated, then dynamic. Client errors (4xx) fail over immediately. |
 | Cards Central API | Direct only | `http.Client` in `api/gateway/cardscentral/search.go` | Always uses a direct client; does not route through dedicated or dynamic proxies. |
 

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -4,6 +4,7 @@ export const PAGE_TITLE =
 
 export const LGS_OPTIONS = [
   "5 Mana",
+  "Agora Hobby",
   "Card Affinity",
   "Cards & Collections",
   "Cards Central",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reverts the Agora Hobby removal from price search (#306) and switches Agora back on using **dedicated proxy + browser TLS fingerprinting** instead of `RESIDENTIAL_PROXY_1`.

### Agora outbound policy (`api/gateway/agora/search.go`)
- `SkipDirect: true` — no direct/datacenter egress (Cloudflare blocks it)
- `SkipWebBotAuth: true` — uses repo browser TLS emulation (`BROWSER_TLS_EMULATION_ENABLED`, bogdanfinn/tls-client profiles)
- Removed `PreferResidentialProxy`
- Dedicated proxy comes from the per-store lease in `searchShop` (same as other proxy-backed stores)

### Restored
- `api/gateway/agora` package
- Agora in `shopRegistry` and frontend `LGS_OPTIONS`
- `AgoraSearchAttemptTimeout` config
- Live structure probe helper for Agora (dedicated + browser TLS, no residential)

### Unchanged from #306
- 5 Mana no longer uses residential proxy

## Verification

Live Agora gateway tests passed via dedicated proxy + browser TLS:

```
Test_Search — 200 from agorahobby.com/store/search (proxy_mode=dedicated)
Test_Search_FiltersMTGCategory — 200, MTG category scoped
```

- [x] `CK_PRICELIST_PROXY= make test`
- [x] `go test -mod=vendor ./gateway/agora/... -run Test_Search -v`
- [x] `go fix ./...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4215feeb-106c-4f9a-bc4c-56e377e22539"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4215feeb-106c-4f9a-bc4c-56e377e22539"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

