### PR TITLE
Fix CK price refresh DynamoDB GSI throttling failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,8 +192,8 @@ Example report shape:
   "generatedAt": "2026-07-11T12:00:00Z",
   "syncedAt": "2026-07-11T00:00:00Z",
   "rankingLimit": 20,
-  "top": [{"nameKey": "lightning bolt", "cardName": "Lightning Bolt", "priceUsd": 1.25, "priceChangePercent": 15}],
-  "bottom": [{"nameKey": "counterspell", "cardName": "Counterspell", "priceUsd": 0.75, "priceChangePercent": -10}]
+  "top": [{"nameKey": "lightning bolt", "cardName": "Lightning Bolt", "priceUsd": 1.25, "priceChangeUsd": 0.16}],
+  "bottom": [{"nameKey": "counterspell", "cardName": "Counterspell", "priceUsd": 0.75, "priceChangeUsd": -0.08}]
 }
 ```
 
@@ -202,8 +202,7 @@ Example report shape:
 The shared `lambda-mtg` role must allow:
 
 - `s3:PutObject` on the export prefix (`arn:aws:s3:::gishathfetch.com/analytics/ck-price-changes/*`)
-- `dynamodb:Query` on both CK price-change GSIs:
-  - `arn:aws:dynamodb:ap-southeast-1:206363131200:table/gishathfetch-ck-prices/index/priceChangePercent-index`
+- `dynamodb:Query` on the CK price-change GSI:
   - `arn:aws:dynamodb:ap-southeast-1:206363131200:table/gishathfetch-ck-prices/index/priceChangeUsd-index`
 
 The daily export ranks top/bottom price changes by USD (`priceChangeUsd-index`). If that GSI is missing from the role policy, the Lambda fails after the DynamoDB refresh with `AccessDeniedException` on `dynamodb:Query`.
@@ -215,7 +214,6 @@ Example inline policy statement to add (merge with existing DynamoDB permissions
   "Effect": "Allow",
   "Action": "dynamodb:Query",
   "Resource": [
-    "arn:aws:dynamodb:ap-southeast-1:206363131200:table/gishathfetch-ck-prices/index/priceChangePercent-index",
     "arn:aws:dynamodb:ap-southeast-1:206363131200:table/gishathfetch-ck-prices/index/priceChangeUsd-index"
   ]
 }

--- a/api/controller/ckprice/ckprice_test.go
+++ b/api/controller/ckprice/ckprice_test.go
@@ -25,10 +25,6 @@ func (m *mockStore) GetByNameKey(_ context.Context, nameKey string) (*cardkingdo
 	return m.listing, nil
 }
 
-func (m *mockStore) GetPriceChangesByPercent(_ context.Context, _ bool, _ int) ([]ckprices.PriceChangeListing, error) {
-	return nil, nil
-}
-
 func (m *mockStore) GetPriceChangesByUsd(_ context.Context, _ bool, _ int) ([]ckprices.PriceChangeListing, error) {
 	return nil, nil
 }

--- a/api/handler/ck_refresh_test.go
+++ b/api/handler/ck_refresh_test.go
@@ -103,10 +103,6 @@ func (m *mockCKRefreshStore) GetByNameKey(_ context.Context, _ string) (*cardkin
 	return nil, nil
 }
 
-func (m *mockCKRefreshStore) GetPriceChangesByPercent(_ context.Context, _ bool, _ int) ([]ckprices.PriceChangeListing, error) {
-	return nil, nil
-}
-
 func (m *mockCKRefreshStore) GetPriceChangesByUsd(_ context.Context, _ bool, _ int) ([]ckprices.PriceChangeListing, error) {
 	return nil, nil
 }

--- a/api/store/ckprices/dynamodb.go
+++ b/api/store/ckprices/dynamodb.go
@@ -2,7 +2,9 @@ package ckprices
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"math/rand"
 	"os"
 	"strings"
 	"time"
@@ -11,20 +13,27 @@ import (
 	"mtg-price-checker-sg/pkg/config"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awsretry "github.com/aws/aws-sdk-go-v2/aws/retry"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/aws/smithy-go"
 )
 
 const (
-	batchGetLimit            = 100
-	batchWriteLimit          = 25
-	priceChangeIndexName     = "priceChangePercent-index"
-	priceChangeUsdIndexName  = "priceChangeUsd-index"
-	priceChangeIndexPKValue  = "CURRENT"
-	syncMetadataKey          = "__sync__"
-	syncMetadataLabel        = "CK price sync metadata"
+	batchGetLimit               = 100
+	batchWriteLimit             = 25
+	batchWriteBackoffMin        = 200 * time.Millisecond
+	batchWriteBackoffMax        = 30 * time.Second
+	batchWriteMaxRetries        = 12
+	batchWriteInterBatchDelay   = 50 * time.Millisecond
+	dynamoDBClientMaxAttempts   = 10
+	priceChangeIndexName        = "priceChangePercent-index"
+	priceChangeUsdIndexName     = "priceChangeUsd-index"
+	priceChangeIndexPKValue     = "CURRENT"
+	syncMetadataKey             = "__sync__"
+	syncMetadataLabel           = "CK price sync metadata"
 )
 
 type dynamoRecord struct {
@@ -60,7 +69,15 @@ func NewDynamoDBStore(ctx context.Context) (*DynamoDBStore, error) {
 		return nil, fmt.Errorf("ckprices: %s is not set", config.CKDynamoDBTableEnv)
 	}
 
-	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(config.AWSRegion))
+	cfg, err := awsconfig.LoadDefaultConfig(ctx,
+		awsconfig.WithRegion(config.AWSRegion),
+		awsconfig.WithRetryer(func() aws.Retryer {
+			return awsretry.AddWithMaxAttempts(
+				awsretry.NewAdaptiveMode(),
+				dynamoDBClientMaxAttempts,
+			)
+		}),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -274,6 +291,11 @@ func (s *DynamoDBStore) PutAll(ctx context.Context, listings map[string]cardking
 		if err := s.writeBatch(ctx, batch); err != nil {
 			return "", err
 		}
+		if end < len(writeRequests) {
+			if err := sleepWithContext(ctx, batchWriteInterBatchDelay); err != nil {
+				return "", err
+			}
+		}
 	}
 
 	return syncedAt, nil
@@ -436,18 +458,84 @@ func (s *DynamoDBStore) writeBatch(ctx context.Context, batch []types.WriteReque
 		s.tableName: batch,
 	}
 
+	attempt := 0
 	for len(pending) > 0 {
 		output, err := s.client.BatchWriteItem(ctx, &dynamodb.BatchWriteItemInput{
 			RequestItems: pending,
 		})
 		if err != nil {
-			return err
+			if !isDynamoDBThrottleError(err) || attempt >= batchWriteMaxRetries {
+				return err
+			}
+			attempt++
+			if err := sleepWithContext(ctx, batchWriteBackoffDuration(attempt)); err != nil {
+				return err
+			}
+			continue
 		}
 		if len(output.UnprocessedItems) == 0 {
 			return nil
 		}
 		pending = output.UnprocessedItems
+		attempt++
+		if attempt > batchWriteMaxRetries {
+			return fmt.Errorf("ckprices: batch write incomplete after %d retries", batchWriteMaxRetries)
+		}
+		if err := sleepWithContext(ctx, batchWriteBackoffDuration(attempt)); err != nil {
+			return err
+		}
 	}
 
 	return nil
+}
+
+func isDynamoDBThrottleError(err error) bool {
+	var throttling *types.ThrottlingException
+	if errors.As(err, &throttling) {
+		return true
+	}
+	var provisioned *types.ProvisionedThroughputExceededException
+	if errors.As(err, &provisioned) {
+		return true
+	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.ErrorCode() {
+		case "ThrottlingException", "ProvisionedThroughputExceededException":
+			return true
+		}
+	}
+	return false
+}
+
+func batchWriteBackoffDuration(attempt int) time.Duration {
+	if attempt <= 0 {
+		return batchWriteBackoffMin
+	}
+
+	delay := batchWriteBackoffMin
+	for i := 1; i < attempt && delay < batchWriteBackoffMax; i++ {
+		delay *= 2
+	}
+	if delay > batchWriteBackoffMax {
+		delay = batchWriteBackoffMax
+	}
+
+	jitter := time.Duration(rand.Int63n(int64(delay / 4)))
+	return delay + jitter
+}
+
+func sleepWithContext(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }

--- a/api/store/ckprices/dynamodb.go
+++ b/api/store/ckprices/dynamodb.go
@@ -29,7 +29,6 @@ const (
 	batchWriteMaxRetries        = 12
 	batchWriteInterBatchDelay   = 50 * time.Millisecond
 	dynamoDBClientMaxAttempts   = 10
-	priceChangeIndexName        = "priceChangePercent-index"
 	priceChangeUsdIndexName     = "priceChangeUsd-index"
 	priceChangeIndexPKValue     = "CURRENT"
 	syncMetadataKey             = "__sync__"
@@ -114,26 +113,6 @@ func (s *DynamoDBStore) GetByNameKey(ctx context.Context, nameKey string) (*card
 	return &listing, nil
 }
 
-func (s *DynamoDBStore) GetPriceChangesByPercent(ctx context.Context, ascending bool, limit int) ([]PriceChangeListing, error) {
-	if limit <= 0 {
-		limit = PriceChangeRankingLimit
-	}
-
-	listings, err := s.queryPriceChangesByPercent(ctx, ascending, limit)
-	if err == nil {
-		return dedupePriceChangeListings(listings, limit), nil
-	}
-	if !isMissingPriceChangeIndex(err) {
-		return nil, err
-	}
-
-	scanned, scanErr := s.scanPriceChangeListings(ctx)
-	if scanErr != nil {
-		return nil, scanErr
-	}
-	return priceChangesByPercentFromListings(scanned, ascending, limit), nil
-}
-
 func (s *DynamoDBStore) GetPriceChangesByUsd(ctx context.Context, ascending bool, limit int) ([]PriceChangeListing, error) {
 	if limit <= 0 {
 		limit = PriceChangeRankingLimit
@@ -172,24 +151,6 @@ func (s *DynamoDBStore) GetTopBottomPriceChanges(ctx context.Context) (*TopBotto
 	}, nil
 }
 
-func (s *DynamoDBStore) queryPriceChangesByPercent(ctx context.Context, ascending bool, limit int) ([]PriceChangeListing, error) {
-	output, err := s.client.Query(ctx, &dynamodb.QueryInput{
-		TableName:              aws.String(s.tableName),
-		IndexName:              aws.String(priceChangeIndexName),
-		KeyConditionExpression: aws.String("priceChangeIndexPK = :pk"),
-		ExpressionAttributeValues: map[string]types.AttributeValue{
-			":pk": &types.AttributeValueMemberS{Value: priceChangeIndexPKValue},
-		},
-		ScanIndexForward: aws.Bool(ascending),
-		Limit:            aws.Int32(int32(limit)),
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return priceChangeListingsFromItems(output.Items)
-}
-
 func (s *DynamoDBStore) queryPriceChangesByUsd(ctx context.Context, ascending bool, limit int) ([]PriceChangeListing, error) {
 	output, err := s.client.Query(ctx, &dynamodb.QueryInput{
 		TableName:              aws.String(s.tableName),
@@ -206,10 +167,6 @@ func (s *DynamoDBStore) queryPriceChangesByUsd(ctx context.Context, ascending bo
 	}
 
 	return priceChangeListingsFromItemsByUsd(output.Items)
-}
-
-func (s *DynamoDBStore) scanPriceChangeListings(ctx context.Context) ([]PriceChangeListing, error) {
-	return s.scanPriceChangeListingsWithFilter(ctx, priceChangeListingFromRecord)
 }
 
 func (s *DynamoDBStore) scanPriceChangeListingsByUsd(ctx context.Context) ([]PriceChangeListing, error) {
@@ -315,7 +272,7 @@ func dynamoRecordFromListing(nameKey string, listing cardkingdom.Listing, synced
 		UpdatedAt:          listing.UpdatedAt,
 		SyncedAt:           syncedAt,
 	}
-	if listing.PriceChangeUsd != nil || listing.PriceChangePercent != nil {
+	if listing.PriceChangeUsd != nil {
 		indexPK := priceChangeIndexPKValue
 		record.PriceChangeIndexPK = &indexPK
 	}
@@ -340,20 +297,6 @@ func listingFromRecord(record dynamoRecord) (cardkingdom.Listing, bool) {
 	}, true
 }
 
-func priceChangeListingFromRecord(record dynamoRecord) (PriceChangeListing, bool) {
-	if record.NameKey == syncMetadataKey || record.PriceChangePercent == nil {
-		return PriceChangeListing{}, false
-	}
-	listing, ok := listingFromRecord(record)
-	if !ok {
-		return PriceChangeListing{}, false
-	}
-	return PriceChangeListing{
-		NameKey: record.NameKey,
-		Listing: listing,
-	}, true
-}
-
 func priceChangeListingFromRecordByUsd(record dynamoRecord) (PriceChangeListing, bool) {
 	if record.NameKey == syncMetadataKey || record.PriceChangeUsd == nil {
 		return PriceChangeListing{}, false
@@ -366,10 +309,6 @@ func priceChangeListingFromRecordByUsd(record dynamoRecord) (PriceChangeListing,
 		NameKey: record.NameKey,
 		Listing: listing,
 	}, true
-}
-
-func priceChangeListingsFromItems(items []map[string]types.AttributeValue) ([]PriceChangeListing, error) {
-	return priceChangeListingsFromItemsWithFilter(items, priceChangeListingFromRecord)
 }
 
 func priceChangeListingsFromItemsByUsd(items []map[string]types.AttributeValue) ([]PriceChangeListing, error) {

--- a/api/store/ckprices/dynamodb_test.go
+++ b/api/store/ckprices/dynamodb_test.go
@@ -1,6 +1,8 @@
 package ckprices
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -121,4 +123,28 @@ func TestSyncMetadataRecordMarshal(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, item, "syncedAt")
 	require.Contains(t, item, "listingCount")
+}
+
+func TestIsDynamoDBThrottleError(t *testing.T) {
+	require.True(t, isDynamoDBThrottleError(&types.ThrottlingException{}))
+	require.True(t, isDynamoDBThrottleError(&types.ProvisionedThroughputExceededException{}))
+	require.False(t, isDynamoDBThrottleError(errors.New("access denied")))
+}
+
+func TestBatchWriteBackoffDuration_IncreasesAndCaps(t *testing.T) {
+	first := batchWriteBackoffDuration(1)
+	second := batchWriteBackoffDuration(2)
+	large := batchWriteBackoffDuration(20)
+
+	require.GreaterOrEqual(t, first, batchWriteBackoffMin)
+	require.GreaterOrEqual(t, second, first)
+	require.LessOrEqual(t, large, batchWriteBackoffMax+(batchWriteBackoffMax/4))
+}
+
+func TestSleepWithContext_RespectsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := sleepWithContext(ctx, time.Second)
+	require.ErrorIs(t, err, context.Canceled)
 }

--- a/api/store/ckprices/dynamodb_test.go
+++ b/api/store/ckprices/dynamodb_test.go
@@ -43,15 +43,18 @@ func TestDynamoRecordFromListing(t *testing.T) {
 	require.Equal(t, priceChangeIndexPKValue, *record.PriceChangeIndexPK)
 }
 
-func TestDynamoRecordFromListing_OmitsPriceChangeIndexWithoutPercent(t *testing.T) {
+func TestDynamoRecordFromListing_OmitsPriceChangeIndexWithoutUsd(t *testing.T) {
 	syncedAt := time.Date(2026, 6, 28, 15, 30, 0, 0, time.UTC).Format(time.RFC3339)
+	priceChangePercent := 12
 	record := dynamoRecordFromListing("new card", cardkingdom.Listing{
-		CardName:  "New Card",
-		PriceUsd:  1.49,
-		UpdatedAt: "2026-06-28T00:00:00Z",
+		CardName:           "New Card",
+		PriceUsd:           1.49,
+		PriceChangePercent: &priceChangePercent,
+		UpdatedAt:          "2026-06-28T00:00:00Z",
 	}, syncedAt)
 
-	require.Nil(t, record.PriceChangePercent)
+	require.NotNil(t, record.PriceChangePercent)
+	require.Nil(t, record.PriceChangeUsd)
 	require.Nil(t, record.PriceChangeIndexPK)
 }
 

--- a/api/store/ckprices/price_change.go
+++ b/api/store/ckprices/price_change.go
@@ -44,43 +44,6 @@ func listingsWithPriceChange(
 	return enriched
 }
 
-func topBottomPriceChangesByPercent(listings []PriceChangeListing, limit int) TopBottomPriceChanges {
-	if limit <= 0 {
-		limit = PriceChangeRankingLimit
-	}
-
-	changed := make([]PriceChangeListing, 0, len(listings))
-	for _, listing := range listings {
-		if listing.PriceChangePercent == nil {
-			continue
-		}
-		changed = append(changed, listing)
-	}
-
-	top := append([]PriceChangeListing(nil), changed...)
-	slices.SortFunc(top, func(a, b PriceChangeListing) int {
-		if *a.PriceChangePercent != *b.PriceChangePercent {
-			return *b.PriceChangePercent - *a.PriceChangePercent
-		}
-		return strings.Compare(a.NameKey, b.NameKey)
-	})
-	top = dedupePriceChangeListings(top, limit)
-
-	bottom := append([]PriceChangeListing(nil), changed...)
-	slices.SortFunc(bottom, func(a, b PriceChangeListing) int {
-		if *a.PriceChangePercent != *b.PriceChangePercent {
-			return *a.PriceChangePercent - *b.PriceChangePercent
-		}
-		return strings.Compare(a.NameKey, b.NameKey)
-	})
-	bottom = dedupePriceChangeListings(bottom, limit)
-
-	return TopBottomPriceChanges{
-		Top:    top,
-		Bottom: bottom,
-	}
-}
-
 func topBottomPriceChangesByUsd(listings []PriceChangeListing, limit int) TopBottomPriceChanges {
 	if limit <= 0 {
 		limit = PriceChangeRankingLimit
@@ -178,14 +141,6 @@ func filterPriceChangesByUsdSign(listings []PriceChangeListing, increases bool) 
 		}
 	}
 	return filtered
-}
-
-func priceChangesByPercentFromListings(listings []PriceChangeListing, ascending bool, limit int) []PriceChangeListing {
-	rankings := topBottomPriceChangesByPercent(listings, limit)
-	if ascending {
-		return rankings.Bottom
-	}
-	return rankings.Top
 }
 
 func priceChangesByUsdFromListings(listings []PriceChangeListing, ascending bool, limit int) []PriceChangeListing {

--- a/api/store/ckprices/price_change_test.go
+++ b/api/store/ckprices/price_change_test.go
@@ -1,7 +1,6 @@
 package ckprices
 
 import (
-	"strconv"
 	"testing"
 
 	"mtg-price-checker-sg/gateway/cardkingdom"
@@ -67,75 +66,6 @@ func TestComputePriceChangeUsd(t *testing.T) {
 	t.Run("missing previous price", func(t *testing.T) {
 		require.Nil(t, computePriceChangeUsd(0, 4.99))
 	})
-}
-
-func TestPriceChangesByPercentFromListings(t *testing.T) {
-	percent := func(value int) *int {
-		return &value
-	}
-	listing := func(nameKey string, change int) PriceChangeListing {
-		return PriceChangeListing{
-			NameKey: nameKey,
-			Listing: cardkingdom.Listing{
-				CardName:           nameKey,
-				PriceChangePercent: percent(change),
-			},
-		}
-	}
-
-	listings := []PriceChangeListing{
-		listing("a", 30),
-		listing("b", 10),
-		listing("c", -30),
-		listing("d", -10),
-	}
-
-	bottom := priceChangesByPercentFromListings(listings, true, 2)
-	require.Len(t, bottom, 2)
-	require.Equal(t, -30, *bottom[0].PriceChangePercent)
-	require.Equal(t, -10, *bottom[1].PriceChangePercent)
-
-	top := priceChangesByPercentFromListings(listings, false, 2)
-	require.Len(t, top, 2)
-	require.Equal(t, 30, *top[0].PriceChangePercent)
-	require.Equal(t, 10, *top[1].PriceChangePercent)
-}
-
-func TestTopBottomPriceChanges(t *testing.T) {
-	percent := func(value int) *int {
-		return &value
-	}
-	listing := func(nameKey string, change int) PriceChangeListing {
-		return PriceChangeListing{
-			NameKey: nameKey,
-			Listing: cardkingdom.Listing{
-				CardName:           nameKey,
-				PriceChangePercent: percent(change),
-			},
-		}
-	}
-
-	listings := make([]PriceChangeListing, 0, 51)
-	for i := 1; i <= 25; i++ {
-		listings = append(listings, listing("increase-"+strconv.Itoa(i), i))
-	}
-	for i := 1; i <= 25; i++ {
-		listings = append(listings, listing("decrease-"+strconv.Itoa(i), -i))
-	}
-	listings = append(listings, PriceChangeListing{
-		NameKey: "no-change",
-		Listing: cardkingdom.Listing{CardName: "No Change"},
-	})
-
-	rankings := topBottomPriceChangesByPercent(listings, PriceChangeRankingLimit)
-
-	require.Len(t, rankings.Top, PriceChangeRankingLimit)
-	require.Equal(t, 25, *rankings.Top[0].PriceChangePercent)
-	require.Equal(t, 6, *rankings.Top[19].PriceChangePercent)
-
-	require.Len(t, rankings.Bottom, PriceChangeRankingLimit)
-	require.Equal(t, -25, *rankings.Bottom[0].PriceChangePercent)
-	require.Equal(t, -6, *rankings.Bottom[19].PriceChangePercent)
 }
 
 func TestPriceChangesByUsdFromListings(t *testing.T) {
@@ -262,25 +192,6 @@ func TestFilterPriceChangesByUsdSign(t *testing.T) {
 	drops := filterPriceChangesByUsdSign(listings, false)
 	require.Len(t, drops, 1)
 	require.Equal(t, "drop", drops[0].NameKey)
-}
-
-func TestPriceChangeListingFromRecord(t *testing.T) {
-	change := 15
-	listing, ok := priceChangeListingFromRecord(dynamoRecord{
-		NameKey:            "lightning bolt",
-		CardName:           "Lightning Bolt",
-		PriceUsd:           1.49,
-		PriceChangePercent: &change,
-	})
-	require.True(t, ok)
-	require.Equal(t, "lightning bolt", listing.NameKey)
-	require.Equal(t, 15, *listing.PriceChangePercent)
-
-	_, ok = priceChangeListingFromRecord(dynamoRecord{NameKey: syncMetadataKey})
-	require.False(t, ok)
-
-	_, ok = priceChangeListingFromRecord(dynamoRecord{NameKey: "new card", CardName: "New Card"})
-	require.False(t, ok)
 }
 
 func TestPriceChangeListingFromRecordByUsd(t *testing.T) {

--- a/api/store/ckprices/store.go
+++ b/api/store/ckprices/store.go
@@ -24,9 +24,6 @@ type TopBottomPriceChanges struct {
 // Store persists Card Kingdom cheapest-by-name listings.
 type Store interface {
 	GetByNameKey(ctx context.Context, nameKey string) (*cardkingdom.Listing, error)
-	// GetPriceChangesByPercent returns listings ordered by priceChangePercent.
-	// ascending=true is equivalent to SQL ORDER BY priceChangePercent ASC LIMIT n.
-	GetPriceChangesByPercent(ctx context.Context, ascending bool, limit int) ([]PriceChangeListing, error)
 	// GetPriceChangesByUsd returns listings ordered by priceChangeUsd.
 	// ascending=true is equivalent to SQL ORDER BY priceChangeUsd ASC LIMIT n.
 	GetPriceChangesByUsd(ctx context.Context, ascending bool, limit int) ([]PriceChangeListing, error)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The daily CK price refresh (`mtg-price-ck-refresh`) intermittently fails with:

```
ThrottlingException: Throughput exceeds the current capacity for one or more global secondary indexes
```

The refresh batch-writes the entire Card Kingdom pricelist in rapid bursts. Items with price changes share the same GSI partition key (`priceChangeIndexPK = "CURRENT"`). The unused `priceChangePercent-index` doubled GSI write load on every price-change item. On-demand GSI capacity auto-scales, but the first daily run can exceed current limits before scaling completes.

## Solution

### 1. DynamoDB write backoff (code)
- Adaptive retry client with 10 max attempts
- Exponential backoff (200ms → 30s, up to 12 retries) on throttle errors and unprocessed items
- 50ms inter-batch pacing between 25-item writes

### 2. Remove unused `priceChangePercent-index` (code)
- Removed `GetPriceChangesByPercent` and percent-index query/scan fallbacks
- Only set `priceChangeIndexPK` when `priceChangeUsd` is present (USD GSI is the only one used by the daily export and frontend)
- Updated README/IAM docs to reference `priceChangeUsd-index` only

`priceChangePercent` is still stored on items for reference, but no longer indexed.

### 3. Delete the GSI in AWS (manual step)

After deploying the code, delete the unused GSI:

```bash
# Confirm the index exists
aws dynamodb describe-table \
  --table-name gishathfetch-ck-prices \
  --region ap-southeast-1 \
  --query 'Table.GlobalSecondaryIndexes[].IndexName'

# Delete priceChangePercent-index (runs asynchronously; table stays available)
aws dynamodb update-table \
  --table-name gishathfetch-ck-prices \
  --region ap-southeast-1 \
  --global-secondary-index-updates \
    '[{"Delete":{"IndexName":"priceChangePercent-index"}}]'

# Wait until deletion completes (IndexStatus becomes absent from describe-table)
aws dynamodb wait table-exists \
  --table-name gishathfetch-ck-prices \
  --region ap-southeast-1

aws dynamodb describe-table \
  --table-name gishathfetch-ck-prices \
  --region ap-southeast-1 \
  --query 'Table.GlobalSecondaryIndexes'
```

Also remove `priceChangePercent-index` from the `lambda-mtg` IAM policy if it is listed there.

**Recommended order:** deploy code first, then delete the GSI. The code no longer queries the percent index, so deletion is safe after deploy.

## Testing

- `go test -mod=vendor ./store/ckprices/...`
- `make test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-270440db-ae6f-476a-abfc-94a3a02a167a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-270440db-ae6f-476a-abfc-94a3a02a167a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

