### PR TITLE
Document API abuse mitigation (Turnstile, session, CloudFront secret)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,26 @@ Proxy target: `VITE_API_PROXY_TARGET` (default `https://api.gishathfetch.com`). 
 `VITE_API_ORIGIN_VERIFY_SECRET` when testing against an environment with
 `API_ORIGIN_VERIFY_SECRET` enabled.
 
+Full reference for the three abuse-mitigation layers:
+[`docs/api-abuse-mitigation.md`](docs/api-abuse-mitigation.md).
+
+#### API abuse mitigation (overview)
+
+Three optional layers; each is **off until configured**:
+
+1. **CloudFront → API origin secret** (`API_ORIGIN_VERIFY_SECRET`): requests must send
+   matching `X-Origin-Verify` (CloudFront custom origin header, Vite proxy, or automation)
+   **or** an allowlisted `Origin`. Enforced on both `/session` and `/search`.
+2. **Session cookie** (`API_SESSION_SECRET`): `GET /session` mints HttpOnly `gf_api_session`
+   (default TTL 15m via `API_SESSION_TTL_SECONDS`). `/search` requires a valid cookie
+   (`session required` / `session expired` → 403). Frontend: `ensureApiSession()` with a
+   10-minute background refresh and one retry on expiry
+   (`frontend/src/utils/apiSession.js`).
+3. **Turnstile** (below): bot check on session mint only.
+
+Production should enable all three together. `make deploy` does not wire these Lambda
+secrets — set them on `mtg-price-scrapper` manually (or via your secrets process).
+
 #### Turnstile (optional)
 
 Turnstile is **off until both keys are set**. With neither key present:

--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ It aggregates listings from supported stores, normalizes results, and sorts by p
 Gishath Fetch is a static React SPA served from S3 behind CloudFront. Search and
 session use **`https://api.gishathfetch.com/search`** and **`/session`** from the
 browser (cross-origin, credentialed). API Gateway invokes a container-based Lambda
-that scrapes LGS sites in parallel. Inbound access may use an origin-verify header
-(optional CloudFront or automation) or an allowlisted browser `Origin`, plus a
-short-lived session cookie (and optional Turnstile on session mint). When
+that scrapes LGS sites in parallel. Inbound API abuse mitigation uses three
+optional layers: a CloudFront→API origin-verify secret (`X-Origin-Verify`), a
+short-lived HttpOnly session cookie (`gf_api_session`), and Cloudflare Turnstile
+on session mint — see
+[`docs/api-abuse-mitigation.md`](docs/api-abuse-mitigation.md). When
 `WEB_BOT_AUTH_ENABLED` is set, outbound scraper requests
 are signed per [Web Bot Auth](https://datatracker.ietf.org/doc/draft-meunier-web-bot-auth-architecture/)
 (RFC 9421 HTTP Message Signatures); the public key directory is published at
@@ -35,6 +37,8 @@ reads that index when `CK_PRICE_LOOKUP_ENABLED` is set.
 
 For per-store timeouts, proxy tiers, and strategy order, see
 [`docs/search-strategies-retries-timeouts.md`](docs/search-strategies-retries-timeouts.md).
+For inbound API access control (origin secret, session cookie, Turnstile), see
+[`docs/api-abuse-mitigation.md`](docs/api-abuse-mitigation.md).
 
 ```mermaid
 flowchart TB
@@ -90,7 +94,7 @@ flowchart TB
 |---------|-----------------|------|
 | Frontend CDN | CloudFront → `gishathfetch.com` | Serves the React SPA from S3 |
 | Web Bot Auth directory | `https://gishathfetch.com/.well-known/http-message-signatures-directory` | Public signing keys for verifiers; built by `make generate-signature-directory` and uploaded on frontend deploy |
-| Search API | API Gateway `api.gishathfetch.com` | `GET /search`, `GET /session`; optional origin verify + session cookie (+ optional Turnstile) |
+| Search API | API Gateway `api.gishathfetch.com` | `GET /search`, `GET /session`; abuse mitigation: origin verify + session cookie + optional Turnstile ([docs](docs/api-abuse-mitigation.md)) |
 | Search Lambda | `mtg-price-scrapper` | Concurrent LGS scraping; optional Web Bot Auth on outbound requests; optional CK price lookup from DynamoDB |
 | CK refresh Lambda | `mtg-price-ck-refresh` | Daily Card Kingdom pricelist download, DynamoDB index rebuild, and CK price change export to S3 |
 | Analytics keywords Lambda | `mtg-analytics-keywords-export` | Daily GA4 export of top search keywords to S3 |
@@ -248,15 +252,34 @@ Example inline policy (merge with existing permissions on the role, or attach as
 }
 ```
 
+## 🛡️ API abuse mitigation
+
+Inbound `/search` and `/session` are gated by three optional layers (each off
+until configured):
+
+1. **CloudFront → API origin secret** — Lambda `API_ORIGIN_VERIFY_SECRET`;
+   trusted hops send `X-Origin-Verify`, or browsers present an allowlisted
+   `Origin`.
+2. **Session token** — `GET /session` mints HttpOnly `gf_api_session`
+   (HMAC via `API_SESSION_SECRET`, default TTL 15m); `/search` requires it.
+3. **Cloudflare Turnstile** — when `TURNSTILE_SECRET_KEY` and
+   `VITE_TURNSTILE_SITE_KEY` are both set, session mint verifies an invisible
+   challenge (`cf_turnstile_response` query param).
+
+Details, env reference, CloudFront header setup, and the browser sequence
+diagram: [`docs/api-abuse-mitigation.md`](docs/api-abuse-mitigation.md).
+
 ## 🔎 Search flow
 
 A search request fans out to every selected store in parallel, each store
 resolves its own listings, and the results are merged, filtered, and sorted
-before being returned.
+before being returned. Callers must pass abuse-mitigation checks first (see
+above) when those controls are enabled in the environment.
 
 ### Request entry & fan-out
 
-1. The handler parses `s` (the search string, minimum 3 characters) and an
+1. The handler enforces origin verify and (for `/search`) the session cookie
+   when configured, then parses `s` (the search string, minimum 3 characters) and an
    optional `lgs` filter (comma-separated store names; empty means all stores).
 2. The controller instantiates each selected store and runs **one goroutine per
    store**, each bounded by a 20s per-site timeout (`config.PerSiteTimeout`).
@@ -333,7 +356,7 @@ flowchart TD
 ```text
 .
 |-- api/         # Go backend (Lambda handler, scraping gateways, tests)
-|-- docs/        # Maintainer docs (search strategies, timeouts, skills)
+|-- docs/        # Maintainer docs (API abuse mitigation, search strategies, skills)
 |-- frontend/    # React + Vite single-page app
 |-- Makefile     # Local helpers for common project tasks
 `-- Dockerfile   # Backend container build definition

--- a/docs/api-abuse-mitigation.md
+++ b/docs/api-abuse-mitigation.md
@@ -1,0 +1,211 @@
+# API abuse mitigation
+
+The search API is public-facing and relatively expensive (parallel LGS scrapes).
+Inbound requests are gated by three optional, layered controls:
+
+1. **CloudFront → API origin secret** (`X-Origin-Verify`)
+2. **Browser session cookie** (`gf_api_session`)
+3. **Cloudflare Turnstile** on session mint
+
+Each layer is **off until its secret/key is configured**. With none set, `/search`
+and `/session` behave as open CORS-allowlisted endpoints (useful for local
+Lambda/`go run` testing). In production, enable all three together.
+
+For agent-oriented enablement notes (env vars, Vite, Turnstile checklist), see
+also [`AGENTS.md`](../AGENTS.md) → *Frontend API connection*.
+
+---
+
+## Request flow (browser)
+
+```mermaid
+sequenceDiagram
+    participant U as Browser
+    participant TS as Cloudflare Turnstile
+    participant API as api.gishathfetch.com
+    participant CF_API as Cloudflare siteverify
+
+    Note over U: SPA load (gishathfetch.com)
+    U->>TS: invisible widget (when site key set)
+    TS-->>U: challenge token
+    U->>API: GET /session?cf_turnstile_response=...
+    Note over API: origin check (allowlisted Origin<br/>or X-Origin-Verify)
+    API->>CF_API: siteverify (when TURNSTILE_SECRET_KEY set)
+    CF_API-->>API: success
+    API-->>U: 204 + Set-Cookie: gf_api_session=...
+    U->>API: GET /search?s=... (credentials: include)
+    Note over API: origin check + session cookie HMAC
+    API-->>U: search JSON
+```
+
+Production SPA calls go **cross-origin** to `https://api.gishathfetch.com`
+(`credentials: "include"`). Frontend CDN CloudFront serves static assets from
+S3; it is not on the search path unless you also front API Gateway with
+CloudFront and inject the origin-verify header (see below).
+
+---
+
+## 1. CloudFront → API origin secret
+
+**Purpose:** Reject callers that are neither an allowlisted browser origin nor a
+trusted edge/automation hop that knows the shared secret.
+
+| Item | Value |
+|------|--------|
+| Lambda env | `API_ORIGIN_VERIFY_SECRET` |
+| Optional header name override | `API_ORIGIN_VERIFY_HEADER` (default `X-Origin-Verify`) |
+| Code | `api/pkg/apiauth/origin.go`, enforced in `handler/search.go` and `handler/session.go` |
+
+When `API_ORIGIN_VERIFY_SECRET` is set, a request passes origin verification if
+**either**:
+
+- The request includes `X-Origin-Verify` (or the configured header) equal to the
+  secret — for CloudFront custom origin headers, the Vite dev proxy, or other
+  trusted automation; **or**
+- The request includes an `Origin` header in the allowlist from
+  `config.GetAllowedOrigins()` (`https://gishathfetch.com`,
+  `http://localhost:5173`, and the JetBrains built-in server).
+
+Otherwise the handler returns **403** (`forbidden`).
+
+### CloudFront setup (API origin)
+
+If CloudFront is configured as a reverse proxy in front of API Gateway (or as a
+custom origin for `/api/*` / search paths), add a **custom origin header**:
+
+- Name: `X-Origin-Verify` (unless you override `API_ORIGIN_VERIFY_HEADER`)
+- Value: the same string as Lambda `API_ORIGIN_VERIFY_SECRET`
+
+Keep the secret out of the SPA bundle. Browsers talking directly to
+`api.gishathfetch.com` rely on the allowlisted `Origin` path instead of this
+header.
+
+### Local Vite proxy
+
+When `VITE_API_BASE_URL=` (empty), Vite proxies `/search` and `/session` to
+`VITE_API_PROXY_TARGET`. Set `VITE_API_ORIGIN_VERIFY_SECRET` in
+`frontend/.env.local` so the proxy injects `X-Origin-Verify` (see
+`frontend/vite.config.js`).
+
+---
+
+## 2. Session token (`gf_api_session`)
+
+**Purpose:** Require a short-lived, HttpOnly cookie before expensive `/search`
+work. Anonymous clients must mint a session first; scripts that skip `/session`
+cannot search when this layer is on.
+
+| Item | Value |
+|------|--------|
+| Lambda env | `API_SESSION_SECRET` (HMAC key) |
+| Optional TTL | `API_SESSION_TTL_SECONDS` (default **900** = 15 minutes) |
+| Cookie name | `gf_api_session` |
+| Cookie attrs | `Path=/`, `HttpOnly`, `SameSite=Lax`, `Secure` when `ENV=prod` |
+| Code | `api/pkg/apiauth/session.go`, `api/handler/session.go`, `api/handler/access.go` |
+
+### Minting (`GET /session`)
+
+1. Origin verification (layer 1) must pass.
+2. `API_SESSION_SECRET` must be set; otherwise **503** (`session not configured`).
+3. Turnstile verification runs when configured (layer 3).
+4. Response is **204 No Content** with `Set-Cookie: gf_api_session=...` and
+   `Cache-Control: no-store`.
+
+Token format: `expiryUnix.nonce.hmac` (HMAC-SHA256 over `expiry.nonce` with
+`API_SESSION_SECRET`).
+
+### Enforcement (`GET /search`)
+
+When `API_SESSION_SECRET` is set, `/search` requires a valid cookie:
+
+| Condition | Response body `error` | Status |
+|-----------|----------------------|--------|
+| Missing / malformed / bad HMAC | `session required` | 403 |
+| Past expiry | `session expired` | 403 |
+
+### Frontend behavior
+
+- `ensureApiSession()` (`frontend/src/utils/apiSession.js`) mints the cookie
+  before search (and shares one in-flight mint).
+- Background refresh every **10 minutes**
+  (`API_SESSION_REFRESH_INTERVAL_MS`) so idle tabs stay under the 15-minute TTL.
+- On 403 session errors, search retries once after a forced remint.
+
+---
+
+## 3. Cloudflare Turnstile (session mint)
+
+**Purpose:** Slow automated session minting (bots/scripts) before a cookie is
+issued. Does not run on `/search` itself — only on `/session`.
+
+| Side | Env / build var | Role |
+|------|-----------------|------|
+| Lambda | `TURNSTILE_SECRET_KEY` | Cloudflare siteverify; no-op when unset |
+| Frontend build | `VITE_TURNSTILE_SITE_KEY` | Loads invisible widget; omit token when unset |
+
+**Enable both together.** Secret-only breaks real browsers; site-key-only adds UI
+work with no server check.
+
+### Token transport
+
+The SPA sends the Turnstile token as the **`cf_turnstile_response` query
+parameter** on `GET /session` so browsers avoid a CORS preflight. Live API
+Gateway `OPTIONS /session` historically did not allow the
+`CF-Turnstile-Response` header. Lambda still accepts that header for
+compatibility (`api/handler/session_turnstile_token.go`).
+
+### Verification
+
+When `TURNSTILE_SECRET_KEY` is set, Lambda POSTs to Cloudflare
+`/turnstile/v0/siteverify` (5s timeout) with the token and optional client IP.
+Failures:
+
+| Condition | Response `error` | Status |
+|-----------|------------------|--------|
+| Token missing | `verification required` | 403 |
+| Siteverify reject / HTTP error | `verification failed` | 403 |
+
+### Production enablement checklist
+
+1. Create a Cloudflare Turnstile widget (**Invisible** matches the SPA). Allow
+   hostnames `gishathfetch.com` and `localhost` (local Vite).
+2. Set `TURNSTILE_SECRET_KEY` on Lambda `mtg-price-scrapper` (not wired by
+   `make deploy`).
+3. Set `VITE_TURNSTILE_SITE_KEY` at **frontend build** time and redeploy the SPA.
+   Production builds may use `frontend/.env.production`; CI must export the key
+   if the workflow does not inject it.
+4. Confirm `/session` mint succeeds from the live site (cookie set, then
+   `/search` works with credentials).
+
+Frontend helpers: `frontend/src/utils/turnstileSession.js`,
+`frontend/src/components/TurnstileBootstrap.jsx`.
+
+---
+
+## Environment reference
+
+| Variable | Where | Default / off | Effect when set |
+|----------|--------|---------------|-----------------|
+| `API_ORIGIN_VERIFY_SECRET` | Lambda | unset = skip | Require `X-Origin-Verify` **or** allowlisted `Origin` |
+| `API_ORIGIN_VERIFY_HEADER` | Lambda | `X-Origin-Verify` | Custom header name for the shared secret |
+| `API_SESSION_SECRET` | Lambda | unset = skip session on `/search`; `/session` 503 | Sign/validate `gf_api_session` |
+| `API_SESSION_TTL_SECONDS` | Lambda | `900` | Cookie / token lifetime |
+| `TURNSTILE_SECRET_KEY` | Lambda | unset = skip | Require Turnstile on `/session` |
+| `VITE_TURNSTILE_SITE_KEY` | Frontend build | unset = no widget | Invisible Turnstile + token on mint |
+| `VITE_API_ORIGIN_VERIFY_SECRET` | Vite only | unset | Proxy injects `X-Origin-Verify` |
+| `VITE_API_PROXY_TARGET` | Vite only | `https://api.gishathfetch.com` | Dev proxy target for `/search`, `/session` |
+| `VITE_API_BASE_URL` | Frontend | production API host in `constants.js` | Empty string → same-origin paths via Vite proxy |
+
+`config.APIAccessControlEnabled()` is true when origin verify **or** session
+secret is configured.
+
+---
+
+## API Gateway routes
+
+Expose **`GET` + `OPTIONS`** for `/search` and `/session` only (legacy `/`,
+`/api`, and `/api/*` paths are still accepted by Lambda path routing for
+compatibility, but should be removed from the gateway once traffic has
+migrated).
+
+CORS allowlist and header policy live in `api/handler/cors.go`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents the three inbound API abuse-mitigation layers added recently:

1. **CloudFront → API origin secret** (`API_ORIGIN_VERIFY_SECRET` / `X-Origin-Verify`, with allowlisted `Origin` fallback)
2. **Session token** (`gf_api_session` via `API_SESSION_SECRET`, mint on `GET /session`, enforce on `/search`)
3. **Cloudflare Turnstile** on session mint (`TURNSTILE_SECRET_KEY` + `VITE_TURNSTILE_SITE_KEY`, `cf_turnstile_response` query param)

## Changes

- New [`docs/api-abuse-mitigation.md`](docs/api-abuse-mitigation.md): request flow, CloudFront setup, session cookie details, Turnstile enablement, env reference
- [`README.md`](README.md): architecture blurb, services table, dedicated abuse-mitigation section, search-flow entry notes
- [`AGENTS.md`](AGENTS.md): agent overview of all three layers (keeps existing Turnstile checklist)

Docs only — no runtime code changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f23abd05-2544-4b9a-b7d0-98756733b635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f23abd05-2544-4b9a-b7d0-98756733b635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

