### PR TITLE
Add Arcane Sanctum to search, store list, and map

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ store simply contributes nothing.
 **5 Mana** is Shopify (Dawn, not BinderPOS). It tries Storefront GraphQL first,
 then falls back to a `main-search` HTML section scrape when GraphQL fails.
 
-**BinderPOS stores** (e.g. Card Affinity, Cards Citadel, Flagship, Game's Haven,
+**BinderPOS stores** (e.g. Arcane Sanctum, Card Affinity, Cards Citadel, Flagship, Game's Haven,
 Fyendal Hobby, Grey Ogre Games, Hideout, Hideyoshi, Mana Pro, MTG Asia,
 OneMTG) share one gateway. Stores with a configured Storefront access token try
 **GraphQL first** (dedicated → direct), then fall back to HTML scrape and

--- a/api/controller/search.go
+++ b/api/controller/search.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"mtg-price-checker-sg/gateway"
 	"mtg-price-checker-sg/gateway/agora"
+	"mtg-price-checker-sg/gateway/arcanesanctum"
 	"mtg-price-checker-sg/gateway/cardaffinity"
 	"mtg-price-checker-sg/gateway/cardsandcollection"
 	"mtg-price-checker-sg/gateway/cardscentral"
@@ -74,6 +75,7 @@ type shopSpec struct {
 
 var shopRegistry = []shopSpec{
 	{name: agora.StoreName, newLGS: agora.NewLGS},
+	{name: arcanesanctum.StoreName, newLGS: arcanesanctum.NewLGS, isBinderpos: true},
 	{name: cardaffinity.StoreName, newLGS: cardaffinity.NewLGS, isBinderpos: true},
 	{name: cardscentral.StoreName, newLGS: cardscentral.NewLGS},
 	{name: cardscitadel.StoreName, newLGS: cardscitadel.NewLGS, isBinderpos: true},

--- a/api/controller/search_test.go
+++ b/api/controller/search_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"mtg-price-checker-sg/gateway"
 	"mtg-price-checker-sg/gateway/agora"
+	"mtg-price-checker-sg/gateway/arcanesanctum"
 	"mtg-price-checker-sg/gateway/cardaffinity"
 	"mtg-price-checker-sg/gateway/cardscitadel"
 	"mtg-price-checker-sg/gateway/hideout"
@@ -431,10 +432,11 @@ func TestBuildStoreStats(t *testing.T) {
 
 func TestIsBinderposStore(t *testing.T) {
 	tests := map[string]bool{
-		cardscitadel.StoreName: true,
-		hideout.StoreName:      true,
-		agora.StoreName:        false,
-		"Unknown Shop":         false,
+		arcanesanctum.StoreName: true,
+		cardscitadel.StoreName:  true,
+		hideout.StoreName:       true,
+		agora.StoreName:         false,
+		"Unknown Shop":          false,
 	}
 
 	for shop, expected := range tests {

--- a/docs/binderpos-search-feature-parity.md
+++ b/docs/binderpos-search-feature-parity.md
@@ -54,6 +54,7 @@ Each store package (`api/gateway/{store}/search.go`) passes a **scrap variant** 
 
 | Store | Scrap variant | GraphQL token | Shopify domain |
 |-------|---------------|---------------|----------------|
+| Arcane Sanctum | 2 | Yes | `30uetm-1y.myshopify.com` |
 | Card Affinity | 2 | No | `563304-2.myshopify.com` |
 | Cards Citadel | 1 | Yes | `card-citadel.myshopify.com` |
 | Flagship | 2 | Yes | `flagship-games.myshopify.com` |
@@ -71,7 +72,7 @@ Each store package (`api/gateway/{store}/search.go`) passes a **scrap variant** 
 | Variant | Stores | Search query shaping | DOM / data source | MTG filter on scrape path |
 |---------|--------|----------------------|-------------------|---------------------------|
 | **1** | Cards Citadel | `searchStr + " mtg"`; wildcard template `/search?q=*%s*` | `div.Norm` + `div.addNow` price text | Query suffix only |
-| **2** | Card Affinity, Flagship, Hideyoshi, Mana Pro, MTG Asia, One MTG | `searchStr + " mtg"` | Embedded `data-product-variants` JSON (`CardInfo`) | `shouldIncludeBinderposProduct` when `data-product-type` present |
+| **2** | Arcane Sanctum, Card Affinity, Flagship, Hideyoshi, Mana Pro, MTG Asia, One MTG | `searchStr + " mtg"` | Embedded `data-product-variants` JSON (`CardInfo`) | `shouldIncludeBinderposProduct` when `data-product-type` present |
 | **3** | Games Haven, GOG, Hideout | `searchStr + " mtg"` | `div.productCard__card` + `ul.productChip__grid` variant chips | Query suffix only |
 | **4** | Fyendal Hobby | `product_type:"MTG Single Cards" AND {searchStr}` | `div.product-item--vertical` theme layout | Server-side product_type filter in query |
 

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -70,6 +70,7 @@ For **field-level feature parity** between HTML scrape, Storefront GraphQL, Deck
 
 | Store | GraphQL token | HTML scrap variant | Max strategy steps |
 |-------|---------------|--------------------|--------------------|
+| Arcane Sanctum | Yes | 2 | 8 |
 | Card Affinity | No | 2 | 6 |
 | Cards Citadel | Yes | 1 | 8 |
 | Flagship | Yes | 2 | 8 |

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -19,7 +19,7 @@
 
   <meta name="author" content="Alvin Yeoh" />
   <meta name="description"
-    content="Compare MTG singles prices across 17 Singapore local game stores and online shops in one search. In-stock results sorted by price." />
+    content="Compare MTG singles prices across 19 Singapore local game stores and online shops in one search. In-stock results sorted by price." />
   <meta name="keywords"
     content="MTG, Magic The Gathering, Singapore, LGS, online shop, card prices, price checker, local game store, TCG, trading card game, singles" />
 
@@ -27,7 +27,7 @@
   <meta property="og:site_name" content="Gishath Fetch">
   <meta property="og:url" content="https://gishathfetch.com/">
   <meta property="og:description"
-    content="Compare MTG singles prices across 17 Singapore local game stores and online shops in one search. In-stock results sorted by price.">
+    content="Compare MTG singles prices across 19 Singapore local game stores and online shops in one search. In-stock results sorted by price.">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://gishathfetch.com/img/og-image.png">
   <meta property="og:image:width" content="1200">
@@ -36,7 +36,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Gishath Fetch: MTG Price Checker for Singapore's LGS & Online Shops">
   <meta name="twitter:description"
-    content="Compare MTG singles prices across 17 Singapore local game stores and online shops in one search. In-stock results sorted by price.">
+    content="Compare MTG singles prices across 19 Singapore local game stores and online shops in one search. In-stock results sorted by price.">
   <meta name="twitter:image" content="https://gishathfetch.com/img/og-image.png">
 
   <link rel="canonical" href="https://gishathfetch.com/">
@@ -62,7 +62,7 @@
     "@context": "https://schema.org",
     "@type": "WebApplication",
     "name": "Gishath Fetch",
-    "description": "Compare MTG singles prices across 17 Singapore local game stores and online shops in one search. In-stock results sorted by price.",
+    "description": "Compare MTG singles prices across 19 Singapore local game stores and online shops in one search. In-stock results sorted by price.",
     "url": "https://gishathfetch.com/",
     "applicationCategory": "UtilityApplication",
     "operatingSystem": "Any",

--- a/frontend/public/site.webmanifest
+++ b/frontend/public/site.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "Gishath Fetch: MTG Price Checker for Singapore's LGS & Online Shops",
   "short_name": "Gishath Fetch",
-  "description": "Compare MTG singles prices across 18 Singapore local game stores and online shops in one search. In-stock results sorted by price.",
+  "description": "Compare MTG singles prices across 19 Singapore local game stores and online shops in one search. In-stock results sorted by price.",
   "icons": [
     {
       "src": "android-chrome-192x192.png",

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -11,6 +11,7 @@ export const PAGE_TITLE =
 const ALL_LGS_OPTIONS = [
   "5 Mana",
   AGORA_STORE_NAME,
+  "Arcane Sanctum",
   "Card Affinity",
   "Cards & Collections",
   "Cards Central",
@@ -58,6 +59,14 @@ export const LGS_MAP = [
     iframe:
       "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3988.778050505021!2d103.85967687451628!3d1.3084089617085968!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x31da19c9f7d7f74d%3A0xeaa1a66df7d4bcd6!2sAgora%20Hobby!5e0!3m2!1sen!2ssg!4v1702820213937!5m2!1sen!2ssg",
     website: "https://agorahobby.com/",
+  },
+  {
+    id: "arcane-sanctum-map",
+    name: "Arcane Sanctum",
+    address: "809 French Rd, #02-36 Kitchener Complex, Singapore 200809",
+    iframe:
+      "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3988.778050505021!2d103.85967687451628!3d1.3084036!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x31da197e8c761a49%3A0x8c56b7150064528b!2sArcane%20Sanctum!5e0!3m2!1sen!2ssg!4v1785400000000!5m2!1sen!2ssg",
+    website: "https://arcanesanctumtcg.com/",
   },
   {
     id: "cards-central-map",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Wires the existing Arcane Sanctum BinderPOS gateway into the public search path and frontend:

- Registers **Arcane Sanctum** in `api/controller/search.go` (`isBinderpos: true`)
- Adds the store to frontend `LGS_OPTIONS` and `LGS_MAP` (809 French Rd, #02-36 Kitchener Complex)
- Updates BinderPOS docs, README, and store-count meta copy (19 shops)

## Screenshots

### Store selector (desktop)

![Store selector desktop with Arcane Sanctum](https://cursor.com/artifacts/c/art-ff864e1b-88d7-46d4-a4d0-66d800dbd029)

### Store selector (mobile)

![Store selector mobile with Arcane Sanctum](https://cursor.com/artifacts/c/art-f56cd801-4065-4586-b413-497f66d92ee8)

### Map modal (desktop)

![Map modal desktop showing Arcane Sanctum](https://cursor.com/artifacts/c/art-90a026fe-a2f0-4de6-9a46-4e441ad0ed3b)

### Map modal (mobile)

![Map modal mobile showing Arcane Sanctum](https://cursor.com/artifacts/c/art-b225ce42-8080-40d8-9ce5-85223f1c46df)

## Test plan

- [x] `make test`
- [x] `cd api && go test -mod=vendor -failfast -timeout 5m ./gateway/arcanesanctum/... ./controller/...`
- [x] Frontend shows Arcane Sanctum in store selector and map modal
- [x] Live gateway search for `rancor` returns Arcane Sanctum stock

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e479705-9b11-4b31-82a7-3b6cae4cc9b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e479705-9b11-4b31-82a7-3b6cae4cc9b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

