### PR TITLE
Fix Dueller's Point foil prices using store price instead of market foil_price

### DIFF
--- a/api/gateway/duellerpoint/search.go
+++ b/api/gateway/duellerpoint/search.go
@@ -135,13 +135,11 @@ func parseSearchResult(item searchResult) (gateway.Card, bool) {
 }
 
 func listingPrice(item searchResult) (float64, bool) {
-	priceStr := strings.TrimSpace(item.Price)
-	if item.FoilType == "foil" {
-		if foilPrice := strings.TrimSpace(item.FoilPrice); foilPrice != "" && foilPrice != "0.0" && foilPrice != "0" {
-			priceStr = foilPrice
-		}
-	}
-	price, err := util.ParsePrice(priceStr)
+	// Store selling price is always in `price`. `foil_price` is market/crawl
+	// data (often TCGPlayer foil market), not the LGS list price — using it
+	// under-reports foil listings (e.g. Birds of Paradise Foil DMR: price
+	// S$19.50 vs foil_price 6.29).
+	price, err := util.ParsePrice(strings.TrimSpace(item.Price))
 	if err != nil || price <= 0 {
 		return 0, false
 	}

--- a/api/gateway/duellerpoint/search_test.go
+++ b/api/gateway/duellerpoint/search_test.go
@@ -34,23 +34,23 @@ func Test_parseSearchResult(t *testing.T) {
 	require.Equal(t, []string{"[The List]"}, card.ExtraInfo)
 }
 
-func Test_parseSearchResult_usesFoilPrice(t *testing.T) {
+func Test_parseSearchResult_usesStorePriceNotFoilMarket(t *testing.T) {
 	card, ok := parseSearchResult(searchResult{
-		Name:               "Lightning Bolt",
-		Slug:               "lightning-bolt-foil",
-		Price:              "17.75",
-		FoilPrice:          "10.16",
-		Quantity:           4,
+		Name:               "Birds Of Paradise",
+		Slug:               "birds-of-paradise-9147fc04-5486-4791-8548-18872867a613",
+		Price:              "19.5",
+		FoilPrice:          "6.29",
+		Quantity:           1,
 		IsActive:           true,
 		FoilType:           "foil",
-		GetNameWithFoil:    "Lightning Bolt (Foil)",
-		GetVariationName:   "Magic 2010 (M10)",
-		TCGPlayerProductID: "32656-foil",
+		GetNameWithFoil:    "Birds Of Paradise (Foil)",
+		GetVariationName:   "Dominaria Remastered",
+		TCGPlayerProductID: "449630-foil",
 	})
 	require.True(t, ok)
 	require.True(t, card.IsFoil)
-	require.InDelta(t, 10.16, card.Price, 0.001)
-	require.Equal(t, "https://product-images.tcgplayer.com/fit-in/437x437/32656.jpg", card.Img)
+	require.InDelta(t, 19.5, card.Price, 0.001)
+	require.Equal(t, "https://product-images.tcgplayer.com/fit-in/437x437/449630.jpg", card.Img)
 }
 
 func Test_parseSearchResult_skipsOutOfStock(t *testing.T) {
@@ -88,6 +88,10 @@ func Test_parseSearchResponse(t *testing.T) {
 		cards = append(cards, card)
 	}
 	require.Len(t, cards, 2)
+	require.InDelta(t, 1.75, cards[0].Price, 0.001)
+	require.False(t, cards[0].IsFoil)
+	require.InDelta(t, 17.75, cards[1].Price, 0.001)
+	require.True(t, cards[1].IsFoil)
 }
 
 const searchResultsFixture = `{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Dueller's Point foil listings were showing the wrong cheapest price because the gateway preferred JSON `foil_price` over `price` when `foil_type` was `"foil"`.

`foil_price` is crawl/market data (often TCGPlayer foil market), not the LGS sell price. The store page uses `price`.

**Repro:** Birds of Paradise (Foil) · Dominaria Remastered
- Before: S$ 6.29 (`foil_price`)
- Product page / after fix: S$ 19.50 (`price`)

## Changes

- Always parse listing price from `price`
- Unit test covering the Birds of Paradise foil case (19.5 vs 6.29)
- Fixture foil assertion updated to expect store price

## Test plan

- [x] `go test -mod=vendor ./gateway/duellerpoint/...`
- [x] Live search for "Birds of Paradise" returns foil DMR at 19.50
- [x] `make test`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d84e737b-e6f9-4546-8b47-f4573f273289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d84e737b-e6f9-4546-8b47-f4573f273289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

