### PR TITLE
Reject widgetReady waiters on Turnstile teardown

### DIFF
--- a/frontend/src/utils/turnstileSession.js
+++ b/frontend/src/utils/turnstileSession.js
@@ -112,7 +112,7 @@ export function teardownTurnstileWidget() {
   }
   widgetId = null;
   widgetContainer = null;
-  widgetReady = createDeferred();
+  failWidgetReady(new Error("turnstile widget teardown"));
 }
 
 export async function prepareTurnstileWidget(container, options = {}) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a Bugbot finding on commit f87c09e: `teardownTurnstileWidget` assigned a new `widgetReady` deferred without settling the previous one, so in-flight `obtainTurnstileToken` calls awaiting `widgetReady.promise` could hang forever after unmount or React Strict Mode cleanup (while token waiters were already rejected).

## Change

- In `teardownTurnstileWidget`, call `failWidgetReady(new Error("turnstile widget teardown"))` instead of `widgetReady = createDeferred()`, matching `prepareTurnstileWidget` error paths.

## Testing

- `make test`
- `cd frontend && npm run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9da251db-7cbf-452f-90c9-8bc0d80fdbe4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9da251db-7cbf-452f-90c9-8bc0d80fdbe4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

