### PR TITLE
Increase CK pricelist download timeout to 12 minutes

### DIFF
--- a/api/gateway/cardkingdom/pricelist_fetch.go
+++ b/api/gateway/cardkingdom/pricelist_fetch.go
@@ -23,8 +23,8 @@ const (
 	// The CK pricelist JSON is ~65MB (~150k products). Through CK_PRICELIST_PROXY
 	// the body can take several minutes after headers return; http.Client.Timeout
 	// covers the full round trip including body read.
-	ckPricelistFetchTimeout = 9 * time.Minute
-	ckPricelistHTTPTimeout  = 8 * time.Minute
+	ckPricelistFetchTimeout = 13 * time.Minute
+	ckPricelistHTTPTimeout  = 12 * time.Minute
 	// Emit body-read progress while large pricelist downloads stream through proxy.
 	ckPricelistBodyReadLogInterval = 15 * time.Second
 )

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -109,8 +109,8 @@ For Agora and 5 Mana, `SkipDirect` is cleared when the host is not the productio
 
 | Item | Value | Source | Notes |
 |------|--------|--------|--------|
-| CK pricelist HTTP timeout | 8m | `ckPricelistHTTPTimeout` in `api/gateway/cardkingdom/pricelist_fetch.go` | Bounds the full `DoOutboundGET` round trip, including streaming the ~65MB JSON body through `CK_PRICELIST_PROXY`. |
-| CK pricelist fetch timeout | 9m | `ckPricelistFetchTimeout` in `api/gateway/cardkingdom/pricelist_fetch.go` | Context deadline for download + JSON decode + cheapest-listing aggregation. |
+| CK pricelist HTTP timeout | 12m | `ckPricelistHTTPTimeout` in `api/gateway/cardkingdom/pricelist_fetch.go` | Bounds the full `DoOutboundGET` round trip, including streaming the ~65MB JSON body through `CK_PRICELIST_PROXY`. |
+| CK pricelist fetch timeout | 13m | `ckPricelistFetchTimeout` in `api/gateway/cardkingdom/pricelist_fetch.go` | Context deadline for download + JSON decode + cheapest-listing aggregation. |
 | CK pricelist body-read progress logs | every 15s | `ckPricelistBodyReadLogInterval` in `api/gateway/cardkingdom/pricelist_fetch.go` | Emits bytes read (and `%` when `Content-Length` is present) while the body streams. |
 
 ---


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The daily CK price refresh timed out on 2026-07-18 while streaming the ~65MB Card Kingdom pricelist through `CK_PRICELIST_PROXY`. Logs showed ~55MB read at 7m51s before `context deadline exceeded` on the HTTP body read (8m client timeout).

This raises the pricelist download timeouts to give slow proxy transfers more headroom:

- **HTTP timeout** (`ckPricelistHTTPTimeout`): 8m → **12m**
- **Fetch timeout** (`ckPricelistFetchTimeout`): 9m → **13m** (keeps 1m buffer for JSON decode + listing aggregation)

## Testing

- `go test -mod=vendor -failfast -timeout 5m ./gateway/cardkingdom/...`
- `make test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dffe23b5-fd86-4c7a-992b-fdfa3284ebbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dffe23b5-fd86-4c7a-992b-fdfa3284ebbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

