### PR TITLE
Preserve CK USD price changes on same-day pricelist re-runs

### DIFF
--- a/api/store/ckprices/dynamodb.go
+++ b/api/store/ckprices/dynamodb.go
@@ -215,9 +215,10 @@ func (s *DynamoDBStore) PutAll(ctx context.Context, listings map[string]cardking
 	if err != nil {
 		return "", err
 	}
-	listings = listingsWithPriceChange(existing, listings)
+	now := time.Now().UTC()
+	listings = listingsWithPriceChange(existing, listings, now)
 
-	syncedAt := time.Now().UTC().Format(time.RFC3339)
+	syncedAt := now.Format(time.RFC3339)
 	writeRequests := make([]types.WriteRequest, 0, len(listings)+1)
 	for nameKey, listing := range listings {
 		record := dynamoRecordFromListing(nameKey, listing, syncedAt)

--- a/api/store/ckprices/price_change.go
+++ b/api/store/ckprices/price_change.go
@@ -40,6 +40,24 @@ func isSameUTCDay(syncedAt string, now time.Time) bool {
 		syncedUTC.Day() == nowUTC.Day()
 }
 
+func hasNonZeroPriceChangeUsd(change *float64) bool {
+	return change != nil && *change != 0
+}
+
+func isZeroPriceChangeUsd(change *float64) bool {
+	return change == nil || *change == 0
+}
+
+func preserveSameDayPriceChangeIfZeroed(existing dynamoRecord, listing cardkingdom.Listing) cardkingdom.Listing {
+	if !hasNonZeroPriceChangeUsd(existing.PriceChangeUsd) || !isZeroPriceChangeUsd(listing.PriceChangeUsd) {
+		return listing
+	}
+	listing.PreviousPriceUsd = existing.PreviousPriceUsd
+	listing.PriceChangePercent = existing.PriceChangePercent
+	listing.PriceChangeUsd = existing.PriceChangeUsd
+	return listing
+}
+
 func listingsWithPriceChange(
 	existing map[string]dynamoRecord,
 	listings map[string]cardkingdom.Listing,
@@ -48,15 +66,12 @@ func listingsWithPriceChange(
 	enriched := make(map[string]cardkingdom.Listing, len(listings))
 	for nameKey, listing := range listings {
 		if previous, ok := existing[nameKey]; ok {
+			previousPriceUsd := previous.PriceUsd
+			listing.PreviousPriceUsd = &previousPriceUsd
+			listing.PriceChangePercent = computePriceChangePercent(previousPriceUsd, listing.PriceUsd)
+			listing.PriceChangeUsd = computePriceChangeUsd(previousPriceUsd, listing.PriceUsd)
 			if isSameUTCDay(previous.SyncedAt, now) {
-				listing.PreviousPriceUsd = previous.PreviousPriceUsd
-				listing.PriceChangePercent = previous.PriceChangePercent
-				listing.PriceChangeUsd = previous.PriceChangeUsd
-			} else {
-				previousPriceUsd := previous.PriceUsd
-				listing.PreviousPriceUsd = &previousPriceUsd
-				listing.PriceChangePercent = computePriceChangePercent(previousPriceUsd, listing.PriceUsd)
-				listing.PriceChangeUsd = computePriceChangeUsd(previousPriceUsd, listing.PriceUsd)
+				listing = preserveSameDayPriceChangeIfZeroed(previous, listing)
 			}
 		}
 		enriched[nameKey] = listing

--- a/api/store/ckprices/price_change.go
+++ b/api/store/ckprices/price_change.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"slices"
 	"strings"
+	"time"
 
 	"mtg-price-checker-sg/gateway/cardkingdom"
 )
@@ -27,17 +28,36 @@ func computePriceChangeUsd(previousPriceUsd, currentPriceUsd float64) *float64 {
 	return &changeUsd
 }
 
+func isSameUTCDay(syncedAt string, now time.Time) bool {
+	syncedTime, err := time.Parse(time.RFC3339, syncedAt)
+	if err != nil {
+		return false
+	}
+	syncedUTC := syncedTime.UTC()
+	nowUTC := now.UTC()
+	return syncedUTC.Year() == nowUTC.Year() &&
+		syncedUTC.Month() == nowUTC.Month() &&
+		syncedUTC.Day() == nowUTC.Day()
+}
+
 func listingsWithPriceChange(
 	existing map[string]dynamoRecord,
 	listings map[string]cardkingdom.Listing,
+	now time.Time,
 ) map[string]cardkingdom.Listing {
 	enriched := make(map[string]cardkingdom.Listing, len(listings))
 	for nameKey, listing := range listings {
 		if previous, ok := existing[nameKey]; ok {
-			previousPriceUsd := previous.PriceUsd
-			listing.PreviousPriceUsd = &previousPriceUsd
-			listing.PriceChangePercent = computePriceChangePercent(previousPriceUsd, listing.PriceUsd)
-			listing.PriceChangeUsd = computePriceChangeUsd(previousPriceUsd, listing.PriceUsd)
+			if isSameUTCDay(previous.SyncedAt, now) {
+				listing.PreviousPriceUsd = previous.PreviousPriceUsd
+				listing.PriceChangePercent = previous.PriceChangePercent
+				listing.PriceChangeUsd = previous.PriceChangeUsd
+			} else {
+				previousPriceUsd := previous.PriceUsd
+				listing.PreviousPriceUsd = &previousPriceUsd
+				listing.PriceChangePercent = computePriceChangePercent(previousPriceUsd, listing.PriceUsd)
+				listing.PriceChangeUsd = computePriceChangeUsd(previousPriceUsd, listing.PriceUsd)
+			}
 		}
 		enriched[nameKey] = listing
 	}

--- a/api/store/ckprices/price_change_test.go
+++ b/api/store/ckprices/price_change_test.go
@@ -2,6 +2,7 @@ package ckprices
 
 import (
 	"testing"
+	"time"
 
 	"mtg-price-checker-sg/gateway/cardkingdom"
 
@@ -213,7 +214,16 @@ func TestPriceChangeListingFromRecordByUsd(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestIsSameUTCDay(t *testing.T) {
+	now := time.Date(2026, 7, 19, 15, 30, 0, 0, time.UTC)
+
+	require.True(t, isSameUTCDay("2026-07-19T08:00:00Z", now))
+	require.False(t, isSameUTCDay("2026-07-18T23:59:59Z", now))
+	require.False(t, isSameUTCDay("not-a-timestamp", now))
+}
+
 func TestListingsWithPriceChange(t *testing.T) {
+	now := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
 	existing := map[string]dynamoRecord{
 		"lightning bolt": {PriceUsd: 1.00},
 		"counterspell":   {PriceUsd: 2.00},
@@ -223,7 +233,7 @@ func TestListingsWithPriceChange(t *testing.T) {
 		"lightning bolt": {PriceUsd: 1.10},
 		"counterspell":   {PriceUsd: 1.80},
 		"new card":       {PriceUsd: 5.00},
-	})
+	}, now)
 
 	require.NotNil(t, enriched["lightning bolt"].PriceChangePercent)
 	require.Equal(t, 10, *enriched["lightning bolt"].PriceChangePercent)
@@ -240,4 +250,33 @@ func TestListingsWithPriceChange(t *testing.T) {
 	require.Nil(t, enriched["new card"].PriceChangePercent)
 	require.Nil(t, enriched["new card"].PriceChangeUsd)
 	require.Nil(t, enriched["new card"].PreviousPriceUsd)
+}
+
+func TestListingsWithPriceChangePreservesSameDayChanges(t *testing.T) {
+	now := time.Date(2026, 7, 19, 15, 0, 0, 0, time.UTC)
+	previousPrice := 1.00
+	changeUsd := 0.10
+	changePercent := 10
+
+	existing := map[string]dynamoRecord{
+		"lightning bolt": {
+			PriceUsd:           1.10,
+			PreviousPriceUsd:   &previousPrice,
+			PriceChangeUsd:     &changeUsd,
+			PriceChangePercent: &changePercent,
+			SyncedAt:           "2026-07-19T08:00:00Z",
+		},
+	}
+
+	enriched := listingsWithPriceChange(existing, map[string]cardkingdom.Listing{
+		"lightning bolt": {PriceUsd: 1.15},
+	}, now)
+
+	require.Equal(t, 1.15, enriched["lightning bolt"].PriceUsd)
+	require.NotNil(t, enriched["lightning bolt"].PreviousPriceUsd)
+	require.Equal(t, 1.00, *enriched["lightning bolt"].PreviousPriceUsd)
+	require.NotNil(t, enriched["lightning bolt"].PriceChangeUsd)
+	require.InDelta(t, 0.10, *enriched["lightning bolt"].PriceChangeUsd, 0.001)
+	require.NotNil(t, enriched["lightning bolt"].PriceChangePercent)
+	require.Equal(t, 10, *enriched["lightning bolt"].PriceChangePercent)
 }

--- a/api/store/ckprices/price_change_test.go
+++ b/api/store/ckprices/price_change_test.go
@@ -252,7 +252,36 @@ func TestListingsWithPriceChange(t *testing.T) {
 	require.Nil(t, enriched["new card"].PreviousPriceUsd)
 }
 
-func TestListingsWithPriceChangePreservesSameDayChanges(t *testing.T) {
+func TestListingsWithPriceChangePreservesSameDayNonZeroChangesWhenRecomputedToZero(t *testing.T) {
+	now := time.Date(2026, 7, 19, 15, 0, 0, 0, time.UTC)
+	previousPrice := 1.00
+	changeUsd := 0.10
+	changePercent := 10
+
+	existing := map[string]dynamoRecord{
+		"lightning bolt": {
+			PriceUsd:           1.10,
+			PreviousPriceUsd:   &previousPrice,
+			PriceChangeUsd:     &changeUsd,
+			PriceChangePercent: &changePercent,
+			SyncedAt:           "2026-07-19T08:00:00Z",
+		},
+	}
+
+	enriched := listingsWithPriceChange(existing, map[string]cardkingdom.Listing{
+		"lightning bolt": {PriceUsd: 1.10},
+	}, now)
+
+	require.Equal(t, 1.10, enriched["lightning bolt"].PriceUsd)
+	require.NotNil(t, enriched["lightning bolt"].PreviousPriceUsd)
+	require.Equal(t, 1.00, *enriched["lightning bolt"].PreviousPriceUsd)
+	require.NotNil(t, enriched["lightning bolt"].PriceChangeUsd)
+	require.InDelta(t, 0.10, *enriched["lightning bolt"].PriceChangeUsd, 0.001)
+	require.NotNil(t, enriched["lightning bolt"].PriceChangePercent)
+	require.Equal(t, 10, *enriched["lightning bolt"].PriceChangePercent)
+}
+
+func TestListingsWithPriceChangeUpdatesSameDayChangesWhenRecomputedNonZero(t *testing.T) {
 	now := time.Date(2026, 7, 19, 15, 0, 0, 0, time.UTC)
 	previousPrice := 1.00
 	changeUsd := 0.10
@@ -274,9 +303,9 @@ func TestListingsWithPriceChangePreservesSameDayChanges(t *testing.T) {
 
 	require.Equal(t, 1.15, enriched["lightning bolt"].PriceUsd)
 	require.NotNil(t, enriched["lightning bolt"].PreviousPriceUsd)
-	require.Equal(t, 1.00, *enriched["lightning bolt"].PreviousPriceUsd)
+	require.Equal(t, 1.10, *enriched["lightning bolt"].PreviousPriceUsd)
 	require.NotNil(t, enriched["lightning bolt"].PriceChangeUsd)
-	require.InDelta(t, 0.10, *enriched["lightning bolt"].PriceChangeUsd, 0.001)
+	require.InDelta(t, 0.05, *enriched["lightning bolt"].PriceChangeUsd, 0.001)
 	require.NotNil(t, enriched["lightning bolt"].PriceChangePercent)
-	require.Equal(t, 10, *enriched["lightning bolt"].PriceChangePercent)
+	require.Equal(t, 5, *enriched["lightning bolt"].PriceChangePercent)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When the CK pricelist download job (`ck-price-refresh-run`) is triggered more than once on the same UTC day, non-zero USD price-change values are no longer overwritten with `0`.

Current prices and listing metadata are still updated on re-runs, and non-zero recomputed deltas are still applied.

## Problem

A second same-day run compared each card's CK price against the price written by the earlier run. When the price had not moved since the first run, the recomputed daily change became `0`, wiping out the earlier non-zero daily move.

## Solution

On same-day re-runs, price changes are recomputed as usual. If the existing record already has a non-zero `priceChangeUsd` and the recomputed value would be `0` (or missing), the existing change fields are kept:

- `previousPriceUsd`
- `priceChangeUsd`
- `priceChangePercent`

If the recomputed change is non-zero, that updated value is used.

## Testing

- Added tests for same-day zero-preservation and same-day non-zero updates
- `make test` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30e1c1f5-c628-4772-9b9a-a28d380466c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30e1c1f5-c628-4772-9b9a-a28d380466c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

