### PR TITLE
Fix CK pricelist download timeout and add body-read progress logs

### DIFF
--- a/api/gateway/cardkingdom/pricelist_fetch.go
+++ b/api/gateway/cardkingdom/pricelist_fetch.go
@@ -25,6 +25,8 @@ const (
 	// covers the full round trip including body read.
 	ckPricelistFetchTimeout = 9 * time.Minute
 	ckPricelistHTTPTimeout  = 8 * time.Minute
+	// Emit body-read progress while large pricelist downloads stream through proxy.
+	ckPricelistBodyReadLogInterval = 15 * time.Second
 )
 
 type ckPricelistPayload struct {
@@ -216,7 +218,13 @@ func downloadCKPricelist(ctx context.Context, downloadURL string) (*ckPricelistP
 
 	log.Printf("ck price refresh: reading pricelist body")
 	readStarted := time.Now()
-	raw, err := io.ReadAll(resp.Body)
+	bodyReader := &progressLogReader{
+		reader:     resp.Body,
+		interval:   ckPricelistBodyReadLogInterval,
+		label:      "ck price refresh: reading pricelist body",
+		totalBytes: resp.ContentLength,
+	}
+	raw, err := io.ReadAll(bodyReader)
 	if err != nil {
 		return nil, fmt.Errorf("%s: read body: %w", ckPricelistErrorPrefix, err)
 	}
@@ -235,6 +243,56 @@ func downloadCKPricelist(ctx context.Context, downloadURL string) (*ckPricelistP
 	}
 
 	return &payload, nil
+}
+
+type progressLogReader struct {
+	reader     io.Reader
+	interval   time.Duration
+	label      string
+	totalBytes int64
+
+	readStarted time.Time
+	readBytes   int64
+	lastLogged  time.Time
+}
+
+func (r *progressLogReader) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	if n <= 0 {
+		return n, err
+	}
+
+	now := time.Now()
+	if r.readStarted.IsZero() {
+		r.readStarted = now
+		r.lastLogged = now
+	}
+	r.readBytes += int64(n)
+
+	if now.Sub(r.lastLogged) >= r.interval {
+		r.logProgress(now)
+		r.lastLogged = now
+	}
+
+	return n, err
+}
+
+func (r *progressLogReader) logProgress(now time.Time) {
+	elapsed := now.Sub(r.readStarted).Round(time.Millisecond)
+	if r.totalBytes > 0 {
+		pct := (float64(r.readBytes) * 100) / float64(r.totalBytes)
+		log.Printf(
+			"%s progress bytes=%d total=%d pct=%.1f%% elapsed=%s",
+			r.label,
+			r.readBytes,
+			r.totalBytes,
+			pct,
+			elapsed,
+		)
+		return
+	}
+
+	log.Printf("%s progress bytes=%d elapsed=%s", r.label, r.readBytes, elapsed)
 }
 
 func cheapestListingsFromPricelist(payload *ckPricelistPayload, updatedAt time.Time) map[string]Listing {

--- a/api/gateway/cardkingdom/pricelist_fetch_test.go
+++ b/api/gateway/cardkingdom/pricelist_fetch_test.go
@@ -1,8 +1,10 @@
 package cardkingdom
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -192,4 +194,28 @@ func TestFetchCheapestFromCKPricelist_FromTestServer(t *testing.T) {
 	require.NoError(t, err)
 	require.InDelta(t, 1.49, cheapest["lightning bolt"].PriceUsd, 0.001)
 	require.InDelta(t, 7.49, cheapest["spectacular spider-man"].PriceUsd, 0.001)
+}
+
+func TestProgressLogReader_PassesThroughAllBytes(t *testing.T) {
+	input := bytes.Repeat([]byte("a"), 4096)
+	out, err := io.ReadAll(&progressLogReader{
+		reader:   bytes.NewReader(input),
+		interval: time.Hour,
+		label:    "test progress",
+	})
+	require.NoError(t, err)
+	require.Equal(t, input, out)
+}
+
+func TestProgressLogReader_LogsWithTotalBytes(t *testing.T) {
+	input := bytes.Repeat([]byte("b"), 1024)
+	reader := &progressLogReader{
+		reader:     bytes.NewReader(input),
+		interval:   0,
+		label:      "test progress",
+		totalBytes: int64(len(input)),
+	}
+	reader.readStarted = time.Now().Add(-time.Second)
+	reader.readBytes = int64(len(input))
+	reader.logProgress(time.Now())
 }

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -109,6 +109,7 @@ For Agora and 5 Mana, `SkipDirect` is cleared when the host is not the productio
 |------|--------|--------|--------|
 | CK pricelist HTTP timeout | 8m | `ckPricelistHTTPTimeout` in `api/gateway/cardkingdom/pricelist_fetch.go` | Bounds the full `DoOutboundGET` round trip, including streaming the ~65MB JSON body through `CK_PRICELIST_PROXY`. |
 | CK pricelist fetch timeout | 9m | `ckPricelistFetchTimeout` in `api/gateway/cardkingdom/pricelist_fetch.go` | Context deadline for download + JSON decode + cheapest-listing aggregation. |
+| CK pricelist body-read progress logs | every 15s | `ckPricelistBodyReadLogInterval` in `api/gateway/cardkingdom/pricelist_fetch.go` | Emits bytes read (and `%` when `Content-Length` is present) while the body streams. |
 | MTGJSON fallback fetch timeout | 8m | `mtgjsonFetchTimeout` in `api/gateway/cardkingdom/mtgjson_fetch.go` | Used when the CK API path fails. |
 | MTGJSON AllPrintings HTTP timeout | 7m | `mtgjsonAllPrintingsHTTPTimeout` in `api/gateway/cardkingdom/mtgjson_fetch.go` | Large bz2 download; keep Lambda timeout at 600s. |
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

CK price refresh logs showed `outbound request: succeeded status=200` followed ~2 minutes later by:

```
ck price pricelist: read body: net/http: request canceled (Client.Timeout or context cancellation while reading body)
```

After increasing timeouts, the body read could still sit on `reading pricelist body` for several minutes with no further logs.

## Root cause

`downloadCKPricelist` uses `DoOutboundGET` with `ckPricelistHTTPTimeout = 2m`. In Go, `http.Client.Timeout` covers the **entire** request lifecycle, including streaming the response body after headers arrive.

The CK pricelist JSON is currently ~65MB (~150k products). Through `CK_PRICELIST_PROXY`, headers can return in a few seconds while the body continues streaming for much longer. The 2-minute client timeout was firing during `io.ReadAll(resp.Body)`.

## Fix

- Increase `ckPricelistHTTPTimeout` from **2m → 8m** (aligned with MTGJSON AllPrintings download cap)
- Increase `ckPricelistFetchTimeout` from **3m → 9m** so the outer context does not cancel first
- Wrap the response body in a progress reader that logs every **15s** while bytes stream in (`bytes`, optional `%` when `Content-Length` is present, `elapsed`)
- Keep start/finish logs around the body read
- Document CK refresh timeouts in `docs/search-strategies-retries-timeouts.md`

Example progress logs after deploy:

```
ck price refresh: reading pricelist body
ck price refresh: reading pricelist body progress bytes=5242880 elapsed=15s
ck price refresh: reading pricelist body progress bytes=10485760 elapsed=30s
...
ck price refresh: read pricelist body bytes=66457351 duration=2m5s
```

## Testing

- `go test -mod=vendor -failfast -timeout 5m ./gateway/cardkingdom/... ./controller/ckprice/... ./handler/...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0f3321c-7263-4eca-b973-db155662c94a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0f3321c-7263-4eca-b973-db155662c94a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

