### PR TITLE
Add FAQ note on Agora and Mox search timeouts

### DIFF
--- a/frontend/src/components/Modals.jsx
+++ b/frontend/src/components/Modals.jsx
@@ -241,6 +241,13 @@ const Modals = ({
                 in the queue. Selecting fewer stores makes searches faster, is
                 gentler on the shops, and helps keep operating costs down.
               </p>
+              <p>
+                <strong>Agora Hobby</strong> and <strong>Mox &amp; Lotus</strong>{" "}
+                are generally slower to respond than other stores, so searches
+                that include them often take longer and time out more
+                frequently. If you need faster results, try searching without
+                those two selected.
+              </p>
             </div>
           </div>
           <div className="mb-4" id="faq-q7">

--- a/frontend/src/components/Modals.jsx
+++ b/frontend/src/components/Modals.jsx
@@ -242,11 +242,11 @@ const Modals = ({
                 gentler on the shops, and helps keep operating costs down.
               </p>
               <p>
-                <strong>Agora Hobby</strong> and <strong>Mox &amp; Lotus</strong>{" "}
-                are generally slower to respond than other stores, so searches
-                that include them often take longer and time out more
-                frequently. If you need faster results, try searching without
-                those two selected.
+                <strong>Agora Hobby</strong> and{" "}
+                <strong>Mox &amp; Lotus</strong> are generally slower to respond
+                than other stores, so searches that include them often take
+                longer and time out more frequently. If you need faster results,
+                try searching without those two selected.
               </p>
             </div>
           </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds a second paragraph under FAQ question 6 ("Why do searches take longer with more stores selected?") clarifying that **Agora Hobby** and **Mox & Lotus** generally respond more slowly and time out more frequently than other stores.

## Screenshots

### Desktop
![FAQ Q6 desktop showing Agora Hobby and Mox & Lotus timeout note](https://cursor.com/artifacts/c/art-11abccd1-c322-41f5-9a00-0ff21ced229e)

### Mobile
![FAQ Q6 mobile showing Agora Hobby and Mox & Lotus timeout note](https://cursor.com/artifacts/c/art-21e05d1e-37f0-4cdc-b4ac-4c8fdc41cc2f)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-889b2b2a-71ab-4e36-9aee-f40e33076d00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-889b2b2a-71ab-4e36-9aee-f40e33076d00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

