### PR TITLE
Fix duplicate pills when toggling top risers/drops

### DIFF
--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -175,7 +175,7 @@ function CKPriceChangeContent({
 
         return (
           <a
-            key={item.cardName}
+            key={item.id}
             href={buildSearchQueryUrl(BASE_URL, item.cardName)}
             className={`btn btn-sm popular-search-pill ${pillModifier} text-decoration-none${
               isActive ? " is-active" : ""
@@ -386,6 +386,7 @@ export default function TopSearchKeywords({
           <div id={contentPanelId}>
             {showPriceChangeControls && priceChangeView === "risers" ? (
               <CKPriceChangeContent
+                key="risers"
                 variant="riser"
                 isLoading={isLoadingPriceChanges}
                 error={priceChangesError}
@@ -395,6 +396,7 @@ export default function TopSearchKeywords({
               />
             ) : showPriceChangeControls && priceChangeView === "drops" ? (
               <CKPriceChangeContent
+                key="drops"
                 variant="drop"
                 isLoading={isLoadingPriceChanges}
                 error={priceChangesError}

--- a/frontend/src/utils/ckPriceChanges.js
+++ b/frontend/src/utils/ckPriceChanges.js
@@ -21,14 +21,22 @@ function parseCKPriceChangeListings(listings, matchesDirection, limit = 20) {
   }
 
   return listings
-    .map((item) => ({
-      cardName: typeof item?.cardName === "string" ? item.cardName.trim() : "",
-      priceChangeUsd:
-        typeof item?.priceChangeUsd === "number" &&
-        Number.isFinite(item.priceChangeUsd)
-          ? item.priceChangeUsd
-          : null,
-    }))
+    .map((item, index) => {
+      const cardName =
+        typeof item?.cardName === "string" ? item.cardName.trim() : "";
+      const nameKey =
+        typeof item?.nameKey === "string" ? item.nameKey.trim() : "";
+
+      return {
+        id: nameKey || (cardName ? `${cardName}-${index}` : `listing-${index}`),
+        cardName,
+        priceChangeUsd:
+          typeof item?.priceChangeUsd === "number" &&
+          Number.isFinite(item.priceChangeUsd)
+            ? item.priceChangeUsd
+            : null,
+      };
+    })
     .filter(
       (item) =>
         item.cardName.length > 0 &&

--- a/frontend/src/utils/ckPriceChanges.test.js
+++ b/frontend/src/utils/ckPriceChanges.test.js
@@ -20,7 +20,11 @@ test("formatPriceChangeUsd formats signed dollar amounts", () => {
 test("parseCKPriceIncreases returns top card names with positive USD changes only", () => {
   const payload = {
     top: [
-      { cardName: "Lightning Bolt", priceChangeUsd: 0.5 },
+      {
+        nameKey: "lightning-bolt",
+        cardName: "Lightning Bolt",
+        priceChangeUsd: 0.5,
+      },
       { cardName: " Counterspell ", priceChangeUsd: 0.1 },
       { cardName: "", priceChangeUsd: 0.05 },
       { cardName: "Sol Ring", priceChangePercent: 5 },
@@ -32,10 +36,36 @@ test("parseCKPriceIncreases returns top card names with positive USD changes onl
   const increases = parseCKPriceIncreases(payload);
 
   assert.equal(increases.length, 2);
+  assert.equal(increases[0].id, "lightning-bolt");
   assert.equal(increases[0].cardName, "Lightning Bolt");
   assert.equal(increases[0].priceChangeUsd, 0.5);
+  assert.equal(increases[1].id, "Counterspell-1");
   assert.equal(increases[1].cardName, "Counterspell");
   assert.equal(increases[1].priceChangeUsd, 0.1);
+});
+
+test("parseCKPriceIncreases assigns unique ids when card names repeat", () => {
+  const payload = {
+    top: [
+      {
+        nameKey: "tony stark // the invincible iron man",
+        cardName: "Tony Stark // The Invincible Iron Man",
+        priceChangeUsd: 26,
+      },
+      {
+        nameKey: "the invincible iron man",
+        cardName: "Tony Stark // The Invincible Iron Man",
+        priceChangeUsd: 26,
+      },
+    ],
+  };
+
+  const increases = parseCKPriceIncreases(payload);
+
+  assert.equal(increases.length, 2);
+  assert.equal(increases[0].id, "tony stark // the invincible iron man");
+  assert.equal(increases[1].id, "the invincible iron man");
+  assert.notEqual(increases[0].id, increases[1].id);
 });
 
 test("parseCKPriceIncreases returns an empty list for invalid payloads", () => {
@@ -47,7 +77,11 @@ test("parseCKPriceIncreases returns an empty list for invalid payloads", () => {
 test("parseCKPriceDrops returns bottom card names with negative USD changes only", () => {
   const payload = {
     bottom: [
-      { cardName: "Counterspell", priceChangeUsd: -1.5 },
+      {
+        nameKey: "counterspell",
+        cardName: "Counterspell",
+        priceChangeUsd: -1.5,
+      },
       { cardName: " Sol Ring ", priceChangeUsd: -0.1 },
       { cardName: "", priceChangeUsd: -0.05 },
       { cardName: "Lightning Bolt", priceChangePercent: -5 },
@@ -59,8 +93,10 @@ test("parseCKPriceDrops returns bottom card names with negative USD changes only
   const drops = parseCKPriceDrops(payload);
 
   assert.equal(drops.length, 2);
+  assert.equal(drops[0].id, "counterspell");
   assert.equal(drops[0].cardName, "Counterspell");
   assert.equal(drops[0].priceChangeUsd, -1.5);
+  assert.equal(drops[1].id, "Sol Ring-1");
   assert.equal(drops[1].cardName, "Sol Ring");
   assert.equal(drops[1].priceChangeUsd, -0.1);
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a bug where toggling between **Top $ risers (24h)** and **Top $ drops (24 Hrs)** caused duplicate pills to accumulate, especially the last riser item (e.g. "Tony Stark // The Invincible Iron Man") appearing in the drops list and multiplying on each toggle.

## Root cause

The CK price changes API can return multiple entries with the same `cardName` but different `nameKey` values (e.g. two Tony Stark listings at positions 18 and 19 in the current `top` array). The UI used `key={item.cardName}`, so React treated those as the same element. When switching between risers and drops, React reconciliation left orphaned DOM nodes that piled up on each toggle.

## Fix

- Assign a stable unique `id` per listing when parsing CK price changes (`nameKey` when present, otherwise `cardName-index` fallback).
- Use `key={item.id}` for pill list items.
- Remount the price-change panel with `key="risers"` / `key="drops"` when switching views.

## Testing

- Added unit test for duplicate `cardName` entries with distinct `nameKey` values.
- Verified parser output against live API: 20 risers with 20 unique ids, 20 drops, Tony Stark absent from drops.
- Reproduced original bug on production before fix (toggle caused accumulating duplicates).
- `node --test frontend/src/utils/ckPriceChanges.test.js` passes.
- `make test` hit unrelated live gateway timeouts (Agora/Card Affinity upstream); no backend changes in this PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f4bf7c8-2eb5-4b7d-b8aa-95ce91ae17d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f4bf7c8-2eb5-4b7d-b8aa-95ce91ae17d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

