### PR TITLE
Fix session endpoint 500 without Origin header

### DIFF
--- a/api/handler/response_headers.go
+++ b/api/handler/response_headers.go
@@ -1,0 +1,13 @@
+package handler
+
+import (
+	"github.com/aws/aws-lambda-go/events"
+)
+
+// ensureResponseHeaders returns a non-nil Headers map on apiResponse.
+func ensureResponseHeaders(apiResponse *events.APIGatewayProxyResponse) map[string]string {
+	if apiResponse.Headers == nil {
+		apiResponse.Headers = map[string]string{}
+	}
+	return apiResponse.Headers
+}

--- a/api/handler/session.go
+++ b/api/handler/session.go
@@ -43,7 +43,8 @@ func Session(ctx context.Context, request events.APIGatewayProxyRequest) (events
 	secure := os.Getenv("ENV") == config.EnvProd
 	apiRes.StatusCode = http.StatusNoContent
 	applyCORSHeaders(&apiRes, origin)
-	apiRes.Headers["Set-Cookie"] = sessionCookieString(token, secure)
-	apiRes.Headers["Cache-Control"] = "no-store"
+	headers := ensureResponseHeaders(&apiRes)
+	headers["Set-Cookie"] = sessionCookieString(token, secure)
+	headers["Cache-Control"] = "no-store"
 	return apiRes, nil
 }

--- a/api/handler/session_test.go
+++ b/api/handler/session_test.go
@@ -1,0 +1,41 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"mtg-price-checker-sg/pkg/apiauth"
+	"mtg-price-checker-sg/pkg/config"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSession_SameOriginWithoutOriginHeader(t *testing.T) {
+	original := sessionTokenFunc
+	sessionTokenFunc = func(now time.Time) (string, error) {
+		return apiauth.NewSessionToken(now)
+	}
+	t.Cleanup(func() { sessionTokenFunc = original })
+
+	require.NoError(t, os.Setenv(config.APISessionSecretEnv, "test-session-secret"))
+	require.NoError(t, os.Setenv("ENV", config.EnvProd))
+	t.Cleanup(func() {
+		_ = os.Unsetenv(config.APISessionSecretEnv)
+		_ = os.Unsetenv("ENV")
+	})
+
+	req := events.APIGatewayProxyRequest{
+		HTTPMethod: http.MethodGet,
+		Headers:    map[string]string{},
+	}
+
+	res, err := Session(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, res.StatusCode)
+	require.NotEmpty(t, res.Headers["Set-Cookie"])
+	require.Contains(t, res.Headers["Set-Cookie"], "gf_api_session=")
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After merging API access control, production search fails because session bootstrap never succeeds.

- `GET /api/session` returns **500** `{"message":"Internal Server Error"}` (Lambda panic)
- `GET /api/search` returns **403** `session required`

## Root cause

Same-origin requests from `https://gishathfetch.com` often **do not send an `Origin` header**. `applyCORSHeaders` returns without initializing `Headers`, then `Session` assigned `Set-Cookie` on a nil map → panic.

## Fix

Initialize the response header map before setting `Set-Cookie` / `Cache-Control`.

## Testing

- `go test ./handler/... -run Session`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c2131505-d73e-4d0f-a8a5-4e57724a98c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c2131505-d73e-4d0f-a8a5-4e57724a98c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

