### PR TITLE
Show Card Kingdom in-stock status in search results

### DIFF
--- a/api/gateway/cardkingdom/pricelist_fetch.go
+++ b/api/gateway/cardkingdom/pricelist_fetch.go
@@ -330,14 +330,20 @@ func listingFromPricelistItem(item ckPricelistItem, baseURL string, updatedAt st
 		return Listing{}, false
 	}
 
+	inStock := listingIsInStock(item)
 	return Listing{
 		CardName:  cardName,
 		Edition:   pricelistEditionLabel(item.Edition, item.Variation),
 		PriceUsd:  priceUsd,
 		URL:       listingURL,
 		IsFoil:    bool(item.IsFoil),
+		InStock:   &inStock,
 		UpdatedAt: updatedAt,
 	}, true
+}
+
+func listingIsInStock(item ckPricelistItem) bool {
+	return int(item.QtyRetail) > 0
 }
 
 func cheapestListedUSD(values ckConditionValues, priceRetail float64) (float64, bool) {

--- a/api/gateway/cardkingdom/pricelist_fetch_test.go
+++ b/api/gateway/cardkingdom/pricelist_fetch_test.go
@@ -115,6 +115,11 @@ const sampleCKPricelist = `{
   ]
 }`
 
+func TestListingIsInStock(t *testing.T) {
+	require.True(t, listingIsInStock(ckPricelistItem{QtyRetail: 1}))
+	require.False(t, listingIsInStock(ckPricelistItem{QtyRetail: 0}))
+}
+
 func TestCheapestListedUSD_UsesNMOnly(t *testing.T) {
 	price, ok := cheapestListedUSD(ckConditionValues{
 		NmPrice: 1.49,
@@ -149,16 +154,22 @@ func TestCheapestListingsFromPricelist(t *testing.T) {
 	require.Equal(t, "4th Edition", listing.Edition)
 	require.InDelta(t, 1.49, listing.PriceUsd, 0.001)
 	require.False(t, listing.IsFoil)
+	require.NotNil(t, listing.InStock)
+	require.True(t, *listing.InStock)
 	require.Equal(t, "https://www.cardkingdom.com/mtg/fourth-edition/lightning-bolt", listing.URL)
 	require.Equal(t, updatedAt.Format(time.RFC3339), listing.UpdatedAt)
 
 	spider := cheapest["spectacular spider-man"]
 	require.InDelta(t, 7.49, spider.PriceUsd, 0.001)
 	require.Equal(t, "0014 - Borderless", spider.Edition)
+	require.NotNil(t, spider.InStock)
+	require.False(t, *spider.InStock)
 
 	tony := cheapest["tony stark // the invincible iron man"]
 	require.InDelta(t, 7.49, tony.PriceUsd, 0.001)
 	require.False(t, tony.IsFoil)
+	require.NotNil(t, tony.InStock)
+	require.True(t, *tony.InStock)
 
 	require.InDelta(t, 7.49, cheapest["tony stark"].PriceUsd, 0.001)
 	require.InDelta(t, 7.49, cheapest["the invincible iron man"].PriceUsd, 0.001)

--- a/api/gateway/cardkingdom/types.go
+++ b/api/gateway/cardkingdom/types.go
@@ -8,8 +8,9 @@ type Listing struct {
 	PreviousPriceUsd   *float64 `json:"previousPriceUsd,omitempty"`
 	PriceChangePercent *int     `json:"priceChangePercent,omitempty"`
 	PriceChangeUsd     *float64 `json:"priceChangeUsd,omitempty"`
-	URL                string  `json:"url"`
-	IsFoil             bool    `json:"isFoil"`
-	UpdatedAt          string  `json:"updatedAt,omitempty"`
-	SyncedAt           string  `json:"syncedAt,omitempty"`
+	URL                string   `json:"url"`
+	IsFoil             bool     `json:"isFoil"`
+	InStock            *bool    `json:"inStock,omitempty"`
+	UpdatedAt          string   `json:"updatedAt,omitempty"`
+	SyncedAt           string   `json:"syncedAt,omitempty"`
 }

--- a/api/store/ckprices/dynamodb.go
+++ b/api/store/ckprices/dynamodb.go
@@ -46,6 +46,7 @@ type dynamoRecord struct {
 	PriceChangeIndexPK *string `dynamodbav:"priceChangeIndexPK,omitempty"`
 	URL                string  `dynamodbav:"url"`
 	IsFoil             bool    `dynamodbav:"isFoil"`
+	InStock            *bool   `dynamodbav:"inStock,omitempty"`
 	UpdatedAt          string  `dynamodbav:"updatedAt"`
 	SyncedAt           string  `dynamodbav:"syncedAt"`
 }
@@ -269,6 +270,7 @@ func dynamoRecordFromListing(nameKey string, listing cardkingdom.Listing, synced
 		PriceChangeUsd:     listing.PriceChangeUsd,
 		URL:                listing.URL,
 		IsFoil:             listing.IsFoil,
+		InStock:            listing.InStock,
 		UpdatedAt:          listing.UpdatedAt,
 		SyncedAt:           syncedAt,
 	}
@@ -292,6 +294,7 @@ func listingFromRecord(record dynamoRecord) (cardkingdom.Listing, bool) {
 		PriceChangeUsd:     record.PriceChangeUsd,
 		URL:                record.URL,
 		IsFoil:             record.IsFoil,
+		InStock:            record.InStock,
 		UpdatedAt:          record.UpdatedAt,
 		SyncedAt:           record.SyncedAt,
 	}, true

--- a/api/store/ckprices/dynamodb_test.go
+++ b/api/store/ckprices/dynamodb_test.go
@@ -58,6 +58,21 @@ func TestDynamoRecordFromListing_OmitsPriceChangeIndexWithoutUsd(t *testing.T) {
 	require.Nil(t, record.PriceChangeIndexPK)
 }
 
+func TestDynamoRecordMarshalIncludesInStock(t *testing.T) {
+	syncedAt := time.Date(2026, 6, 28, 15, 30, 0, 0, time.UTC).Format(time.RFC3339)
+	inStock := true
+	record := dynamoRecordFromListing("lightning bolt", cardkingdom.Listing{
+		UpdatedAt: "2026-06-28T00:00:00Z",
+		InStock:   &inStock,
+	}, syncedAt)
+	item, err := attributevalue.MarshalMap(record)
+	require.NoError(t, err)
+	require.Contains(t, item, "inStock")
+	av, ok := item["inStock"].(*types.AttributeValueMemberBOOL)
+	require.True(t, ok)
+	require.True(t, av.Value)
+}
+
 func TestDynamoRecordMarshalOmitsQuantity(t *testing.T) {
 	syncedAt := time.Date(2026, 6, 28, 15, 30, 0, 0, time.UTC).Format(time.RFC3339)
 	record := dynamoRecordFromListing("lightning bolt", cardkingdom.Listing{UpdatedAt: "2026-06-28T00:00:00Z"}, syncedAt)

--- a/frontend/src/components/CardKingdomPrice.jsx
+++ b/frontend/src/components/CardKingdomPrice.jsx
@@ -57,7 +57,9 @@ const CardKingdomPrice = ({ price }) => {
             {" · "}
             <span
               className={
-                price.inStock ? "text-success fw-semibold" : "text-muted"
+                price.inStock
+                  ? "text-success fw-semibold"
+                  : "text-danger fw-semibold"
               }
             >
               {stockLabel}

--- a/frontend/src/components/CardKingdomPrice.jsx
+++ b/frontend/src/components/CardKingdomPrice.jsx
@@ -24,12 +24,23 @@ const formatDataDate = (value) => {
   return `${day} ${month} ${year}`;
 };
 
+const stockStatusLabel = (inStock) => {
+  if (inStock === true) {
+    return "In stock";
+  }
+  if (inStock === false) {
+    return "Out of stock";
+  }
+  return null;
+};
+
 const CardKingdomPrice = ({ price }) => {
   if (!price) {
     return null;
   }
 
   const dataDate = formatDataDate(price.updatedAt);
+  const stockLabel = stockStatusLabel(price.inStock);
 
   return (
     <div
@@ -41,6 +52,18 @@ const CardKingdomPrice = ({ price }) => {
         <strong>{formatUsd(price.priceUsd)}</strong>
         {price.edition ? ` · ${price.edition}` : ""}
         {price.isFoil ? " · Foil" : ""}
+        {stockLabel ? (
+          <>
+            {" · "}
+            <span
+              className={
+                price.inStock ? "text-success fw-semibold" : "text-muted"
+              }
+            >
+              {stockLabel}
+            </span>
+          </>
+        ) : null}
         {dataDate ? ` · as of ${dataDate}` : ""}
         {" · "}
         <a


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Card Kingdom search results now show whether the cheapest listed edition is **In stock** or **Out of stock**, based on retail quantity from the CK pricelist API.

## Changes

- Add optional `inStock` field to `cardkingdom.Listing` (populated from `qty_retail` when syncing the CK pricelist)
- Persist `inStock` in DynamoDB so lookups return stock status with price data
- Display stock status in the `CardKingdomPrice` banner above search results (green for in stock, red for out of stock)
- Omit the label when stock status is unknown (e.g. MTGJSON fallback or pre-refresh DynamoDB rows)

## Screenshots

### Desktop — In stock
![Card Kingdom in stock on desktop](https://cursor.com/artifacts/c/art-8904b16d-f84d-45b1-8857-ef4c52eb78e9)

### Desktop — Out of stock
![Card Kingdom out of stock on desktop](https://cursor.com/artifacts/c/art-0ab916bb-d162-4558-bde2-40432af0d595)

### Mobile — In stock
![Card Kingdom in stock on mobile](https://cursor.com/artifacts/c/art-acaf10e9-1b3e-46e2-b380-264402b68a49)

### Mobile — Out of stock
![Card Kingdom out of stock on mobile](https://cursor.com/artifacts/c/art-7407bd35-8967-4f92-8d12-3567f9a766d5)

## Testing

- `go test -mod=vendor ./gateway/cardkingdom/... ./store/ckprices/... ./handler/...`
- `go fix ./...`
- Full `make test` hit an unrelated live Agora gateway 403 in this environment

## Notes

Stock status appears after the next CK price refresh job runs. Until then, existing DynamoDB rows without `inStock` will not show a stock label.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f248a720-5e14-4cd6-9393-7663a460dac5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f248a720-5e14-4cd6-9393-7663a460dac5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

