### PR TITLE
Turnstile audit: enablement docs + optional-path hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,9 +110,35 @@ Proxy target: `VITE_API_PROXY_TARGET` (default `https://api.gishathfetch.com`). 
 `VITE_API_ORIGIN_VERIFY_SECRET` when testing against an environment with
 `API_ORIGIN_VERIFY_SECRET` enabled.
 
-When Turnstile is enabled in production, set `TURNSTILE_SECRET_KEY` on the search Lambda and
-`VITE_TURNSTILE_SITE_KEY` at frontend build time. Session minting (`GET /session`) expects
-the browser to send `CF-Turnstile-Response` (see `frontend/src/utils/apiSession.js`).
+#### Turnstile (optional)
+
+Turnstile is **off until both keys are set**. With neither key present:
+
+- Backend (`TURNSTILE_SECRET_KEY` unset): `VerifyTurnstile` is a no-op; `GET /session` mints normally.
+- Frontend (`VITE_TURNSTILE_SITE_KEY` unset): no widget/script; session bootstrap omits `CF-Turnstile-Response`.
+
+To enable in production, do **all** of the following together (secret-only breaks clients):
+
+1. Create a Cloudflare Turnstile widget (Invisible mode matches the SPA). Allow hostnames
+   `gishathfetch.com` and `localhost` (local Vite).
+2. Set `TURNSTILE_SECRET_KEY` on Lambda `mtg-price-scrapper` (not wired by `make deploy`).
+3. Set `VITE_TURNSTILE_SITE_KEY` at **frontend build** time and redeploy the SPA
+   (`frontend-update` / CI). The deploy workflow does not inject this today — export it in the
+   environment that runs `npm run build`, or add it to `.github/workflows/deploy-on-merge.yml`.
+4. Fix API Gateway CORS for the custom header. `CF-Turnstile-Response` triggers a browser
+   preflight. Live `OPTIONS /session` currently returns `204` without
+   `Access-Control-Allow-Origin` / `Access-Control-Allow-Headers`, so enabling Turnstile will
+   block cross-origin session mint from `gishathfetch.com` until gateway CORS allows at least:
+   - Origins: `https://gishathfetch.com`, `http://localhost:5173`
+   - Headers: `Content-Type`, `CF-Turnstile-Response`
+   - Methods: `GET`, `OPTIONS`
+   - Credentials: `true`  
+   Lambda already emits these on OPTIONS (`api/handler/cors.go`); if API Gateway CORS is
+   enabled, it must include the same Allow-Headers (gateway may ignore integration CORS
+   headers). Prefer letting Lambda handle OPTIONS, or align gateway CORS with the Lambda list.
+
+Session minting (`GET /session`) expects the browser to send `CF-Turnstile-Response`
+(see `frontend/src/utils/apiSession.js`).
 
 **API Gateway (manual):** expose `GET` + `OPTIONS` for `/search` and `/session` only; remove
 legacy `/`, `/api`, and `/api/*` routes when traffic has migrated.

--- a/api/handler/cors_options_turnstile_test.go
+++ b/api/handler/cors_options_turnstile_test.go
@@ -1,0 +1,23 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSession_OptionsIncludesTurnstileCORSHeader(t *testing.T) {
+	res, err := Session(context.Background(), events.APIGatewayProxyRequest{
+		HTTPMethod: http.MethodOptions,
+		Headers:    map[string]string{"origin": "https://gishathfetch.com"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, res.StatusCode)
+	require.Equal(t, "https://gishathfetch.com", res.Headers["Access-Control-Allow-Origin"])
+	require.Equal(t, "true", res.Headers["Access-Control-Allow-Credentials"])
+	require.Contains(t, res.Headers["Access-Control-Allow-Headers"], "CF-Turnstile-Response")
+	require.Contains(t, res.Headers["Access-Control-Allow-Methods"], "GET")
+}

--- a/frontend/src/utils/apiSession.js
+++ b/frontend/src/utils/apiSession.js
@@ -34,21 +34,26 @@ export async function ensureApiSession(options = {}) {
 }
 
 async function bootstrapSession() {
-  const headers = {};
-  const turnstileToken = await obtainTurnstileToken();
-  if (turnstileToken) {
-    headers["CF-Turnstile-Response"] = turnstileToken;
-  }
+  try {
+    const headers = {};
+    const turnstileToken = await obtainTurnstileToken();
+    if (turnstileToken) {
+      headers["CF-Turnstile-Response"] = turnstileToken;
+    }
 
-  const res = await fetch(API_SESSION_URL, {
-    method: "GET",
-    credentials: "include",
-    headers,
-  });
+    const res = await fetch(API_SESSION_URL, {
+      method: "GET",
+      credentials: "include",
+      headers,
+    });
 
-  if (!res.ok) {
+    if (!res.ok) {
+      throw new Error(`API session failed (${res.status})`);
+    }
+  } catch (err) {
+    // Always drop a pending/used token so the next mint gets a fresh challenge.
     resetTurnstileChallenge();
-    throw new Error(`API session failed (${res.status})`);
+    throw err;
   }
 }
 

--- a/frontend/src/utils/turnstileSession.js
+++ b/frontend/src/utils/turnstileSession.js
@@ -146,9 +146,11 @@ export async function prepareTurnstileWidget(container, options = {}) {
   }
 
   try {
+    // Widget mode (Invisible / Managed / …) is chosen in the Cloudflare dashboard for the
+    // sitekey. execution: "execute" defers the challenge until obtainTurnstileToken().
     const id = window.turnstile.render(container, {
       sitekey: siteKey(),
-      size: "invisible",
+      execution: "execute",
       callback: onTurnstileToken,
       "expired-callback": onTurnstileExpired,
       "error-callback": onTurnstileError,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Audit of the Turnstile implementation with **no keys configured** (current state).

### Verdict (keys unset)

Safe and working. Both sides treat Turnstile as optional:

| Side | Gate | Behavior without key |
|------|------|----------------------|
| Backend | `TURNSTILE_SECRET_KEY` | `VerifyTurnstile` returns nil; session mint unchanged |
| Frontend | `VITE_TURNSTILE_SITE_KEY` | No widget/script; `/session` called without `CF-Turnstile-Response` |

Live probe: `GET https://api.gishathfetch.com/session` returns **204** + `gf_api_session` cookie without a Turnstile header.

Unit tests cover skip / require / siteverify success / siteverify failure.

### Blocker before enabling keys

Custom header `CF-Turnstile-Response` triggers a browser **CORS preflight**. Live `OPTIONS /session` returns `204` with only `Vary: Origin` — no `Access-Control-Allow-Origin` / `Access-Control-Allow-Headers`. Lambda already emits the right CORS headers (`api/handler/cors.go`); API Gateway CORS (manual) must allow `CF-Turnstile-Response` or stop overriding OPTIONS, or production session mint will fail once the SPA sends the header.

Also enable **both** keys together: secret-only rejects every `/session`; sitekey-only runs the widget but the API ignores tokens.

### Changes in this PR

- Document Turnstile enablement checklist in `AGENTS.md` (keys, build-time sitekey, AGW CORS)
- OPTIONS CORS regression test for `CF-Turnstile-Response`
- Frontend: `execution: "execute"` (deferred challenge; widget mode comes from the CF sitekey)
- Reset Turnstile on any session bootstrap failure (not only non-OK HTTP)

### Test plan

- [x] `make test`
- [x] Focused Turnstile/Session handler + apiauth tests
- [x] Live `/session` without Turnstile header (204)
- [ ] After AGW CORS fix + keys: browser session mint with Turnstile from `gishathfetch.com`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35d80570-52d2-49f1-a747-5c995d621ccc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35d80570-52d2-49f1-a747-5c995d621ccc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

