### PR TITLE
Increase CK pricelist fetch timeout to 14 minutes

### DIFF
--- a/api/gateway/cardkingdom/pricelist_fetch.go
+++ b/api/gateway/cardkingdom/pricelist_fetch.go
@@ -23,8 +23,8 @@ const (
 	// The CK pricelist JSON is ~65MB (~150k products). Through CK_PRICELIST_PROXY
 	// the body can take several minutes after headers return; http.Client.Timeout
 	// covers the full round trip including body read.
-	ckPricelistFetchTimeout = 13 * time.Minute
-	ckPricelistHTTPTimeout  = 12 * time.Minute
+	ckPricelistFetchTimeout = 14 * time.Minute
+	ckPricelistHTTPTimeout  = 13 * time.Minute
 	// Emit body-read progress while large pricelist downloads stream through proxy.
 	ckPricelistBodyReadLogInterval = 15 * time.Second
 )

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -109,8 +109,8 @@ For Agora and 5 Mana, `SkipDirect` is cleared when the host is not the productio
 
 | Item | Value | Source | Notes |
 |------|--------|--------|--------|
-| CK pricelist HTTP timeout | 12m | `ckPricelistHTTPTimeout` in `api/gateway/cardkingdom/pricelist_fetch.go` | Bounds the full `DoOutboundGET` round trip, including streaming the ~65MB JSON body through `CK_PRICELIST_PROXY`. |
-| CK pricelist fetch timeout | 13m | `ckPricelistFetchTimeout` in `api/gateway/cardkingdom/pricelist_fetch.go` | Context deadline for download + JSON decode + cheapest-listing aggregation. |
+| CK pricelist HTTP timeout | 13m | `ckPricelistHTTPTimeout` in `api/gateway/cardkingdom/pricelist_fetch.go` | Bounds the full `DoOutboundGET` round trip, including streaming the ~65MB JSON body through `CK_PRICELIST_PROXY`. |
+| CK pricelist fetch timeout | 14m | `ckPricelistFetchTimeout` in `api/gateway/cardkingdom/pricelist_fetch.go` | Context deadline for download + JSON decode + cheapest-listing aggregation. |
 | CK pricelist body-read progress logs | every 15s | `ckPricelistBodyReadLogInterval` in `api/gateway/cardkingdom/pricelist_fetch.go` | Emits bytes read (and `%` when `Content-Length` is present) while the body streams. |
 
 ---


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Increases the Card Kingdom pricelist parsing timeout from 13 minutes to 14 minutes.

- `ckPricelistFetchTimeout`: 13m → 14m (context deadline for download + JSON decode + listing aggregation)
- `ckPricelistHTTPTimeout`: 12m → 13m (keeps a 1-minute buffer for parsing after the HTTP body finishes streaming)

## Testing

- `go test -mod=vendor -failfast -timeout 5m ./gateway/cardkingdom/...` — passed
- `make test` — cardkingdom tests passed; full suite hit an unrelated flaky `duellerpoint` live gateway timeout
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bebe6695-71f6-46df-b6dc-dbdb6217c486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bebe6695-71f6-46df-b6dc-dbdb6217c486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

