### PR TITLE
Enable Agora via code constants instead of env vars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ frontend-dev:
 	cd frontend && npm install && npm run dev
 
 frontend-build: generate-signature-directory
-	cd frontend && npm install && AGORA_SEARCH_ENABLED=$${AGORA_SEARCH_ENABLED:-false} npm run build
+	cd frontend && npm install && npm run build
 
 SIGNATURE_DIRECTORY_BIN=.cache/signature-directory
 

--- a/api/controller/search.go
+++ b/api/controller/search.go
@@ -476,7 +476,7 @@ func initAndMapShops(lgs []string) map[string]gateway.LGS {
 
 	lgsMap := make(map[string]gateway.LGS, len(shopRegistry))
 	for _, shop := range shopRegistry {
-		if shop.name == agora.StoreName && !config.AgoraSearchEnabled() {
+		if shop.name == agora.StoreName && !config.AgoraSearchEnabled {
 			continue
 		}
 		if len(selectedLGS) > 0 {

--- a/api/controller/search_test.go
+++ b/api/controller/search_test.go
@@ -10,7 +10,6 @@ import (
 	"mtg-price-checker-sg/gateway/cardaffinity"
 	"mtg-price-checker-sg/gateway/cardscitadel"
 	"mtg-price-checker-sg/gateway/hideout"
-	"mtg-price-checker-sg/pkg/config"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -18,23 +17,7 @@ import (
 	"time"
 )
 
-func TestInitAndMapShops_SkipsAgoraWhenDisabled(t *testing.T) {
-	t.Setenv(config.AgoraSearchEnabledEnv, "false")
-	shops := initAndMapShops([]string{agora.StoreName, hideout.StoreName})
-
-	if len(shops) != 1 {
-		t.Fatalf("expected 1 shop after filtering disabled Agora, got %d", len(shops))
-	}
-	if _, ok := shops[agora.StoreName]; ok {
-		t.Fatalf("did not expect %q when Agora search is disabled", agora.StoreName)
-	}
-	if _, ok := shops[hideout.StoreName]; !ok {
-		t.Fatalf("expected %q to be included", hideout.StoreName)
-	}
-}
-
 func TestInitAndMapShops_FiltersByRequestedLGS(t *testing.T) {
-	t.Setenv(config.AgoraSearchEnabledEnv, "true")
 	shops := initAndMapShops([]string{agora.StoreName, hideout.StoreName})
 
 	if len(shops) != 2 {

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -25,9 +25,6 @@ const (
 	SearchAttemptTimeout = 5 * time.Second
 	// AgoraSearchAttemptTimeout is the per-attempt cap for Agora Hobby only.
 	AgoraSearchAttemptTimeout = 10 * time.Second
-	// AgoraSearchEnabledEnv toggles Agora Hobby search in the search Lambda.
-	// Defaults to disabled when unset or invalid.
-	AgoraSearchEnabledEnv = "AGORA_SEARCH_ENABLED"
 	// DynamicProxyEnv contains an authenticated proxy URL used for explicit
 	// dynamic-proxy fallback attempts, which BinderPOS reserves for the final
 	// two attempts after dedicated and direct/no-proxy scrap and decklist tries.
@@ -101,20 +98,8 @@ const (
 // When false, each request picks a random dedicated proxy instead of acquiring a lease.
 const UseLeasedDedicatedProxy = false
 
-// AgoraSearchEnabled reports whether Agora Hobby is included in search requests.
-func AgoraSearchEnabled() bool {
-	rawValue := strings.TrimSpace(os.Getenv(AgoraSearchEnabledEnv))
-	if rawValue == "" {
-		return false
-	}
-
-	enabled, err := strconv.ParseBool(rawValue)
-	if err != nil {
-		return false
-	}
-
-	return enabled
-}
+// AgoraSearchEnabled toggles Agora Hobby search in the search Lambda.
+const AgoraSearchEnabled = true
 
 func UseDynamicProxy() bool {
 	rawValue := strings.TrimSpace(os.Getenv(UseDynamicProxyEnv))

--- a/api/pkg/config/config_test.go
+++ b/api/pkg/config/config_test.go
@@ -5,33 +5,9 @@ import (
 )
 
 func TestAgoraSearchEnabled(t *testing.T) {
-	t.Run("defaults to disabled when unset", func(t *testing.T) {
-		t.Setenv(AgoraSearchEnabledEnv, "")
-		if AgoraSearchEnabled() {
-			t.Fatalf("expected agora search to be disabled by default")
-		}
-	})
-
-	t.Run("respects explicit true", func(t *testing.T) {
-		t.Setenv(AgoraSearchEnabledEnv, "true")
-		if !AgoraSearchEnabled() {
-			t.Fatalf("expected agora search to be enabled")
-		}
-	})
-
-	t.Run("respects explicit false", func(t *testing.T) {
-		t.Setenv(AgoraSearchEnabledEnv, "false")
-		if AgoraSearchEnabled() {
-			t.Fatalf("expected agora search to be disabled")
-		}
-	})
-
-	t.Run("defaults to disabled for invalid value", func(t *testing.T) {
-		t.Setenv(AgoraSearchEnabledEnv, "not-a-bool")
-		if AgoraSearchEnabled() {
-			t.Fatalf("expected invalid toggle to default to disabled")
-		}
-	})
+	if !AgoraSearchEnabled {
+		t.Fatalf("expected agora search to be enabled")
+	}
 }
 
 func TestUseDynamicProxy(t *testing.T) {

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -2,27 +2,8 @@
 
 const AGORA_STORE_NAME = "Agora Hobby";
 
-function parseBoolEnv(value, defaultValue = false) {
-  if (value === undefined || value === null || value === "") {
-    return defaultValue;
-  }
-
-  const normalized = String(value).trim().toLowerCase();
-  if (normalized === "true" || normalized === "1") {
-    return true;
-  }
-  if (normalized === "false" || normalized === "0") {
-    return false;
-  }
-
-  return defaultValue;
-}
-
-// Build-time toggle via AGORA_SEARCH_ENABLED (defaults to disabled).
-export const AGORA_SEARCH_ENABLED = parseBoolEnv(
-  import.meta.env.AGORA_SEARCH_ENABLED,
-  false,
-);
+// Toggle Agora Hobby in the store list and search UI.
+export const AGORA_SEARCH_ENABLED = true;
 
 export const PAGE_TITLE =
   "Gishath Fetch: MTG Price Checker for Singapore's LGS & Online Shops";

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -7,7 +7,7 @@ const signatureDirectoryMediaType =
 
 // https://vite.dev/config/
 export default defineConfig({
-  envPrefix: ["VITE_", "AGORA_"],
+  envPrefix: ["VITE_"],
   plugins: [
     react(),
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces the `AGORA_SEARCH_ENABLED` environment variable with compile-time constants on both backend and frontend, enabling Agora Hobby by default.

## Changes

- **Backend** (`api/pkg/config/config.go`): `const AgoraSearchEnabled = true`
- **Frontend** (`frontend/src/constants.js`): `export const AGORA_SEARCH_ENABLED = true`
- Removed `AGORA_` from Vite `envPrefix` and the Makefile build override
- Updated controller/config tests to match the new constant-based toggle

## How to disable later

Set the const to `false` in:
- `api/pkg/config/config.go` → `AgoraSearchEnabled`
- `frontend/src/constants.js` → `AGORA_SEARCH_ENABLED`

## Testing

- `go fix ./...`
- `go test ./controller/... ./pkg/config/...` — pass
- Full `make test` hit a flaky live Dueller's Point gateway timeout (unrelated)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7cee9f41-f820-41f9-8e96-3dd95c1dd786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7cee9f41-f820-41f9-8e96-3dd95c1dd786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

