### PR TITLE
Filter CK risers/drops export to current pricelist keys

### DIFF
--- a/api/controller/ckprice/ckprice.go
+++ b/api/controller/ckprice/ckprice.go
@@ -76,14 +76,20 @@ func listingIsFresh(listing *cardkingdom.Listing, now time.Time) bool {
 	return !now.After(freshnessTime.Add(config.CKPriceMaxAge))
 }
 
+// RefreshResult is the outcome of a Card Kingdom pricelist download and DynamoDB upsert.
+type RefreshResult struct {
+	ListingCount int
+	Listings     map[string]cardkingdom.Listing
+}
+
 // RefreshPrices downloads Card Kingdom retail prices from the CK pricelist API and upserts the DynamoDB index.
-func RefreshPrices(ctx context.Context, store ckprices.Store) (int, error) {
+func RefreshPrices(ctx context.Context, store ckprices.Store) (*RefreshResult, error) {
 	log.Printf("ck price refresh: fetching card kingdom pricelist")
 	fetchStarted := time.Now()
 
 	listings, err := fetchCheapestFunc(ctx)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 
 	log.Printf("ck price refresh: fetched card kingdom pricelist listings=%d duration=%s", len(listings), time.Since(fetchStarted).Round(time.Millisecond))
@@ -92,9 +98,12 @@ func RefreshPrices(ctx context.Context, store ckprices.Store) (int, error) {
 	writeStarted := time.Now()
 	syncedAt, err := store.PutAll(ctx, listings)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 	log.Printf("ck price refresh: wrote dynamodb listings=%d syncedAt=%s duration=%s", len(listings), syncedAt, time.Since(writeStarted).Round(time.Millisecond))
 
-	return len(listings), nil
+	return &RefreshResult{
+		ListingCount: len(listings),
+		Listings:     listings,
+	}, nil
 }

--- a/api/controller/ckprice/ckprice.go
+++ b/api/controller/ckprice/ckprice.go
@@ -102,6 +102,17 @@ func RefreshPrices(ctx context.Context, store ckprices.Store) (*RefreshResult, e
 	}
 	log.Printf("ck price refresh: wrote dynamodb listings=%d syncedAt=%s duration=%s", len(listings), syncedAt, time.Since(writeStarted).Round(time.Millisecond))
 
+	deleteStarted := time.Now()
+	deleted, err := store.DeleteListingsNotInPricelist(ctx, listings)
+	if err != nil {
+		return nil, err
+	}
+	log.Printf(
+		"ck price refresh: deleted dynamodb listings not in pricelist count=%d duration=%s",
+		deleted,
+		time.Since(deleteStarted).Round(time.Millisecond),
+	)
+
 	return &RefreshResult{
 		ListingCount: len(listings),
 		Listings:     listings,

--- a/api/controller/ckprice/ckprice_test.go
+++ b/api/controller/ckprice/ckprice_test.go
@@ -37,6 +37,10 @@ func (m *mockStore) PutAll(_ context.Context, _ map[string]cardkingdom.Listing) 
 	return "", nil
 }
 
+func (m *mockStore) DeleteListingsNotInPricelist(_ context.Context, _ map[string]cardkingdom.Listing) (int, error) {
+	return 0, nil
+}
+
 func TestGetLatestPrice_UsesVerifiedName(t *testing.T) {
 	originalVerify := verifyCardNameFunc
 	defer func() { verifyCardNameFunc = originalVerify }()

--- a/api/handler/ck_refresh.go
+++ b/api/handler/ck_refresh.go
@@ -44,15 +44,16 @@ func runCKPriceRefresh(ctx context.Context) (err error) {
 		return err
 	}
 
-	refreshedCount, err = refreshCKPricesFunc(ctx, store)
+	refreshResult, err := refreshCKPricesFunc(ctx, store)
 	if err != nil {
 		log.Printf("ck price refresh: failed: %v", err)
 		return err
 	}
+	refreshedCount = refreshResult.ListingCount
 
 	log.Printf("ck price refresh: finished refreshed=%d", refreshedCount)
 
-	changes, err := store.GetTopBottomPriceChanges(ctx)
+	changes, err := ckprices.TopBottomPriceChangesInPricelist(ctx, store, refreshResult.Listings)
 	if err != nil {
 		log.Printf("ck price refresh: failed reading price changes: %v", err)
 		return err

--- a/api/handler/ck_refresh_test.go
+++ b/api/handler/ck_refresh_test.go
@@ -150,6 +150,10 @@ func (m *mockCKRefreshStore) PutAll(_ context.Context, _ map[string]cardkingdom.
 	return "", nil
 }
 
+func (m *mockCKRefreshStore) DeleteListingsNotInPricelist(_ context.Context, _ map[string]cardkingdom.Listing) (int, error) {
+	return 0, nil
+}
+
 type mockCKPriceReportWriter struct {
 	written bool
 }

--- a/api/handler/ck_refresh_test.go
+++ b/api/handler/ck_refresh_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"mtg-price-checker-sg/controller/ckprice"
 	"mtg-price-checker-sg/gateway/cardkingdom"
 	"mtg-price-checker-sg/store/ckpricereport"
 	"mtg-price-checker-sg/store/ckprices"
@@ -32,16 +33,38 @@ func TestRunCKPriceRefresh_SendsSuccessAlert(t *testing.T) {
 	}
 
 	writer := &mockCKPriceReportWriter{}
+	pricelist := map[string]cardkingdom.Listing{
+		"bolt":         {CardName: "Lightning Bolt", PriceUsd: 1.25},
+		"counterspell": {CardName: "Counterspell", PriceUsd: 0.75},
+	}
 	newCKRefreshStoreFunc = func(_ context.Context) (ckprices.Store, error) {
 		return &mockCKRefreshStore{
-			changes: &ckprices.TopBottomPriceChanges{
-				Top:    []ckprices.PriceChangeListing{{NameKey: "bolt"}},
-				Bottom: []ckprices.PriceChangeListing{{NameKey: "counterspell"}},
+			priceChangesByUsd: map[bool][]ckprices.PriceChangeListing{
+				false: {
+					{
+						NameKey: "bolt",
+						Listing: cardkingdom.Listing{
+							CardName:       "Lightning Bolt",
+							PriceUsd:       1.25,
+							PriceChangeUsd: new(0.16),
+						},
+					},
+				},
+				true: {
+					{
+						NameKey: "counterspell",
+						Listing: cardkingdom.Listing{
+							CardName:       "Counterspell",
+							PriceUsd:       0.75,
+							PriceChangeUsd: new(-0.08),
+						},
+					},
+				},
 			},
 		}, nil
 	}
-	refreshCKPricesFunc = func(_ context.Context, _ ckprices.Store) (int, error) {
-		return 42, nil
+	refreshCKPricesFunc = func(_ context.Context, _ ckprices.Store) (*ckprice.RefreshResult, error) {
+		return &ckprice.RefreshResult{ListingCount: 42, Listings: pricelist}, nil
 	}
 	newCKPriceReportWriterFunc = func(_ context.Context) (ckpricereport.Writer, error) {
 		return writer, nil
@@ -81,8 +104,8 @@ func TestRunCKPriceRefresh_SendsFailureAlert(t *testing.T) {
 	newCKRefreshStoreFunc = func(_ context.Context) (ckprices.Store, error) {
 		return &mockCKRefreshStore{}, nil
 	}
-	refreshCKPricesFunc = func(_ context.Context, _ ckprices.Store) (int, error) {
-		return 0, refreshErr
+	refreshCKPricesFunc = func(_ context.Context, _ ckprices.Store) (*ckprice.RefreshResult, error) {
+		return nil, refreshErr
 	}
 
 	if err := runCKPriceRefresh(context.Background()); err == nil {
@@ -96,14 +119,23 @@ func TestRunCKPriceRefresh_SendsFailureAlert(t *testing.T) {
 }
 
 type mockCKRefreshStore struct {
-	changes *ckprices.TopBottomPriceChanges
+	changes           *ckprices.TopBottomPriceChanges
+	priceChangesByUsd map[bool][]ckprices.PriceChangeListing
+}
+
+//go:fix inline
+func floatPtr(value float64) *float64 {
+	return new(value)
 }
 
 func (m *mockCKRefreshStore) GetByNameKey(_ context.Context, _ string) (*cardkingdom.Listing, error) {
 	return nil, nil
 }
 
-func (m *mockCKRefreshStore) GetPriceChangesByUsd(_ context.Context, _ bool, _ int) ([]ckprices.PriceChangeListing, error) {
+func (m *mockCKRefreshStore) GetPriceChangesByUsd(_ context.Context, ascending bool, _ int) ([]ckprices.PriceChangeListing, error) {
+	if m.priceChangesByUsd != nil {
+		return m.priceChangesByUsd[ascending], nil
+	}
 	return nil, nil
 }
 
@@ -147,8 +179,8 @@ func TestHandle_RoutesCKPriceRefreshRun(t *testing.T) {
 	newCKRefreshStoreFunc = func(_ context.Context) (ckprices.Store, error) {
 		return &mockCKRefreshStore{}, nil
 	}
-	refreshCKPricesFunc = func(_ context.Context, _ ckprices.Store) (int, error) {
-		return 1, nil
+	refreshCKPricesFunc = func(_ context.Context, _ ckprices.Store) (*ckprice.RefreshResult, error) {
+		return &ckprice.RefreshResult{ListingCount: 1}, nil
 	}
 	newCKPriceReportWriterFunc = func(_ context.Context) (ckpricereport.Writer, error) {
 		return writer, nil

--- a/api/store/ckprices/dynamodb.go
+++ b/api/store/ckprices/dynamodb.go
@@ -260,6 +260,81 @@ func (s *DynamoDBStore) PutAll(ctx context.Context, listings map[string]cardking
 	return syncedAt, nil
 }
 
+func (s *DynamoDBStore) DeleteListingsNotInPricelist(
+	ctx context.Context,
+	pricelist map[string]cardkingdom.Listing,
+) (int, error) {
+	if len(pricelist) == 0 {
+		return 0, nil
+	}
+
+	deleted := 0
+	deleteRequests := make([]types.WriteRequest, 0, batchWriteLimit)
+	flushDeletes := func() error {
+		if len(deleteRequests) == 0 {
+			return nil
+		}
+		if err := s.writeBatch(ctx, deleteRequests); err != nil {
+			return err
+		}
+		deleted += len(deleteRequests)
+		deleteRequests = deleteRequests[:0]
+		return nil
+	}
+
+	var exclusiveStartKey map[string]types.AttributeValue
+	for {
+		output, err := s.client.Scan(ctx, &dynamodb.ScanInput{
+			TableName:            aws.String(s.tableName),
+			ProjectionExpression: aws.String("nameKey"),
+			ExclusiveStartKey:    exclusiveStartKey,
+		})
+		if err != nil {
+			return deleted, err
+		}
+
+		for _, item := range output.Items {
+			var record dynamoRecord
+			if err := attributevalue.UnmarshalMap(item, &record); err != nil {
+				return deleted, err
+			}
+			if !shouldDeleteCKListingNameKey(record.NameKey, pricelist) {
+				continue
+			}
+			deleteRequests = append(deleteRequests, types.WriteRequest{
+				DeleteRequest: &types.DeleteRequest{
+					Key: map[string]types.AttributeValue{
+						"nameKey": &types.AttributeValueMemberS{Value: record.NameKey},
+					},
+				},
+			})
+			if len(deleteRequests) >= batchWriteLimit {
+				if err := flushDeletes(); err != nil {
+					return deleted, err
+				}
+			}
+		}
+
+		if len(output.LastEvaluatedKey) == 0 {
+			break
+		}
+		exclusiveStartKey = output.LastEvaluatedKey
+	}
+
+	if err := flushDeletes(); err != nil {
+		return deleted, err
+	}
+	return deleted, nil
+}
+
+func shouldDeleteCKListingNameKey(nameKey string, pricelist map[string]cardkingdom.Listing) bool {
+	if nameKey == "" || nameKey == syncMetadataKey {
+		return false
+	}
+	_, ok := pricelist[nameKey]
+	return !ok
+}
+
 func dynamoRecordFromListing(nameKey string, listing cardkingdom.Listing, syncedAt string) dynamoRecord {
 	record := dynamoRecord{
 		NameKey:            nameKey,

--- a/api/store/ckprices/dynamodb_test.go
+++ b/api/store/ckprices/dynamodb_test.go
@@ -166,3 +166,14 @@ func TestSleepWithContext_RespectsCancellation(t *testing.T) {
 	err := sleepWithContext(ctx, time.Second)
 	require.ErrorIs(t, err, context.Canceled)
 }
+
+func TestShouldDeleteCKListingNameKey(t *testing.T) {
+	pricelist := map[string]cardkingdom.Listing{
+		"lightning bolt": {CardName: "Lightning Bolt"},
+	}
+
+	require.False(t, shouldDeleteCKListingNameKey("", pricelist))
+	require.False(t, shouldDeleteCKListingNameKey(syncMetadataKey, pricelist))
+	require.False(t, shouldDeleteCKListingNameKey("lightning bolt", pricelist))
+	require.True(t, shouldDeleteCKListingNameKey("juzám djinn", pricelist))
+}

--- a/api/store/ckprices/price_change.go
+++ b/api/store/ckprices/price_change.go
@@ -191,7 +191,7 @@ func priceChangesByUsdFromListings(listings []PriceChangeListing, ascending bool
 // exported top/bottom lists. It must be larger than PriceChangeRankingLimit so
 // stale DynamoDB rows missing from the latest pricelist can be skipped while
 // still filling the export.
-const priceChangeRankingCandidateLimit = 200
+const priceChangeRankingCandidateLimit = 50
 
 // TopBottomPriceChangesInPricelist returns the largest increases and decreases
 // whose name keys appear in the latest Card Kingdom pricelist snapshot.

--- a/api/store/ckprices/price_change.go
+++ b/api/store/ckprices/price_change.go
@@ -2,6 +2,7 @@ package ckprices
 
 import (
 	"cmp"
+	"context"
 	"math"
 	"slices"
 	"strings"
@@ -184,4 +185,67 @@ func priceChangesByUsdFromListings(listings []PriceChangeListing, ascending bool
 		return rankings.Bottom
 	}
 	return rankings.Top
+}
+
+// priceChangeRankingCandidateLimit is how many GSI rows to read when building the
+// exported top/bottom lists. It must be larger than PriceChangeRankingLimit so
+// stale DynamoDB rows missing from the latest pricelist can be skipped while
+// still filling the export.
+const priceChangeRankingCandidateLimit = 200
+
+// TopBottomPriceChangesInPricelist returns the largest increases and decreases
+// whose name keys appear in the latest Card Kingdom pricelist snapshot.
+func TopBottomPriceChangesInPricelist(
+	ctx context.Context,
+	store Store,
+	pricelist map[string]cardkingdom.Listing,
+) (*TopBottomPriceChanges, error) {
+	if len(pricelist) == 0 {
+		return &TopBottomPriceChanges{}, nil
+	}
+
+	topRaw, err := store.GetPriceChangesByUsd(ctx, false, priceChangeRankingCandidateLimit)
+	if err != nil {
+		return nil, err
+	}
+	bottomRaw, err := store.GetPriceChangesByUsd(ctx, true, priceChangeRankingCandidateLimit)
+	if err != nil {
+		return nil, err
+	}
+
+	return &TopBottomPriceChanges{
+		Top: finalizePriceChangesInPricelist(
+			topRaw,
+			pricelist,
+			true,
+			PriceChangeRankingLimit,
+		),
+		Bottom: finalizePriceChangesInPricelist(
+			bottomRaw,
+			pricelist,
+			false,
+			PriceChangeRankingLimit,
+		),
+	}, nil
+}
+
+func finalizePriceChangesInPricelist(
+	listings []PriceChangeListing,
+	pricelist map[string]cardkingdom.Listing,
+	increases bool,
+	limit int,
+) []PriceChangeListing {
+	if limit <= 0 {
+		limit = PriceChangeRankingLimit
+	}
+
+	signed := filterPriceChangesByUsdSign(listings, increases)
+	inPricelist := make([]PriceChangeListing, 0, len(signed))
+	for _, listing := range signed {
+		if _, ok := pricelist[listing.NameKey]; !ok {
+			continue
+		}
+		inPricelist = append(inPricelist, listing)
+	}
+	return dedupePriceChangeListings(inPricelist, limit)
 }

--- a/api/store/ckprices/price_change_test.go
+++ b/api/store/ckprices/price_change_test.go
@@ -359,6 +359,10 @@ func (m *mockPriceChangeStore) PutAll(context.Context, map[string]cardkingdom.Li
 	return "", nil
 }
 
+func (m *mockPriceChangeStore) DeleteListingsNotInPricelist(context.Context, map[string]cardkingdom.Listing) (int, error) {
+	return 0, nil
+}
+
 func TestListingsWithPriceChangeUpdatesSameDayChangesWhenRecomputedNonZero(t *testing.T) {
 	now := time.Date(2026, 7, 19, 15, 0, 0, 0, time.UTC)
 	previousPrice := 1.00

--- a/api/store/ckprices/price_change_test.go
+++ b/api/store/ckprices/price_change_test.go
@@ -1,6 +1,7 @@
 package ckprices
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -279,6 +280,83 @@ func TestListingsWithPriceChangePreservesSameDayNonZeroChangesWhenRecomputedToZe
 	require.InDelta(t, 0.10, *enriched["lightning bolt"].PriceChangeUsd, 0.001)
 	require.NotNil(t, enriched["lightning bolt"].PriceChangePercent)
 	require.Equal(t, 10, *enriched["lightning bolt"].PriceChangePercent)
+}
+
+func TestFinalizePriceChangesInPricelist_DropsStaleRowsAndBackfills(t *testing.T) {
+	usd := func(value float64) *float64 {
+		return &value
+	}
+	pricelist := map[string]cardkingdom.Listing{
+		"live riser": {CardName: "Live Riser"},
+		"live drop":  {CardName: "Live Drop"},
+	}
+
+	listings := []PriceChangeListing{
+		{NameKey: "orphan riser", Listing: cardkingdom.Listing{PriceChangeUsd: usd(50)}},
+		{NameKey: "live riser", Listing: cardkingdom.Listing{PriceChangeUsd: usd(5)}},
+		{NameKey: "another orphan", Listing: cardkingdom.Listing{PriceChangeUsd: usd(4)}},
+	}
+
+	increases := finalizePriceChangesInPricelist(listings, pricelist, true, 20)
+	require.Len(t, increases, 1)
+	require.Equal(t, "live riser", increases[0].NameKey)
+	require.InDelta(t, 5, *increases[0].PriceChangeUsd, 0.001)
+
+	drops := finalizePriceChangesInPricelist([]PriceChangeListing{
+		{NameKey: "orphan drop", Listing: cardkingdom.Listing{PriceChangeUsd: usd(-50)}},
+		{NameKey: "live drop", Listing: cardkingdom.Listing{PriceChangeUsd: usd(-2)}},
+	}, pricelist, false, 20)
+	require.Len(t, drops, 1)
+	require.Equal(t, "live drop", drops[0].NameKey)
+}
+
+func TestTopBottomPriceChangesInPricelist(t *testing.T) {
+	usd := func(value float64) *float64 {
+		return &value
+	}
+	store := &mockPriceChangeStore{
+		byAscending: map[bool][]PriceChangeListing{
+			false: {
+				{NameKey: "stale", Listing: cardkingdom.Listing{PriceChangeUsd: usd(99)}},
+				{NameKey: "bolt", Listing: cardkingdom.Listing{CardName: "Lightning Bolt", PriceChangeUsd: usd(1)}},
+			},
+			true: {
+				{NameKey: "stale", Listing: cardkingdom.Listing{PriceChangeUsd: usd(-99)}},
+				{NameKey: "counterspell", Listing: cardkingdom.Listing{CardName: "Counterspell", PriceChangeUsd: usd(-1)}},
+			},
+		},
+	}
+	pricelist := map[string]cardkingdom.Listing{
+		"bolt":         {CardName: "Lightning Bolt"},
+		"counterspell": {CardName: "Counterspell"},
+	}
+
+	changes, err := TopBottomPriceChangesInPricelist(context.Background(), store, pricelist)
+	require.NoError(t, err)
+	require.Len(t, changes.Top, 1)
+	require.Equal(t, "bolt", changes.Top[0].NameKey)
+	require.Len(t, changes.Bottom, 1)
+	require.Equal(t, "counterspell", changes.Bottom[0].NameKey)
+}
+
+type mockPriceChangeStore struct {
+	byAscending map[bool][]PriceChangeListing
+}
+
+func (m *mockPriceChangeStore) GetByNameKey(context.Context, string) (*cardkingdom.Listing, error) {
+	return nil, nil
+}
+
+func (m *mockPriceChangeStore) GetPriceChangesByUsd(_ context.Context, ascending bool, _ int) ([]PriceChangeListing, error) {
+	return m.byAscending[ascending], nil
+}
+
+func (m *mockPriceChangeStore) GetTopBottomPriceChanges(context.Context) (*TopBottomPriceChanges, error) {
+	return &TopBottomPriceChanges{}, nil
+}
+
+func (m *mockPriceChangeStore) PutAll(context.Context, map[string]cardkingdom.Listing) (string, error) {
+	return "", nil
 }
 
 func TestListingsWithPriceChangeUpdatesSameDayChangesWhenRecomputedNonZero(t *testing.T) {

--- a/api/store/ckprices/store.go
+++ b/api/store/ckprices/store.go
@@ -29,4 +29,7 @@ type Store interface {
 	GetPriceChangesByUsd(ctx context.Context, ascending bool, limit int) ([]PriceChangeListing, error)
 	GetTopBottomPriceChanges(ctx context.Context) (*TopBottomPriceChanges, error)
 	PutAll(ctx context.Context, listings map[string]cardkingdom.Listing) (syncedAt string, err error)
+	// DeleteListingsNotInPricelist removes card rows whose nameKey is absent from
+	// the latest pricelist snapshot. Sync metadata is never deleted.
+	DeleteListingsNotInPricelist(ctx context.Context, pricelist map[string]cardkingdom.Listing) (deleted int, err error)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stale DynamoDB CK rows (for example orphaned MTGJSON-era `nameKey`s that no longer appear in the Card Kingdom pricelist) could still rank in the top 20 price increases/decreases exported to `latest.json`.

The daily refresh now:

1. Upserts the pricelist into DynamoDB.
2. **Scans the table and deletes** any card row whose `nameKey` is **not** in the current pricelist (the `__sync__` metadata row is preserved).
3. Builds the S3 report from up to **50** GSI candidates per direction, keeping only rows still present in the pricelist snapshot, then deduping to 20 risers/drops.

## Changes

- `DeleteListingsNotInPricelist` on `ckprices.Store` / `DynamoDBStore`.
- `ckprice.RefreshPrices` invokes deletion after `PutAll`.
- `priceChangeRankingCandidateLimit` reduced from 200 → **50**.

## Testing

- `go test ./store/ckprices/... ./handler/... ./controller/ckprice/...`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1598922-0734-4568-9322-fff54fa72984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1598922-0734-4568-9322-fff54fa72984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

