### PR TITLE
Add direct fallback after dedicated for Agora Hobby

### DIFF
--- a/api/gateway/agora/search.go
+++ b/api/gateway/agora/search.go
@@ -78,17 +78,12 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 }
 
 func agoraOutboundOpts(pageURL *url.URL) gateway.OutboundRequestOptions {
-	opts := gateway.OutboundRequestOptions{
-		Style:          gateway.OutboundStyleHTML,
-		PageURL:        pageURL,
-		SkipWebBotAuth: true,
-		SkipDirect:     true,
+	return gateway.OutboundRequestOptions{
+		Style:                gateway.OutboundStyleHTML,
+		PageURL:              pageURL,
+		SkipWebBotAuth:       true,
+		PreferDedicatedFirst: true,
 	}
-	// Non-production hosts (httptest unit tests) must use the direct transport.
-	if pageURL == nil || pageURL.Host != "agorahobby.com" {
-		opts.SkipDirect = false
-	}
-	return opts
 }
 
 func parseStoreItem(se *goquery.Selection, storeName string, apiURL *url.URL, searchStr string) (gateway.Card, bool) {

--- a/api/gateway/agora/search_opts_test.go
+++ b/api/gateway/agora/search_opts_test.go
@@ -13,7 +13,8 @@ func TestAgoraOutboundOpts_ProductionHost(t *testing.T) {
 
 	opts := agoraOutboundOpts(pageURL)
 	require.True(t, opts.SkipWebBotAuth)
-	require.True(t, opts.SkipDirect)
+	require.False(t, opts.SkipDirect)
+	require.True(t, opts.PreferDedicatedFirst)
 	require.False(t, opts.PreferResidentialProxy)
 }
 
@@ -24,5 +25,6 @@ func TestAgoraOutboundOpts_NonProductionHostAllowsDirect(t *testing.T) {
 	opts := agoraOutboundOpts(pageURL)
 	require.True(t, opts.SkipWebBotAuth)
 	require.False(t, opts.SkipDirect)
+	require.True(t, opts.PreferDedicatedFirst)
 	require.False(t, opts.PreferResidentialProxy)
 }

--- a/api/gateway/moxandlotus/search.go
+++ b/api/gateway/moxandlotus/search.go
@@ -138,7 +138,7 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 		}.Encode(),
 	}
 
-	resp, err := gateway.DoOutboundGET(ctx, apiURL.String(), gateway.OutboundRequestOptions{}, config.SearchAttemptTimeout)
+	resp, err := gateway.DoOutboundGET(ctx, apiURL.String(), moxOutboundOpts(), config.SearchAttemptTimeout)
 	if err != nil {
 		return cards, err
 	}
@@ -205,6 +205,12 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 	}
 
 	return cards, nil
+}
+
+func moxOutboundOpts() gateway.OutboundRequestOptions {
+	return gateway.OutboundRequestOptions{
+		PreferDedicatedFirst: true,
+	}
 }
 
 func resolveCardImageURL(expansionCode, cardNumber string, imagePath any) (string, bool) {

--- a/api/gateway/moxandlotus/search_test.go
+++ b/api/gateway/moxandlotus/search_test.go
@@ -9,6 +9,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestMoxOutboundOpts(t *testing.T) {
+	opts := moxOutboundOpts()
+	require.True(t, opts.PreferDedicatedFirst)
+	require.False(t, opts.SkipDirect)
+	require.False(t, opts.PreferResidentialProxy)
+}
+
 func Test_Search(t *testing.T) {
 	s := NewLGS()
 	result, err := s.Search(context.Background(), "Abrade")

--- a/api/gateway/outbound_get.go
+++ b/api/gateway/outbound_get.go
@@ -130,53 +130,83 @@ func buildOutboundGETAttempts(ctx context.Context, timeout time.Duration, opts O
 		}}
 	}
 
-	var attempts []outboundAttempt
-	if !opts.SkipDirect {
+	appendDirect := func(dst []outboundAttempt) []outboundAttempt {
+		if opts.SkipDirect {
+			return dst
+		}
 		client, err := newOutboundHTTPClient("", timeout, profile)
 		if err != nil {
-			return attempts
+			return dst
 		}
-		attempts = append(attempts, outboundAttempt{
+		return append(dst, outboundAttempt{
 			strategy: "direct",
 			client:   client,
 		})
 	}
 
-	if opts.PreferResidentialProxy {
-		if proxyURL, ok := util.GetResidentialProxyURL(); ok {
-			client, err := newOutboundHTTPClient(proxyURL, timeout, profile)
-			if err == nil {
-				attempts = append(attempts, outboundAttempt{
-					strategy: "residential-1",
-					proxyURL: proxyURL,
-					client:   client,
-				})
-			}
+	appendResidential := func(dst []outboundAttempt) []outboundAttempt {
+		if !opts.PreferResidentialProxy {
+			return dst
 		}
+		proxyURL, ok := util.GetResidentialProxyURL()
+		if !ok {
+			return dst
+		}
+		client, err := newOutboundHTTPClient(proxyURL, timeout, profile)
+		if err != nil {
+			return dst
+		}
+		return append(dst, outboundAttempt{
+			strategy: "residential-1",
+			proxyURL: proxyURL,
+			client:   client,
+		})
 	}
 
 	// Match colly's selectOutboundProxy policy: one dedicated proxy per store search.
 	// When searchShop pins a request-scoped lease, reuse that URL instead of
 	// picking a new random slot for each outbound store.
-	if proxyURL, ok := dedicatedProxyURLForOutbound(ctx); ok {
-		client, err := newOutboundHTTPClient(proxyURL, timeout, profile)
-		if err == nil {
-			attempts = append(attempts, outboundAttempt{
-				strategy: dedicatedProxyStrategyName(proxyURL),
-				proxyURL: proxyURL,
-				client:   client,
-			})
+	appendDedicated := func(dst []outboundAttempt) []outboundAttempt {
+		proxyURL, ok := dedicatedProxyURLForOutbound(ctx)
+		if !ok {
+			return dst
 		}
+		client, err := newOutboundHTTPClient(proxyURL, timeout, profile)
+		if err != nil {
+			return dst
+		}
+		return append(dst, outboundAttempt{
+			strategy: dedicatedProxyStrategyName(proxyURL),
+			proxyURL: proxyURL,
+			client:   client,
+		})
 	}
 
-	if client, ok := dynamicProxyHTTPClient(timeout, profile); ok {
-		attempts = append(attempts, outboundAttempt{
+	appendDynamic := func(dst []outboundAttempt) []outboundAttempt {
+		client, ok := dynamicProxyHTTPClient(timeout, profile)
+		if !ok {
+			return dst
+		}
+		return append(dst, outboundAttempt{
 			strategy: "dynamic",
 			proxyURL: DynamicProxyURL(),
 			client:   client,
 		})
 	}
 
+	var attempts []outboundAttempt
+	if opts.PreferDedicatedFirst {
+		attempts = appendDedicated(attempts)
+		attempts = appendDirect(attempts)
+		attempts = appendResidential(attempts)
+		attempts = appendDynamic(attempts)
+		return attempts
+	}
+
+	attempts = appendDirect(attempts)
+	attempts = appendResidential(attempts)
+	attempts = appendDedicated(attempts)
+	attempts = appendDynamic(attempts)
 	return attempts
 }
 

--- a/api/gateway/outbound_get_test.go
+++ b/api/gateway/outbound_get_test.go
@@ -21,6 +21,7 @@ func clearProxyEnv(t *testing.T) {
 		t.Setenv(fmt.Sprintf("DEDICATED_PROXY_%d", i), "")
 	}
 	t.Setenv("DYNAMIC_PROXY", "")
+	t.Setenv("USE_DYNAMIC_PROXY", "")
 	t.Setenv("RESIDENTIAL_PROXY_1", "")
 }
 
@@ -108,6 +109,34 @@ func TestBuildOutboundGETAttempts_SkipDirect(t *testing.T) {
 	attempts := buildOutboundGETAttempts(context.Background(), 2*time.Second, OutboundRequestOptions{SkipDirect: true})
 	require.Len(t, attempts, 1)
 	require.True(t, strings.HasPrefix(attempts[0].strategy, "dedicated-"))
+}
+
+func TestBuildOutboundGETAttempts_PreferDedicatedFirst(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("DEDICATED_PROXY_1", "1.2.3.4|8080|user|pass")
+	t.Setenv("DYNAMIC_PROXY", "9.9.9.9|8080|dyn|pass")
+	t.Setenv("USE_DYNAMIC_PROXY", "true")
+
+	attempts := buildOutboundGETAttempts(context.Background(), 2*time.Second, OutboundRequestOptions{
+		PreferDedicatedFirst: true,
+	})
+	require.Len(t, attempts, 3)
+	require.Equal(t, "dedicated-1", attempts[0].strategy)
+	require.Equal(t, "direct", attempts[1].strategy)
+	require.Equal(t, "dynamic", attempts[2].strategy)
+}
+
+func TestBuildOutboundGETAttempts_PreferDedicatedFirstWithoutDedicated(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("DYNAMIC_PROXY", "9.9.9.9|8080|dyn|pass")
+	t.Setenv("USE_DYNAMIC_PROXY", "true")
+
+	attempts := buildOutboundGETAttempts(context.Background(), 2*time.Second, OutboundRequestOptions{
+		PreferDedicatedFirst: true,
+	})
+	require.Len(t, attempts, 2)
+	require.Equal(t, "direct", attempts[0].strategy)
+	require.Equal(t, "dynamic", attempts[1].strategy)
 }
 
 func TestBuildOutboundGETAttempts_OnlyProxyURL(t *testing.T) {

--- a/api/gateway/outbound_request.go
+++ b/api/gateway/outbound_request.go
@@ -24,6 +24,9 @@ type OutboundRequestOptions struct {
 	Accept string
 	// SkipDirect omits the direct transport from DoOutboundGET fallback chains.
 	SkipDirect bool
+	// PreferDedicatedFirst places dedicated proxy attempts before direct when both
+	// are enabled, producing dedicated → direct → dynamic.
+	PreferDedicatedFirst bool
 	// PreferResidentialProxy prepends RESIDENTIAL_PROXY_1 to DoOutboundGET fallback
 	// chains before dedicated and dynamic transports.
 	PreferResidentialProxy bool

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -87,11 +87,11 @@ All BinderPOS stores configure a Shopify domain for decklist steps. Card Affinit
 
 ## Backend: non-BinderPOS stores
 
-Shared `net/http` transport fallback for `DoOutboundGET` / `DoOutboundRoundTrip` (`api/gateway/outbound_get.go`): **direct → dedicated (request-scoped lease or one random slot) → dynamic**. Each transport is tried once; client errors (4xx) and connection errors advance immediately to the next transport. No automatic retry of the same transport.
+Shared `net/http` transport fallback for `DoOutboundGET` / `DoOutboundRoundTrip` (`api/gateway/outbound_get.go`): **direct → dedicated (request-scoped lease or one random slot) → dynamic**. Callers can reorder with `PreferDedicatedFirst` (**dedicated → direct → dynamic**) or omit direct with `SkipDirect`. Each transport is tried once; client errors (4xx) and connection errors advance immediately to the next transport. No automatic retry of the same transport.
 
 | Store | Strategy | Per-attempt timeout | Proxy / transport order | Retries |
 |-------|----------|----------------------|-------------------------|---------|
-| Agora Hobby | HTML search page (`/store/search`) | 20s | **Dedicated → dynamic**; skips direct on `agorahobby.com` (browser TLS via `SkipWebBotAuth` + `BROWSER_TLS_EMULATION_ENABLED`) | Transport fallback only |
+| Agora Hobby | HTML search page (`/store/search`) | 20s | **Dedicated → direct → dynamic** (`PreferDedicatedFirst`; browser TLS via `SkipWebBotAuth` + `BROWSER_TLS_EMULATION_ENABLED`) | Transport fallback only |
 | 5 Mana | **graphql** → **html** (Dawn `main-search` section) | 5s per path | **Dedicated → dynamic**; skips direct on `5-mana.sg` | GraphQL 5xx is final; other GraphQL errors fall through to HTML. Transport fallback per path. |
 | Cards Central | JSON API (`/api/lgs/search?q=…`) | 5s | Direct → dedicated → dynamic | Transport fallback only |
 | Dueller's Point | HTML search page (`/products/search`) | 5s | Direct → dedicated → dynamic | Transport fallback only |
@@ -101,7 +101,7 @@ Shared `net/http` transport fallback for `DoOutboundGET` / `DoOutboundRoundTrip`
 
 Store implementations: `api/gateway/agora/search.go`, `api/gateway/fivemana/search.go` + `graphql.go`, `api/gateway/cardscentral/search.go`, `api/gateway/duellerpoint/search.go`, `api/gateway/moxandlotus/search.go`, `api/gateway/cardsandcollection/search.go`, `api/gateway/tcgmarketplace/search.go`.
 
-For Agora and 5 Mana, `SkipDirect` is cleared when the host is not the production domain so httptest unit tests can use the direct transport.
+For 5 Mana, `SkipDirect` is cleared when the host is not the production domain so httptest unit tests can use the direct transport. Agora keeps direct in the fallback chain after dedicated (`PreferDedicatedFirst`).
 
 ---
 

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -95,13 +95,13 @@ Shared `net/http` transport fallback for `DoOutboundGET` / `DoOutboundRoundTrip`
 | 5 Mana | **graphql** → **html** (Dawn `main-search` section) | 5s per path | **Dedicated → dynamic**; skips direct on `5-mana.sg` | GraphQL 5xx is final; other GraphQL errors fall through to HTML. Transport fallback per path. |
 | Cards Central | JSON API (`/api/lgs/search?q=…`) | 5s | Direct → dedicated → dynamic | Transport fallback only |
 | Dueller's Point | HTML search page (`/products/search`) | 5s | Direct → dedicated → dynamic | Transport fallback only |
-| Mox & Lotus | JSON API GET (`/api/products?search=…`) | 5s | Direct → dedicated → dynamic | Transport fallback only |
+| Mox & Lotus | JSON API GET (`/api/products?search=…`) | 5s | **Dedicated → direct → dynamic** (`PreferDedicatedFirst`) | Transport fallback only |
 | Cards & Collections | Elasticsearch-style POST (`/api/catalog/`) | 5s | Direct → dedicated → dynamic | Transport fallback only |
 | The TCG Marketplace | CardLink POST (`:3501/encoder/advancedsearch`) | 5s | Direct → dedicated → dynamic | Transport fallback only |
 
 Store implementations: `api/gateway/agora/search.go`, `api/gateway/fivemana/search.go` + `graphql.go`, `api/gateway/cardscentral/search.go`, `api/gateway/duellerpoint/search.go`, `api/gateway/moxandlotus/search.go`, `api/gateway/cardsandcollection/search.go`, `api/gateway/tcgmarketplace/search.go`.
 
-For 5 Mana, `SkipDirect` is cleared when the host is not the production domain so httptest unit tests can use the direct transport. Agora keeps direct in the fallback chain after dedicated (`PreferDedicatedFirst`).
+For 5 Mana, `SkipDirect` is cleared when the host is not the production domain so httptest unit tests can use the direct transport. Agora and Mox & Lotus keep direct in the fallback chain after dedicated (`PreferDedicatedFirst`).
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Agora Hobby and Mox & Lotus now use **dedicated → direct → dynamic** outbound transport order via `PreferDedicatedFirst`.

Previously:
- **Agora** skipped direct (`SkipDirect`) → dedicated → dynamic only
- **Mox & Lotus** used the default direct → dedicated → dynamic

When dedicated proxies return **429**, both stores now try direct before dynamic.

## Changes

- New `OutboundRequestOptions.PreferDedicatedFirst` in `api/gateway/outbound_request.go`
- `buildOutboundGETAttempts` honors that ordering in `api/gateway/outbound_get.go`
- Agora and Mox & Lotus enable `PreferDedicatedFirst`
- Unit coverage for the new attempt order and store opts
- Docs updated in `docs/search-strategies-retries-timeouts.md`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0d4ca83-bdfe-44ff-a793-07f9423492bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0d4ca83-bdfe-44ff-a793-07f9423492bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

