### PR TITLE
Increase Agora per-attempt search timeout to 20s

### DIFF
--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -23,8 +23,8 @@ const (
 	// SearchAttemptTimeout bounds a single search strategy attempt (BinderPOS step
 	// or default colly scrape).
 	SearchAttemptTimeout = 5 * time.Second
-	// AgoraSearchAttemptTimeout is the per-attempt cap for Agora Hobby only.
-	AgoraSearchAttemptTimeout = 10 * time.Second
+	// AgoraSearchAttemptTimeout is the per-attempt cap for Agora Hobby only (matches per-store deadline).
+	AgoraSearchAttemptTimeout = PerSiteTimeout
 	// DynamicProxyEnv contains an authenticated proxy URL used for explicit
 	// dynamic-proxy fallback attempts, which BinderPOS reserves for the final
 	// two attempts after dedicated and direct/no-proxy scrap and decklist tries.

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -10,7 +10,7 @@ This document records **where** the app configures search behavior, **timeouts**
 |------|--------|--------|--------|
 | Per-store deadline | 20s | `config.PerSiteTimeout` in `api/pkg/config/config.go`; used in `searchShop` as `context.WithTimeout` in `api/controller/search.go` | One goroutine per selected store; each `LGS.Search` runs under this cap. |
 | Per-attempt timeout (default) | 5s | `config.SearchAttemptTimeout` in `api/pkg/config/config.go` | Bounds each BinderPOS strategy step, default colly scrape request, and most `DoOutboundGET` / `DoOutboundRoundTrip` calls. |
-| Agora per-attempt timeout | 10s | `config.AgoraSearchAttemptTimeout` in `api/pkg/config/config.go`; applied in `api/gateway/agora/search.go` | Agora keeps a longer single-scrape cap. |
+| Agora per-attempt timeout | 20s | `config.AgoraSearchAttemptTimeout` in `api/pkg/config/config.go`; applied in `api/gateway/agora/search.go` | Same as per-store deadline (`PerSiteTimeout`). |
 | Colly request timeout (default scrapers) | 5s | `applyCollectorDefaults` → `c.SetRequestTimeout(config.SearchAttemptTimeout)` in `api/gateway/collector.go` | Overrides gocolly’s default 10s for optimized collectors. |
 | Max concurrent store searches | 6 | `maxConcurrentStoreSearches` in `api/controller/search.go` | Worker pool size when fanning out to selected stores. |
 | Minimum end-to-end response time | 1s | `responseThreshold` in `searchShops` in `api/controller/search.go` | If all stores finish in under 1s, the handler **sleeps** the remainder so the API “feels” less instant. |
@@ -91,7 +91,7 @@ Shared `net/http` transport fallback for `DoOutboundGET` / `DoOutboundRoundTrip`
 
 | Store | Strategy | Per-attempt timeout | Proxy / transport order | Retries |
 |-------|----------|----------------------|-------------------------|---------|
-| Agora Hobby | HTML search page (`/store/search`) | 10s | **Dedicated → dynamic**; skips direct on `agorahobby.com` (browser TLS via `SkipWebBotAuth` + `BROWSER_TLS_EMULATION_ENABLED`) | Transport fallback only |
+| Agora Hobby | HTML search page (`/store/search`) | 20s | **Dedicated → dynamic**; skips direct on `agorahobby.com` (browser TLS via `SkipWebBotAuth` + `BROWSER_TLS_EMULATION_ENABLED`) | Transport fallback only |
 | 5 Mana | **graphql** → **html** (Dawn `main-search` section) | 5s per path | **Dedicated → dynamic**; skips direct on `5-mana.sg` | GraphQL 5xx is final; other GraphQL errors fall through to HTML. Transport fallback per path. |
 | Cards Central | JSON API (`/api/lgs/search?q=…`) | 5s | Direct → dedicated → dynamic | Transport fallback only |
 | Dueller's Point | HTML search page (`/products/search`) | 5s | Direct → dedicated → dynamic | Transport fallback only |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Raises Agora Hobby’s per-attempt outbound timeout from 10s to 20s by setting `AgoraSearchAttemptTimeout` to `PerSiteTimeout`, so a single HTTP attempt can use the full per-store deadline.

## Changes

- `api/pkg/config/config.go`: `AgoraSearchAttemptTimeout = PerSiteTimeout` (20s)
- `docs/search-strategies-retries-timeouts.md`: updated Agora timing table rows

## Testing

- `make test` (full backend suite)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9782b38c-7b48-4aa5-8e4d-0b0f8ab2845e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9782b38c-7b48-4aa5-8e4d-0b0f8ab2845e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

