### PR TITLE
Fix Turnstile session mint blocked by API Gateway CORS preflight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,7 @@ Proxy target: `VITE_API_PROXY_TARGET` (default `https://api.gishathfetch.com`). 
 Turnstile is **off until both keys are set**. With neither key present:
 
 - Backend (`TURNSTILE_SECRET_KEY` unset): `VerifyTurnstile` is a no-op; `GET /session` mints normally.
-- Frontend (`VITE_TURNSTILE_SITE_KEY` unset): no widget/script; session bootstrap omits `CF-Turnstile-Response`.
+- Frontend (`VITE_TURNSTILE_SITE_KEY` unset): no widget/script; session bootstrap omits the Turnstile token.
 
 To enable in production, do **all** of the following together (secret-only breaks clients):
 
@@ -125,19 +125,14 @@ To enable in production, do **all** of the following together (secret-only break
 3. Set `VITE_TURNSTILE_SITE_KEY` at **frontend build** time and redeploy the SPA
    (`frontend-update` / CI). The deploy workflow does not inject this today — export it in the
    environment that runs `npm run build`, or add it to `.github/workflows/deploy-on-merge.yml`.
-4. Fix API Gateway CORS for the custom header. `CF-Turnstile-Response` triggers a browser
-   preflight. Live `OPTIONS /session` currently returns `204` without
-   `Access-Control-Allow-Origin` / `Access-Control-Allow-Headers`, so enabling Turnstile will
-   block cross-origin session mint from `gishathfetch.com` until gateway CORS allows at least:
-   - Origins: `https://gishathfetch.com`, `http://localhost:5173`
-   - Headers: `Content-Type`, `CF-Turnstile-Response`
-   - Methods: `GET`, `OPTIONS`
-   - Credentials: `true`  
-   Lambda already emits these on OPTIONS (`api/handler/cors.go`); if API Gateway CORS is
-   enabled, it must include the same Allow-Headers (gateway may ignore integration CORS
-   headers). Prefer letting Lambda handle OPTIONS, or align gateway CORS with the Lambda list.
+4. **Session mint CORS:** The SPA sends the Turnstile token as the `cf_turnstile_response`
+   query parameter on `GET /session` (not `CF-Turnstile-Response`) so the browser does not
+   need a preflight. Live API Gateway `OPTIONS /session` does not return
+   `Access-Control-Allow-Headers` for that custom header, which otherwise surfaces as a generic
+   “Unable to connect” error in the UI. Lambda still accepts the header for compatibility.
+   Optionally align API Gateway CORS with `api/handler/cors.go` if you prefer the header.
 
-Session minting (`GET /session`) expects the browser to send `CF-Turnstile-Response`
+Session minting (`GET /session`) expects a Turnstile token when the secret is set
 (see `frontend/src/utils/apiSession.js`).
 
 **API Gateway (manual):** expose `GET` + `OPTIONS` for `/search` and `/session` only; remove

--- a/api/handler/session.go
+++ b/api/handler/session.go
@@ -38,7 +38,7 @@ func Session(ctx context.Context, request events.APIGatewayProxyRequest) (events
 		return errorResponse(apiRes, origin, "session not configured", http.StatusServiceUnavailable)
 	}
 
-	turnstileToken := headerValue(request.Headers, apiauth.TurnstileResponseHeader)
+	turnstileToken := turnstileTokenFromRequest(request)
 	remoteIP := request.RequestContext.Identity.SourceIP
 	if err := verifyTurnstileFunc(ctx, turnstileToken, remoteIP); err != nil {
 		message := "verification failed"

--- a/api/handler/session_turnstile_test.go
+++ b/api/handler/session_turnstile_test.go
@@ -45,4 +45,14 @@ func TestSession_TurnstileRequiredWhenConfigured(t *testing.T) {
 	res, err = Session(context.Background(), req)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusNoContent, res.StatusCode)
+
+	req = events.APIGatewayProxyRequest{
+		HTTPMethod: http.MethodGet,
+		QueryStringParameters: map[string]string{
+			apiauth.TurnstileResponseQueryParam: "valid-token",
+		},
+	}
+	res, err = Session(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, res.StatusCode)
 }

--- a/api/handler/session_turnstile_token.go
+++ b/api/handler/session_turnstile_token.go
@@ -1,0 +1,17 @@
+package handler
+
+import (
+	"mtg-price-checker-sg/pkg/apiauth"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+func turnstileTokenFromRequest(request events.APIGatewayProxyRequest) string {
+	if token := headerValue(request.Headers, apiauth.TurnstileResponseHeader); token != "" {
+		return token
+	}
+	if request.QueryStringParameters == nil {
+		return ""
+	}
+	return request.QueryStringParameters[apiauth.TurnstileResponseQueryParam]
+}

--- a/api/handler/session_turnstile_token_test.go
+++ b/api/handler/session_turnstile_token_test.go
@@ -1,0 +1,60 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"testing"
+
+	"mtg-price-checker-sg/pkg/apiauth"
+	"mtg-price-checker-sg/pkg/config"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTurnstileTokenFromRequest_PrefersHeader(t *testing.T) {
+	req := events.APIGatewayProxyRequest{
+		Headers: map[string]string{
+			apiauth.TurnstileResponseHeader: "from-header",
+		},
+		QueryStringParameters: map[string]string{
+			apiauth.TurnstileResponseQueryParam: "from-query",
+		},
+	}
+	require.Equal(t, "from-header", turnstileTokenFromRequest(req))
+}
+
+func TestTurnstileTokenFromRequest_QueryParam(t *testing.T) {
+	req := events.APIGatewayProxyRequest{
+		HTTPMethod: http.MethodGet,
+		QueryStringParameters: map[string]string{
+			apiauth.TurnstileResponseQueryParam: "from-query",
+		},
+	}
+	require.Equal(t, "from-query", turnstileTokenFromRequest(req))
+}
+
+func TestSession_TurnstileQueryParamAccepted(t *testing.T) {
+	originalVerify := verifyTurnstileFunc
+	verifyTurnstileFunc = func(_ context.Context, token, _ string) error {
+		if token != "query-token" {
+			return apiauth.ErrTurnstileTokenMissing
+		}
+		return nil
+	}
+	t.Cleanup(func() { verifyTurnstileFunc = originalVerify })
+
+	require.NoError(t, os.Setenv(config.APISessionSecretEnv, "test-session-secret"))
+	t.Cleanup(func() { _ = os.Unsetenv(config.APISessionSecretEnv) })
+
+	req := events.APIGatewayProxyRequest{
+		HTTPMethod: http.MethodGet,
+		QueryStringParameters: map[string]string{
+			apiauth.TurnstileResponseQueryParam: "query-token",
+		},
+	}
+	res, err := Session(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, res.StatusCode)
+}

--- a/api/pkg/apiauth/turnstile.go
+++ b/api/pkg/apiauth/turnstile.go
@@ -17,6 +17,9 @@ import (
 const (
 	// TurnstileResponseHeader is the request header carrying the browser Turnstile token.
 	TurnstileResponseHeader = "CF-Turnstile-Response"
+	// TurnstileResponseQueryParam is an alternate token carrier for GET /session so browsers
+	// avoid a CORS preflight when API Gateway does not echo Allow-Headers for the header above.
+	TurnstileResponseQueryParam = "cf_turnstile_response"
 	turnstileSiteverifyURLDefault = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
 	turnstileVerifyTimeout  = 5 * time.Second
 )

--- a/frontend/src/utils/apiSession.js
+++ b/frontend/src/utils/apiSession.js
@@ -33,18 +33,23 @@ export async function ensureApiSession(options = {}) {
   }
 }
 
+const TURNSTILE_SESSION_QUERY_PARAM = "cf_turnstile_response";
+
+function sessionMintUrl(turnstileToken) {
+  if (!turnstileToken) {
+    return API_SESSION_URL;
+  }
+  const url = new URL(API_SESSION_URL, window.location.origin);
+  url.searchParams.set(TURNSTILE_SESSION_QUERY_PARAM, turnstileToken);
+  return url.toString();
+}
+
 async function bootstrapSession() {
   try {
-    const headers = {};
     const turnstileToken = await obtainTurnstileToken();
-    if (turnstileToken) {
-      headers["CF-Turnstile-Response"] = turnstileToken;
-    }
-
-    const res = await fetch(API_SESSION_URL, {
+    const res = await fetch(sessionMintUrl(turnstileToken), {
       method: "GET",
       credentials: "include",
-      headers,
     });
 
     if (!res.ok) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After enabling Turnstile, search shows **"Unable to connect to the server"** because session mint sends `CF-Turnstile-Response`, which triggers a CORS preflight. Live `OPTIONS https://api.gishathfetch.com/session` returns `204` without `Access-Control-Allow-Origin` / `Access-Control-Allow-Headers`, so the browser blocks the request before Lambda runs (surfacing as `Failed to fetch` / `TypeError`).

## Fix

- Frontend: pass the Turnstile token as `cf_turnstile_response` on `GET /session` (simple cross-origin GET, no preflight).
- Backend: accept the same query param (header still supported).

## Deploy

Merge and let CI run `make deploy` so **both** Lambda and the SPA update.

## Also verify

- `TURNSTILE_SECRET_KEY` on Lambda matches the widget for the committed site key.
- Turnstile widget hostnames include `gishathfetch.com`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-681edbba-1407-49e3-bef7-eddbad73fc55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-681edbba-1407-49e3-bef7-eddbad73fc55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

