### PR TITLE
Add AGORA_SEARCH_ENABLED env toggle for Agora search

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ frontend-dev:
 	cd frontend && npm install && npm run dev
 
 frontend-build: generate-signature-directory
-	cd frontend && npm install && npm run build
+	cd frontend && npm install && VITE_AGORA_SEARCH_ENABLED=$${VITE_AGORA_SEARCH_ENABLED:-$${AGORA_SEARCH_ENABLED:-false}} npm run build
 
 SIGNATURE_DIRECTORY_BIN=.cache/signature-directory
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ frontend-dev:
 	cd frontend && npm install && npm run dev
 
 frontend-build: generate-signature-directory
-	cd frontend && npm install && VITE_AGORA_SEARCH_ENABLED=$${VITE_AGORA_SEARCH_ENABLED:-$${AGORA_SEARCH_ENABLED:-false}} npm run build
+	cd frontend && npm install && AGORA_SEARCH_ENABLED=$${AGORA_SEARCH_ENABLED:-false} npm run build
 
 SIGNATURE_DIRECTORY_BIN=.cache/signature-directory
 

--- a/api/controller/search.go
+++ b/api/controller/search.go
@@ -476,6 +476,9 @@ func initAndMapShops(lgs []string) map[string]gateway.LGS {
 
 	lgsMap := make(map[string]gateway.LGS, len(shopRegistry))
 	for _, shop := range shopRegistry {
+		if shop.name == agora.StoreName && !config.AgoraSearchEnabled() {
+			continue
+		}
 		if len(selectedLGS) > 0 {
 			if _, exists := selectedLGS[shop.name]; !exists {
 				continue

--- a/api/controller/search_test.go
+++ b/api/controller/search_test.go
@@ -10,6 +10,7 @@ import (
 	"mtg-price-checker-sg/gateway/cardaffinity"
 	"mtg-price-checker-sg/gateway/cardscitadel"
 	"mtg-price-checker-sg/gateway/hideout"
+	"mtg-price-checker-sg/pkg/config"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -17,7 +18,23 @@ import (
 	"time"
 )
 
+func TestInitAndMapShops_SkipsAgoraWhenDisabled(t *testing.T) {
+	t.Setenv(config.AgoraSearchEnabledEnv, "false")
+	shops := initAndMapShops([]string{agora.StoreName, hideout.StoreName})
+
+	if len(shops) != 1 {
+		t.Fatalf("expected 1 shop after filtering disabled Agora, got %d", len(shops))
+	}
+	if _, ok := shops[agora.StoreName]; ok {
+		t.Fatalf("did not expect %q when Agora search is disabled", agora.StoreName)
+	}
+	if _, ok := shops[hideout.StoreName]; !ok {
+		t.Fatalf("expected %q to be included", hideout.StoreName)
+	}
+}
+
 func TestInitAndMapShops_FiltersByRequestedLGS(t *testing.T) {
+	t.Setenv(config.AgoraSearchEnabledEnv, "true")
 	shops := initAndMapShops([]string{agora.StoreName, hideout.StoreName})
 
 	if len(shops) != 2 {

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -25,6 +25,9 @@ const (
 	SearchAttemptTimeout = 5 * time.Second
 	// AgoraSearchAttemptTimeout is the per-attempt cap for Agora Hobby only.
 	AgoraSearchAttemptTimeout = 10 * time.Second
+	// AgoraSearchEnabledEnv toggles Agora Hobby search in the search Lambda.
+	// Defaults to disabled when unset or invalid.
+	AgoraSearchEnabledEnv = "AGORA_SEARCH_ENABLED"
 	// DynamicProxyEnv contains an authenticated proxy URL used for explicit
 	// dynamic-proxy fallback attempts, which BinderPOS reserves for the final
 	// two attempts after dedicated and direct/no-proxy scrap and decklist tries.
@@ -101,6 +104,21 @@ const (
 // UseLeasedDedicatedProxy enables exclusive per-request leases from the dedicated proxy pool.
 // When false, each request picks a random dedicated proxy instead of acquiring a lease.
 const UseLeasedDedicatedProxy = false
+
+// AgoraSearchEnabled reports whether Agora Hobby is included in search requests.
+func AgoraSearchEnabled() bool {
+	rawValue := strings.TrimSpace(os.Getenv(AgoraSearchEnabledEnv))
+	if rawValue == "" {
+		return false
+	}
+
+	enabled, err := strconv.ParseBool(rawValue)
+	if err != nil {
+		return false
+	}
+
+	return enabled
+}
 
 func UseDynamicProxy() bool {
 	rawValue := strings.TrimSpace(os.Getenv(UseDynamicProxyEnv))

--- a/api/pkg/config/config_test.go
+++ b/api/pkg/config/config_test.go
@@ -4,6 +4,36 @@ import (
 	"testing"
 )
 
+func TestAgoraSearchEnabled(t *testing.T) {
+	t.Run("defaults to disabled when unset", func(t *testing.T) {
+		t.Setenv(AgoraSearchEnabledEnv, "")
+		if AgoraSearchEnabled() {
+			t.Fatalf("expected agora search to be disabled by default")
+		}
+	})
+
+	t.Run("respects explicit true", func(t *testing.T) {
+		t.Setenv(AgoraSearchEnabledEnv, "true")
+		if !AgoraSearchEnabled() {
+			t.Fatalf("expected agora search to be enabled")
+		}
+	})
+
+	t.Run("respects explicit false", func(t *testing.T) {
+		t.Setenv(AgoraSearchEnabledEnv, "false")
+		if AgoraSearchEnabled() {
+			t.Fatalf("expected agora search to be disabled")
+		}
+	})
+
+	t.Run("defaults to disabled for invalid value", func(t *testing.T) {
+		t.Setenv(AgoraSearchEnabledEnv, "not-a-bool")
+		if AgoraSearchEnabled() {
+			t.Fatalf("expected invalid toggle to default to disabled")
+		}
+	})
+}
+
 func TestUseDynamicProxy(t *testing.T) {
 	t.Run("defaults to disabled when unset", func(t *testing.T) {
 		t.Setenv(UseDynamicProxyEnv, "")

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -19,7 +19,7 @@
 
   <meta name="author" content="Alvin Yeoh" />
   <meta name="description"
-    content="Compare MTG singles prices across 18 Singapore local game stores and online shops in one search. In-stock results sorted by price." />
+    content="Compare MTG singles prices across 17 Singapore local game stores and online shops in one search. In-stock results sorted by price." />
   <meta name="keywords"
     content="MTG, Magic The Gathering, Singapore, LGS, online shop, card prices, price checker, local game store, TCG, trading card game, singles" />
 
@@ -27,7 +27,7 @@
   <meta property="og:site_name" content="Gishath Fetch">
   <meta property="og:url" content="https://gishathfetch.com/">
   <meta property="og:description"
-    content="Compare MTG singles prices across 18 Singapore local game stores and online shops in one search. In-stock results sorted by price.">
+    content="Compare MTG singles prices across 17 Singapore local game stores and online shops in one search. In-stock results sorted by price.">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://gishathfetch.com/img/og-image.png">
   <meta property="og:image:width" content="1200">
@@ -36,7 +36,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Gishath Fetch: MTG Price Checker for Singapore's LGS & Online Shops">
   <meta name="twitter:description"
-    content="Compare MTG singles prices across 18 Singapore local game stores and online shops in one search. In-stock results sorted by price.">
+    content="Compare MTG singles prices across 17 Singapore local game stores and online shops in one search. In-stock results sorted by price.">
   <meta name="twitter:image" content="https://gishathfetch.com/img/og-image.png">
 
   <link rel="canonical" href="https://gishathfetch.com/">
@@ -62,7 +62,7 @@
     "@context": "https://schema.org",
     "@type": "WebApplication",
     "name": "Gishath Fetch",
-    "description": "Compare MTG singles prices across 18 Singapore local game stores and online shops in one search. In-stock results sorted by price.",
+    "description": "Compare MTG singles prices across 17 Singapore local game stores and online shops in one search. In-stock results sorted by price.",
     "url": "https://gishathfetch.com/",
     "applicationCategory": "UtilityApplication",
     "operatingSystem": "Any",

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -18,9 +18,9 @@ function parseBoolEnv(value, defaultValue = false) {
   return defaultValue;
 }
 
-// Build-time toggle via VITE_AGORA_SEARCH_ENABLED (defaults to disabled).
+// Build-time toggle via AGORA_SEARCH_ENABLED (defaults to disabled).
 export const AGORA_SEARCH_ENABLED = parseBoolEnv(
-  import.meta.env.VITE_AGORA_SEARCH_ENABLED,
+  import.meta.env.AGORA_SEARCH_ENABLED,
   false,
 );
 

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,10 +1,35 @@
 // --- App Constants ---
+
+const AGORA_STORE_NAME = "Agora Hobby";
+
+function parseBoolEnv(value, defaultValue = false) {
+  if (value === undefined || value === null || value === "") {
+    return defaultValue;
+  }
+
+  const normalized = String(value).trim().toLowerCase();
+  if (normalized === "true" || normalized === "1") {
+    return true;
+  }
+  if (normalized === "false" || normalized === "0") {
+    return false;
+  }
+
+  return defaultValue;
+}
+
+// Build-time toggle via VITE_AGORA_SEARCH_ENABLED (defaults to disabled).
+export const AGORA_SEARCH_ENABLED = parseBoolEnv(
+  import.meta.env.VITE_AGORA_SEARCH_ENABLED,
+  false,
+);
+
 export const PAGE_TITLE =
   "Gishath Fetch: MTG Price Checker for Singapore's LGS & Online Shops";
 
-export const LGS_OPTIONS = [
+const ALL_LGS_OPTIONS = [
   "5 Mana",
-  "Agora Hobby",
+  AGORA_STORE_NAME,
   "Card Affinity",
   "Cards & Collections",
   "Cards Central",
@@ -22,6 +47,10 @@ export const LGS_OPTIONS = [
   "OneMtg",
   "The TCG Marketplace",
 ];
+
+export const LGS_OPTIONS = AGORA_SEARCH_ENABLED
+  ? ALL_LGS_OPTIONS
+  : ALL_LGS_OPTIONS.filter((store) => store !== AGORA_STORE_NAME);
 
 export const SITE_TAGLINE =
   "Magic: The Gathering price checker for Singapore's LGS and online shops";

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -7,6 +7,7 @@ const signatureDirectoryMediaType =
 
 // https://vite.dev/config/
 export default defineConfig({
+  envPrefix: ["VITE_", "AGORA_"],
   plugins: [
     react(),
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an environment-variable feature toggle for Agora Hobby search on both backend and frontend. Agora is **disabled by default**. The Agora map listing on the homepage is unchanged.

## Changes

### Backend
- Added `AGORA_SEARCH_ENABLED` env var in `api/pkg/config/config.go` with `AgoraSearchEnabled()` helper (defaults to `false`).
- `initAndMapShops` skips Agora when the toggle is off, even if the client requests it.

### Frontend
- Reads the same `AGORA_SEARCH_ENABLED` env var at build time via Vite `envPrefix: ["VITE_", "AGORA_"]`.
- `LGS_OPTIONS` excludes Agora when disabled; `LGS_MAP` still includes the Agora entry.
- Updated static SEO copy in `frontend/index.html` from 18 to 17 searchable stores.

### Deploy
- `Makefile` `frontend-build` defaults `AGORA_SEARCH_ENABLED=false` when unset.

## Enabling Agora search

Set `AGORA_SEARCH_ENABLED=true` on the search Lambda and when building the frontend (e.g. `AGORA_SEARCH_ENABLED=true make frontend-build`).

## Testing

- `go test ./controller/... ./pkg/config/...` — passed
- `AGORA_SEARCH_ENABLED=false npm run build` — passed
- `make test` — controller/config/gateway unit tests pass; live Agora gateway test fails with 403 without dedicated proxy (pre-existing environment limitation)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0a8d6f4-a95e-4a26-8be8-845010fd5c89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0a8d6f4-a95e-4a26-8be8-845010fd5c89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

