### PR TITLE
Add Arcane Sanctum BinderPOS gateway package

### DIFF
--- a/api/gateway/arcanesanctum/search.go
+++ b/api/gateway/arcanesanctum/search.go
@@ -1,0 +1,34 @@
+package arcanesanctum
+
+import (
+	"context"
+
+	"mtg-price-checker-sg/gateway"
+	"mtg-price-checker-sg/gateway/binderpos"
+)
+
+const StoreName = "Arcane Sanctum"
+const StoreBaseURL = "https://arcanesanctumtcg.com"
+const StoreStorefrontAccessToken = "228ce7e7cffe6623f36634d0ca085e9e"
+const StoreShopifyDomain = "30uetm-1y.myshopify.com"
+const StoreSearchURL = "/search?q=%s"
+
+type Store struct {
+	Name         string
+	BaseUrl      string
+	SearchUrl    string
+	BinderposGwy binderpos.Gateway
+}
+
+func NewLGS() gateway.LGS {
+	return Store{
+		Name:         StoreName,
+		BaseUrl:      StoreBaseURL,
+		SearchUrl:    StoreSearchURL,
+		BinderposGwy: binderpos.New(),
+	}
+}
+
+func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, error) {
+	return s.BinderposGwy.Search(ctx, 2, s.Name, s.BaseUrl, StoreShopifyDomain, s.SearchUrl, searchStr, StoreStorefrontAccessToken)
+}

--- a/api/gateway/arcanesanctum/search_test.go
+++ b/api/gateway/arcanesanctum/search_test.go
@@ -1,0 +1,73 @@
+package arcanesanctum
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"mtg-price-checker-sg/gateway"
+	"mtg-price-checker-sg/gateway/gatewaytest"
+
+	"github.com/joho/godotenv"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	_ = godotenv.Load("../../.env")
+}
+
+func Test_Search(t *testing.T) {
+	s := NewLGS()
+	result, err := s.Search(context.Background(), "Reanimate")
+	gatewaytest.RequireSearchOrProbe(t, err, result, gatewaytest.CardExpect{
+		URLContains: StoreBaseURL + "/products/",
+		Source:      StoreName,
+	}, func(t *testing.T, ctx context.Context) {
+		requireArcaneSanctumStorefrontGraphQL(t, ctx)
+	})
+}
+
+// requireArcaneSanctumStorefrontGraphQL verifies the Shopify Storefront GraphQL
+// search endpoint still accepts the configured token. Arcane Sanctum's custom
+// theme does not expose BinderPOS HTML scrape markers, so GraphQL is the
+// reliable upstream probe when live inventory is empty.
+func requireArcaneSanctumStorefrontGraphQL(t *testing.T, ctx context.Context) {
+	t.Helper()
+
+	payload := []byte(`{"query":"query ($q: String!) { search(query: $q, first: 1, types: PRODUCT) { edges { node { ... on Product { title } } } } }","variables":{"q":"mtg"}}`)
+	resp, err := gateway.DoOutboundRoundTrip(ctx, gateway.OutboundRequestOptions{
+		Style: gateway.OutboundStyleJSON,
+	}, 20*time.Second, func() (*http.Request, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, StoreBaseURL+"/api/2024-10/graphql.json", bytes.NewReader(payload))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-Shopify-Storefront-Access-Token", StoreStorefrontAccessToken)
+		return req, nil
+	})
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := gateway.ReadResponseBody(resp)
+	require.NoError(t, err)
+
+	var parsed struct {
+		Data *struct {
+			Search *struct {
+				Edges []struct{} `json:"edges"`
+			} `json:"search"`
+		} `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	require.NoError(t, json.Unmarshal(body, &parsed))
+	require.Empty(t, parsed.Errors, "storefront graphql errors: %v", parsed.Errors)
+	require.NotNil(t, parsed.Data)
+	require.NotNil(t, parsed.Data.Search)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a new `api/gateway/arcanesanctum` package that wraps the existing BinderPOS gateway for [Arcane Sanctum](https://arcanesanctumtcg.com/).

- **Integration method:** BinderPOS scrap variant 2 with Shopify Storefront GraphQL
- **Shopify domain:** `30uetm-1y.myshopify.com`
- **Search path:** `/search?q=%s`

Controller `shopRegistry` and frontend `LGS_OPTIONS` are **intentionally unchanged** — the store is not yet wired into live search requests.

## Implementation notes

Arcane Sanctum uses a custom Shopify theme that does not expose standard BinderPOS HTML scrape markers (`data-product-variants`, `productCard__card`, etc.). Search therefore relies on Storefront GraphQL as the primary data source. The live test uses a GraphQL structure probe as fallback when inventory is empty, instead of the usual BinderPOS HTML structure probe.

## Testing

- `cd api && go test -mod=vendor -failfast -timeout 5m ./gateway/arcanesanctum/... ./controller/...`
- `make test` hit an unrelated transient timeout in `gateway/duellerpoint`

## Follow-up (not in this PR)

- Register in `api/controller/search.go` `shopRegistry`
- Add to `frontend/src/constants.js` `ALL_LGS_OPTIONS` / `LGS_MAP`
- Update `docs/search-strategies-retries-timeouts.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e95cb894-a3d2-4b49-aeb3-b59a098d80e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e95cb894-a3d2-4b49-aeb3-b59a098d80e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

