### PR TITLE
Tune Mox & Lotus timeout to 10s and page limit to 24

### DIFF
--- a/api/gateway/gatewaytest/live_probes.go
+++ b/api/gateway/gatewaytest/live_probes.go
@@ -80,7 +80,7 @@ func RequireDuellersPointSearchStructure(t *testing.T, ctx context.Context, base
 func RequireMoxAndLotusAPIStructure(t *testing.T, ctx context.Context, query string) {
 	t.Helper()
 	probeURL := BuildURL("https", "moxandlotus.sg", "/api/products", url.Values{
-		"limit":          {"48"},
+		"limit":          {"24"},
 		"full_search":    {"true"},
 		"showStatus":     {"false"},
 		"is_paginated":   {"true"},

--- a/api/gateway/moxandlotus/search.go
+++ b/api/gateway/moxandlotus/search.go
@@ -19,7 +19,8 @@ import (
 const StoreName = "Mox & Lotus"
 const StoreBaseURL = "https://moxandlotus.sg"
 const StoreSearchURL = "/products?title="
-const StoreApiURL = "/api/products?&limit=48&full_search=true&showStatus=false&is_paginated=true&in_stock=true&sortVariation=true&&category_id=1&variation_code=all&order_by=Price%20Low%20to%20High&search="
+const StoreApiURL = "/api/products?&limit=24&full_search=true&showStatus=false&is_paginated=true&in_stock=true&sortVariation=true&&category_id=1&variation_code=all&order_by=Price%20Low%20to%20High&search="
+const storeSearchLimit = "24"
 const CardImageURL = "https://d3nmvyqkci0c2u.cloudfront.net/%s/%s.png"
 
 type response struct {
@@ -125,7 +126,7 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 		Host:   "moxandlotus.sg",
 		Path:   "/api/products", // base part of StoreApiURL
 		RawQuery: url.Values{
-			"limit":          {"48"},
+			"limit":          {storeSearchLimit},
 			"full_search":    {"true"},
 			"showStatus":     {"false"},
 			"is_paginated":   {"true"},
@@ -138,7 +139,7 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 		}.Encode(),
 	}
 
-	resp, err := gateway.DoOutboundGET(ctx, apiURL.String(), moxOutboundOpts(), config.SearchAttemptTimeout)
+	resp, err := gateway.DoOutboundGET(ctx, apiURL.String(), moxOutboundOpts(), config.MoxAndLotusSearchAttemptTimeout)
 	if err != nil {
 		return cards, err
 	}

--- a/api/gateway/moxandlotus/search_test.go
+++ b/api/gateway/moxandlotus/search_test.go
@@ -16,6 +16,10 @@ func TestMoxOutboundOpts(t *testing.T) {
 	require.False(t, opts.PreferResidentialProxy)
 }
 
+func TestMoxSearchLimit(t *testing.T) {
+	require.Equal(t, "24", storeSearchLimit)
+}
+
 func Test_Search(t *testing.T) {
 	s := NewLGS()
 	result, err := s.Search(context.Background(), "Abrade")

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -25,6 +25,8 @@ const (
 	SearchAttemptTimeout = 5 * time.Second
 	// AgoraSearchAttemptTimeout is the per-attempt cap for Agora Hobby only (matches per-store deadline).
 	AgoraSearchAttemptTimeout = PerSiteTimeout
+	// MoxAndLotusSearchAttemptTimeout is the per-attempt cap for Mox & Lotus.
+	MoxAndLotusSearchAttemptTimeout = 10 * time.Second
 	// DynamicProxyEnv contains an authenticated proxy URL used for explicit
 	// dynamic-proxy fallback attempts, which BinderPOS reserves for the final
 	// two attempts after dedicated and direct/no-proxy scrap and decklist tries.

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -11,6 +11,7 @@ This document records **where** the app configures search behavior, **timeouts**
 | Per-store deadline | 20s | `config.PerSiteTimeout` in `api/pkg/config/config.go`; used in `searchShop` as `context.WithTimeout` in `api/controller/search.go` | One goroutine per selected store; each `LGS.Search` runs under this cap. |
 | Per-attempt timeout (default) | 5s | `config.SearchAttemptTimeout` in `api/pkg/config/config.go` | Bounds each BinderPOS strategy step, default colly scrape request, and most `DoOutboundGET` / `DoOutboundRoundTrip` calls. |
 | Agora per-attempt timeout | 20s | `config.AgoraSearchAttemptTimeout` in `api/pkg/config/config.go`; applied in `api/gateway/agora/search.go` | Same as per-store deadline (`PerSiteTimeout`). |
+| Mox & Lotus per-attempt timeout | 10s | `config.MoxAndLotusSearchAttemptTimeout` in `api/pkg/config/config.go`; applied in `api/gateway/moxandlotus/search.go` | Longer than the default 5s attempt timeout. |
 | Colly request timeout (default scrapers) | 5s | `applyCollectorDefaults` → `c.SetRequestTimeout(config.SearchAttemptTimeout)` in `api/gateway/collector.go` | Overrides gocolly’s default 10s for optimized collectors. |
 | Max concurrent store searches | 6 | `maxConcurrentStoreSearches` in `api/controller/search.go` | Worker pool size when fanning out to selected stores. |
 | Minimum end-to-end response time | 1s | `responseThreshold` in `searchShops` in `api/controller/search.go` | If all stores finish in under 1s, the handler **sleeps** the remainder so the API “feels” less instant. |
@@ -95,7 +96,7 @@ Shared `net/http` transport fallback for `DoOutboundGET` / `DoOutboundRoundTrip`
 | 5 Mana | **graphql** → **html** (Dawn `main-search` section) | 5s per path | **Dedicated → dynamic**; skips direct on `5-mana.sg` | GraphQL 5xx is final; other GraphQL errors fall through to HTML. Transport fallback per path. |
 | Cards Central | JSON API (`/api/lgs/search?q=…`) | 5s | Direct → dedicated → dynamic | Transport fallback only |
 | Dueller's Point | HTML search page (`/products/search`) | 5s | Direct → dedicated → dynamic | Transport fallback only |
-| Mox & Lotus | JSON API GET (`/api/products?search=…`) | 5s | **Dedicated → direct → dynamic** (`PreferDedicatedFirst`) | Transport fallback only |
+| Mox & Lotus | JSON API GET (`/api/products?search=…`, `limit=24`) | 10s | **Dedicated → direct → dynamic** (`PreferDedicatedFirst`) | Transport fallback only |
 | Cards & Collections | Elasticsearch-style POST (`/api/catalog/`) | 5s | Direct → dedicated → dynamic | Transport fallback only |
 | The TCG Marketplace | CardLink POST (`:3501/encoder/advancedsearch`) | 5s | Direct → dedicated → dynamic | Transport fallback only |
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Tune Mox & Lotus search performance settings:

- Per-attempt timeout: **5s → 10s** (`config.MoxAndLotusSearchAttemptTimeout`)
- Products API page `limit`: **48 → 24**

## Changes

- `api/pkg/config/config.go` — new 10s timeout constant
- `api/gateway/moxandlotus/search.go` — use 10s timeout and `limit=24`
- Live structure probe and docs updated to match

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0d4ca83-bdfe-44ff-a793-07f9423492bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0d4ca83-bdfe-44ff-a793-07f9423492bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

