### PR TITLE
Use CF-Turnstile-Response header for session mint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,15 +145,20 @@ To enable in production, do **all** of the following together (secret-only break
 3. Set `VITE_TURNSTILE_SITE_KEY` at **frontend build** time and redeploy the SPA
    (`frontend-update` / CI). The deploy workflow does not inject this today — export it in the
    environment that runs `npm run build`, or add it to `.github/workflows/deploy-on-merge.yml`.
-4. **Session mint CORS:** The SPA sends the Turnstile token as the `cf_turnstile_response`
-   query parameter on `GET /session` (not `CF-Turnstile-Response`) so the browser does not
-   need a preflight. Live API Gateway `OPTIONS /session` does not return
-   `Access-Control-Allow-Headers` for that custom header, which otherwise surfaces as a generic
-   “Unable to connect” error in the UI. Lambda still accepts the header for compatibility.
-   Optionally align API Gateway CORS with `api/handler/cors.go` if you prefer the header.
+4. **API Gateway CORS** (HTTP API → CORS) for cross-origin session mint from
+   `gishathfetch.com`. Required when the SPA sends `CF-Turnstile-Response`
+   (triggers a preflight). Minimum:
+   - **Allow origins:** `https://gishathfetch.com`, `http://localhost:5173`
+   - **Allow methods:** `GET`, `OPTIONS` (empty methods breaks preflight)
+   - **Allow headers:** `Content-Type`, `CF-Turnstile-Response` (browser sends
+     `cf-turnstile-response` in preflight; either casing in the console is fine)
+   - **Allow credentials:** yes
+   - **Max age:** `3600` is reasonable (caches preflight for one hour; use `0`
+     while iterating on CORS). Lambda also accepts `cf_turnstile_response` as a
+     query fallback (`api/handler/session_turnstile_token.go`).
 
-Session minting (`GET /session`) expects a Turnstile token when the secret is set
-(see `frontend/src/utils/apiSession.js`).
+Session minting (`GET /session`) sends `CF-Turnstile-Response` when the secret is
+set (see `frontend/src/utils/apiSession.js`).
 
 **API Gateway (manual):** expose `GET` + `OPTIONS` for `/search` and `/session` only; remove
 legacy `/`, `/api`, and `/api/*` routes when traffic has migrated.

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ until configured):
    (HMAC via `API_SESSION_SECRET`, default TTL 15m); `/search` requires it.
 3. **Cloudflare Turnstile** — when `TURNSTILE_SECRET_KEY` and
    `VITE_TURNSTILE_SITE_KEY` are both set, session mint verifies an invisible
-   challenge (`cf_turnstile_response` query param).
+   challenge (`CF-Turnstile-Response` header on `GET /session`).
 
 Details, env reference, CloudFront header setup, and the browser sequence
 diagram: [`docs/api-abuse-mitigation.md`](docs/api-abuse-mitigation.md).

--- a/docs/api-abuse-mitigation.md
+++ b/docs/api-abuse-mitigation.md
@@ -28,7 +28,7 @@ sequenceDiagram
     Note over U: SPA load (gishathfetch.com)
     U->>TS: invisible widget (when site key set)
     TS-->>U: challenge token
-    U->>API: GET /session?cf_turnstile_response=...
+    U->>API: GET /session (CF-Turnstile-Response)
     Note over API: origin check (allowlisted Origin<br/>or X-Origin-Verify)
     API->>CF_API: siteverify (when TURNSTILE_SECRET_KEY set)
     CF_API-->>API: success
@@ -148,11 +148,13 @@ work with no server check.
 
 ### Token transport
 
-The SPA sends the Turnstile token as the **`cf_turnstile_response` query
-parameter** on `GET /session` so browsers avoid a CORS preflight. Live API
-Gateway `OPTIONS /session` historically did not allow the
-`CF-Turnstile-Response` header. Lambda still accepts that header for
-compatibility (`api/handler/session_turnstile_token.go`).
+The SPA sends the Turnstile token in the **`CF-Turnstile-Response`** request
+header on `GET /session` (Cloudflare’s documented browser transport). That
+triggers a CORS preflight; API Gateway must allow `GET`, `OPTIONS`, the SPA
+origin, credentials, and `cf-turnstile-response` / `CF-Turnstile-Response` in
+**Allow headers** and **Allow methods**. Lambda also accepts
+**`cf_turnstile_response`** as a query fallback for compatibility
+(`api/handler/session_turnstile_token.go`).
 
 ### Verification
 

--- a/frontend/src/utils/apiSession.js
+++ b/frontend/src/utils/apiSession.js
@@ -33,23 +33,18 @@ export async function ensureApiSession(options = {}) {
   }
 }
 
-const TURNSTILE_SESSION_QUERY_PARAM = "cf_turnstile_response";
-
-function sessionMintUrl(turnstileToken) {
-  if (!turnstileToken) {
-    return API_SESSION_URL;
-  }
-  const url = new URL(API_SESSION_URL, window.location.origin);
-  url.searchParams.set(TURNSTILE_SESSION_QUERY_PARAM, turnstileToken);
-  return url.toString();
-}
-
 async function bootstrapSession() {
   try {
+    const headers = {};
     const turnstileToken = await obtainTurnstileToken();
-    const res = await fetch(sessionMintUrl(turnstileToken), {
+    if (turnstileToken) {
+      headers["CF-Turnstile-Response"] = turnstileToken;
+    }
+
+    const res = await fetch(API_SESSION_URL, {
       method: "GET",
       credentials: "include",
+      headers,
     });
 
     if (!res.ok) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restores Cloudflare’s documented transport: the Turnstile token is sent as **`CF-Turnstile-Response`** on `GET /session` instead of the `cf_turnstile_response` query parameter.

Requires API Gateway CORS (already fixed in production): **GET + OPTIONS**, allowlisted origin, credentials, and `cf-turnstile-response` in allow-headers.

Lambda **query fallback** remains for rollback compatibility (`session_turnstile_token.go`).

## Docs

- `AGENTS.md`, `README.md`, and `docs/api-abuse-mitigation.md` updated for header transport and gateway CORS checklist (including optional **max-age 3600**).

## Deploy

Merge and run the normal frontend deploy. No Lambda change required.

## Verify after deploy

1. Hard refresh / clear cache, search from https://gishathfetch.com/
2. DevTools: `GET /session` should include header `CF-Turnstile-Response` (and a prior **OPTIONS** with 204 + CORS headers), then **204** + session cookie.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-681edbba-1407-49e3-bef7-eddbad73fc55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-681edbba-1407-49e3-bef7-eddbad73fc55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

