### PR TITLE
Fix CK pricelist download timing out while reading 65MB body

### DIFF
--- a/api/gateway/cardkingdom/pricelist_fetch.go
+++ b/api/gateway/cardkingdom/pricelist_fetch.go
@@ -20,8 +20,11 @@ import (
 const (
 	defaultCKPricelistURL   = "https://api.cardkingdom.com/api/v2/pricelist"
 	ckPricelistErrorPrefix  = "ck price pricelist"
-	ckPricelistFetchTimeout = 3 * time.Minute
-	ckPricelistHTTPTimeout  = 2 * time.Minute
+	// The CK pricelist JSON is ~65MB (~150k products). Through CK_PRICELIST_PROXY
+	// the body can take several minutes after headers return; http.Client.Timeout
+	// covers the full round trip including body read.
+	ckPricelistFetchTimeout = 9 * time.Minute
+	ckPricelistHTTPTimeout  = 8 * time.Minute
 )
 
 type ckPricelistPayload struct {
@@ -211,10 +214,17 @@ func downloadCKPricelist(ctx context.Context, downloadURL string) (*ckPricelistP
 		return nil, fmt.Errorf("%s: status %d: %s", ckPricelistErrorPrefix, resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 
+	log.Printf("ck price refresh: reading pricelist body")
+	readStarted := time.Now()
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("%s: read body: %w", ckPricelistErrorPrefix, err)
 	}
+	log.Printf(
+		"ck price refresh: read pricelist body bytes=%d duration=%s",
+		len(raw),
+		time.Since(readStarted).Round(time.Millisecond),
+	)
 
 	var payload ckPricelistPayload
 	if err := json.Unmarshal(raw, &payload); err != nil {

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -103,6 +103,17 @@ For Agora and 5 Mana, `SkipDirect` is cleared when the host is not the productio
 
 ---
 
+## Backend: CK price refresh (`api/gateway/cardkingdom/`)
+
+| Item | Value | Source | Notes |
+|------|--------|--------|--------|
+| CK pricelist HTTP timeout | 8m | `ckPricelistHTTPTimeout` in `api/gateway/cardkingdom/pricelist_fetch.go` | Bounds the full `DoOutboundGET` round trip, including streaming the ~65MB JSON body through `CK_PRICELIST_PROXY`. |
+| CK pricelist fetch timeout | 9m | `ckPricelistFetchTimeout` in `api/gateway/cardkingdom/pricelist_fetch.go` | Context deadline for download + JSON decode + cheapest-listing aggregation. |
+| MTGJSON fallback fetch timeout | 8m | `mtgjsonFetchTimeout` in `api/gateway/cardkingdom/mtgjson_fetch.go` | Used when the CK API path fails. |
+| MTGJSON AllPrintings HTTP timeout | 7m | `mtgjsonAllPrintingsHTTPTimeout` in `api/gateway/cardkingdom/mtgjson_fetch.go` | Large bz2 download; keep Lambda timeout at 600s. |
+
+---
+
 ## Frontend
 
 Constants live in `frontend/src/hooks/useSearch.js` (and related).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

CK price refresh logs showed `outbound request: succeeded status=200` followed ~2 minutes later by:

```
ck price pricelist: read body: net/http: request canceled (Client.Timeout or context cancellation while reading body)
```

## Root cause

`downloadCKPricelist` uses `DoOutboundGET` with `ckPricelistHTTPTimeout = 2m`. In Go, `http.Client.Timeout` covers the **entire** request lifecycle, including streaming the response body after headers arrive.

The CK pricelist JSON is currently ~65MB (~150k products). Through `CK_PRICELIST_PROXY`, headers can return in a few seconds while the body continues streaming for much longer. The 2-minute client timeout was firing during `io.ReadAll(resp.Body)`.

Timeline from the reported run:
- `17:19:11` — headers received (status 200)
- `17:21:06` — body read canceled (~115s later, matching the 2m client timeout)

## Fix

- Increase `ckPricelistHTTPTimeout` from **2m → 8m** (aligned with MTGJSON AllPrintings download cap)
- Increase `ckPricelistFetchTimeout` from **3m → 9m** so the outer context does not cancel first
- Add logs when body read starts and completes (`bytes` + `duration`) so future stalls are easier to spot
- Document CK refresh timeouts in `docs/search-strategies-retries-timeouts.md`

## Testing

- `go test -mod=vendor -failfast -timeout 5m ./gateway/cardkingdom/... ./controller/ckprice/... ./handler/...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0f3321c-7263-4eca-b973-db155662c94a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0f3321c-7263-4eca-b973-db155662c94a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

