### PR TITLE
Update CK price change tab labels to "Top risers/drops @ CK (24h)"

### DIFF
--- a/frontend/src/components/TopSearchKeywords.jsx
+++ b/frontend/src/components/TopSearchKeywords.jsx
@@ -360,11 +360,11 @@ export default function TopSearchKeywords({
                   }`}
                   aria-pressed={priceChangeView === "risers"}
                   aria-controls={contentPanelId}
-                  aria-label="Top dollar risers in 24 hours"
+                  aria-label="Top risers at Card Kingdom in 24 hours"
                   disabled={isLoadingPriceChanges}
                   onClick={() => handlePriceChangeSelect("risers")}
                 >
-                  Top $ risers (24h)
+                  Top risers @ CK (24h)
                 </button>
                 <button
                   type="button"
@@ -373,11 +373,11 @@ export default function TopSearchKeywords({
                   }`}
                   aria-pressed={priceChangeView === "drops"}
                   aria-controls={contentPanelId}
-                  aria-label="Top dollar drops in 24 hours"
+                  aria-label="Top drops at Card Kingdom in 24 hours"
                   disabled={isLoadingPriceChanges}
                   onClick={() => handlePriceChangeSelect("drops")}
                 >
-                  Top $ drops (24 Hrs)
+                  Top drops @ CK (24h)
                 </button>
               </>
             ) : null}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the Card Kingdom 24h price-change toggle labels on the homepage:

- **Risers:** `Top risers @ CK (24h)` (was `Top $ risers (24h)`)
- **Drops:** `Top drops @ CK (24h)` (was `Top $ drops (24 Hrs)`)

Aria labels now say "at Card Kingdom" for screen readers.

## Files

- `frontend/src/components/TopSearchKeywords.jsx`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d5395982-b12b-4e63-a107-ee681fac9fa5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d5395982-b12b-4e63-a107-ee681fac9fa5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

