### PR TITLE
Clarify search timing with totalDurationMs in stats

### DIFF
--- a/api/gateway/scryfall/verify.go
+++ b/api/gateway/scryfall/verify.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"mtg-price-checker-sg/gateway"
 )
@@ -14,7 +15,12 @@ import (
 const (
 	autocompleteURL = "https://api.scryfall.com/cards/autocomplete"
 	namedURL        = "https://api.scryfall.com/cards/named"
+	// httpClientTimeout bounds each Scryfall round trip even when the caller
+	// context has a long deadline (e.g. Lambda remaining time).
+	httpClientTimeout = 3 * time.Second
 )
+
+var scryfallHTTPClient = &http.Client{Timeout: httpClientTimeout}
 
 var httpGet = func(ctx context.Context, requestURL string) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
@@ -26,7 +32,7 @@ var httpGet = func(ctx context.Context, requestURL string) (*http.Response, erro
 	}); err != nil {
 		return nil, err
 	}
-	return http.DefaultClient.Do(req)
+	return scryfallHTTPClient.Do(req)
 }
 
 // VerifyCardName returns the canonical Scryfall card name when query matches a card.

--- a/api/handler/search.go
+++ b/api/handler/search.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"mtg-price-checker-sg/controller"
 	"mtg-price-checker-sg/controller/ckprice"
@@ -25,6 +26,10 @@ type WebResponse struct {
 	Data             []controller.Card       `json:"data"`
 	Errors           []controller.StoreError `json:"errors"`
 	Stats            []controller.StoreStat  `json:"stats"`
+	// TotalDurationMs is wall-clock time for the full multi-store search
+	// (including the minimum response pad). Per-store Stats[].DurationMs
+	// only cover each store's own work and can be much lower than this.
+	TotalDurationMs  int64                   `json:"totalDurationMs"`
 	CardKingdomPrice *cardkingdom.Listing    `json:"cardKingdomPrice,omitempty"`
 }
 
@@ -107,20 +112,23 @@ func Search(ctx context.Context, request events.APIGatewayProxyRequest) (events.
 	}
 
 	var (
-		inStockCards []controller.Card
-		storeErrors  []controller.StoreError
-		storeStats   []controller.StoreStat
-		ckPrice      *cardkingdom.Listing
-		searchErr    error
+		inStockCards      []controller.Card
+		storeErrors       []controller.StoreError
+		storeStats        []controller.StoreStat
+		totalDurationMs   int64
+		ckPrice           *cardkingdom.Listing
+		searchErr         error
 	)
 
 	var wg sync.WaitGroup
 
 	wg.Go(func() {
+		searchStart := time.Now()
 		inStockCards, storeErrors, storeStats, searchErr = searchFunc(ctx, controller.SearchInput{
 			SearchString: searchString,
 			Lgs:          lgs,
 		})
+		totalDurationMs = time.Since(searchStart).Milliseconds()
 	})
 
 	if config.CKPriceLookupEnabled() {
@@ -152,6 +160,7 @@ func Search(ctx context.Context, request events.APIGatewayProxyRequest) (events.
 	} else {
 		webRes.Stats = storeStats
 	}
+	webRes.TotalDurationMs = totalDurationMs
 	webRes.CardKingdomPrice = ckPrice
 
 	return searchSuccessResponse(apiRes, webRes, origin)

--- a/api/handler/search.go
+++ b/api/handler/search.go
@@ -26,9 +26,10 @@ type WebResponse struct {
 	Data             []controller.Card       `json:"data"`
 	Errors           []controller.StoreError `json:"errors"`
 	Stats            []controller.StoreStat  `json:"stats"`
-	// TotalDurationMs is wall-clock time for the full multi-store search
-	// (including the minimum response pad). Per-store Stats[].DurationMs
-	// only cover each store's own work and can be much lower than this.
+	// TotalDurationMs is wall-clock time until the search response is ready,
+	// including store fan-out, the minimum response pad, and any Card Kingdom
+	// enrichment wait. Per-store Stats[].DurationMs only cover each store's
+	// own work and can be much lower than this when enrichment is slow.
 	TotalDurationMs  int64                   `json:"totalDurationMs"`
 	CardKingdomPrice *cardkingdom.Listing    `json:"cardKingdomPrice,omitempty"`
 }
@@ -112,28 +113,29 @@ func Search(ctx context.Context, request events.APIGatewayProxyRequest) (events.
 	}
 
 	var (
-		inStockCards      []controller.Card
-		storeErrors       []controller.StoreError
-		storeStats        []controller.StoreStat
-		totalDurationMs   int64
-		ckPrice           *cardkingdom.Listing
-		searchErr         error
+		inStockCards []controller.Card
+		storeErrors  []controller.StoreError
+		storeStats   []controller.StoreStat
+		ckPrice      *cardkingdom.Listing
+		searchErr    error
 	)
 
+	requestStart := time.Now()
 	var wg sync.WaitGroup
 
 	wg.Go(func() {
-		searchStart := time.Now()
 		inStockCards, storeErrors, storeStats, searchErr = searchFunc(ctx, controller.SearchInput{
 			SearchString: searchString,
 			Lgs:          lgs,
 		})
-		totalDurationMs = time.Since(searchStart).Milliseconds()
 	})
 
 	if config.CKPriceLookupEnabled() {
 		wg.Go(func() {
-			price, err := lookupCKPriceFunc(ctx, searchString)
+			ckCtx, cancel := context.WithTimeout(ctx, config.CKPriceLookupTimeout)
+			defer cancel()
+
+			price, err := lookupCKPriceFunc(ckCtx, searchString)
 			if err != nil {
 				log.Printf("ck price lookup for [%s]: %v", searchString, err)
 				return
@@ -143,6 +145,7 @@ func Search(ctx context.Context, request events.APIGatewayProxyRequest) (events.
 	}
 
 	wg.Wait()
+	totalDurationMs := time.Since(requestStart).Milliseconds()
 
 	if searchErr != nil {
 		return errorResponse(apiRes, origin, "err searching for cards", http.StatusInternalServerError)

--- a/api/handler/search_test.go
+++ b/api/handler/search_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"mtg-price-checker-sg/controller"
 	"mtg-price-checker-sg/gateway/cardkingdom"
@@ -255,4 +256,56 @@ func Test_Search_Err(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_Search_CKPriceLookupTimeoutDoesNotBlockPastCap(t *testing.T) {
+	originalSearchFunc := searchFunc
+	originalLookupCKPriceFunc := lookupCKPriceFunc
+	defer func() {
+		searchFunc = originalSearchFunc
+		lookupCKPriceFunc = originalLookupCKPriceFunc
+	}()
+
+	t.Setenv("ENV", config.EnvProd)
+	t.Setenv(config.CKPriceLookupEnabledEnv, "true")
+
+	searchFunc = func(_ context.Context, _ controller.SearchInput) ([]controller.Card, []controller.StoreError, []controller.StoreStat, error) {
+		return []controller.Card{}, []controller.StoreError{}, []controller.StoreStat{
+			{Store: "Arcane Sanctum", ItemCount: 0, DurationMs: 700},
+		}, nil
+	}
+	lookupCKPriceFunc = func(ctx context.Context, _ string) (*cardkingdom.Listing, error) {
+		timer := time.NewTimer(10 * time.Second)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-timer.C:
+			return &cardkingdom.Listing{CardName: "late", PriceUsd: 1}, nil
+		}
+	}
+
+	start := time.Now()
+	result, err := Search(context.Background(), events.APIGatewayProxyRequest{
+		QueryStringParameters: map[string]string{
+			"s":   "Birds of Paradise",
+			"lgs": "Arcane Sanctum",
+		},
+	})
+	elapsed := time.Since(start)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, result.StatusCode)
+
+	// Enrichment is capped at CKPriceLookupTimeout; a hung CK path must not
+	// stretch a fast single-store search toward double-digit seconds.
+	require.Less(t, elapsed, config.CKPriceLookupTimeout+time.Second)
+	require.GreaterOrEqual(t, elapsed, config.CKPriceLookupTimeout)
+
+	var webRes WebResponse
+	require.NoError(t, json.Unmarshal([]byte(result.Body), &webRes))
+	require.Nil(t, webRes.CardKingdomPrice)
+	require.GreaterOrEqual(t, webRes.TotalDurationMs, config.CKPriceLookupTimeout.Milliseconds())
+	require.Equal(t, []controller.StoreStat{
+		{Store: "Arcane Sanctum", ItemCount: 0, DurationMs: 700},
+	}, webRes.Stats)
 }

--- a/api/handler/search_test.go
+++ b/api/handler/search_test.go
@@ -126,6 +126,7 @@ func Test_Search_Success(t *testing.T) {
 			require.Equal(t, tc.expBodyData, webRes.Data)
 			require.Equal(t, tc.expBodyErrors, webRes.Errors)
 			require.Equal(t, tc.expBodyStats, webRes.Stats)
+			require.GreaterOrEqual(t, webRes.TotalDurationMs, int64(0))
 		})
 	}
 }

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -52,6 +52,9 @@ const (
 	CKDynamoDBTableEnv = "CK_DYNAMODB_TABLE"
 	// CKPriceLookupEnabledEnv toggles Card Kingdom price lookup on search responses.
 	CKPriceLookupEnabledEnv = "CK_PRICE_LOOKUP_ENABLED"
+	// CKPriceLookupTimeout caps Card Kingdom enrichment on /search so a slow
+	// Scryfall/DynamoDB path cannot delay returning store results.
+	CKPriceLookupTimeout = 2 * time.Second
 	// CKPriceMaxAge is how old a DynamoDB CK listing may be before search omits it.
 	CKPriceMaxAge = 48 * time.Hour
 	// CKPricelistURLEnv overrides the Card Kingdom singles pricelist download URL.

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -15,6 +15,7 @@ This document records **where** the app configures search behavior, **timeouts**
 | Colly request timeout (default scrapers) | 5s | `applyCollectorDefaults` → `c.SetRequestTimeout(config.SearchAttemptTimeout)` in `api/gateway/collector.go` | Overrides gocolly’s default 10s for optimized collectors. |
 | Max concurrent store searches | 9 | `maxConcurrentStoreSearches` in `api/controller/search.go` | Worker pool size when fanning out to selected stores. |
 | Minimum end-to-end response time | 1s | `responseThreshold` in `searchShops` in `api/controller/search.go` | If all stores finish in under 1s, the handler **sleeps** the remainder so the API “feels” less instant. |
+| Card Kingdom enrichment on `/search` | parallel, **2s** cap | See [CK price on search](#backend-ck-price-on-search-apihandlersearchgo-and-refresh-apigatewaycardkingdom) below | Store fan-out and CK lookup run together; CK cannot delay the response past its timeout. |
 | Colly HTTP retries | None | `api/gateway/collector.go` (`configureRequestOptimizations`, `registerNoRetryErrorHandler`) | **Single HTTP attempt** per colly request path; no automatic colly/gateway retry of failed visits. |
 | Dedicated proxy per store search | 1 lease | `searchShop` in `api/controller/search.go` + `WithRequestDedicatedProxy` in `api/gateway/request_dedicated_proxy.go` | When dedicated proxies are configured, each store search acquires **one** dedicated-proxy lease for its own goroutine. Up to nine concurrent store searches share the worker pool, but at most **three** proxy-backed searches may hold a dedicated lease at once (`DedicatedProxySearchMaxConcurrent` in `api/gateway/dedicated_proxy_search_gate.go`). Additional proxy-backed stores wait for a slot before leasing. |
 
@@ -107,10 +108,13 @@ For 5 Mana, `SkipDirect` is cleared when the host is not the production domain s
 
 ---
 
-## Backend: CK price refresh (`api/gateway/cardkingdom/`)
+## Backend: CK price on search (`api/handler/search.go`) and refresh (`api/gateway/cardkingdom/`)
 
 | Item | Value | Source | Notes |
 |------|--------|--------|--------|
+| CK lookup on `/search` | parallel with store search | `Search` in `api/handler/search.go` | When enabled (`CKPriceLookupEnabled`), enrichment runs in a sibling goroutine; response waits for search **and** CK (subject to the timeout below). |
+| CK lookup timeout on `/search` | 2s | `config.CKPriceLookupTimeout` | Cancels Scryfall + DynamoDB work so store results are not blocked by a slow enrichment path. Timed-out lookups omit `cardKingdomPrice`. |
+| Scryfall verify HTTP timeout | 3s per request | `httpClientTimeout` in `api/gateway/scryfall/verify.go` | `VerifyCardName` may do autocomplete then exact-named; each call uses this client timeout. |
 | CK pricelist transport | direct → residential | `downloadCKPricelist` in `api/gateway/cardkingdom/pricelist_fetch.go` | Tries direct egress first; on failure retries via `RESIDENTIAL_PROXY_1`, then `CK_PRICELIST_PROXY` when configured. |
 | CK pricelist HTTP timeout | 13m | `ckPricelistHTTPTimeout` in `api/gateway/cardkingdom/pricelist_fetch.go` | Bounds the full `DoOutboundGET` round trip, including streaming the ~65MB JSON body when the residential proxy fallback is used. |
 | CK pricelist fetch timeout | 14m | `ckPricelistFetchTimeout` in `api/gateway/cardkingdom/pricelist_fetch.go` | Context deadline for download + JSON decode + cheapest-listing aggregation. |

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -56,6 +56,7 @@ export default function App() {
     searchError,
     searchStoreErrors,
     searchStoreStats,
+    searchTotalDurationMs,
     onDismissStoreErrors,
     storesWarning,
     cardKingdomPrice,
@@ -262,6 +263,7 @@ export default function App() {
 
       <SearchStats
         stats={searchStoreStats}
+        totalDurationMs={searchTotalDurationMs}
         hasSearched={hasSearched}
         isSearching={isSearching}
       />

--- a/frontend/src/components/SearchStats.jsx
+++ b/frontend/src/components/SearchStats.jsx
@@ -21,7 +21,12 @@ function readShowStatsPreference() {
   }
 }
 
-const SearchStats = ({ stats, hasSearched, isSearching }) => {
+const SearchStats = ({
+  stats,
+  totalDurationMs,
+  hasSearched,
+  isSearching,
+}) => {
   const [showStats, setShowStats] = useState(readShowStatsPreference);
 
   useEffect(() => {
@@ -37,6 +42,8 @@ const SearchStats = ({ stats, hasSearched, isSearching }) => {
   }
 
   const storeStats = Array.isArray(stats) ? stats : [];
+  const hasTotal =
+    Number.isFinite(totalDurationMs) && totalDurationMs >= 0;
 
   return (
     <div className="search-stats mt-3 rounded py-2 px-3">
@@ -51,37 +58,52 @@ const SearchStats = ({ stats, hasSearched, isSearching }) => {
 
       {showStats && (
         <div className="search-stats-panel mt-2">
-          {storeStats.length === 0 ? (
+          {storeStats.length === 0 && !hasTotal ? (
             <p className="small text-muted mb-0">
               No store timing data for this search.
             </p>
           ) : (
-            <div className="table-responsive">
-              <table className="table table-sm table-borderless mb-0 search-stats-table">
-                <thead>
-                  <tr>
-                    <th scope="col">Store</th>
-                    <th scope="col" className="text-end">
-                      Items
-                    </th>
-                    <th scope="col" className="text-end">
-                      Time
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {storeStats.map((stat) => (
-                    <tr key={stat.store}>
-                      <td>{stat.store}</td>
-                      <td className="text-end">{stat.itemCount}</td>
-                      <td className="text-end text-nowrap">
-                        {formatDurationMs(stat.durationMs)}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+            <>
+              {hasTotal && (
+                <p className="small text-muted mb-2 search-stats-total">
+                  Total search time:{" "}
+                  <span className="text-body fw-semibold">
+                    {formatDurationMs(totalDurationMs)}
+                  </span>
+                  {storeStats.length > 1
+                    ? " (waits for all selected stores; per-store times below)"
+                    : null}
+                </p>
+              )}
+              {storeStats.length > 0 && (
+                <div className="table-responsive">
+                  <table className="table table-sm table-borderless mb-0 search-stats-table">
+                    <thead>
+                      <tr>
+                        <th scope="col">Store</th>
+                        <th scope="col" className="text-end">
+                          Items
+                        </th>
+                        <th scope="col" className="text-end">
+                          Time
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {storeStats.map((stat) => (
+                        <tr key={stat.store}>
+                          <td>{stat.store}</td>
+                          <td className="text-end">{stat.itemCount}</td>
+                          <td className="text-end text-nowrap">
+                            {formatDurationMs(stat.durationMs)}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </>
           )}
         </div>
       )}

--- a/frontend/src/components/SearchStats.jsx
+++ b/frontend/src/components/SearchStats.jsx
@@ -21,12 +21,7 @@ function readShowStatsPreference() {
   }
 }
 
-const SearchStats = ({
-  stats,
-  totalDurationMs,
-  hasSearched,
-  isSearching,
-}) => {
+const SearchStats = ({ stats, totalDurationMs, hasSearched, isSearching }) => {
   const [showStats, setShowStats] = useState(readShowStatsPreference);
 
   useEffect(() => {
@@ -42,8 +37,7 @@ const SearchStats = ({
   }
 
   const storeStats = Array.isArray(stats) ? stats : [];
-  const hasTotal =
-    Number.isFinite(totalDurationMs) && totalDurationMs >= 0;
+  const hasTotal = Number.isFinite(totalDurationMs) && totalDurationMs >= 0;
 
   return (
     <div className="search-stats mt-3 rounded py-2 px-3">

--- a/frontend/src/components/SearchStats.jsx
+++ b/frontend/src/components/SearchStats.jsx
@@ -65,8 +65,8 @@ const SearchStats = ({ stats, totalDurationMs, hasSearched, isSearching }) => {
                     {formatDurationMs(totalDurationMs)}
                   </span>
                   {storeStats.length > 1
-                    ? " (waits for all selected stores; per-store times below)"
-                    : null}
+                    ? " (waits for all selected stores and Card Kingdom enrichment; per-store times below)"
+                    : " (includes Card Kingdom enrichment wait; per-store time below)"}
                 </p>
               )}
               {storeStats.length > 0 && (

--- a/frontend/src/hooks/useSearch.js
+++ b/frontend/src/hooks/useSearch.js
@@ -59,6 +59,7 @@ export default function useSearch() {
   const [searchError, setSearchError] = useState(null);
   const [searchStoreErrors, setSearchStoreErrors] = useState([]);
   const [searchStoreStats, setSearchStoreStats] = useState([]);
+  const [searchTotalDurationMs, setSearchTotalDurationMs] = useState(null);
   const [cardKingdomPrice, setCardKingdomPrice] = useState(null);
   const [dismissedStoreErrorsKey, setDismissedStoreErrorsKey] = useState(null);
   const [storesWarning, setStoresWarning] = useState(null);
@@ -182,6 +183,7 @@ export default function useSearch() {
       setSearchError(null);
       setSearchStoreErrors([]);
       setSearchStoreStats([]);
+      setSearchTotalDurationMs(null);
       setDismissedStoreErrorsKey(null);
 
       if (window.gtag) {
@@ -257,8 +259,12 @@ export default function useSearch() {
               ? result.errors
               : [];
             const storeStats = Array.isArray(result.stats) ? result.stats : [];
+            const totalDurationMs = Number.isFinite(result.totalDurationMs)
+              ? result.totalDurationMs
+              : null;
             setSearchStoreErrors(storeErrors);
             setSearchStoreStats(storeStats);
+            setSearchTotalDurationMs(totalDurationMs);
             setDismissedStoreErrorsKey(null);
             if (!skipHistorySyncRef.current) {
               syncSearchHistory({
@@ -267,6 +273,7 @@ export default function useSearch() {
                 results: result.data || [],
                 storeErrors,
                 storeStats,
+                totalDurationMs,
                 hasSearched: true,
                 searchError: null,
                 cardKingdomPrice: result.cardKingdomPrice ?? null,
@@ -294,6 +301,7 @@ export default function useSearch() {
               setSearchError(null);
               setSearchStoreErrors([]);
               setSearchStoreStats([]);
+              setSearchTotalDurationMs(null);
               setDismissedStoreErrorsKey(null);
               userCancelledRef.current = false;
             }
@@ -304,6 +312,7 @@ export default function useSearch() {
           setSearchResults([]);
           setSearchStoreErrors([]);
           setSearchStoreStats([]);
+          setSearchTotalDurationMs(null);
           setDismissedStoreErrorsKey(null);
 
           let nextSearchError;
@@ -342,6 +351,7 @@ export default function useSearch() {
               results: [],
               storeErrors: [],
               storeStats: [],
+              totalDurationMs: null,
               hasSearched: true,
               searchError: nextSearchError,
               cardKingdomPrice: null,
@@ -405,6 +415,7 @@ export default function useSearch() {
         setSearchResults([]);
         setSearchStoreErrors([]);
         setSearchStoreStats([]);
+        setSearchTotalDurationMs(null);
         setSearchError(null);
         setCardKingdomPrice(null);
         setDismissedStoreErrorsKey(null);
@@ -433,6 +444,9 @@ export default function useSearch() {
       setSearchResults(state.results || []);
       setSearchStoreErrors(state.storeErrors || []);
       setSearchStoreStats(state.storeStats || []);
+      setSearchTotalDurationMs(
+        Number.isFinite(state.totalDurationMs) ? state.totalDurationMs : null,
+      );
       setHasSearched(!!state.hasSearched);
       setSearchError(state.searchError || null);
       setCardKingdomPrice(state.cardKingdomPrice ?? null);
@@ -685,6 +699,7 @@ export default function useSearch() {
     searchError,
     searchStoreErrors: visibleStoreErrors,
     searchStoreStats,
+    searchTotalDurationMs,
     onDismissStoreErrors: dismissStoreErrors,
     storesWarning,
     cardKingdomPrice,

--- a/frontend/src/utils/searchUrl.js
+++ b/frontend/src/utils/searchUrl.js
@@ -12,6 +12,7 @@ import {
  *   results: object[],
  *   storeErrors: object[],
  *   storeStats: object[],
+ *   totalDurationMs: number | null,
  *   hasSearched: boolean,
  *   searchError: string | null,
  *   cardKingdomPrice: object | null,
@@ -29,6 +30,10 @@ export function buildSearchHistoryState(snapshot) {
     results: snapshot.results,
     storeErrors: snapshot.storeErrors,
     storeStats: snapshot.storeStats || [],
+    totalDurationMs:
+      Number.isFinite(snapshot.totalDurationMs) && snapshot.totalDurationMs >= 0
+        ? snapshot.totalDurationMs
+        : null,
     hasSearched: snapshot.hasSearched,
     searchError: snapshot.searchError,
     cardKingdomPrice: snapshot.cardKingdomPrice ?? null,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reported with **only Arcane Sanctum selected**: store stats ~700ms, but `/search` took 10s+.

### Root cause (single-store timing)

`/search` runs **Card Kingdom enrichment in parallel** (Scryfall name verify + DynamoDB) and **waits for it** before responding. That wait was:

- uncapped (Scryfall used `http.DefaultClient` with no timeout; DynamoDB retries can stretch)
- **not included** in per-store `stats[].durationMs`

So Arcane could finish in ~700ms while the response stayed open until CK enrichment finished (10s+).

Empty Arcane results for Birds of Paradise remain an inventory miss (their Shopify catalog has no matching product).

### Fixes

- Cap CK enrichment on `/search` at **2s** (`CKPriceLookupTimeout`); timed-out lookups omit `cardKingdomPrice`
- Scryfall HTTP client timeout **3s**
- Expose `totalDurationMs` as full response wall clock (stores + enrichment wait)
- Search Stats UI shows total time with a note about enrichment

## Screenshots

### Desktop
![Search stats total duration desktop](https://cursor.com/artifacts/c/art-19dbd251-3222-456f-a7c7-0034a26ef5a8)

### Mobile
![Search stats total duration mobile](https://cursor.com/artifacts/c/art-d394edba-bed1-4417-a449-6357b3d73c42)

## Test plan

- [x] Handler test: hung CK path is capped (~2s), store stats still report ~700ms
- [x] `make test`
- [x] `cd frontend && npm run lint`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82474664-1ba2-4833-8284-1adb3d784951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82474664-1ba2-4833-8284-1adb3d784951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

