### PR TITLE
Same-origin API access control (CloudFront verify + session cookies)

### DIFF
--- a/api/handler/access.go
+++ b/api/handler/access.go
@@ -1,0 +1,119 @@
+package handler
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"mtg-price-checker-sg/pkg/apiauth"
+	"mtg-price-checker-sg/pkg/config"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+func enforceOriginVerify(
+	apiRes events.APIGatewayProxyResponse,
+	origin string,
+	headers map[string]string,
+) (events.APIGatewayProxyResponse, bool) {
+	if err := apiauth.VerifyOriginHeader(headers); err != nil {
+		return accessDeniedResponse(apiRes, origin, "forbidden"), false
+	}
+	return apiRes, true
+}
+
+func enforceSession(
+	apiRes events.APIGatewayProxyResponse,
+	origin string,
+	headers map[string]string,
+) (events.APIGatewayProxyResponse, bool) {
+	if config.APISessionSecret() == "" {
+		return apiRes, true
+	}
+
+	cookieHeader := headerValue(headers, "cookie")
+	token := cookieValue(cookieHeader, apiauth.SessionCookieName())
+	if err := apiauth.ValidateSessionToken(token, time.Now().UTC()); err != nil {
+		message := "session required"
+		if errors.Is(err, apiauth.ErrSessionExpired) {
+			message = "session expired"
+		}
+		return accessDeniedResponse(apiRes, origin, message), false
+	}
+
+	return apiRes, true
+}
+
+func accessDeniedResponse(
+	apiRes events.APIGatewayProxyResponse,
+	origin string,
+	message string,
+) events.APIGatewayProxyResponse {
+	return mustErrorResponse(apiRes, origin, message, http.StatusForbidden)
+}
+
+func mustErrorResponse(
+	apiRes events.APIGatewayProxyResponse,
+	origin string,
+	message string,
+	statusCode int,
+) events.APIGatewayProxyResponse {
+	res, err := errorResponse(apiRes, origin, message, statusCode)
+	if err != nil {
+		res.StatusCode = http.StatusInternalServerError
+		res.Body = `{"error":"internal error","statusCode":500}` + "\n"
+	}
+	return res
+}
+
+func headerValue(headers map[string]string, lowerName string) string {
+	if headers == nil {
+		return ""
+	}
+	if v := headers[lowerName]; v != "" {
+		return v
+	}
+	for k, v := range headers {
+		if strings.EqualFold(k, lowerName) {
+			return v
+		}
+	}
+	return ""
+}
+
+func cookieValue(cookieHeader, name string) string {
+	if cookieHeader == "" {
+		return ""
+	}
+	for part := range strings.SplitSeq(cookieHeader, ";") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		key, value, ok := strings.Cut(part, "=")
+		if !ok {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(key), name) {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func sessionCookieString(token string, secure bool) string {
+	maxAge := int(config.APISessionTTL().Seconds())
+	parts := []string{
+		fmt.Sprintf("%s=%s", apiauth.SessionCookieName(), token),
+		"Path=/api",
+		fmt.Sprintf("Max-Age=%d", maxAge),
+		"HttpOnly",
+		"SameSite=Lax",
+	}
+	if secure {
+		parts = append(parts, "Secure")
+	}
+	return strings.Join(parts, "; ")
+}

--- a/api/handler/access_test.go
+++ b/api/handler/access_test.go
@@ -1,0 +1,54 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"testing"
+
+	"mtg-price-checker-sg/controller"
+	"mtg-price-checker-sg/gateway/cardkingdom"
+	"mtg-price-checker-sg/pkg/config"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_normalizeAPIPath(t *testing.T) {
+	t.Parallel()
+	req := events.APIGatewayProxyRequest{Path: "/api/session"}
+	require.Equal(t, "session", normalizeAPIPath(req))
+
+	req = events.APIGatewayProxyRequest{Path: "/prod/api"}
+	require.Equal(t, "", normalizeAPIPath(req))
+}
+
+func Test_Search_AccessControl(t *testing.T) {
+	originalSearchFunc := searchFunc
+	originalLookupCKPriceFunc := lookupCKPriceFunc
+	defer func() {
+		searchFunc = originalSearchFunc
+		lookupCKPriceFunc = originalLookupCKPriceFunc
+	}()
+	searchFunc = func(_ context.Context, _ controller.SearchInput) ([]controller.Card, []controller.StoreError, error) {
+		return nil, nil, nil
+	}
+	lookupCKPriceFunc = func(_ context.Context, _ string) (*cardkingdom.Listing, error) {
+		return nil, nil
+	}
+
+	require.NoError(t, os.Setenv("ENV", config.EnvProd))
+	require.NoError(t, os.Setenv(config.APIOriginVerifySecretEnv, "verify-secret"))
+	require.NoError(t, os.Setenv(config.APISessionSecretEnv, "session-secret"))
+	t.Cleanup(func() {
+		_ = os.Unsetenv(config.APIOriginVerifySecretEnv)
+		_ = os.Unsetenv(config.APISessionSecretEnv)
+	})
+
+	req := events.APIGatewayProxyRequest{
+		QueryStringParameters: map[string]string{"s": "bolt"},
+	}
+	result, err := Search(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusForbidden, result.StatusCode)
+}

--- a/api/handler/access_test.go
+++ b/api/handler/access_test.go
@@ -19,6 +19,9 @@ func Test_normalizeAPIPath(t *testing.T) {
 	req := events.APIGatewayProxyRequest{Path: "/api/session"}
 	require.Equal(t, "session", normalizeAPIPath(req))
 
+	req = events.APIGatewayProxyRequest{Path: "/api/search"}
+	require.Equal(t, "search", normalizeAPIPath(req))
+
 	req = events.APIGatewayProxyRequest{Path: "/prod/api"}
 	require.Equal(t, "", normalizeAPIPath(req))
 }

--- a/api/handler/cors.go
+++ b/api/handler/cors.go
@@ -19,6 +19,7 @@ func applyCORSHeaders(apiResponse *events.APIGatewayProxyResponse, origin string
 		"Access-Control-Allow-Origin":  origin,
 		"Access-Control-Allow-Methods": "GET, OPTIONS",
 		"Access-Control-Allow-Headers": "Content-Type",
+		"Access-Control-Allow-Credentials": "true",
 		"Vary":                         "Origin",
 	}
 }

--- a/api/handler/http_api.go
+++ b/api/handler/http_api.go
@@ -1,0 +1,22 @@
+package handler
+
+import (
+	"context"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+// RouteHTTPAPI dispatches API Gateway proxy requests to handlers.
+func RouteHTTPAPI(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	origin := request.Headers["origin"]
+	if request.HTTPMethod == "OPTIONS" {
+		return optionsResponse(origin)
+	}
+
+	switch normalizeAPIPath(request) {
+	case "session":
+		return Session(ctx, request)
+	default:
+		return Search(ctx, request)
+	}
+}

--- a/api/handler/http_api.go
+++ b/api/handler/http_api.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/aws/aws-lambda-go/events"
 )
@@ -16,7 +17,10 @@ func RouteHTTPAPI(ctx context.Context, request events.APIGatewayProxyRequest) (e
 	switch normalizeAPIPath(request) {
 	case "session":
 		return Session(ctx, request)
-	default:
+	case "search":
 		return Search(ctx, request)
+	default:
+		var apiRes events.APIGatewayProxyResponse
+		return errorResponse(apiRes, origin, "not found", http.StatusNotFound)
 	}
 }

--- a/api/handler/path.go
+++ b/api/handler/path.go
@@ -1,0 +1,31 @@
+package handler
+
+import (
+	"strings"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+// normalizeAPIPath returns the path segment after optional stage and /api prefixes.
+func normalizeAPIPath(request events.APIGatewayProxyRequest) string {
+	path := strings.TrimSpace(request.Path)
+	if path == "" {
+		path = strings.TrimSpace(request.RequestContext.Path)
+	}
+	if path == "" {
+		path = "/"
+	}
+
+	for _, prefix := range []string{"/prod", "/staging", "/dev"} {
+		if strings.HasPrefix(path, prefix+"/") || path == prefix {
+			path = strings.TrimPrefix(path, prefix)
+			if path == "" {
+				path = "/"
+			}
+		}
+	}
+
+	path = strings.TrimPrefix(path, "/api")
+	path = strings.TrimPrefix(path, "/")
+	return path
+}

--- a/api/handler/router.go
+++ b/api/handler/router.go
@@ -26,5 +26,5 @@ func Handle(ctx context.Context, event json.RawMessage) (any, error) {
 		return events.APIGatewayProxyResponse{}, err
 	}
 
-	return Search(ctx, apiRequest)
+	return RouteHTTPAPI(ctx, apiRequest)
 }

--- a/api/handler/search.go
+++ b/api/handler/search.go
@@ -56,6 +56,13 @@ func Search(ctx context.Context, request events.APIGatewayProxyRequest) (events.
 		return optionsResponse(origin)
 	}
 
+	if res, ok := enforceOriginVerify(apiRes, origin, request.Headers); !ok {
+		return res, nil
+	}
+	if res, ok := enforceSession(apiRes, origin, request.Headers); !ok {
+		return res, nil
+	}
+
 	searchString, err := url.QueryUnescape(strings.TrimSpace(request.QueryStringParameters["s"]))
 	if err != nil {
 		searchString = ""

--- a/api/handler/session.go
+++ b/api/handler/session.go
@@ -1,0 +1,49 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"time"
+
+	"mtg-price-checker-sg/pkg/apiauth"
+	"mtg-price-checker-sg/pkg/config"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+var sessionTokenFunc = apiauth.NewSessionToken
+
+// Session mints an HttpOnly cookie the browser must send before search requests.
+func Session(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	var apiRes events.APIGatewayProxyResponse
+	origin := request.Headers["origin"]
+
+	if request.HTTPMethod == "OPTIONS" {
+		return optionsResponse(origin)
+	}
+
+	if request.HTTPMethod != http.MethodGet {
+		return errorResponse(apiRes, origin, "method not allowed", http.StatusMethodNotAllowed)
+	}
+
+	if res, ok := enforceOriginVerify(apiRes, origin, request.Headers); !ok {
+		return res, nil
+	}
+
+	if config.APISessionSecret() == "" {
+		return errorResponse(apiRes, origin, "session not configured", http.StatusServiceUnavailable)
+	}
+
+	token, err := sessionTokenFunc(time.Now().UTC())
+	if err != nil {
+		return errorResponse(apiRes, origin, "err creating session", http.StatusInternalServerError)
+	}
+
+	secure := os.Getenv("ENV") == config.EnvProd
+	apiRes.StatusCode = http.StatusNoContent
+	applyCORSHeaders(&apiRes, origin)
+	apiRes.Headers["Set-Cookie"] = sessionCookieString(token, secure)
+	apiRes.Headers["Cache-Control"] = "no-store"
+	return apiRes, nil
+}

--- a/api/pkg/apiauth/origin.go
+++ b/api/pkg/apiauth/origin.go
@@ -1,0 +1,42 @@
+package apiauth
+
+import (
+	"crypto/subtle"
+	"errors"
+	"strings"
+
+	"mtg-price-checker-sg/pkg/config"
+)
+
+var errOriginVerifyFailed = errors.New("origin verification failed")
+
+// VerifyOriginHeader ensures the CloudFront origin secret header matches when configured.
+func VerifyOriginHeader(headers map[string]string) error {
+	secret := config.APIOriginVerifySecret()
+	if secret == "" {
+		return nil
+	}
+
+	headerName := strings.ToLower(config.APIOriginVerifyHeader())
+	got := strings.TrimSpace(headerValue(headers, headerName))
+	if got == "" || subtle.ConstantTimeCompare([]byte(got), []byte(secret)) != 1 {
+		return errOriginVerifyFailed
+	}
+
+	return nil
+}
+
+func headerValue(headers map[string]string, lowerName string) string {
+	if headers == nil {
+		return ""
+	}
+	if v := headers[lowerName]; v != "" {
+		return v
+	}
+	for k, v := range headers {
+		if strings.EqualFold(k, lowerName) {
+			return v
+		}
+	}
+	return ""
+}

--- a/api/pkg/apiauth/session.go
+++ b/api/pkg/apiauth/session.go
@@ -1,0 +1,96 @@
+package apiauth
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"mtg-price-checker-sg/pkg/config"
+)
+
+const (
+	sessionCookieName = "gf_api_session"
+	sessionParts      = 3
+)
+
+var (
+	// ErrInvalidSessionToken indicates a malformed or tampered session cookie.
+	ErrInvalidSessionToken = errors.New("invalid session token")
+	// ErrSessionExpired indicates the session cookie is past its expiry.
+	ErrSessionExpired = errors.New("session expired")
+)
+
+// SessionCookieName is the HttpOnly cookie used for search authorization.
+func SessionCookieName() string {
+	return sessionCookieName
+}
+
+// NewSessionToken mints a signed session value for Set-Cookie.
+func NewSessionToken(now time.Time) (string, error) {
+	secret := config.APISessionSecret()
+	if secret == "" {
+		return "", errors.New("session secret not configured")
+	}
+
+	nonce := make([]byte, 16)
+	if _, err := rand.Read(nonce); err != nil {
+		return "", err
+	}
+
+	expiry := now.Add(config.APISessionTTL()).Unix()
+	payload := fmt.Sprintf("%d.%s", expiry, base64.RawURLEncoding.EncodeToString(nonce))
+	sig := signSession(secret, payload)
+	return payload + "." + base64.RawURLEncoding.EncodeToString(sig), nil
+}
+
+// ValidateSessionToken checks the cookie value and returns nil when valid.
+func ValidateSessionToken(token string, now time.Time) error {
+	secret := config.APISessionSecret()
+	if secret == "" {
+		return nil
+	}
+
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return ErrInvalidSessionToken
+	}
+
+	parts := strings.Split(token, ".")
+	if len(parts) != sessionParts {
+		return ErrInvalidSessionToken
+	}
+
+	expiryUnix, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		return ErrInvalidSessionToken
+	}
+	if now.Unix() > expiryUnix {
+		return ErrSessionExpired
+	}
+
+	payload := parts[0] + "." + parts[1]
+	sig, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return ErrInvalidSessionToken
+	}
+
+	expected := signSession(secret, payload)
+	if subtle.ConstantTimeCompare(sig, expected) != 1 {
+		return ErrInvalidSessionToken
+	}
+
+	return nil
+}
+
+func signSession(secret, payload string) []byte {
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(payload))
+	return mac.Sum(nil)
+}

--- a/api/pkg/apiauth/session_test.go
+++ b/api/pkg/apiauth/session_test.go
@@ -1,0 +1,44 @@
+package apiauth
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"mtg-price-checker-sg/pkg/config"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionTokenRoundTrip(t *testing.T) {
+	require.NoError(t, os.Setenv(config.APISessionSecretEnv, "test-session-secret"))
+	t.Cleanup(func() { _ = os.Unsetenv(config.APISessionSecretEnv) })
+
+	now := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	token, err := NewSessionToken(now)
+	require.NoError(t, err)
+	require.NoError(t, ValidateSessionToken(token, now.Add(time.Minute)))
+}
+
+func TestSessionTokenExpired(t *testing.T) {
+	require.NoError(t, os.Setenv(config.APISessionSecretEnv, "test-session-secret"))
+	t.Cleanup(func() { _ = os.Unsetenv(config.APISessionSecretEnv) })
+
+	now := time.Date(2026, 7, 28, 12, 0, 0, 0, time.UTC)
+	token, err := NewSessionToken(now)
+	require.NoError(t, err)
+
+	err = ValidateSessionToken(token, now.Add(config.APISessionTTL()+time.Second))
+	require.ErrorIs(t, err, ErrSessionExpired)
+}
+
+func TestVerifyOriginHeader(t *testing.T) {
+	require.NoError(t, os.Setenv(config.APIOriginVerifySecretEnv, "cloudfront-secret"))
+	t.Cleanup(func() { _ = os.Unsetenv(config.APIOriginVerifySecretEnv) })
+
+	err := VerifyOriginHeader(map[string]string{"x-origin-verify": "cloudfront-secret"})
+	require.NoError(t, err)
+
+	err = VerifyOriginHeader(map[string]string{"x-origin-verify": "wrong"})
+	require.ErrorIs(t, err, errOriginVerifyFailed)
+}

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -92,6 +92,15 @@ const (
 	SiteBaseURL = "https://gishathfetch.com/"
 	// AWSRegion is the AWS region used for DynamoDB and other managed services.
 	AWSRegion = "ap-southeast-1"
+
+	// APIOriginVerifySecretEnv is the shared secret CloudFront adds as a custom origin header.
+	APIOriginVerifySecretEnv = "API_ORIGIN_VERIFY_SECRET"
+	// APIOriginVerifyHeaderEnv overrides the origin verify header name (default X-Origin-Verify).
+	APIOriginVerifyHeaderEnv = "API_ORIGIN_VERIFY_HEADER"
+	// APISessionSecretEnv signs HttpOnly browser session cookies for search requests.
+	APISessionSecretEnv = "API_SESSION_SECRET"
+	// APISessionTTLEnv overrides session lifetime in seconds (default 15 minutes).
+	APISessionTTLEnv = "API_SESSION_TTL_SECONDS"
 )
 
 // UseLeasedDedicatedProxy enables exclusive per-request leases from the dedicated proxy pool.
@@ -166,4 +175,45 @@ func GetAllowedOrigins() []string {
 		"http://localhost:5173",
 		"http://localhost:63342", // JetBrains IDE built-in HTTP server (local dev only)
 	}
+}
+
+const (
+	defaultAPIOriginVerifyHeader = "X-Origin-Verify"
+	defaultAPISessionTTL         = 15 * time.Minute
+)
+
+// APIOriginVerifySecret returns the CloudFront origin verification secret when set.
+func APIOriginVerifySecret() string {
+	return strings.TrimSpace(os.Getenv(APIOriginVerifySecretEnv))
+}
+
+// APIOriginVerifyHeader returns the header CloudFront must send to API Gateway.
+func APIOriginVerifyHeader() string {
+	if v := strings.TrimSpace(os.Getenv(APIOriginVerifyHeaderEnv)); v != "" {
+		return v
+	}
+	return defaultAPIOriginVerifyHeader
+}
+
+// APISessionSecret returns the HMAC secret for browser session cookies when set.
+func APISessionSecret() string {
+	return strings.TrimSpace(os.Getenv(APISessionSecretEnv))
+}
+
+// APISessionTTL is how long a minted browser session remains valid.
+func APISessionTTL() time.Duration {
+	rawValue := strings.TrimSpace(os.Getenv(APISessionTTLEnv))
+	if rawValue == "" {
+		return defaultAPISessionTTL
+	}
+	seconds, err := strconv.Atoi(rawValue)
+	if err != nil || seconds <= 0 {
+		return defaultAPISessionTTL
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+// APIAccessControlEnabled is true when origin verification or session enforcement is configured.
+func APIAccessControlEnabled() bool {
+	return APIOriginVerifySecret() != "" || APISessionSecret() != ""
 }

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -171,7 +171,10 @@ export const MIN_SEARCH_LENGTH = 3;
 // rejecting bot paragraph spam.
 export const MAX_SEARCH_LENGTH = 150;
 
-export const API_BASE_URL = "https://api.gishathfetch.com/";
+export const API_BASE_URL = "/api/";
+
+/** Same-origin endpoint that mints the HttpOnly search session cookie. */
+export const API_SESSION_URL = "/api/session";
 
 export const BASE_URL = "https://gishathfetch.com/";
 

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -171,7 +171,7 @@ export const MIN_SEARCH_LENGTH = 3;
 // rejecting bot paragraph spam.
 export const MAX_SEARCH_LENGTH = 150;
 
-export const API_BASE_URL = "/api/";
+export const API_SEARCH_URL = "/api/search";
 
 /** Same-origin endpoint that mints the HttpOnly search session cookie. */
 export const API_SESSION_URL = "/api/session";

--- a/frontend/src/hooks/useSearch.js
+++ b/frontend/src/hooks/useSearch.js
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
-  API_BASE_URL,
+  API_SEARCH_URL,
   BASE_URL,
   LGS_OPTIONS,
   MAX_SEARCH_LENGTH,
@@ -173,7 +173,7 @@ export default function useSearch() {
         window.gtag("event", "search", { search_term: query });
       }
 
-      const searchUrl = `${API_BASE_URL}?s=${encodeURIComponent(query)}&lgs=${encodeURIComponent(stores.join(","))}`;
+      const searchUrl = `${API_SEARCH_URL}?s=${encodeURIComponent(query)}&lgs=${encodeURIComponent(stores.join(","))}`;
 
       const progressInterval = setInterval(() => {
         setSearchProgress((prev) => {

--- a/frontend/src/hooks/useSearch.js
+++ b/frontend/src/hooks/useSearch.js
@@ -7,6 +7,7 @@ import {
   MIN_SEARCH_LENGTH,
   PAGE_TITLE,
 } from "../constants";
+import { ensureApiSession } from "../utils/apiSession";
 import {
   buildSearchHistoryState,
   buildSearchUrl,
@@ -78,6 +79,12 @@ export default function useSearch() {
   useEffect(() => {
     searchResultsRef.current = searchResults;
   }, [searchResults]);
+
+  useEffect(() => {
+    ensureApiSession().catch(() => {
+      // Search will retry session bootstrap before the first API call.
+    });
+  }, []);
 
   const syncSearchHistory = useCallback((snapshot) => {
     if (window.location.hostname === "localhost") {
@@ -177,7 +184,13 @@ export default function useSearch() {
       }, SEARCH_PROGRESS_INTERVAL_MS);
       progressIntervalRef.current = progressInterval;
 
-      fetch(searchUrl, { signal: searchAbortController.signal })
+      ensureApiSession()
+        .then(() =>
+          fetch(searchUrl, {
+            signal: searchAbortController.signal,
+            credentials: "include",
+          }),
+        )
         .then(async (res) => {
           if (!res.ok) {
             let errorBody = null;
@@ -328,66 +341,69 @@ export default function useSearch() {
     userCancelledRef.current = false;
   }, []);
 
-  const applyHistoryState = useCallback((state) => {
-    invalidateInFlightSearch();
-    restoringHistoryRef.current = true;
-    skipSuggestionsRef.current = true;
-    setShowSuggestions(false);
+  const applyHistoryState = useCallback(
+    (state) => {
+      invalidateInFlightSearch();
+      restoringHistoryRef.current = true;
+      skipSuggestionsRef.current = true;
+      setShowSuggestions(false);
 
-    if (!isSearchHistoryState(state)) {
-      const urlParams = new URLSearchParams(window.location.search);
-      const query =
-        urlParams.has("s") && urlParams.get("s") !== ""
-          ? decodeURIComponent(urlParams.get("s"))
-          : "";
-      const urlStores = getStoresFromUrl(urlParams);
-      const stores = urlStores ?? getInitialSelectedStores(urlParams);
+      if (!isSearchHistoryState(state)) {
+        const urlParams = new URLSearchParams(window.location.search);
+        const query =
+          urlParams.has("s") && urlParams.get("s") !== ""
+            ? decodeURIComponent(urlParams.get("s"))
+            : "";
+        const urlStores = getStoresFromUrl(urlParams);
+        const stores = urlStores ?? getInitialSelectedStores(urlParams);
 
-      setSearchQuery(query);
-      setSelectedStores(stores);
-      persistSelectedStores(stores);
-      setSearchResults([]);
-      setSearchStoreErrors([]);
-      setSearchError(null);
-      setCardKingdomPrice(null);
-      setDismissedStoreErrorsKey(null);
-      setHasSearched(false);
-      setIsSearching(false);
-      setSearchProgress("Search");
-      applyHomeSeo();
+        setSearchQuery(query);
+        setSelectedStores(stores);
+        persistSelectedStores(stores);
+        setSearchResults([]);
+        setSearchStoreErrors([]);
+        setSearchError(null);
+        setCardKingdomPrice(null);
+        setDismissedStoreErrorsKey(null);
+        setHasSearched(false);
+        setIsSearching(false);
+        setSearchProgress("Search");
+        applyHomeSeo();
 
-      if (
-        query.length >= MIN_SEARCH_LENGTH &&
-        query.length <= MAX_SEARCH_LENGTH
-      ) {
-        skipHistorySyncRef.current = true;
+        if (
+          query.length >= MIN_SEARCH_LENGTH &&
+          query.length <= MAX_SEARCH_LENGTH
+        ) {
+          skipHistorySyncRef.current = true;
+          restoringHistoryRef.current = false;
+          performSearchRef.current(query, stores);
+          return;
+        }
+
         restoringHistoryRef.current = false;
-        performSearchRef.current(query, stores);
         return;
       }
 
+      setSearchQuery(state.query || "");
+      setSelectedStores(state.stores || LGS_OPTIONS);
+      persistSelectedStores(state.stores || LGS_OPTIONS);
+      setSearchResults(state.results || []);
+      setSearchStoreErrors(state.storeErrors || []);
+      setHasSearched(!!state.hasSearched);
+      setSearchError(state.searchError || null);
+      setCardKingdomPrice(state.cardKingdomPrice ?? null);
+      setDismissedStoreErrorsKey(null);
+      setIsSearching(false);
+      setSearchProgress("Search");
+      if (state.query) {
+        applySearchSeo(state.query);
+      } else {
+        applyHomeSeo();
+      }
       restoringHistoryRef.current = false;
-      return;
-    }
-
-    setSearchQuery(state.query || "");
-    setSelectedStores(state.stores || LGS_OPTIONS);
-    persistSelectedStores(state.stores || LGS_OPTIONS);
-    setSearchResults(state.results || []);
-    setSearchStoreErrors(state.storeErrors || []);
-    setHasSearched(!!state.hasSearched);
-    setSearchError(state.searchError || null);
-    setCardKingdomPrice(state.cardKingdomPrice ?? null);
-    setDismissedStoreErrorsKey(null);
-    setIsSearching(false);
-    setSearchProgress("Search");
-    if (state.query) {
-      applySearchSeo(state.query);
-    } else {
-      applyHomeSeo();
-    }
-    restoringHistoryRef.current = false;
-  }, [invalidateInFlightSearch]);
+    },
+    [invalidateInFlightSearch],
+  );
 
   useEffect(() => {
     const onPopState = (event) => {

--- a/frontend/src/utils/apiSession.js
+++ b/frontend/src/utils/apiSession.js
@@ -1,0 +1,30 @@
+import { API_SESSION_URL } from "../constants";
+
+let sessionBootstrapPromise = null;
+
+/**
+ * Ensures the browser holds a valid HttpOnly API session cookie (minted by GET /api/session).
+ * Safe to call repeatedly; concurrent callers share one in-flight request.
+ */
+export function ensureApiSession() {
+  if (!sessionBootstrapPromise) {
+    sessionBootstrapPromise = fetch(API_SESSION_URL, {
+      method: "GET",
+      credentials: "include",
+    }).then((res) => {
+      if (!res.ok) {
+        throw new Error(`API session failed (${res.status})`);
+      }
+    });
+  }
+
+  return sessionBootstrapPromise.catch((err) => {
+    sessionBootstrapPromise = null;
+    throw err;
+  });
+}
+
+/** Clears the cached bootstrap promise (for tests or after auth errors). */
+export function resetApiSessionCache() {
+  sessionBootstrapPromise = null;
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -37,6 +37,23 @@ export default defineConfig({
         target: "https://gishathfetch.com",
         changeOrigin: true,
       },
+      "/api": {
+        target:
+          process.env.VITE_API_PROXY_TARGET || "https://api.gishathfetch.com",
+        changeOrigin: true,
+        rewrite: (path) => {
+          const stripped = path.replace(/^\/api/, "");
+          return stripped === "" ? "/" : stripped;
+        },
+        configure: (proxy) => {
+          proxy.on("proxyReq", (proxyReq) => {
+            const verifySecret = process.env.VITE_API_ORIGIN_VERIFY_SECRET;
+            if (verifySecret) {
+              proxyReq.setHeader("X-Origin-Verify", verifySecret);
+            }
+          });
+        },
+      },
     },
   },
 });

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -41,10 +41,6 @@ export default defineConfig({
         target:
           process.env.VITE_API_PROXY_TARGET || "https://api.gishathfetch.com",
         changeOrigin: true,
-        rewrite: (path) => {
-          const stripped = path.replace(/^\/api/, "");
-          return stripped === "" ? "/" : stripped;
-        },
         configure: (proxy) => {
           proxy.on("proxyReq", (proxyReq) => {
             const verifySecret = process.env.VITE_API_ORIGIN_VERIFY_SECRET;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Manual follow-up (before production is locked down)

1. **API Gateway** — Expose `GET` + `OPTIONS` for **`/api/search`** and **`/api/session`** to the search Lambda (remove or keep legacy `GET /api` only if you still need it).
2. **CloudFront** — `/api/*` behavior → API origin, **CachingDisabled**, origin request policy **`AllViewerExceptHostHeader`**, custom header `X-Origin-Verify` when phase A is enabled.
3. **Lambda (`mtg-price-scrapper`)** — Set `API_ORIGIN_VERIFY_SECRET` and `API_SESSION_SECRET` (`openssl rand -base64 48`; use different values).
4. **Deploy order** — Lambda (secrets off) → routes + CloudFront → set secrets → deploy frontend.

**Search URL (production):** `https://gishathfetch.com/api/search?s=...&lgs=...`

Until CloudFront and Lambda secrets are configured together, leave secrets unset or users will get **403** on search.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2131505-d73e-4d0f-a8a5-4e57724a98c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2131505-d73e-4d0f-a8a5-4e57724a98c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

