### PR TITLE
Refactor Slack alert names to brand-agnostic terminology

### DIFF
--- a/api/controller/search.go
+++ b/api/controller/search.go
@@ -57,7 +57,7 @@ type StoreError struct {
 	StatusCode int    `json:"statusCode,omitempty"`
 }
 
-var sendSlackAlert = alert.SendSlackAlert
+var sendAlert = alert.SendAlert
 
 type shopSpec struct {
 	name        string
@@ -159,9 +159,9 @@ func fetchCardsConcurrently(ctx context.Context, searchString string, shops map[
 	}
 
 	wg.Wait()
-	cards, siteErrors, slackErrorMessages := aggregator.snapshot()
-	if len(slackErrorMessages) > 0 {
-		go sendSlackAlert(formatSlackErrorSummary(searchString, slackErrorMessages))
+	cards, siteErrors, alertErrorMessages := aggregator.snapshot()
+	if len(alertErrorMessages) > 0 {
+		go sendAlert(formatAlertErrorSummary(searchString, alertErrorMessages))
 	}
 	if len(siteErrors) > 0 {
 		log.Printf("Shops with errors for [%s]: %d", searchString, len(siteErrors))
@@ -179,7 +179,7 @@ type fetchResultAggregator struct {
 	mu                   sync.Mutex
 	cards                []gateway.Card
 	siteErrors           map[string]error
-	slackErrorMessages []string
+	alertErrorMessages []string
 	shopDurations        []shopSearchDuration
 }
 
@@ -187,7 +187,7 @@ func newFetchResultAggregator(shopCount int) *fetchResultAggregator {
 	return &fetchResultAggregator{
 		cards:                []gateway.Card{},
 		siteErrors:           make(map[string]error, shopCount),
-		slackErrorMessages: make([]string, 0, shopCount),
+		alertErrorMessages: make([]string, 0, shopCount),
 	}
 }
 
@@ -206,9 +206,9 @@ func (f *fetchResultAggregator) addSiteError(shopName string, err error) {
 	f.mu.Unlock()
 }
 
-func (f *fetchResultAggregator) addSlackErrorMessage(message string) {
+func (f *fetchResultAggregator) addAlertErrorMessage(message string) {
 	f.mu.Lock()
-	f.slackErrorMessages = append(f.slackErrorMessages, message)
+	f.alertErrorMessages = append(f.alertErrorMessages, message)
 	f.mu.Unlock()
 }
 
@@ -231,9 +231,9 @@ func (f *fetchResultAggregator) snapshot() ([]gateway.Card, map[string]error, []
 	cards := append([]gateway.Card(nil), f.cards...)
 	siteErrors := make(map[string]error, len(f.siteErrors))
 	maps.Copy(siteErrors, f.siteErrors)
-	slackErrorMessages := append([]string(nil), f.slackErrorMessages...)
+	alertErrorMessages := append([]string(nil), f.alertErrorMessages...)
 
-	return cards, siteErrors, slackErrorMessages
+	return cards, siteErrors, alertErrorMessages
 }
 
 func searchShop(
@@ -280,7 +280,7 @@ func recoverShopPanic(shopName string, aggregator *fetchResultAggregator) {
 		errMsg := fmt.Sprintf("Recovered from panic in shop [%s]: %v", shopName, r)
 		log.Println(errMsg)
 		aggregator.addSiteError(shopName, fmt.Errorf("panic: %v", r))
-		aggregator.addSlackErrorMessage(errMsg)
+		aggregator.addAlertErrorMessage(errMsg)
 	}
 }
 
@@ -293,7 +293,7 @@ func recordShopSearchError(searchString, shopName string, err error, aggregator 
 			gateway.EnsureHTTPStatusInErrorMessage(err.Error()),
 		)
 		log.Println(errMsg)
-		aggregator.addSlackErrorMessage(errMsg)
+		aggregator.addAlertErrorMessage(errMsg)
 	}
 	aggregator.addSiteError(shopName, err)
 }
@@ -318,7 +318,7 @@ func formatShopSearchSummary(searchString string, totalDuration time.Duration, s
 	)
 }
 
-func formatSlackErrorSummary(searchString string, errorMessages []string) string {
+func formatAlertErrorSummary(searchString string, errorMessages []string) string {
 	sortedMessages := append([]string(nil), errorMessages...)
 	sort.Strings(sortedMessages)
 

--- a/api/controller/search_test.go
+++ b/api/controller/search_test.go
@@ -546,7 +546,7 @@ func TestFetchCardsConcurrently_ConcurrentSearchesGetDistinctDedicatedProxies(t 
 	}
 }
 
-func TestFetchCardsConcurrently_CollatesSlackErrors(t *testing.T) {
+func TestFetchCardsConcurrently_CollatesAlertErrors(t *testing.T) {
 	shops := map[string]gateway.LGS{
 		"ErrorShopA": &MockLGS{
 			SearchFunc: func(ctx context.Context, searchStr string) ([]gateway.Card, error) {
@@ -569,8 +569,8 @@ func TestFetchCardsConcurrently_CollatesSlackErrors(t *testing.T) {
 	alertMessages := make([]string, 0, 1)
 	alertDone := make(chan struct{}, 1)
 
-	originalSendSlackAlert := sendSlackAlert
-	sendSlackAlert = func(message string) {
+	originalSendAlert := sendAlert
+	sendAlert = func(message string) {
 		mu.Lock()
 		alertMessages = append(alertMessages, message)
 		mu.Unlock()
@@ -580,7 +580,7 @@ func TestFetchCardsConcurrently_CollatesSlackErrors(t *testing.T) {
 		}
 	}
 	t.Cleanup(func() {
-		sendSlackAlert = originalSendSlackAlert
+		sendAlert = originalSendAlert
 	})
 
 	_, siteErrors := fetchCardsConcurrently(context.Background(), "Abrade", shops)
@@ -591,7 +591,7 @@ func TestFetchCardsConcurrently_CollatesSlackErrors(t *testing.T) {
 	select {
 	case <-alertDone:
 	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for collated slack alert")
+		t.Fatal("timed out waiting for collated alert")
 	}
 
 	time.Sleep(50 * time.Millisecond)
@@ -617,7 +617,7 @@ func TestFetchCardsConcurrently_CollatesSlackErrors(t *testing.T) {
 	}
 }
 
-func TestFetchCardsConcurrently_ReportsPerSiteTimeoutToSlack(t *testing.T) {
+func TestFetchCardsConcurrently_ReportsPerSiteTimeoutToAlert(t *testing.T) {
 	shops := map[string]gateway.LGS{
 		"Timeout Shop": &MockLGS{
 			SearchFunc: func(ctx context.Context, searchStr string) ([]gateway.Card, error) {
@@ -630,8 +630,8 @@ func TestFetchCardsConcurrently_ReportsPerSiteTimeoutToSlack(t *testing.T) {
 	alertMessages := make([]string, 0, 1)
 	alertDone := make(chan struct{}, 1)
 
-	originalSendSlackAlert := sendSlackAlert
-	sendSlackAlert = func(message string) {
+	originalSendAlert := sendAlert
+	sendAlert = func(message string) {
 		mu.Lock()
 		alertMessages = append(alertMessages, message)
 		mu.Unlock()
@@ -641,7 +641,7 @@ func TestFetchCardsConcurrently_ReportsPerSiteTimeoutToSlack(t *testing.T) {
 		}
 	}
 	t.Cleanup(func() {
-		sendSlackAlert = originalSendSlackAlert
+		sendAlert = originalSendAlert
 	})
 
 	_, siteErrors := fetchCardsConcurrently(context.Background(), "Abrade", shops)
@@ -655,7 +655,7 @@ func TestFetchCardsConcurrently_ReportsPerSiteTimeoutToSlack(t *testing.T) {
 	select {
 	case <-alertDone:
 	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for timeout slack alert")
+		t.Fatal("timed out waiting for timeout alert")
 	}
 
 	time.Sleep(50 * time.Millisecond)
@@ -670,7 +670,7 @@ func TestFetchCardsConcurrently_ReportsPerSiteTimeoutToSlack(t *testing.T) {
 	}
 }
 
-func TestFetchCardsConcurrently_SkipsCanceledForSlack(t *testing.T) {
+func TestFetchCardsConcurrently_SkipsCanceledForAlert(t *testing.T) {
 	shops := map[string]gateway.LGS{
 		"Canceled Shop": &MockLGS{
 			SearchFunc: func(ctx context.Context, searchStr string) ([]gateway.Card, error) {
@@ -680,15 +680,15 @@ func TestFetchCardsConcurrently_SkipsCanceledForSlack(t *testing.T) {
 	}
 
 	alertSent := make(chan struct{}, 1)
-	originalSendSlackAlert := sendSlackAlert
-	sendSlackAlert = func(message string) {
+	originalSendAlert := sendAlert
+	sendAlert = func(message string) {
 		select {
 		case alertSent <- struct{}{}:
 		default:
 		}
 	}
 	t.Cleanup(func() {
-		sendSlackAlert = originalSendSlackAlert
+		sendAlert = originalSendAlert
 	})
 
 	_, siteErrors := fetchCardsConcurrently(context.Background(), "Abrade", shops)
@@ -701,7 +701,7 @@ func TestFetchCardsConcurrently_SkipsCanceledForSlack(t *testing.T) {
 
 	select {
 	case <-alertSent:
-		t.Fatal("did not expect slack alert for canceled search")
+		t.Fatal("did not expect alert for canceled search")
 	case <-time.After(200 * time.Millisecond):
 	}
 }
@@ -793,8 +793,8 @@ func TestFormatShopSearchSummary(t *testing.T) {
 	}
 }
 
-func TestFormatSlackErrorSummary(t *testing.T) {
-	got := formatSlackErrorSummary("Uro, Titan of Nature's Wrath", []string{
+func TestFormatAlertErrorSummary(t *testing.T) {
+	got := formatAlertErrorSummary("Uro, Titan of Nature's Wrath", []string{
 		"Error encountered searching [Tefuda] for [Uro, Titan of Nature's Wrath]: attempt 3 (scrap-direct): 503 Service Unavailable (proxy_mode=direct proxy=none)",
 		"Error encountered searching [Hideout] for [Uro, Titan of Nature's Wrath]: attempt 2 (scrap-direct): 503 Service Unavailable (proxy_mode=direct proxy=none)",
 		"Recovered from panic in shop [ShopPanic]: panic value",

--- a/api/handler/analytics_keywords.go
+++ b/api/handler/analytics_keywords.go
@@ -30,10 +30,10 @@ func runAnalyticsKeywordsExport(ctx context.Context) (err error) {
 
 	defer func() {
 		if err != nil {
-			sendJobSlackAlert(formatAnalyticsKeywordsExportFailure(err))
+			sendJobAlert(formatAnalyticsKeywordsExportFailure(err))
 			return
 		}
-		sendJobSlackAlert(formatAnalyticsKeywordsExportSuccess(generatedAt))
+		sendJobAlert(formatAnalyticsKeywordsExportSuccess(generatedAt))
 	}()
 
 	reporter, err := newGA4ReporterFunc(ctx)

--- a/api/handler/analytics_keywords_test.go
+++ b/api/handler/analytics_keywords_test.go
@@ -16,15 +16,15 @@ func TestHandle_RoutesAnalyticsKeywordsExportRun(t *testing.T) {
 	originalReporterFunc := newGA4ReporterFunc
 	originalBuildFunc := buildAnalyticsKeywordsReportFunc
 	originalWriterFunc := newAnalyticsReportWriterFunc
-	originalAlertFunc := sendJobSlackAlert
+	originalAlertFunc := sendJobAlert
 	defer func() {
 		newGA4ReporterFunc = originalReporterFunc
 		buildAnalyticsKeywordsReportFunc = originalBuildFunc
 		newAnalyticsReportWriterFunc = originalWriterFunc
-		sendJobSlackAlert = originalAlertFunc
+		sendJobAlert = originalAlertFunc
 	}()
 
-	sendJobSlackAlert = func(string) {}
+	sendJobAlert = func(string) {}
 
 	writer := &mockAnalyticsWriter{}
 	newGA4ReporterFunc = func(_ context.Context) (ga4.Reporter, error) {
@@ -54,20 +54,20 @@ func TestHandle_RoutesAnalyticsKeywordsExportRun(t *testing.T) {
 	}
 }
 
-func TestRunAnalyticsKeywordsExport_SendsSuccessSlackAlert(t *testing.T) {
+func TestRunAnalyticsKeywordsExport_SendsSuccessAlert(t *testing.T) {
 	originalReporterFunc := newGA4ReporterFunc
 	originalBuildFunc := buildAnalyticsKeywordsReportFunc
 	originalWriterFunc := newAnalyticsReportWriterFunc
-	originalAlertFunc := sendJobSlackAlert
+	originalAlertFunc := sendJobAlert
 	defer func() {
 		newGA4ReporterFunc = originalReporterFunc
 		buildAnalyticsKeywordsReportFunc = originalBuildFunc
 		newAnalyticsReportWriterFunc = originalWriterFunc
-		sendJobSlackAlert = originalAlertFunc
+		sendJobAlert = originalAlertFunc
 	}()
 
 	var gotAlert string
-	sendJobSlackAlert = func(message string) {
+	sendJobAlert = func(message string) {
 		gotAlert = message
 	}
 
@@ -95,21 +95,21 @@ func TestRunAnalyticsKeywordsExport_SendsSuccessSlackAlert(t *testing.T) {
 
 	want := "Analytics keywords export finished: generatedAt=2026-07-11T12:00:00Z"
 	if gotAlert != want {
-		t.Fatalf("slack alert = %q, want %q", gotAlert, want)
+		t.Fatalf("alert = %q, want %q", gotAlert, want)
 	}
 }
 
-func TestRunAnalyticsKeywordsExport_SendsFailureSlackAlert(t *testing.T) {
+func TestRunAnalyticsKeywordsExport_SendsFailureAlert(t *testing.T) {
 	originalReporterFunc := newGA4ReporterFunc
-	originalAlertFunc := sendJobSlackAlert
+	originalAlertFunc := sendJobAlert
 	defer func() {
 		newGA4ReporterFunc = originalReporterFunc
-		sendJobSlackAlert = originalAlertFunc
+		sendJobAlert = originalAlertFunc
 	}()
 
 	reportErr := errors.New("ga4 credentials missing")
 	var gotAlert string
-	sendJobSlackAlert = func(message string) {
+	sendJobAlert = func(message string) {
 		gotAlert = message
 	}
 	newGA4ReporterFunc = func(_ context.Context) (ga4.Reporter, error) {
@@ -122,7 +122,7 @@ func TestRunAnalyticsKeywordsExport_SendsFailureSlackAlert(t *testing.T) {
 
 	want := "Analytics keywords export failed: ga4 credentials missing"
 	if gotAlert != want {
-		t.Fatalf("slack alert = %q, want %q", gotAlert, want)
+		t.Fatalf("alert = %q, want %q", gotAlert, want)
 	}
 }
 

--- a/api/handler/ck_refresh.go
+++ b/api/handler/ck_refresh.go
@@ -32,10 +32,10 @@ func runCKPriceRefresh(ctx context.Context) (err error) {
 
 	defer func() {
 		if err != nil {
-			sendJobSlackAlert(formatCKPriceRefreshFailure(err))
+			sendJobAlert(formatCKPriceRefreshFailure(err))
 			return
 		}
-		sendJobSlackAlert(formatCKPriceRefreshSuccess(refreshedCount, topCount, bottomCount, generatedAt))
+		sendJobAlert(formatCKPriceRefreshSuccess(refreshedCount, topCount, bottomCount, generatedAt))
 	}()
 
 	store, err := newCKRefreshStoreFunc(ctx)

--- a/api/handler/ck_refresh_test.go
+++ b/api/handler/ck_refresh_test.go
@@ -12,22 +12,22 @@ import (
 	"mtg-price-checker-sg/store/ckprices"
 )
 
-func TestRunCKPriceRefresh_SendsSuccessSlackAlert(t *testing.T) {
+func TestRunCKPriceRefresh_SendsSuccessAlert(t *testing.T) {
 	originalStoreFunc := newCKRefreshStoreFunc
 	originalRefreshFunc := refreshCKPricesFunc
 	originalWriterFunc := newCKPriceReportWriterFunc
 	originalNowFunc := ckPriceReportNowFunc
-	originalAlertFunc := sendJobSlackAlert
+	originalAlertFunc := sendJobAlert
 	defer func() {
 		newCKRefreshStoreFunc = originalStoreFunc
 		refreshCKPricesFunc = originalRefreshFunc
 		newCKPriceReportWriterFunc = originalWriterFunc
 		ckPriceReportNowFunc = originalNowFunc
-		sendJobSlackAlert = originalAlertFunc
+		sendJobAlert = originalAlertFunc
 	}()
 
 	var gotAlert string
-	sendJobSlackAlert = func(message string) {
+	sendJobAlert = func(message string) {
 		gotAlert = message
 	}
 
@@ -59,23 +59,23 @@ func TestRunCKPriceRefresh_SendsSuccessSlackAlert(t *testing.T) {
 
 	want := "CK price refresh finished: refreshed=42, top=1, bottom=1, generatedAt=2026-07-11T12:00:00Z"
 	if gotAlert != want {
-		t.Fatalf("slack alert = %q, want %q", gotAlert, want)
+		t.Fatalf("alert = %q, want %q", gotAlert, want)
 	}
 }
 
-func TestRunCKPriceRefresh_SendsFailureSlackAlert(t *testing.T) {
+func TestRunCKPriceRefresh_SendsFailureAlert(t *testing.T) {
 	originalRefreshFunc := refreshCKPricesFunc
 	originalStoreFunc := newCKRefreshStoreFunc
-	originalAlertFunc := sendJobSlackAlert
+	originalAlertFunc := sendJobAlert
 	defer func() {
 		refreshCKPricesFunc = originalRefreshFunc
 		newCKRefreshStoreFunc = originalStoreFunc
-		sendJobSlackAlert = originalAlertFunc
+		sendJobAlert = originalAlertFunc
 	}()
 
 	refreshErr := errors.New("card kingdom pricelist download failed")
 	var gotAlert string
-	sendJobSlackAlert = func(message string) {
+	sendJobAlert = func(message string) {
 		gotAlert = message
 	}
 	newCKRefreshStoreFunc = func(_ context.Context) (ckprices.Store, error) {
@@ -91,7 +91,7 @@ func TestRunCKPriceRefresh_SendsFailureSlackAlert(t *testing.T) {
 
 	want := "CK price refresh failed: card kingdom pricelist download failed"
 	if gotAlert != want {
-		t.Fatalf("slack alert = %q, want %q", gotAlert, want)
+		t.Fatalf("alert = %q, want %q", gotAlert, want)
 	}
 }
 
@@ -132,16 +132,16 @@ func TestHandle_RoutesCKPriceRefreshRun(t *testing.T) {
 	originalRefreshFunc := refreshCKPricesFunc
 	originalWriterFunc := newCKPriceReportWriterFunc
 	originalNowFunc := ckPriceReportNowFunc
-	originalAlertFunc := sendJobSlackAlert
+	originalAlertFunc := sendJobAlert
 	defer func() {
 		newCKRefreshStoreFunc = originalStoreFunc
 		refreshCKPricesFunc = originalRefreshFunc
 		newCKPriceReportWriterFunc = originalWriterFunc
 		ckPriceReportNowFunc = originalNowFunc
-		sendJobSlackAlert = originalAlertFunc
+		sendJobAlert = originalAlertFunc
 	}()
 
-	sendJobSlackAlert = func(string) {}
+	sendJobAlert = func(string) {}
 
 	writer := &mockCKPriceReportWriter{}
 	newCKRefreshStoreFunc = func(_ context.Context) (ckprices.Store, error) {

--- a/api/handler/job_alert.go
+++ b/api/handler/job_alert.go
@@ -6,7 +6,7 @@ import (
 	"mtg-price-checker-sg/pkg/alert"
 )
 
-var sendJobSlackAlert = alert.SendJobSlackAlert
+var sendJobAlert = alert.SendJobAlert
 
 func formatCKPriceRefreshSuccess(refreshedCount, topCount, bottomCount int, generatedAt string) string {
 	return fmt.Sprintf(

--- a/api/pkg/alert/webhook.go
+++ b/api/pkg/alert/webhook.go
@@ -9,51 +9,51 @@ import (
 )
 
 const (
-	SlackAlertWebhookEnv    = "SLACK_ALERT_WEBHOOK"
-	SlackJobWebhookURLEnv   = "SLACK_JOB_WEBHOOK"
+	AlertWebhookEnv    = "SLACK_ALERT_WEBHOOK"
+	JobAlertWebhookEnv = "SLACK_JOB_WEBHOOK"
 )
 
-type SlackPayload struct {
+type WebhookPayload struct {
 	Text string `json:"text"`
 }
 
-// SendSlackAlert sends a message to the search-error Slack webhook.
+// SendAlert sends a message to the search-error alert webhook.
 // It is fire-and-forget; errors are logged but not returned to disrupt the main flow.
-func SendSlackAlert(message string) {
-	sendSlackWebhook(SlackAlertWebhookEnv, message)
+func SendAlert(message string) {
+	sendWebhookAlert(AlertWebhookEnv, message)
 }
 
-// SendJobSlackAlert sends a message to the scheduled-job Slack webhook.
+// SendJobAlert sends a message to the scheduled-job alert webhook.
 // It is fire-and-forget; errors are logged but not returned to disrupt the main flow.
-func SendJobSlackAlert(message string) {
-	sendSlackWebhook(SlackJobWebhookURLEnv, message)
+func SendJobAlert(message string) {
+	sendWebhookAlert(JobAlertWebhookEnv, message)
 }
 
-func sendSlackWebhook(webhookURLEnv, message string) {
+func sendWebhookAlert(webhookURLEnv, message string) {
 	webhookURL := os.Getenv(webhookURLEnv)
 	if webhookURL == "" {
 		log.Printf("%s not set, skipping alert", webhookURLEnv)
 		return
 	}
 
-	payload := SlackPayload{
+	payload := WebhookPayload{
 		Text: message,
 	}
 
 	jsonPayload, err := json.Marshal(payload)
 	if err != nil {
-		log.Printf("Failed to marshal slack payload: %v", err)
+		log.Printf("Failed to marshal alert payload: %v", err)
 		return
 	}
 
 	resp, err := http.Post(webhookURL, "application/json", bytes.NewBuffer(jsonPayload))
 	if err != nil {
-		log.Printf("Failed to send slack alert: %v", err)
+		log.Printf("Failed to send alert: %v", err)
 		return
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		log.Printf("Slack API returned non-2xx status: %d", resp.StatusCode)
+		log.Printf("Alert webhook returned non-2xx status: %d", resp.StatusCode)
 	}
 }

--- a/api/pkg/alert/webhook_test.go
+++ b/api/pkg/alert/webhook_test.go
@@ -14,15 +14,15 @@ func init() {
 	_ = godotenv.Load("../../.env")
 }
 
-func TestSendSlackAlert(t *testing.T) {
-	testSendSlackWebhook(t, SlackAlertWebhookEnv, SendSlackAlert)
+func TestSendAlert(t *testing.T) {
+	testSendWebhookAlert(t, AlertWebhookEnv, SendAlert)
 }
 
-func TestSendJobSlackAlert(t *testing.T) {
-	testSendSlackWebhook(t, SlackJobWebhookURLEnv, SendJobSlackAlert)
+func TestSendJobAlert(t *testing.T) {
+	testSendWebhookAlert(t, JobAlertWebhookEnv, SendJobAlert)
 }
 
-func testSendSlackWebhook(t *testing.T, webhookURLEnv string, sendAlert func(string)) {
+func testSendWebhookAlert(t *testing.T, webhookURLEnv string, sendAlert func(string)) {
 	t.Helper()
 
 	t.Run("Success", func(t *testing.T) {
@@ -34,7 +34,7 @@ func testSendSlackWebhook(t *testing.T, webhookURLEnv string, sendAlert func(str
 				t.Errorf("Expected Content-Type application/json, got %s", r.Header.Get("Content-Type"))
 			}
 
-			var payload SlackPayload
+			var payload WebhookPayload
 			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 				t.Errorf("Failed to decode request body: %v", err)
 			}
@@ -67,20 +67,20 @@ func testSendSlackWebhook(t *testing.T, webhookURLEnv string, sendAlert func(str
 	})
 }
 
-func TestSendSlackAlert_Integration(t *testing.T) {
-	webhookURL := os.Getenv(SlackAlertWebhookEnv)
+func TestSendAlert_Integration(t *testing.T) {
+	webhookURL := os.Getenv(AlertWebhookEnv)
 	if webhookURL == "" {
 		t.Skip("SLACK_ALERT_WEBHOOK not set, skipping integration test")
 	}
 
-	SendSlackAlert("Integration Test Message (Ignore this)")
+	SendAlert("Integration Test Message (Ignore this)")
 }
 
-func TestSendJobSlackAlert_Integration(t *testing.T) {
-	webhookURL := os.Getenv(SlackJobWebhookURLEnv)
+func TestSendJobAlert_Integration(t *testing.T) {
+	webhookURL := os.Getenv(JobAlertWebhookEnv)
 	if webhookURL == "" {
 		t.Skip("SLACK_JOB_WEBHOOK not set, skipping integration test")
 	}
 
-	SendJobSlackAlert("Integration Test Message (Ignore this)")
+	SendJobAlert("Integration Test Message (Ignore this)")
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Renames Slack-specific alert functions, variables, and types to brand-agnostic terminology so switching notification providers later only requires changes in the alert package.

Environment variable names (`SLACK_ALERT_WEBHOOK`, `SLACK_JOB_WEBHOOK`) are unchanged.

## Changes

### `api/pkg/alert/`
- Renamed `slack.go` → `webhook.go`, `slack_test.go` → `webhook_test.go`
- `SendSlackAlert` → `SendAlert`
- `SendJobSlackAlert` → `SendJobAlert`
- `SlackPayload` → `WebhookPayload`
- `SlackAlertWebhookEnv` → `AlertWebhookEnv` (value still `SLACK_ALERT_WEBHOOK`)
- `SlackJobWebhookURLEnv` → `JobAlertWebhookEnv` (value still `SLACK_JOB_WEBHOOK`)

### Call sites
- `controller/search.go`: `sendAlert`, `alertErrorMessages`, `formatAlertErrorSummary`, etc.
- `handler/job_alert.go`: `sendJobAlert`
- Updated related tests to match new names

## Testing

- `make test` (full suite)
- `go test -mod=vendor -failfast -timeout 5m ./pkg/alert/... ./handler/... ./controller/...`
- `go fix ./...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d93262ec-7155-4ac4-8ad5-707c39c069d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d93262ec-7155-4ac4-8ad5-707c39c069d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

