### PR TITLE
Try direct CK pricelist download before residential proxy fallback

### DIFF
--- a/api/gateway/cardkingdom/pricelist_fetch.go
+++ b/api/gateway/cardkingdom/pricelist_fetch.go
@@ -20,9 +20,9 @@ import (
 const (
 	defaultCKPricelistURL   = "https://api.cardkingdom.com/api/v2/pricelist"
 	ckPricelistErrorPrefix  = "ck price pricelist"
-	// The CK pricelist JSON is ~65MB (~150k products). Through CK_PRICELIST_PROXY
-	// the body can take several minutes after headers return; http.Client.Timeout
-	// covers the full round trip including body read.
+	// The CK pricelist JSON is ~65MB (~150k products). When the residential proxy
+	// fallback is used, the body can take several minutes after headers return;
+	// http.Client.Timeout covers the full round trip including body read.
 	ckPricelistFetchTimeout = 14 * time.Minute
 	ckPricelistHTTPTimeout  = 13 * time.Minute
 	// Emit body-read progress while large pricelist downloads stream through proxy.
@@ -194,18 +194,31 @@ func ckPricelistURL() string {
 }
 
 func ckPricelistOutboundOptions() gateway.OutboundRequestOptions {
-	opts := gateway.OutboundRequestOptions{
+	return gateway.OutboundRequestOptions{
 		Accept:         "application/json",
 		SkipWebBotAuth: true,
 	}
-	if proxyURL, ok := util.GetCKPricelistProxyURL(); ok {
-		opts.OnlyProxyURL = proxyURL
+}
+
+func ckPricelistResidentialProxyURL() (string, bool) {
+	if proxyURL, ok := util.GetResidentialProxyURL(); ok {
+		return proxyURL, true
 	}
-	return opts
+	return util.GetCKPricelistProxyURL()
 }
 
 func downloadCKPricelist(ctx context.Context, downloadURL string) (*ckPricelistPayload, error) {
 	resp, err := gateway.DoOutboundGET(ctx, downloadURL, ckPricelistOutboundOptions(), ckPricelistHTTPTimeout)
+	if err != nil {
+		proxyURL, ok := ckPricelistResidentialProxyURL()
+		if !ok {
+			return nil, fmt.Errorf("%s: download: %w", ckPricelistErrorPrefix, err)
+		}
+		log.Printf("ck price refresh: direct pricelist download failed, retrying via residential proxy")
+		proxyOpts := ckPricelistOutboundOptions()
+		proxyOpts.OnlyProxyURL = proxyURL
+		resp, err = gateway.DoOutboundGET(ctx, downloadURL, proxyOpts, ckPricelistHTTPTimeout)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("%s: download: %w", ckPricelistErrorPrefix, err)
 	}

--- a/api/gateway/cardkingdom/pricelist_fetch_test.go
+++ b/api/gateway/cardkingdom/pricelist_fetch_test.go
@@ -188,20 +188,39 @@ func TestCheapestListingsFromPricelist(t *testing.T) {
 	require.InDelta(t, 7.49, cheapest["the invincible iron man"].PriceUsd, 0.001)
 }
 
-func TestCKPricelistOutboundOptions_UsesConfiguredProxy(t *testing.T) {
+func TestCKPricelistOutboundOptions_UsesDirectFirst(t *testing.T) {
 	t.Setenv("CK_PRICELIST_PROXY", "res.proxy|8080|user|pass")
 
 	opts := ckPricelistOutboundOptions()
-	require.Equal(t, "http://user:pass@res.proxy:8080", opts.OnlyProxyURL)
+	require.Empty(t, opts.OnlyProxyURL)
 	require.Equal(t, "application/json", opts.Accept)
 	require.True(t, opts.SkipWebBotAuth)
 }
 
-func TestCKPricelistOutboundOptions_NoProxyWhenUnset(t *testing.T) {
+func TestCKPricelistResidentialProxyURL_PrefersResidential(t *testing.T) {
+	t.Setenv("RESIDENTIAL_PROXY_1", "res1.proxy|8080|user|pass")
+	t.Setenv("CK_PRICELIST_PROXY", "res2.proxy|8080|user|pass")
+
+	got, ok := ckPricelistResidentialProxyURL()
+	require.True(t, ok)
+	require.Equal(t, "http://user:pass@res1.proxy:8080", got)
+}
+
+func TestCKPricelistResidentialProxyURL_FallsBackToCKProxy(t *testing.T) {
+	t.Setenv("RESIDENTIAL_PROXY_1", "")
+	t.Setenv("CK_PRICELIST_PROXY", "res2.proxy|8080|user|pass")
+
+	got, ok := ckPricelistResidentialProxyURL()
+	require.True(t, ok)
+	require.Equal(t, "http://user:pass@res2.proxy:8080", got)
+}
+
+func TestCKPricelistResidentialProxyURL_Unset(t *testing.T) {
+	t.Setenv("RESIDENTIAL_PROXY_1", "")
 	t.Setenv("CK_PRICELIST_PROXY", "")
 
-	opts := ckPricelistOutboundOptions()
-	require.Empty(t, opts.OnlyProxyURL)
+	_, ok := ckPricelistResidentialProxyURL()
+	require.False(t, ok)
 }
 
 func TestFetchCheapestFromCKPricelist_FromTestServer(t *testing.T) {

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -109,7 +109,8 @@ For Agora and 5 Mana, `SkipDirect` is cleared when the host is not the productio
 
 | Item | Value | Source | Notes |
 |------|--------|--------|--------|
-| CK pricelist HTTP timeout | 13m | `ckPricelistHTTPTimeout` in `api/gateway/cardkingdom/pricelist_fetch.go` | Bounds the full `DoOutboundGET` round trip, including streaming the ~65MB JSON body through `CK_PRICELIST_PROXY`. |
+| CK pricelist transport | direct → residential | `downloadCKPricelist` in `api/gateway/cardkingdom/pricelist_fetch.go` | Tries direct egress first; on failure retries via `RESIDENTIAL_PROXY_1`, then `CK_PRICELIST_PROXY` when configured. |
+| CK pricelist HTTP timeout | 13m | `ckPricelistHTTPTimeout` in `api/gateway/cardkingdom/pricelist_fetch.go` | Bounds the full `DoOutboundGET` round trip, including streaming the ~65MB JSON body when the residential proxy fallback is used. |
 | CK pricelist fetch timeout | 14m | `ckPricelistFetchTimeout` in `api/gateway/cardkingdom/pricelist_fetch.go` | Context deadline for download + JSON decode + cheapest-listing aggregation. |
 | CK pricelist body-read progress logs | every 15s | `ckPricelistBodyReadLogInterval` in `api/gateway/cardkingdom/pricelist_fetch.go` | Emits bytes read (and `%` when `Content-Length` is present) while the body streams. |
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates CK pricelist download to try **direct egress first**, then retry via a **residential proxy** only when the direct attempt fails.

Residential proxy resolution order:
1. `RESIDENTIAL_PROXY_1`
2. `CK_PRICELIST_PROXY` (backward compatible fallback)

This avoids routing the full ~65MB pricelist through the proxy when direct access works (as verified in the cloud environment), while keeping a residential fallback for environments where Card Kingdom blocks direct egress.

## Changes

- `ckPricelistOutboundOptions()` no longer forces `OnlyProxyURL` up front
- `downloadCKPricelist()` retries with residential proxy on direct failure
- Added `ckPricelistResidentialProxyURL()` helper and unit tests
- Updated CK pricelist transport notes in `docs/search-strategies-retries-timeouts.md`

## Testing

- `go test -mod=vendor ./gateway/cardkingdom/... ./controller/ckprice/...`
- Full `make test` hit an unrelated live `gateway/cardaffinity` 503 on dedicated proxy

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-214a3709-f1e1-4199-b028-7d7531ad2247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-214a3709-f1e1-4199-b028-7d7531ad2247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

