### PR TITLE
Harden Turnstile session mint against intermittent incognito failures

### DIFF
--- a/api/handler/session.go
+++ b/api/handler/session.go
@@ -39,8 +39,7 @@ func Session(ctx context.Context, request events.APIGatewayProxyRequest) (events
 	}
 
 	turnstileToken := turnstileTokenFromRequest(request)
-	remoteIP := request.RequestContext.Identity.SourceIP
-	if err := verifyTurnstileFunc(ctx, turnstileToken, remoteIP); err != nil {
+	if err := verifyTurnstileFunc(ctx, turnstileToken); err != nil {
 		message := "verification failed"
 		if errors.Is(err, apiauth.ErrTurnstileTokenMissing) {
 			message = "verification required"

--- a/api/handler/session_turnstile_test.go
+++ b/api/handler/session_turnstile_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestSession_TurnstileRequiredWhenConfigured(t *testing.T) {
 	originalVerify := verifyTurnstileFunc
-	verifyTurnstileFunc = func(_ context.Context, token, _ string) error {
+	verifyTurnstileFunc = func(_ context.Context, token string) error {
 		if token == "" {
 			return apiauth.ErrTurnstileTokenMissing
 		}

--- a/api/handler/session_turnstile_token_test.go
+++ b/api/handler/session_turnstile_token_test.go
@@ -37,7 +37,7 @@ func TestTurnstileTokenFromRequest_QueryParam(t *testing.T) {
 
 func TestSession_TurnstileQueryParamAccepted(t *testing.T) {
 	originalVerify := verifyTurnstileFunc
-	verifyTurnstileFunc = func(_ context.Context, token, _ string) error {
+	verifyTurnstileFunc = func(_ context.Context, token string) error {
 		if token != "query-token" {
 			return apiauth.ErrTurnstileTokenMissing
 		}

--- a/api/pkg/apiauth/turnstile.go
+++ b/api/pkg/apiauth/turnstile.go
@@ -43,13 +43,12 @@ var (
 
 // VerifyTurnstile checks the token with Cloudflare when TURNSTILE_SECRET_KEY is set.
 //
-// remoteIP is intentionally unused: siteverify's optional remoteip field has caused
-// intermittent invalid-input-response failures when API Gateway SourceIP disagrees
-// with the address Cloudflare observed for the challenge (IPv4/IPv6 dual-stack and
-// privacy/VPN egress are common in incognito). Token cryptographic validation is
-// sufficient for session mint abuse mitigation.
-func VerifyTurnstile(ctx context.Context, token, remoteIP string) error {
-	_ = remoteIP
+// siteverify's optional remoteip field is intentionally not sent: API Gateway
+// SourceIP can disagree with the address Cloudflare observed for the challenge
+// (IPv4/IPv6 dual-stack and privacy/VPN egress are common in incognito), which
+// caused intermittent invalid-input-response failures. Token cryptographic
+// validation is sufficient for session mint abuse mitigation.
+func VerifyTurnstile(ctx context.Context, token string) error {
 	secret := config.TurnstileSecretKey()
 	if secret == "" {
 		return nil

--- a/api/pkg/apiauth/turnstile.go
+++ b/api/pkg/apiauth/turnstile.go
@@ -42,7 +42,14 @@ var (
 )
 
 // VerifyTurnstile checks the token with Cloudflare when TURNSTILE_SECRET_KEY is set.
+//
+// remoteIP is intentionally unused: siteverify's optional remoteip field has caused
+// intermittent invalid-input-response failures when API Gateway SourceIP disagrees
+// with the address Cloudflare observed for the challenge (IPv4/IPv6 dual-stack and
+// privacy/VPN egress are common in incognito). Token cryptographic validation is
+// sufficient for session mint abuse mitigation.
 func VerifyTurnstile(ctx context.Context, token, remoteIP string) error {
+	_ = remoteIP
 	secret := config.TurnstileSecretKey()
 	if secret == "" {
 		return nil
@@ -56,9 +63,6 @@ func VerifyTurnstile(ctx context.Context, token, remoteIP string) error {
 	form := url.Values{}
 	form.Set("secret", secret)
 	form.Set("response", token)
-	if ip := strings.TrimSpace(remoteIP); ip != "" {
-		form.Set("remoteip", ip)
-	}
 
 	req, err := http.NewRequestWithContext(
 		ctx,

--- a/api/pkg/apiauth/turnstile_test.go
+++ b/api/pkg/apiauth/turnstile_test.go
@@ -29,7 +29,7 @@ func TestVerifyTurnstile_AcceptsSuccessfulSiteverify(t *testing.T) {
 		require.NoError(t, r.ParseForm())
 		require.Equal(t, "test-secret", r.Form.Get("secret"))
 		require.Equal(t, "good-token", r.Form.Get("response"))
-		require.Equal(t, "203.0.113.1", r.Form.Get("remoteip"))
+		require.Empty(t, r.Form.Get("remoteip"), "remoteip must be omitted to avoid intermittent IP mismatch failures")
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"success":true}`))
 	}))

--- a/api/pkg/apiauth/turnstile_test.go
+++ b/api/pkg/apiauth/turnstile_test.go
@@ -13,13 +13,13 @@ import (
 
 func TestVerifyTurnstile_SkipsWhenSecretUnset(t *testing.T) {
 	t.Setenv(config.TurnstileSecretKeyEnv, "")
-	require.NoError(t, VerifyTurnstile(context.Background(), "", ""))
+	require.NoError(t, VerifyTurnstile(context.Background(), ""))
 }
 
 func TestVerifyTurnstile_RequiresTokenWhenSecretSet(t *testing.T) {
 	t.Setenv(config.TurnstileSecretKeyEnv, "test-secret")
 
-	err := VerifyTurnstile(context.Background(), "", "203.0.113.1")
+	err := VerifyTurnstile(context.Background(), "")
 	require.ErrorIs(t, err, ErrTurnstileTokenMissing)
 }
 
@@ -41,7 +41,7 @@ func TestVerifyTurnstile_AcceptsSuccessfulSiteverify(t *testing.T) {
 
 	t.Setenv(config.TurnstileSecretKeyEnv, "test-secret")
 
-	err := VerifyTurnstile(context.Background(), "good-token", "203.0.113.1")
+	err := VerifyTurnstile(context.Background(), "good-token")
 	require.NoError(t, err)
 }
 
@@ -57,6 +57,6 @@ func TestVerifyTurnstile_RejectsFailedSiteverify(t *testing.T) {
 
 	t.Setenv(config.TurnstileSecretKeyEnv, "test-secret")
 
-	err := VerifyTurnstile(context.Background(), "bad-token", "")
+	err := VerifyTurnstile(context.Background(), "bad-token")
 	require.ErrorIs(t, err, ErrTurnstileVerificationFailed)
 }

--- a/docs/api-abuse-mitigation.md
+++ b/docs/api-abuse-mitigation.md
@@ -159,7 +159,13 @@ origin, credentials, and `cf-turnstile-response` / `CF-Turnstile-Response` in
 ### Verification
 
 When `TURNSTILE_SECRET_KEY` is set, Lambda POSTs to Cloudflare
-`/turnstile/v0/siteverify` (5s timeout) with the token and optional client IP.
+`/turnstile/v0/siteverify` (5s timeout) with the token. The optional
+`remoteip` field is **not** sent: API Gateway `SourceIP` can disagree with the
+address Cloudflare saw for the challenge (IPv4/IPv6 dual-stack, VPN/privacy
+egress), which has caused intermittent `invalid-input-response` failures —
+especially noticeable in cold/incognito sessions. Token validation alone is
+enough for session-mint abuse mitigation.
+
 Failures:
 
 | Condition | Response `error` | Status |
@@ -180,7 +186,9 @@ Failures:
    `/search` works with credentials).
 
 Frontend helpers: `frontend/src/utils/turnstileSession.js`,
-`frontend/src/components/TurnstileBootstrap.jsx`.
+`frontend/src/components/TurnstileBootstrap.jsx`. The SPA retries session mint
+a few times with a fresh Turnstile token (private-browsing challenge blips) and
+never reuses a token after a mint attempt (tokens are single-use).
 
 ---
 

--- a/frontend/src/components/TurnstileBootstrap.jsx
+++ b/frontend/src/components/TurnstileBootstrap.jsx
@@ -5,8 +5,12 @@ import {
   teardownTurnstileWidget,
 } from "../utils/turnstileSession";
 
+const PREPARE_RETRY_DELAY_MS = 1500;
+const PREPARE_MAX_ATTEMPTS = 3;
+
 /**
  * Invisible Turnstile widget used to obtain tokens for GET /session on the API host.
+ * Retries prepare a few times — script/challenge load is flaky under private browsing.
  */
 export default function TurnstileBootstrap() {
   const containerRef = useRef(null);
@@ -18,17 +22,35 @@ export default function TurnstileBootstrap() {
 
     let cancelled = false;
     const abort = new AbortController();
-    prepareTurnstileWidget(containerRef.current, {
-      signal: abort.signal,
-    }).catch(() => {
-      if (!cancelled) {
+    let retryTimer = null;
+
+    const prepareWithRetry = async (attempt) => {
+      try {
+        await prepareTurnstileWidget(containerRef.current, {
+          signal: abort.signal,
+        });
+      } catch {
+        if (cancelled || abort.signal.aborted) {
+          return;
+        }
+        if (attempt < PREPARE_MAX_ATTEMPTS) {
+          retryTimer = setTimeout(() => {
+            prepareWithRetry(attempt + 1);
+          }, PREPARE_RETRY_DELAY_MS * attempt);
+          return;
+        }
         // Session bootstrap will surface errors on the next search.
       }
-    });
+    };
+
+    prepareWithRetry(1);
 
     return () => {
       cancelled = true;
       abort.abort();
+      if (retryTimer != null) {
+        clearTimeout(retryTimer);
+      }
       teardownTurnstileWidget();
     };
   }, []);

--- a/frontend/src/hooks/useSearch.js
+++ b/frontend/src/hooks/useSearch.js
@@ -310,12 +310,13 @@ export default function useSearch() {
           } else if (
             typeof err.message === "string" &&
             (err.message.includes("turnstile") ||
-              err.message.includes("API session verification") ||
-              err.message.includes("API session blocked") ||
-              err.message.includes("API session failed"))
+              err.message.includes("API session verification"))
           ) {
             nextSearchError =
               "Could not verify this browser session. Please refresh the page and try again.";
+          } else if (err.message.includes("API session failed")) {
+            nextSearchError =
+              "The server is experiencing issues. Please try again later.";
           } else if (err.message.startsWith("Error (")) {
             nextSearchError = err.message;
           } else if (err.message.includes("Server error")) {

--- a/frontend/src/hooks/useSearch.js
+++ b/frontend/src/hooks/useSearch.js
@@ -307,6 +307,15 @@ export default function useSearch() {
           ) {
             nextSearchError =
               "Unable to connect to the server. Please check your internet connection and try again.";
+          } else if (
+            typeof err.message === "string" &&
+            (err.message.includes("turnstile") ||
+              err.message.includes("API session verification") ||
+              err.message.includes("API session blocked") ||
+              err.message.includes("API session failed"))
+          ) {
+            nextSearchError =
+              "Could not verify this browser session. Please refresh the page and try again.";
           } else if (err.message.startsWith("Error (")) {
             nextSearchError = err.message;
           } else if (err.message.includes("Server error")) {

--- a/frontend/src/utils/apiSession.js
+++ b/frontend/src/utils/apiSession.js
@@ -60,27 +60,13 @@ async function mintApiSession() {
     headers["CF-Turnstile-Response"] = turnstileToken;
   }
 
-  let res;
-  try {
-    res = await fetch(API_SESSION_URL, {
-      method: "GET",
-      credentials: "include",
-      headers,
-    });
-  } catch (err) {
-    // Custom header triggers a CORS preflight; a misconfigured gateway surfaces as Failed to fetch.
-    if (
-      turnstileToken &&
-      (err?.name === "TypeError" ||
-        (typeof err?.message === "string" &&
-          err.message.includes("Failed to fetch")))
-    ) {
-      throw new Error(
-        "API session blocked (CORS/network). If this persists, check API Gateway Allow-Headers for CF-Turnstile-Response.",
-      );
-    }
-    throw err;
-  }
+  // Network failures surface as TypeError; rethrow as-is so the UI keeps the
+  // accurate "unable to connect" copy instead of blaming session verification.
+  const res = await fetch(API_SESSION_URL, {
+    method: "GET",
+    credentials: "include",
+    headers,
+  });
 
   // Tokens are single-use; never reuse after a mint attempt.
   resetTurnstileChallenge();

--- a/frontend/src/utils/apiSession.js
+++ b/frontend/src/utils/apiSession.js
@@ -7,6 +7,9 @@ import {
 /** Refresh before default API session TTL (15m) so idle tabs stay authorized. */
 export const API_SESSION_REFRESH_INTERVAL_MS = 10 * 60 * 1000;
 
+/** Turnstile / network blips are common in private browsing; retry with a fresh token. */
+const SESSION_MINT_MAX_ATTEMPTS = 3;
+
 let sessionBootstrapPromise = null;
 
 /**
@@ -22,7 +25,7 @@ export async function ensureApiSession(options = {}) {
   }
 
   if (!sessionBootstrapPromise) {
-    sessionBootstrapPromise = bootstrapSession();
+    sessionBootstrapPromise = bootstrapSessionWithRetry();
   }
 
   try {
@@ -33,27 +36,62 @@ export async function ensureApiSession(options = {}) {
   }
 }
 
-async function bootstrapSession() {
-  try {
-    const headers = {};
-    const turnstileToken = await obtainTurnstileToken();
-    if (turnstileToken) {
-      headers["CF-Turnstile-Response"] = turnstileToken;
-    }
+async function bootstrapSessionWithRetry() {
+  let lastError = null;
 
-    const res = await fetch(API_SESSION_URL, {
+  for (let attempt = 1; attempt <= SESSION_MINT_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      await mintApiSession();
+      return;
+    } catch (err) {
+      lastError = err;
+      // Drop any pending/used token so the next attempt runs a fresh challenge.
+      resetTurnstileChallenge();
+    }
+  }
+
+  throw lastError ?? new Error("API session failed");
+}
+
+async function mintApiSession() {
+  const headers = {};
+  const turnstileToken = await obtainTurnstileToken();
+  if (turnstileToken) {
+    headers["CF-Turnstile-Response"] = turnstileToken;
+  }
+
+  let res;
+  try {
+    res = await fetch(API_SESSION_URL, {
       method: "GET",
       credentials: "include",
       headers,
     });
-
-    if (!res.ok) {
-      throw new Error(`API session failed (${res.status})`);
-    }
   } catch (err) {
-    // Always drop a pending/used token so the next mint gets a fresh challenge.
-    resetTurnstileChallenge();
+    // Custom header triggers a CORS preflight; a misconfigured gateway surfaces as Failed to fetch.
+    if (
+      turnstileToken &&
+      (err?.name === "TypeError" ||
+        (typeof err?.message === "string" &&
+          err.message.includes("Failed to fetch")))
+    ) {
+      throw new Error(
+        "API session blocked (CORS/network). If this persists, check API Gateway Allow-Headers for CF-Turnstile-Response.",
+      );
+    }
     throw err;
+  }
+
+  // Tokens are single-use; never reuse after a mint attempt.
+  resetTurnstileChallenge();
+
+  if (!res.ok) {
+    if (res.status === 403) {
+      throw new Error(
+        "API session verification failed. Please try searching again.",
+      );
+    }
+    throw new Error(`API session failed (${res.status})`);
   }
 }
 

--- a/frontend/src/utils/turnstileSession.js
+++ b/frontend/src/utils/turnstileSession.js
@@ -66,6 +66,11 @@ function loadTurnstileScript() {
     document.head.appendChild(script);
   });
 
+  // A rejected load must not be cached — prepare retries need a fresh attempt.
+  scriptLoadPromise.catch(() => {
+    scriptLoadPromise = null;
+  });
+
   return scriptLoadPromise;
 }
 

--- a/frontend/src/utils/turnstileSession.js
+++ b/frontend/src/utils/turnstileSession.js
@@ -2,6 +2,7 @@ const TURNSTILE_SCRIPT_SRC =
   "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
 
 const TURNSTILE_TIMEOUT_MS = 30_000;
+const TURNSTILE_WIDGET_READY_TIMEOUT_MS = 20_000;
 
 let scriptLoadPromise = null;
 let widgetId = null;
@@ -190,13 +191,32 @@ function waitForTurnstileToken() {
   return promise.finally(() => clearTimeout(timeout));
 }
 
+function waitForWidgetReady() {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error("turnstile widget timeout"));
+    }, TURNSTILE_WIDGET_READY_TIMEOUT_MS);
+
+    widgetReady.promise.then(
+      (value) => {
+        clearTimeout(timeout);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timeout);
+        reject(err);
+      },
+    );
+  });
+}
+
 export async function obtainTurnstileToken() {
   if (!isTurnstileConfigured()) {
     return "";
   }
 
-  await widgetReady.promise;
-  if (widgetId == null) {
+  await waitForWidgetReady();
+  if (widgetId == null || !window.turnstile) {
     throw new Error("turnstile widget not ready");
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Verdict

**Yes — Turnstile is a plausible cause** of occasional live-site errors in incognito.

Production has Turnstile fully enabled (`VITE_TURNSTILE_SITE_KEY` in the SPA build + `TURNSTILE_SECRET_KEY` on Lambda). Cold/incognito sessions always mint via `GET /session` with a fresh invisible challenge, so flaky challenge/siteverify shows up there first. CORS for `CF-Turnstile-Response` looks correct on live today (OPTIONS returns allow-headers including `cf-turnstile-response`); the remaining intermittent risk is Turnstile itself.

## What we found

1. **Siteverify `remoteip`** — Lambda forwarded API Gateway `SourceIP`. That can disagree with the IP Cloudflare saw for the challenge (IPv4/IPv6 dual-stack, VPN/privacy egress common in private browsing), which is a known source of intermittent `invalid-input-response` failures. `remoteip` is optional; we now omit it (parameter removed entirely).
2. **No mint retries** — a single challenge blip or 403 verification failure failed the search with a generic error.
3. **Token reuse risk** — Turnstile tokens are single-use; the client now clears the challenge after every mint attempt.
4. **Widget readiness** — private browsing can delay/fail script load; widget ready now times out, and bootstrap retries prepare a few times.
5. **Error copy** — Turnstile/session failures now map to clearer messages.

## Second-pass review fixes

A self-review of the first commit found and fixed three more issues:

- **Rejected script-load promise was cached forever** — a transient Turnstile script-load failure (ad-blocker/privacy flakiness) made every subsequent bootstrap retry fail instantly. The cached promise is now cleared on rejection so retries re-attempt the load.
- **Offline users were mislabeled** — the first commit remapped fetch `TypeError` to a session/CORS message, which would show "Could not verify this browser session" to users who are simply offline. The original error is now rethrown, preserving the accurate "Unable to connect to the server" copy.
- **Session 5xx mapped to the wrong message** — `API session failed (5xx)` now shows the server-issues copy instead of the verification copy.

## Functional verification (real browser, real Cloudflare challenge)

Ran the built SPA through the Vite proxy with a Cloudflare test sitekey (the production key rejects non-allowlisted hosts — error 110200 on localhost, which is expected and confirms domain validation works):

| Scenario | Result |
|---|---|
| First mint forged 403 → retry | Retried with a fresh challenge, mint succeeded, `/search` carried the session cookie, results rendered |
| `/session` network failure (aborted) | Shows "Unable to connect to the server. Please check your internet connection and try again." |
| `/session` always 403 | Retries 3×, then shows "Could not verify this browser session. Please refresh the page and try again." |

Note: Cloudflare's always-pass test key returns a constant dummy token, so per-attempt token uniqueness was verified structurally (fresh challenge per attempt) rather than by value.

## Screenshots

Search recovered after a forced first-403 (retry path), desktop:

![Search succeeds after session mint retry](https://cursor.com/artifacts/c/art-a1d76d2f-8c9b-48a9-b765-87f7a031ebb6)

Session verification exhausted error copy, desktop:

![Session verification error desktop](https://cursor.com/artifacts/c/art-24425472-14fd-4c91-91ff-e3fabfffb457)

Session verification exhausted error copy, mobile:

![Session verification error mobile](https://cursor.com/artifacts/c/art-5197aed7-d773-4ed4-bdfd-faf6d7948cf6)

## Deploy notes

Needs **both** Lambda + frontend deploy (`make deploy` / normal CI) so the siteverify change and SPA retries ship together.

## Test plan

- [x] `cd api && go fix ./...`
- [x] `make test`
- [x] `cd frontend && npm run lint`
- [x] Browser verification of retry / offline / exhausted-verification paths (above)
- [ ] After deploy: hard refresh / incognito on https://gishathfetch.com/, search a few times, confirm `/session` 204 + cookie, no intermittent verification errors

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b243ef8d-f912-40bd-b68b-5db04e3c8a70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b243ef8d-f912-40bd-b68b-5db04e3c8a70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

