### PR TITLE
API host /search + /session, Turnstile, cookie Path=/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,15 +101,21 @@ This writes `homepage-desktop.png` (1440x900, full page) and `homepage-mobile.pn
 
 ### Frontend API connection
 
-Production search uses same-origin paths `/api/session` and `/api/search` (see
-`frontend/src/constants.js`). CloudFront proxies `/api/*` to API Gateway. Local dev: Vite
-proxies `/api` to `VITE_API_PROXY_TARGET` (default `https://api.gishathfetch.com`);
-set `VITE_API_ORIGIN_VERIFY_SECRET` in `frontend/.env.local` when testing against
-an environment with `API_ORIGIN_VERIFY_SECRET` enabled.
+Production search uses **`https://api.gishathfetch.com/search`** and **`/session`** (see
+`frontend/src/constants.js`). Set `VITE_API_BASE_URL=` (empty) in `frontend/.env.local` to use
+Vite proxies on `/search` and `/session` during local dev; otherwise the SPA calls the API host
+directly (CORS allowlist includes `http://localhost:5173`).
+
+Proxy target: `VITE_API_PROXY_TARGET` (default `https://api.gishathfetch.com`). Set
+`VITE_API_ORIGIN_VERIFY_SECRET` when testing against an environment with
+`API_ORIGIN_VERIFY_SECRET` enabled.
 
 When Turnstile is enabled in production, set `TURNSTILE_SECRET_KEY` on the search Lambda and
-`VITE_TURNSTILE_SITE_KEY` at frontend build time. Session minting (`GET /api/session`) expects
+`VITE_TURNSTILE_SITE_KEY` at frontend build time. Session minting (`GET /session`) expects
 the browser to send `CF-Turnstile-Response` (see `frontend/src/utils/apiSession.js`).
+
+**API Gateway (manual):** expose `GET` + `OPTIONS` for `/search` and `/session` only; remove
+legacy `/`, `/api`, and `/api/*` routes when traffic has migrated.
 
 ### Backend local mode
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,10 @@ proxies `/api` to `VITE_API_PROXY_TARGET` (default `https://api.gishathfetch.com
 set `VITE_API_ORIGIN_VERIFY_SECRET` in `frontend/.env.local` when testing against
 an environment with `API_ORIGIN_VERIFY_SECRET` enabled.
 
+When Turnstile is enabled in production, set `TURNSTILE_SECRET_KEY` on the search Lambda and
+`VITE_TURNSTILE_SITE_KEY` at frontend build time. Session minting (`GET /api/session`) expects
+the browser to send `CF-Turnstile-Response` (see `frontend/src/utils/apiSession.js`).
+
 ### Backend local mode
 
 When `ENV` is unset (local mode), `go run ./cmd/main.go` executes a hardcoded test search for "Opt" across a subset of stores and prints the JSON result to stdout. No server is started; the process exits after printing.

--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ It aggregates listings from supported stores, normalizes results, and sorts by p
 
 ### System overview
 
-Gishath Fetch is a static React SPA served from S3 behind CloudFront. Search
-uses same-origin `GET /api/search` on `gishathfetch.com`; CloudFront forwards
-`/api/*` to API Gateway (`api.gishathfetch.com` origin) and a container-based
-Lambda that scrapes LGS sites in parallel. Inbound access uses an origin-verify
-header (CloudFront → Lambda) and a short-lived session cookie. When
+Gishath Fetch is a static React SPA served from S3 behind CloudFront. Search and
+session use **`https://api.gishathfetch.com/search`** and **`/session`** from the
+browser (cross-origin, credentialed). API Gateway invokes a container-based Lambda
+that scrapes LGS sites in parallel. Inbound access may use an origin-verify header
+(optional CloudFront or automation) or an allowlisted browser `Origin`, plus a
+short-lived session cookie (and optional Turnstile on session mint). When
 `WEB_BOT_AUTH_ENABLED` is set, outbound scraper requests
 are signed per [Web Bot Auth](https://datatracker.ietf.org/doc/draft-meunier-web-bot-auth-architecture/)
 (RFC 9421 HTTP Message Signatures); the public key directory is published at
@@ -64,8 +65,7 @@ flowchart TB
     Browser -->|HTTPS| CF
     CF --> S3
     Browser -->|gtag search events| GA4
-    Browser -->|GET /api/session, /api/search| CF
-    CF -->|/api/* + X-Origin-Verify| AGW
+    Browser -->|GET /session, /search| AGW
     AGW --> SearchLambda
     SearchLambda -->|optional Web Bot Auth signatures| Proxies
     Proxies --> LGS
@@ -90,7 +90,7 @@ flowchart TB
 |---------|-----------------|------|
 | Frontend CDN | CloudFront → `gishathfetch.com` | Serves the React SPA from S3 |
 | Web Bot Auth directory | `https://gishathfetch.com/.well-known/http-message-signatures-directory` | Public signing keys for verifiers; built by `make generate-signature-directory` and uploaded on frontend deploy |
-| Search API | CloudFront `/api/*` → API Gateway (`api.gishathfetch.com` origin) | `GET /api/search`, `GET /api/session`; origin verify + session cookie |
+| Search API | API Gateway `api.gishathfetch.com` | `GET /search`, `GET /session`; optional origin verify + session cookie (+ optional Turnstile) |
 | Search Lambda | `mtg-price-scrapper` | Concurrent LGS scraping; optional Web Bot Auth on outbound requests; optional CK price lookup from DynamoDB |
 | CK refresh Lambda | `mtg-price-ck-refresh` | Daily Card Kingdom pricelist download, DynamoDB index rebuild, and CK price change export to S3 |
 | Analytics keywords Lambda | `mtg-analytics-keywords-export` | Daily GA4 export of top search keywords to S3 |

--- a/api/handler/access.go
+++ b/api/handler/access.go
@@ -107,7 +107,7 @@ func sessionCookieString(token string, secure bool) string {
 	maxAge := int(config.APISessionTTL().Seconds())
 	parts := []string{
 		fmt.Sprintf("%s=%s", apiauth.SessionCookieName(), token),
-		"Path=/api",
+		"Path=/",
 		fmt.Sprintf("Max-Age=%d", maxAge),
 		"HttpOnly",
 		"SameSite=Lax",

--- a/api/handler/access_test.go
+++ b/api/handler/access_test.go
@@ -14,18 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_normalizeAPIPath(t *testing.T) {
-	t.Parallel()
-	req := events.APIGatewayProxyRequest{Path: "/api/session"}
-	require.Equal(t, "session", normalizeAPIPath(req))
-
-	req = events.APIGatewayProxyRequest{Path: "/api/search"}
-	require.Equal(t, "search", normalizeAPIPath(req))
-
-	req = events.APIGatewayProxyRequest{Path: "/prod/api"}
-	require.Equal(t, "", normalizeAPIPath(req))
-}
-
 func Test_Search_AccessControl(t *testing.T) {
 	originalSearchFunc := searchFunc
 	originalLookupCKPriceFunc := lookupCKPriceFunc

--- a/api/handler/cors.go
+++ b/api/handler/cors.go
@@ -18,7 +18,7 @@ func applyCORSHeaders(apiResponse *events.APIGatewayProxyResponse, origin string
 	apiResponse.Headers = map[string]string{
 		"Access-Control-Allow-Origin":  origin,
 		"Access-Control-Allow-Methods": "GET, OPTIONS",
-		"Access-Control-Allow-Headers": "Content-Type",
+		"Access-Control-Allow-Headers": "Content-Type, CF-Turnstile-Response",
 		"Access-Control-Allow-Credentials": "true",
 		"Vary":                         "Origin",
 	}

--- a/api/handler/path.go
+++ b/api/handler/path.go
@@ -6,7 +6,8 @@ import (
 	"github.com/aws/aws-lambda-go/events"
 )
 
-// normalizeAPIPath returns the path segment after optional stage and /api prefixes.
+// normalizeAPIPath returns the route name (e.g. search, session) after optional stage
+// and legacy /api prefixes.
 func normalizeAPIPath(request events.APIGatewayProxyRequest) string {
 	path := strings.TrimSpace(request.Path)
 	if path == "" {

--- a/api/handler/path_test.go
+++ b/api/handler/path_test.go
@@ -1,0 +1,31 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_normalizeAPIPath(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		path string
+		want string
+	}{
+		{"/search", "search"},
+		{"/session", "session"},
+		{"/api/search", "search"},
+		{"/api/session", "session"},
+		{"/prod/search", "search"},
+		{"/prod/api/search", "search"},
+		{"/prod/api", ""},
+		{"/", ""},
+	}
+
+	for _, tc := range cases {
+		req := events.APIGatewayProxyRequest{Path: tc.path}
+		require.Equal(t, tc.want, normalizeAPIPath(req), "path %q", tc.path)
+	}
+}

--- a/api/handler/session.go
+++ b/api/handler/session.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"os"
 	"time"
@@ -13,6 +14,8 @@ import (
 )
 
 var sessionTokenFunc = apiauth.NewSessionToken
+
+var verifyTurnstileFunc = apiauth.VerifyTurnstile
 
 // Session mints an HttpOnly cookie the browser must send before search requests.
 func Session(ctx context.Context, request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
@@ -33,6 +36,16 @@ func Session(ctx context.Context, request events.APIGatewayProxyRequest) (events
 
 	if config.APISessionSecret() == "" {
 		return errorResponse(apiRes, origin, "session not configured", http.StatusServiceUnavailable)
+	}
+
+	turnstileToken := headerValue(request.Headers, apiauth.TurnstileResponseHeader)
+	remoteIP := request.RequestContext.Identity.SourceIP
+	if err := verifyTurnstileFunc(ctx, turnstileToken, remoteIP); err != nil {
+		message := "verification failed"
+		if errors.Is(err, apiauth.ErrTurnstileTokenMissing) {
+			message = "verification required"
+		}
+		return accessDeniedResponse(apiRes, origin, message), nil
 	}
 
 	token, err := sessionTokenFunc(time.Now().UTC())

--- a/api/handler/session_turnstile_test.go
+++ b/api/handler/session_turnstile_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"os"
 	"testing"
-	"time"
 
 	"mtg-price-checker-sg/pkg/apiauth"
 	"mtg-price-checker-sg/pkg/config"
@@ -14,18 +13,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSession_SameOriginWithoutOriginHeader(t *testing.T) {
-	original := sessionTokenFunc
-	sessionTokenFunc = func(now time.Time) (string, error) {
-		return apiauth.NewSessionToken(now)
+func TestSession_TurnstileRequiredWhenConfigured(t *testing.T) {
+	originalVerify := verifyTurnstileFunc
+	verifyTurnstileFunc = func(_ context.Context, token, _ string) error {
+		if token == "" {
+			return apiauth.ErrTurnstileTokenMissing
+		}
+		return nil
 	}
-	t.Cleanup(func() { sessionTokenFunc = original })
+	t.Cleanup(func() { verifyTurnstileFunc = originalVerify })
 
 	require.NoError(t, os.Setenv(config.APISessionSecretEnv, "test-session-secret"))
-	require.NoError(t, os.Setenv("ENV", config.EnvProd))
+	require.NoError(t, os.Setenv(config.TurnstileSecretKeyEnv, "turnstile-secret"))
 	t.Cleanup(func() {
 		_ = os.Unsetenv(config.APISessionSecretEnv)
-		_ = os.Unsetenv("ENV")
 		_ = os.Unsetenv(config.TurnstileSecretKeyEnv)
 	})
 
@@ -36,7 +37,12 @@ func TestSession_SameOriginWithoutOriginHeader(t *testing.T) {
 
 	res, err := Session(context.Background(), req)
 	require.NoError(t, err)
+	require.Equal(t, http.StatusForbidden, res.StatusCode)
+
+	req.Headers = map[string]string{
+		apiauth.TurnstileResponseHeader: "valid-token",
+	}
+	res, err = Session(context.Background(), req)
+	require.NoError(t, err)
 	require.Equal(t, http.StatusNoContent, res.StatusCode)
-	require.NotEmpty(t, res.Headers["Set-Cookie"])
-	require.Contains(t, res.Headers["Set-Cookie"], "gf_api_session=")
 }

--- a/api/pkg/apiauth/origin.go
+++ b/api/pkg/apiauth/origin.go
@@ -3,6 +3,7 @@ package apiauth
 import (
 	"crypto/subtle"
 	"errors"
+	"slices"
 	"strings"
 
 	"mtg-price-checker-sg/pkg/config"
@@ -10,7 +11,9 @@ import (
 
 var errOriginVerifyFailed = errors.New("origin verification failed")
 
-// VerifyOriginHeader ensures the CloudFront origin secret header matches when configured.
+// VerifyOriginHeader enforces access when API_ORIGIN_VERIFY_SECRET is set.
+// Requests with a matching X-Origin-Verify header pass (e.g. CloudFront origin).
+// Browser calls to api.gishathfetch.com may omit that header and use an allowlisted Origin instead.
 func VerifyOriginHeader(headers map[string]string) error {
 	secret := config.APIOriginVerifySecret()
 	if secret == "" {
@@ -19,11 +22,19 @@ func VerifyOriginHeader(headers map[string]string) error {
 
 	headerName := strings.ToLower(config.APIOriginVerifyHeader())
 	got := strings.TrimSpace(headerValue(headers, headerName))
-	if got == "" || subtle.ConstantTimeCompare([]byte(got), []byte(secret)) != 1 {
+	if got != "" {
+		if subtle.ConstantTimeCompare([]byte(got), []byte(secret)) == 1 {
+			return nil
+		}
 		return errOriginVerifyFailed
 	}
 
-	return nil
+	origin := strings.TrimSpace(headerValue(headers, "origin"))
+	if origin != "" && slices.Contains(config.GetAllowedOrigins(), origin) {
+		return nil
+	}
+
+	return errOriginVerifyFailed
 }
 
 func headerValue(headers map[string]string, lowerName string) string {

--- a/api/pkg/apiauth/session_test.go
+++ b/api/pkg/apiauth/session_test.go
@@ -41,4 +41,10 @@ func TestVerifyOriginHeader(t *testing.T) {
 
 	err = VerifyOriginHeader(map[string]string{"x-origin-verify": "wrong"})
 	require.ErrorIs(t, err, errOriginVerifyFailed)
+
+	err = VerifyOriginHeader(map[string]string{"origin": "https://gishathfetch.com"})
+	require.NoError(t, err)
+
+	err = VerifyOriginHeader(map[string]string{})
+	require.ErrorIs(t, err, errOriginVerifyFailed)
 }

--- a/api/pkg/apiauth/turnstile.go
+++ b/api/pkg/apiauth/turnstile.go
@@ -1,0 +1,95 @@
+package apiauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"mtg-price-checker-sg/pkg/config"
+)
+
+const (
+	// TurnstileResponseHeader is the request header carrying the browser Turnstile token.
+	TurnstileResponseHeader = "CF-Turnstile-Response"
+	turnstileSiteverifyURLDefault = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+	turnstileVerifyTimeout  = 5 * time.Second
+)
+
+var (
+	// ErrTurnstileTokenMissing indicates the client did not send a Turnstile token.
+	ErrTurnstileTokenMissing = errors.New("turnstile token missing")
+	// ErrTurnstileVerificationFailed indicates Cloudflare rejected the token.
+	ErrTurnstileVerificationFailed = errors.New("turnstile verification failed")
+)
+
+type turnstileSiteverifyResponse struct {
+	Success    bool     `json:"success"`
+	ErrorCodes []string `json:"error-codes"`
+}
+
+var (
+	turnstileHTTPClient   = &http.Client{Timeout: turnstileVerifyTimeout}
+	turnstileSiteverifyURL = turnstileSiteverifyURLDefault
+)
+
+// VerifyTurnstile checks the token with Cloudflare when TURNSTILE_SECRET_KEY is set.
+func VerifyTurnstile(ctx context.Context, token, remoteIP string) error {
+	secret := config.TurnstileSecretKey()
+	if secret == "" {
+		return nil
+	}
+
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return ErrTurnstileTokenMissing
+	}
+
+	form := url.Values{}
+	form.Set("secret", secret)
+	form.Set("response", token)
+	if ip := strings.TrimSpace(remoteIP); ip != "" {
+		form.Set("remoteip", ip)
+	}
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		turnstileSiteverifyURL,
+		strings.NewReader(form.Encode()),
+	)
+	if err != nil {
+		return fmt.Errorf("turnstile request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	res, err := turnstileHTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("turnstile siteverify: %w", err)
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(res.Body, 1<<20))
+	if err != nil {
+		return fmt.Errorf("turnstile response: %w", err)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return ErrTurnstileVerificationFailed
+	}
+
+	var parsed turnstileSiteverifyResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return fmt.Errorf("turnstile decode: %w", err)
+	}
+	if !parsed.Success {
+		return ErrTurnstileVerificationFailed
+	}
+
+	return nil
+}

--- a/api/pkg/apiauth/turnstile_test.go
+++ b/api/pkg/apiauth/turnstile_test.go
@@ -1,0 +1,68 @@
+package apiauth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"mtg-price-checker-sg/pkg/config"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyTurnstile_SkipsWhenSecretUnset(t *testing.T) {
+	t.Parallel()
+	require.NoError(t, os.Unsetenv(config.TurnstileSecretKeyEnv))
+	require.NoError(t, VerifyTurnstile(context.Background(), "", ""))
+}
+
+func TestVerifyTurnstile_RequiresTokenWhenSecretSet(t *testing.T) {
+	t.Parallel()
+	require.NoError(t, os.Setenv(config.TurnstileSecretKeyEnv, "test-secret"))
+	t.Cleanup(func() { _ = os.Unsetenv(config.TurnstileSecretKeyEnv) })
+
+	err := VerifyTurnstile(context.Background(), "", "203.0.113.1")
+	require.ErrorIs(t, err, ErrTurnstileTokenMissing)
+}
+
+func TestVerifyTurnstile_AcceptsSuccessfulSiteverify(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.NoError(t, r.ParseForm())
+		require.Equal(t, "test-secret", r.Form.Get("secret"))
+		require.Equal(t, "good-token", r.Form.Get("response"))
+		require.Equal(t, "203.0.113.1", r.Form.Get("remoteip"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"success":true}`))
+	}))
+	t.Cleanup(server.Close)
+
+	originalURL := turnstileSiteverifyURL
+	turnstileSiteverifyURL = server.URL
+	t.Cleanup(func() { turnstileSiteverifyURL = originalURL })
+
+	require.NoError(t, os.Setenv(config.TurnstileSecretKeyEnv, "test-secret"))
+	t.Cleanup(func() { _ = os.Unsetenv(config.TurnstileSecretKeyEnv) })
+
+	err := VerifyTurnstile(context.Background(), "good-token", "203.0.113.1")
+	require.NoError(t, err)
+}
+
+func TestVerifyTurnstile_RejectsFailedSiteverify(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"success":false,"error-codes":["invalid-input-response"]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	originalURL := turnstileSiteverifyURL
+	turnstileSiteverifyURL = server.URL
+	t.Cleanup(func() { turnstileSiteverifyURL = originalURL })
+
+	require.NoError(t, os.Setenv(config.TurnstileSecretKeyEnv, "test-secret"))
+	t.Cleanup(func() { _ = os.Unsetenv(config.TurnstileSecretKeyEnv) })
+
+	err := VerifyTurnstile(context.Background(), "bad-token", "")
+	require.ErrorIs(t, err, ErrTurnstileVerificationFailed)
+}

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -101,6 +101,8 @@ const (
 	APISessionSecretEnv = "API_SESSION_SECRET"
 	// APISessionTTLEnv overrides session lifetime in seconds (default 15 minutes).
 	APISessionTTLEnv = "API_SESSION_TTL_SECONDS"
+	// TurnstileSecretKeyEnv is the Cloudflare Turnstile secret for siteverify on /api/session.
+	TurnstileSecretKeyEnv = "TURNSTILE_SECRET_KEY"
 )
 
 // UseLeasedDedicatedProxy enables exclusive per-request leases from the dedicated proxy pool.
@@ -211,6 +213,11 @@ func APISessionTTL() time.Duration {
 		return defaultAPISessionTTL
 	}
 	return time.Duration(seconds) * time.Second
+}
+
+// TurnstileSecretKey returns the Cloudflare Turnstile secret when session minting requires verification.
+func TurnstileSecretKey() string {
+	return strings.TrimSpace(os.Getenv(TurnstileSecretKeyEnv))
 }
 
 // APIAccessControlEnabled is true when origin verification or session enforcement is configured.

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -101,7 +101,7 @@ const (
 	APISessionSecretEnv = "API_SESSION_SECRET"
 	// APISessionTTLEnv overrides session lifetime in seconds (default 15 minutes).
 	APISessionTTLEnv = "API_SESSION_TTL_SECONDS"
-	// TurnstileSecretKeyEnv is the Cloudflare Turnstile secret for siteverify on /api/session.
+	// TurnstileSecretKeyEnv is the Cloudflare Turnstile secret for siteverify on GET /session.
 	TurnstileSecretKeyEnv = "TURNSTILE_SECRET_KEY"
 )
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,6 +8,7 @@ import Header from "./components/Header";
 import SearchForm from "./components/SearchForm";
 import SearchResults from "./components/SearchResults";
 import TopSearchKeywords from "./components/TopSearchKeywords";
+import TurnstileBootstrap from "./components/TurnstileBootstrap";
 
 const CartOffcanvas = lazy(() => import("./components/CartOffcanvas"));
 const Modals = lazy(() => import("./components/Modals"));
@@ -193,6 +194,7 @@ export default function App() {
   // --- Main Render ---
   return (
     <div id="top" className="container-xl my-3 px-3 pb-3">
+      <TurnstileBootstrap />
       <Header theme={theme} onToggleTheme={handleThemeToggle} />
 
       <SearchForm

--- a/frontend/src/components/TurnstileBootstrap.jsx
+++ b/frontend/src/components/TurnstileBootstrap.jsx
@@ -5,7 +5,7 @@ import {
 } from "../utils/turnstileSession";
 
 /**
- * Invisible Turnstile widget used to obtain tokens for GET /api/session.
+ * Invisible Turnstile widget used to obtain tokens for GET /session on the API host.
  */
 export default function TurnstileBootstrap() {
   const containerRef = useRef(null);

--- a/frontend/src/components/TurnstileBootstrap.jsx
+++ b/frontend/src/components/TurnstileBootstrap.jsx
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from "react";
+import {
+  isTurnstileConfigured,
+  prepareTurnstileWidget,
+} from "../utils/turnstileSession";
+
+/**
+ * Invisible Turnstile widget used to obtain tokens for GET /api/session.
+ */
+export default function TurnstileBootstrap() {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    if (!isTurnstileConfigured()) {
+      return undefined;
+    }
+
+    let cancelled = false;
+    prepareTurnstileWidget(containerRef.current).catch(() => {
+      if (!cancelled) {
+        // Session bootstrap will surface errors on the next search.
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!isTurnstileConfigured()) {
+    return null;
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className="turnstile-bootstrap"
+      aria-hidden="true"
+    />
+  );
+}

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -171,10 +171,29 @@ export const MIN_SEARCH_LENGTH = 3;
 // rejecting bot paragraph spam.
 export const MAX_SEARCH_LENGTH = 150;
 
-export const API_SEARCH_URL = "/api/search";
+const DEFAULT_API_BASE_URL = "https://api.gishathfetch.com";
 
-/** Same-origin endpoint that mints the HttpOnly search session cookie. */
-export const API_SESSION_URL = "/api/session";
+function resolveApiBaseUrl() {
+  const raw = import.meta.env.VITE_API_BASE_URL;
+  if (raw === "") {
+    return "";
+  }
+  if (typeof raw === "string" && raw.trim() !== "") {
+    return raw.trim().replace(/\/$/, "");
+  }
+  return DEFAULT_API_BASE_URL;
+}
+
+export const API_BASE_URL = resolveApiBaseUrl();
+
+function apiUrl(path) {
+  return API_BASE_URL ? `${API_BASE_URL}${path}` : path;
+}
+
+export const API_SEARCH_URL = apiUrl("/search");
+
+/** API host endpoint that mints the HttpOnly search session cookie. */
+export const API_SESSION_URL = apiUrl("/session");
 
 export const BASE_URL = "https://gishathfetch.com/";
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -22,6 +22,18 @@ body {
   min-height: 100vh;
 }
 
+.turnstile-bootstrap {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 #logo {
   width: 120px;
 }

--- a/frontend/src/utils/apiSession.js
+++ b/frontend/src/utils/apiSession.js
@@ -1,4 +1,8 @@
 import { API_SESSION_URL } from "../constants";
+import {
+  obtainTurnstileToken,
+  resetTurnstileChallenge,
+} from "./turnstileSession";
 
 let sessionBootstrapPromise = null;
 
@@ -6,25 +10,40 @@ let sessionBootstrapPromise = null;
  * Ensures the browser holds a valid HttpOnly API session cookie (minted by GET /api/session).
  * Safe to call repeatedly; concurrent callers share one in-flight request.
  */
-export function ensureApiSession() {
+export async function ensureApiSession() {
   if (!sessionBootstrapPromise) {
-    sessionBootstrapPromise = fetch(API_SESSION_URL, {
-      method: "GET",
-      credentials: "include",
-    }).then((res) => {
-      if (!res.ok) {
-        throw new Error(`API session failed (${res.status})`);
-      }
-    });
+    sessionBootstrapPromise = bootstrapSession();
   }
 
-  return sessionBootstrapPromise.catch((err) => {
+  try {
+    await sessionBootstrapPromise;
+  } catch (err) {
     sessionBootstrapPromise = null;
     throw err;
+  }
+}
+
+async function bootstrapSession() {
+  const headers = {};
+  const turnstileToken = await obtainTurnstileToken();
+  if (turnstileToken) {
+    headers["CF-Turnstile-Response"] = turnstileToken;
+  }
+
+  const res = await fetch(API_SESSION_URL, {
+    method: "GET",
+    credentials: "include",
+    headers,
   });
+
+  if (!res.ok) {
+    resetTurnstileChallenge();
+    throw new Error(`API session failed (${res.status})`);
+  }
 }
 
 /** Clears the cached bootstrap promise (for tests or after auth errors). */
 export function resetApiSessionCache() {
   sessionBootstrapPromise = null;
+  resetTurnstileChallenge();
 }

--- a/frontend/src/utils/apiSession.js
+++ b/frontend/src/utils/apiSession.js
@@ -7,7 +7,7 @@ import {
 let sessionBootstrapPromise = null;
 
 /**
- * Ensures the browser holds a valid HttpOnly API session cookie (minted by GET /api/session).
+ * Ensures the browser holds a valid HttpOnly API session cookie (minted by GET /session on the API host).
  * Safe to call repeatedly; concurrent callers share one in-flight request.
  */
 export async function ensureApiSession() {

--- a/frontend/src/utils/turnstileSession.js
+++ b/frontend/src/utils/turnstileSession.js
@@ -1,0 +1,158 @@
+const TURNSTILE_SCRIPT_SRC =
+  "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
+
+const TURNSTILE_TIMEOUT_MS = 30_000;
+
+let scriptLoadPromise = null;
+let widgetId = null;
+let widgetReadyResolve;
+const widgetReadyPromise = new Promise((resolve) => {
+  widgetReadyResolve = resolve;
+});
+
+let cachedToken = "";
+let pendingTokenPromise = null;
+
+function siteKey() {
+  const key = import.meta.env.VITE_TURNSTILE_SITE_KEY;
+  return typeof key === "string" ? key.trim() : "";
+}
+
+export function isTurnstileConfigured() {
+  return siteKey() !== "";
+}
+
+function loadTurnstileScript() {
+  if (!isTurnstileConfigured()) {
+    return Promise.resolve();
+  }
+  if (window.turnstile) {
+    return Promise.resolve();
+  }
+  if (scriptLoadPromise) {
+    return scriptLoadPromise;
+  }
+
+  scriptLoadPromise = new Promise((resolve, reject) => {
+    const existing = document.querySelector(
+      `script[src^="https://challenges.cloudflare.com/turnstile/"]`,
+    );
+    if (existing) {
+      existing.addEventListener("load", () => resolve(), { once: true });
+      existing.addEventListener(
+        "error",
+        () => reject(new Error("turnstile script failed")),
+        { once: true },
+      );
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.src = TURNSTILE_SCRIPT_SRC;
+    script.async = true;
+    script.defer = true;
+    script.onload = () => resolve();
+    script.onerror = () => reject(new Error("turnstile script failed"));
+    document.head.appendChild(script);
+  });
+
+  return scriptLoadPromise;
+}
+
+export function registerTurnstileWidget(id) {
+  widgetId = id;
+  widgetReadyResolve();
+}
+
+export function onTurnstileToken(token) {
+  cachedToken = token;
+  if (pendingTokenPromise) {
+    pendingTokenPromise.resolve(token);
+    pendingTokenPromise = null;
+  }
+}
+
+export function onTurnstileExpired() {
+  cachedToken = "";
+}
+
+export function onTurnstileError() {
+  cachedToken = "";
+  if (pendingTokenPromise) {
+    pendingTokenPromise.reject(new Error("turnstile challenge failed"));
+    pendingTokenPromise = null;
+  }
+}
+
+export async function prepareTurnstileWidget(container) {
+  if (!isTurnstileConfigured() || !container) {
+    return;
+  }
+
+  await loadTurnstileScript();
+  if (widgetId != null) {
+    return;
+  }
+
+  const id = window.turnstile.render(container, {
+    sitekey: siteKey(),
+    size: "invisible",
+    callback: onTurnstileToken,
+    "expired-callback": onTurnstileExpired,
+    "error-callback": onTurnstileError,
+  });
+  registerTurnstileWidget(id);
+}
+
+function waitForTurnstileToken() {
+  if (cachedToken) {
+    return Promise.resolve(cachedToken);
+  }
+
+  if (pendingTokenPromise) {
+    return pendingTokenPromise.promise;
+  }
+
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  pendingTokenPromise = { promise, resolve, reject };
+
+  const timeout = setTimeout(() => {
+    if (pendingTokenPromise) {
+      pendingTokenPromise.reject(new Error("turnstile timeout"));
+      pendingTokenPromise = null;
+    }
+  }, TURNSTILE_TIMEOUT_MS);
+
+  return promise.finally(() => clearTimeout(timeout));
+}
+
+export async function obtainTurnstileToken() {
+  if (!isTurnstileConfigured()) {
+    return "";
+  }
+
+  await widgetReadyPromise;
+  if (widgetId == null) {
+    throw new Error("turnstile widget not ready");
+  }
+
+  if (cachedToken) {
+    return cachedToken;
+  }
+
+  window.turnstile.execute(widgetId);
+  return waitForTurnstileToken();
+}
+
+export function resetTurnstileChallenge() {
+  cachedToken = "";
+  pendingTokenPromise = null;
+  if (widgetId != null && window.turnstile) {
+    window.turnstile.reset(widgetId);
+  }
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -5,6 +5,18 @@ const signatureDirectoryPath = "/.well-known/http-message-signatures-directory";
 const signatureDirectoryMediaType =
   "application/http-message-signatures-directory+json";
 
+const apiProxyTarget =
+  process.env.VITE_API_PROXY_TARGET || "https://api.gishathfetch.com";
+
+function configureApiProxy(proxy) {
+  proxy.on("proxyReq", (proxyReq) => {
+    const verifySecret = process.env.VITE_API_ORIGIN_VERIFY_SECRET;
+    if (verifySecret) {
+      proxyReq.setHeader("X-Origin-Verify", verifySecret);
+    }
+  });
+}
+
 // https://vite.dev/config/
 export default defineConfig({
   envPrefix: ["VITE_"],
@@ -37,18 +49,15 @@ export default defineConfig({
         target: "https://gishathfetch.com",
         changeOrigin: true,
       },
-      "/api": {
-        target:
-          process.env.VITE_API_PROXY_TARGET || "https://api.gishathfetch.com",
+      "/search": {
+        target: apiProxyTarget,
         changeOrigin: true,
-        configure: (proxy) => {
-          proxy.on("proxyReq", (proxyReq) => {
-            const verifySecret = process.env.VITE_API_ORIGIN_VERIFY_SECRET;
-            if (verifySecret) {
-              proxyReq.setHeader("X-Origin-Verify", verifySecret);
-            }
-          });
-        },
+        configure: configureApiProxy,
+      },
+      "/session": {
+        target: apiProxyTarget,
+        changeOrigin: true,
+        configure: configureApiProxy,
       },
     },
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Turnstile** on `GET /session` via `CF-Turnstile-Response` (optional when secrets unset).
- **API URLs:** browser uses `https://api.gishathfetch.com/search` and `/session` (no `/api` prefix on the API host).
- **Session cookie** `Path=/` so it applies to `/search` and `/session`.
- **Legacy paths:** Lambda still accepts `/api/search` and `/api/session` during migration.
- **Origin verify:** when `API_ORIGIN_VERIFY_SECRET` is set, requests pass with a matching `X-Origin-Verify` header **or** an allowlisted browser `Origin` (needed for credentialed cross-origin calls from `gishathfetch.com`).

## API Gateway (manual)

- Add **`GET` + `OPTIONS`** for `/search` and `/session`.
- Remove **`/`**, **`/api`**, and old **`/api/search`** / **`/api/session`** when ready.
- Remove CloudFront **`/api/*`** behavior on `gishathfetch.com` if unused.

## Frontend env

| Variable | Purpose |
|----------|---------|
| `VITE_API_BASE_URL` | Default `https://api.gishathfetch.com`; set to empty string for local Vite proxy |
| `VITE_API_PROXY_TARGET` | Dev proxy target (default `https://api.gishathfetch.com`) |
| `VITE_TURNSTILE_SITE_KEY` | Turnstile site key when enabled |
| `VITE_API_ORIGIN_VERIFY_SECRET` | Optional dev proxy origin header |

## Tests

- `make test`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53f65e04-85ad-4a47-9058-499349681e3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53f65e04-85ad-4a47-9058-499349681e3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

