### PR TITLE
Fix Turnstile session hangs and remount bugs

### DIFF
--- a/frontend/src/components/TurnstileBootstrap.jsx
+++ b/frontend/src/components/TurnstileBootstrap.jsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 import {
   isTurnstileConfigured,
   prepareTurnstileWidget,
+  teardownTurnstileWidget,
 } from "../utils/turnstileSession";
 
 /**
@@ -16,7 +17,10 @@ export default function TurnstileBootstrap() {
     }
 
     let cancelled = false;
-    prepareTurnstileWidget(containerRef.current).catch(() => {
+    const abort = new AbortController();
+    prepareTurnstileWidget(containerRef.current, {
+      signal: abort.signal,
+    }).catch(() => {
       if (!cancelled) {
         // Session bootstrap will surface errors on the next search.
       }
@@ -24,6 +28,8 @@ export default function TurnstileBootstrap() {
 
     return () => {
       cancelled = true;
+      abort.abort();
+      teardownTurnstileWidget();
     };
   }, []);
 

--- a/frontend/src/utils/turnstileSession.js
+++ b/frontend/src/utils/turnstileSession.js
@@ -5,10 +5,19 @@ const TURNSTILE_TIMEOUT_MS = 30_000;
 
 let scriptLoadPromise = null;
 let widgetId = null;
-let widgetReadyResolve;
-const widgetReadyPromise = new Promise((resolve) => {
-  widgetReadyResolve = resolve;
-});
+let widgetContainer = null;
+
+function createDeferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+let widgetReady = createDeferred();
 
 let cachedToken = "";
 let pendingTokenPromise = null;
@@ -59,9 +68,23 @@ function loadTurnstileScript() {
   return scriptLoadPromise;
 }
 
+function rejectPendingTokenWaiters(err) {
+  if (pendingTokenPromise) {
+    pendingTokenPromise.reject(err);
+    pendingTokenPromise = null;
+  }
+}
+
+function failWidgetReady(err) {
+  widgetReady.reject(
+    err instanceof Error ? err : new Error("turnstile widget failed"),
+  );
+  widgetReady = createDeferred();
+}
+
 export function registerTurnstileWidget(id) {
   widgetId = id;
-  widgetReadyResolve();
+  widgetReady.resolve();
 }
 
 export function onTurnstileToken(token) {
@@ -78,30 +101,64 @@ export function onTurnstileExpired() {
 
 export function onTurnstileError() {
   cachedToken = "";
-  if (pendingTokenPromise) {
-    pendingTokenPromise.reject(new Error("turnstile challenge failed"));
-    pendingTokenPromise = null;
-  }
+  rejectPendingTokenWaiters(new Error("turnstile challenge failed"));
 }
 
-export async function prepareTurnstileWidget(container) {
+export function teardownTurnstileWidget() {
+  rejectPendingTokenWaiters(new Error("turnstile widget teardown"));
+  cachedToken = "";
+  if (widgetId != null && window.turnstile?.remove) {
+    window.turnstile.remove(widgetId);
+  }
+  widgetId = null;
+  widgetContainer = null;
+  widgetReady = createDeferred();
+}
+
+export async function prepareTurnstileWidget(container, options = {}) {
+  const { signal } = options;
   if (!isTurnstileConfigured() || !container) {
     return;
   }
 
-  await loadTurnstileScript();
-  if (widgetId != null) {
+  try {
+    await loadTurnstileScript();
+  } catch (err) {
+    failWidgetReady(err);
+    throw err;
+  }
+
+  if (signal?.aborted || !container.isConnected) {
     return;
   }
 
-  const id = window.turnstile.render(container, {
-    sitekey: siteKey(),
-    size: "invisible",
-    callback: onTurnstileToken,
-    "expired-callback": onTurnstileExpired,
-    "error-callback": onTurnstileError,
-  });
-  registerTurnstileWidget(id);
+  if (widgetId != null) {
+    if (widgetContainer === container && container.isConnected) {
+      return;
+    }
+    teardownTurnstileWidget();
+  }
+
+  if (!window.turnstile) {
+    const err = new Error("turnstile script unavailable");
+    failWidgetReady(err);
+    throw err;
+  }
+
+  try {
+    const id = window.turnstile.render(container, {
+      sitekey: siteKey(),
+      size: "invisible",
+      callback: onTurnstileToken,
+      "expired-callback": onTurnstileExpired,
+      "error-callback": onTurnstileError,
+    });
+    widgetContainer = container;
+    registerTurnstileWidget(id);
+  } catch (err) {
+    failWidgetReady(err);
+    throw err;
+  }
 }
 
 function waitForTurnstileToken() {
@@ -136,7 +193,7 @@ export async function obtainTurnstileToken() {
     return "";
   }
 
-  await widgetReadyPromise;
+  await widgetReady.promise;
   if (widgetId == null) {
     throw new Error("turnstile widget not ready");
   }
@@ -151,7 +208,7 @@ export async function obtainTurnstileToken() {
 
 export function resetTurnstileChallenge() {
   cachedToken = "";
-  pendingTokenPromise = null;
+  rejectPendingTokenWaiters(new Error("turnstile challenge reset"));
   if (widgetId != null && window.turnstile) {
     window.turnstile.reset(widgetId);
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses three Bugbot findings on Turnstile session bootstrap:

1. **Readiness never resolves** — `widgetReady` is now a replaceable deferred. Script load / render failures call `failWidgetReady()` so `obtainTurnstileToken()` rejects instead of awaiting forever.
2. **Reset drops token waiters** — `resetTurnstileChallenge()` rejects in-flight `waitForTurnstileToken()` waiters via shared `rejectPendingTokenWaiters()` (also used on error, teardown, and Turnstile error callback).
3. **Widget not re-mounted** — `prepareTurnstileWidget()` re-renders when the container changes or is detached; `teardownTurnstileWidget()` removes the widget and resets readiness on unmount. `TurnstileBootstrap` uses `AbortController` to skip render after cleanup.

## Testing

- `cd frontend && npm run lint`
- `make test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e469502a-b7c3-43f9-80c6-799dd9998b6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e469502a-b7c3-43f9-80c6-799dd9998b6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

