### PR TITLE
Refresh API session in background and auto-retry expired searches

### DIFF
--- a/frontend/src/hooks/useSearch.js
+++ b/frontend/src/hooks/useSearch.js
@@ -7,7 +7,12 @@ import {
   MIN_SEARCH_LENGTH,
   PAGE_TITLE,
 } from "../constants";
-import { ensureApiSession } from "../utils/apiSession";
+import {
+  API_SESSION_REFRESH_INTERVAL_MS,
+  ensureApiSession,
+  isApiSessionAccessDenied,
+  resetApiSessionCache,
+} from "../utils/apiSession";
 import {
   buildSearchHistoryState,
   buildSearchUrl,
@@ -84,6 +89,14 @@ export default function useSearch() {
     ensureApiSession().catch(() => {
       // Search will retry session bootstrap before the first API call.
     });
+
+    const refreshTimer = setInterval(() => {
+      ensureApiSession({ forceRefresh: true }).catch(() => {
+        // Next search or interval will try again.
+      });
+    }, API_SESSION_REFRESH_INTERVAL_MS);
+
+    return () => clearInterval(refreshTimer);
   }, []);
 
   const syncSearchHistory = useCallback((snapshot) => {
@@ -184,43 +197,54 @@ export default function useSearch() {
       }, SEARCH_PROGRESS_INTERVAL_MS);
       progressIntervalRef.current = progressInterval;
 
-      ensureApiSession()
-        .then(() =>
-          fetch(searchUrl, {
-            signal: searchAbortController.signal,
-            credentials: "include",
-          }),
-        )
-        .then(async (res) => {
-          if (!res.ok) {
-            let errorBody = null;
-            try {
-              errorBody = await res.json();
-            } catch {
-              // Ignore malformed error responses.
-            }
+      const fetchSearchResult = async (sessionRetried) => {
+        await ensureApiSession({ forceRefresh: sessionRetried });
 
-            const validationMessage =
-              typeof errorBody?.error === "string" && errorBody.error
-                ? errorBody.error
-                : null;
-            const statusCode = errorBody?.statusCode || res.status;
+        const res = await fetch(searchUrl, {
+          signal: searchAbortController.signal,
+          credentials: "include",
+        });
 
-            if (validationMessage) {
-              throw new Error(
-                formatErrorWithStatusCode(validationMessage, statusCode),
-              );
-            }
+        if (!res.ok) {
+          let errorBody = null;
+          try {
+            errorBody = await res.json();
+          } catch {
+            // Ignore malformed error responses.
+          }
 
+          const validationMessage =
+            typeof errorBody?.error === "string" && errorBody.error
+              ? errorBody.error
+              : null;
+          const statusCode = errorBody?.statusCode || res.status;
+
+          if (
+            !sessionRetried &&
+            isApiSessionAccessDenied(validationMessage, statusCode)
+          ) {
+            resetApiSessionCache();
+            return fetchSearchResult(true);
+          }
+
+          if (validationMessage) {
             throw new Error(
-              formatErrorWithStatusCode(
-                res.statusText || "The server returned an error.",
-                statusCode,
-              ),
+              formatErrorWithStatusCode(validationMessage, statusCode),
             );
           }
-          return res.json();
-        })
+
+          throw new Error(
+            formatErrorWithStatusCode(
+              res.statusText || "The server returned an error.",
+              statusCode,
+            ),
+          );
+        }
+
+        return res.json();
+      };
+
+      fetchSearchResult(false)
         .then((result) => {
           if (requestId !== activeSearchRequestIdRef.current) return;
           if (result && Object.hasOwn(result, "data")) {

--- a/frontend/src/utils/apiSession.js
+++ b/frontend/src/utils/apiSession.js
@@ -1,12 +1,21 @@
 import { API_SESSION_URL } from "../constants";
 
+/** Refresh before default API session TTL (15m) so idle tabs stay authorized. */
+export const API_SESSION_REFRESH_INTERVAL_MS = 10 * 60 * 1000;
+
 let sessionBootstrapPromise = null;
 
 /**
  * Ensures the browser holds a valid HttpOnly API session cookie (minted by GET /api/session).
- * Safe to call repeatedly; concurrent callers share one in-flight request.
+ * Safe to call repeatedly; concurrent callers share one in-flight request unless forceRefresh.
  */
-export function ensureApiSession() {
+export function ensureApiSession(options = {}) {
+  const { forceRefresh = false } = options;
+
+  if (forceRefresh) {
+    sessionBootstrapPromise = null;
+  }
+
   if (!sessionBootstrapPromise) {
     sessionBootstrapPromise = fetch(API_SESSION_URL, {
       method: "GET",
@@ -22,6 +31,18 @@ export function ensureApiSession() {
     sessionBootstrapPromise = null;
     throw err;
   });
+}
+
+/** True when search API rejected the request for missing or expired session cookie. */
+export function isApiSessionAccessDenied(message, statusCode) {
+  if (statusCode !== 403) {
+    return false;
+  }
+  if (typeof message !== "string" || !message) {
+    return false;
+  }
+  const lower = message.toLowerCase();
+  return lower === "session required" || lower === "session expired";
 }
 
 /** Clears the cached bootstrap promise (for tests or after auth errors). */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Search requests require a short-lived HttpOnly session cookie (default 15 minutes). Previously the app called `GET /api/session` once on load and cached that promise forever, so lingering on the page past TTL led to `session required` / `session expired` errors on the next search with no automatic recovery.

## Changes

- **Background refresh**: While the tab is open, mint a fresh session every 10 minutes (before the default 15-minute TTL).
- **Auto-retry on search**: If a search returns 403 with a session auth message, clear the session cache, fetch a new session, and retry the search once without showing an error to the user.

## Testing

- `make test` (Go suite)
- `cd frontend && npm run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6d9de4f-990e-4a94-a85d-2c0bcd07f7be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6d9de4f-990e-4a94-a85d-2c0bcd07f7be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

