### PR TITLE
Add post-search multi-store filter

### DIFF
--- a/frontend/src/components/ResultFilters.jsx
+++ b/frontend/src/components/ResultFilters.jsx
@@ -10,9 +10,19 @@ const ResultFilters = ({
   onFoilOnlyChange,
   cheapestPerStore,
   onCheapestPerStoreChange,
+  availableStores,
+  selectedStores,
+  onToggleStore,
+  onSelectAllStores,
+  onSelectNoStores,
   hasActiveFilters,
   onClearFilters,
 }) => {
+  const allStoresSelected =
+    availableStores.length > 0 &&
+    selectedStores.length === availableStores.length;
+  const noStoresSelected = selectedStores.length === 0;
+
   return (
     <div className="mb-3 text-start result-filters rounded py-3 px-3">
       <div className="row g-2 align-items-end">
@@ -81,6 +91,68 @@ const ResultFilters = ({
           )}
         </div>
       </div>
+
+      {availableStores.length > 0 && (
+        <div className="mt-3 pt-3 border-top border-secondary-subtle">
+          <div className="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-2">
+            <Form.Label className="small fw-semibold mb-0">Stores</Form.Label>
+            <div className="d-flex flex-wrap align-items-center gap-2">
+              <fieldset className="store-selector-bulk-toggle border-0 p-0 m-0">
+                <legend className="visually-hidden">
+                  Select all or no stores in results
+                </legend>
+                <button
+                  type="button"
+                  className={`btn btn-sm store-selector-bulk-btn${
+                    allStoresSelected ? " is-active" : ""
+                  }`}
+                  aria-pressed={allStoresSelected}
+                  onClick={onSelectAllStores}
+                >
+                  All
+                </button>
+                <button
+                  type="button"
+                  className={`btn btn-sm store-selector-bulk-btn${
+                    noStoresSelected ? " is-active" : ""
+                  }`}
+                  aria-pressed={noStoresSelected}
+                  onClick={onSelectNoStores}
+                >
+                  None
+                </button>
+              </fieldset>
+              <span
+                className="store-selector-count text-muted small"
+                aria-live="polite"
+              >
+                {selectedStores.length} of {availableStores.length} selected
+              </span>
+            </div>
+          </div>
+
+          <fieldset className="store-selector-pills border-0 p-0 m-0">
+            <legend className="visually-hidden">Filter results by store</legend>
+            {availableStores.map((store) => {
+              const isSelected = selectedStores.includes(store);
+
+              return (
+                <button
+                  key={store}
+                  type="button"
+                  className={`btn btn-sm store-selector-pill${
+                    isSelected ? " is-selected" : ""
+                  }`}
+                  aria-pressed={isSelected}
+                  onClick={() => onToggleStore(store)}
+                >
+                  {store}
+                </button>
+              );
+            })}
+          </fieldset>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/SearchResults.jsx
+++ b/frontend/src/components/SearchResults.jsx
@@ -39,8 +39,8 @@ const EmptyFilteredState = ({ onClearFilters }) => (
   <div className="mb-3 text-center py-4 px-3">
     <div className="fw-semibold mb-2">No results match your filters</div>
     <p className="small text-muted mb-3">
-      Try a different condition, turning off foil only or cheapest per store, or
-      clear your filters.
+      Try a different condition, store selection, foil only, or cheapest per
+      store, or clear your filters.
     </p>
     <button
       type="button"
@@ -80,6 +80,11 @@ const SearchResults = ({
     setFoilOnly,
     cheapestPerStore,
     setCheapestPerStore,
+    availableStores,
+    selectedStores,
+    toggleStoreFilter,
+    selectAllStores,
+    selectNoStores,
     hasActiveFilters,
     clearFilters,
   } = useResultFilters(results, searchQuery);
@@ -211,6 +216,11 @@ const SearchResults = ({
                   onFoilOnlyChange={setFoilOnly}
                   cheapestPerStore={cheapestPerStore}
                   onCheapestPerStoreChange={setCheapestPerStore}
+                  availableStores={availableStores}
+                  selectedStores={selectedStores}
+                  onToggleStore={toggleStoreFilter}
+                  onSelectAllStores={selectAllStores}
+                  onSelectNoStores={selectNoStores}
                   hasActiveFilters={hasActiveFilters}
                   onClearFilters={clearFilters}
                 />

--- a/frontend/src/hooks/useResultFilters.js
+++ b/frontend/src/hooks/useResultFilters.js
@@ -8,6 +8,7 @@ export default function useResultFilters(results, searchQuery) {
   const [qualityFilter, setQualityFilter] = useState("all");
   const [foilOnly, setFoilOnly] = useState(false);
   const [cheapestPerStore, setCheapestPerStore] = useState(false);
+  const [storeFilter, setStoreFilter] = useState(null);
 
   // Reset filters when the user runs a new search.
   // biome-ignore lint/correctness/useExhaustiveDependencies: searchQuery triggers filter reset on new search
@@ -16,7 +17,20 @@ export default function useResultFilters(results, searchQuery) {
     setQualityFilter("all");
     setFoilOnly(false);
     setCheapestPerStore(false);
+    setStoreFilter(null);
   }, [searchQuery]);
+
+  const availableStores = useMemo(() => {
+    const stores = new Set();
+    for (const card of results) {
+      if (card.src) {
+        stores.add(card.src);
+      }
+    }
+    return [...stores].sort();
+  }, [results]);
+
+  const selectedStores = storeFilter ?? availableStores;
 
   const availableQualities = useMemo(() => {
     const qualities = new Set();
@@ -37,6 +51,11 @@ export default function useResultFilters(results, searchQuery) {
 
     if (foilOnly) {
       filtered = filtered.filter((card) => card.isFoil);
+    }
+
+    if (storeFilter !== null) {
+      const allowedStores = new Set(storeFilter);
+      filtered = filtered.filter((card) => allowedStores.has(card.src));
     }
 
     if (cheapestPerStore) {
@@ -66,15 +85,55 @@ export default function useResultFilters(results, searchQuery) {
     });
 
     return filtered;
-  }, [results, sortBy, qualityFilter, foilOnly, cheapestPerStore, searchQuery]);
+  }, [
+    results,
+    sortBy,
+    qualityFilter,
+    foilOnly,
+    storeFilter,
+    cheapestPerStore,
+    searchQuery,
+  ]);
+
+  const isStoreFilterActive =
+    storeFilter !== null && storeFilter.length < availableStores.length;
 
   const hasActiveFilters =
-    qualityFilter !== "all" || foilOnly || cheapestPerStore;
+    qualityFilter !== "all" ||
+    foilOnly ||
+    cheapestPerStore ||
+    isStoreFilterActive;
+
+  const toggleStoreFilter = (store) => {
+    const current = storeFilter ?? availableStores;
+    const next = current.includes(store)
+      ? current.filter((name) => name !== store)
+      : [...current, store];
+
+    if (
+      next.length === availableStores.length &&
+      availableStores.every((name) => next.includes(name))
+    ) {
+      setStoreFilter(null);
+      return;
+    }
+
+    setStoreFilter(next);
+  };
+
+  const selectAllStores = () => {
+    setStoreFilter(null);
+  };
+
+  const selectNoStores = () => {
+    setStoreFilter([]);
+  };
 
   const clearFilters = () => {
     setQualityFilter("all");
     setFoilOnly(false);
     setCheapestPerStore(false);
+    setStoreFilter(null);
   };
 
   return {
@@ -88,6 +147,12 @@ export default function useResultFilters(results, searchQuery) {
     setFoilOnly,
     cheapestPerStore,
     setCheapestPerStore,
+    availableStores,
+    selectedStores,
+    toggleStoreFilter,
+    selectAllStores,
+    selectNoStores,
+    isStoreFilterActive,
     hasActiveFilters,
     clearFilters,
   };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a post-search store filter so users can narrow displayed results by selecting one or more stores after a search completes.

- Store pills appear in the result filters bar, populated from stores present in the current results
- Supports multi-select via pill toggles, plus **All** / **None** bulk actions
- Integrates with existing filter state: resets on new search, counts toward "Showing X of Y", and clears with **Clear filters**
- Reuses existing `store-selector` pill styling for consistency with the pre-search store picker

## Screenshots

### Desktop

![Post-search store filter on desktop](https://cursor.com/artifacts/c/art-38e88166-0327-485e-924b-50cc705c6830)

### Mobile

![Post-search store filter on mobile](https://cursor.com/artifacts/c/art-3f11848d-71d7-440f-a072-bd9b8abc4fdb)

## Testing

- `npm run lint` (only pre-existing format warnings in unrelated files)
- `make test` — failed on unrelated flaky live gateway test (`gateway/duellerpoint` context deadline exceeded); no backend changes in this PR
- Manually verified store filter toggling, result count updates, and responsive layout on desktop and mobile

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-779c2504-4eb0-47e8-98e9-ef2894d4c8d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-779c2504-4eb0-47e8-98e9-ef2894d4c8d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

