### PR TITLE
Clarify why search can feel >10s when stats show ~1s

### DIFF
--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -129,9 +129,25 @@ Constants live in `frontend/src/hooks/useSearch.js` (and related).
 | Item | Value | Notes |
 |------|--------|--------|
 | Autocomplete debounce | 300ms | `AUTOCOMPLETE_DEBOUNCE_MS`; delays Scryfall autocomplete fetches after typing. |
-| Search progress UI tick | 1000ms | `SEARCH_PROGRESS_INTERVAL_MS`; animates the “Searching LGS . . .” label. |
+| Search progress UI tick | 1000ms | `SEARCH_PROGRESS_INTERVAL_MS`; animates the “Searching LGS . . .” / “Checking session . . .” label. |
 | Programmatic search delay on load (URL with `?s=`) | 100ms | `setTimeout` before `performSearch` in the mount `useEffect`. |
 | API `fetch` timeout / retries | None in code | Uses browser `fetch` with `AbortController` only; no app-level timeout or automatic retry. |
+| Session before `/search` | `ensureApiSession()` | Awaited inside the search spinner; may run Turnstile + `GET /session` (up to 3 mint attempts). Not included in API `totalDurationMs`. |
+| Client wall clock in SearchStats | `clientDurationMs` | Measured from search start to JSON response; compared with API `totalDurationMs` to surface outside-API wait. |
+
+## End-to-end latency vs search stats
+
+`totalDurationMs` / per-store `durationMs` only cover work **inside** the Lambda search handler after auth checks (store fan-out, 1s minimum response pad, CK enrichment capped at 2s). Wall-clock time until the UI shows results can be much larger when any of these run first:
+
+| Layer | Typical when slow | Included in `totalDurationMs`? |
+|-------|-------------------|--------------------------------|
+| Turnstile challenge + `GET /session` | First visit, expired cookie, forced remint after 403 | No |
+| Lambda cold start | Idle API after scale-to-zero | No (starts before handler timing) |
+| API Gateway / network RTT | Distant client, congested path | No |
+| Store scrape + 1s pad + CK ≤2s | Measured API search | Yes |
+| React render of results | Rarely material for small result sets | No (after fetch) |
+
+Example: Cards Central finishes in ~374ms, API pads to ~1.00s, stats show that 1.00s — while the browser may still have spent several seconds on session/Turnstile or cold start before `/search` returned.
 
 ---
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -57,6 +57,7 @@ export default function App() {
     searchStoreErrors,
     searchStoreStats,
     searchTotalDurationMs,
+    searchClientDurationMs,
     onDismissStoreErrors,
     storesWarning,
     cardKingdomPrice,
@@ -264,6 +265,7 @@ export default function App() {
       <SearchStats
         stats={searchStoreStats}
         totalDurationMs={searchTotalDurationMs}
+        clientDurationMs={searchClientDurationMs}
         hasSearched={hasSearched}
         isSearching={isSearching}
       />

--- a/frontend/src/components/Modals.jsx
+++ b/frontend/src/components/Modals.jsx
@@ -125,17 +125,11 @@ const Modals = ({
               </li>
               <li>
                 <a href="#faq-q7" className="link-offset-2">
-                  Why can &quot;Time to results&quot; be much slower than API
-                  search time?
-                </a>
-              </li>
-              <li>
-                <a href="#faq-q8" className="link-offset-2">
                   How can I get accurate results from every store?
                 </a>
               </li>
               <li>
-                <a href="#faq-q9" className="link-offset-2">
+                <a href="#faq-q8" className="link-offset-2">
                   What is in Trending?
                 </a>
               </li>
@@ -258,32 +252,7 @@ const Modals = ({
           </div>
           <div className="mb-4" id="faq-q7">
             <div className="q-header">
-              <h5>
-                7. Why can &quot;Time to results&quot; be much slower than API
-                search time?
-              </h5>
-            </div>
-            <div className="q-answer">
-              <p>
-                Search stats split two clocks. <strong>API search time</strong>{" "}
-                is only the server work that fans out to stores (plus a short
-                Card Kingdom enrichment wait). <strong>Time to results</strong>{" "}
-                is the full browser wait from clicking Search until results
-                appear.
-              </p>
-              <p>
-                Extra time outside the API search clock usually comes from
-                session verification (including Turnstile when enabled), a cold
-                API start after idle, or network latency. Per-store times never
-                include those steps. A single fast store can finish in a few
-                hundred milliseconds while the page still waits on session or
-                cold start.
-              </p>
-            </div>
-          </div>
-          <div className="mb-4" id="faq-q8">
-            <div className="q-header">
-              <h5>8. How can I get accurate results from every store?</h5>
+              <h5>7. How can I get accurate results from every store?</h5>
             </div>
             <div className="q-answer">
               <p>
@@ -298,9 +267,9 @@ const Modals = ({
               </p>
             </div>
           </div>
-          <div className="mb-4" id="faq-q9">
+          <div className="mb-4" id="faq-q8">
             <div className="q-header">
-              <h5>9. What is in Trending?</h5>
+              <h5>8. What is in Trending?</h5>
             </div>
             <div className="q-answer">
               <p>

--- a/frontend/src/components/Modals.jsx
+++ b/frontend/src/components/Modals.jsx
@@ -125,11 +125,17 @@ const Modals = ({
               </li>
               <li>
                 <a href="#faq-q7" className="link-offset-2">
-                  How can I get accurate results from every store?
+                  Why can &quot;Time to results&quot; be much slower than API
+                  search time?
                 </a>
               </li>
               <li>
                 <a href="#faq-q8" className="link-offset-2">
+                  How can I get accurate results from every store?
+                </a>
+              </li>
+              <li>
+                <a href="#faq-q9" className="link-offset-2">
                   What is in Trending?
                 </a>
               </li>
@@ -252,7 +258,32 @@ const Modals = ({
           </div>
           <div className="mb-4" id="faq-q7">
             <div className="q-header">
-              <h5>7. How can I get accurate results from every store?</h5>
+              <h5>
+                7. Why can &quot;Time to results&quot; be much slower than API
+                search time?
+              </h5>
+            </div>
+            <div className="q-answer">
+              <p>
+                Search stats split two clocks. <strong>API search time</strong>{" "}
+                is only the server work that fans out to stores (plus a short
+                Card Kingdom enrichment wait). <strong>Time to results</strong>{" "}
+                is the full browser wait from clicking Search until results
+                appear.
+              </p>
+              <p>
+                Extra time outside the API search clock usually comes from
+                session verification (including Turnstile when enabled), a cold
+                API start after idle, or network latency. Per-store times never
+                include those steps. A single fast store can finish in a few
+                hundred milliseconds while the page still waits on session or
+                cold start.
+              </p>
+            </div>
+          </div>
+          <div className="mb-4" id="faq-q8">
+            <div className="q-header">
+              <h5>8. How can I get accurate results from every store?</h5>
             </div>
             <div className="q-answer">
               <p>
@@ -267,9 +298,9 @@ const Modals = ({
               </p>
             </div>
           </div>
-          <div className="mb-4" id="faq-q8">
+          <div className="mb-4" id="faq-q9">
             <div className="q-header">
-              <h5>8. What is in Trending?</h5>
+              <h5>9. What is in Trending?</h5>
             </div>
             <div className="q-answer">
               <p>

--- a/frontend/src/components/SearchStats.jsx
+++ b/frontend/src/components/SearchStats.jsx
@@ -21,7 +21,13 @@ function readShowStatsPreference() {
   }
 }
 
-const SearchStats = ({ stats, totalDurationMs, hasSearched, isSearching }) => {
+const SearchStats = ({
+  stats,
+  totalDurationMs,
+  clientDurationMs,
+  hasSearched,
+  isSearching,
+}) => {
   const [showStats, setShowStats] = useState(readShowStatsPreference);
 
   useEffect(() => {
@@ -38,6 +44,10 @@ const SearchStats = ({ stats, totalDurationMs, hasSearched, isSearching }) => {
 
   const storeStats = Array.isArray(stats) ? stats : [];
   const hasTotal = Number.isFinite(totalDurationMs) && totalDurationMs >= 0;
+  const hasClient = Number.isFinite(clientDurationMs) && clientDurationMs >= 0;
+  const clientGapMs =
+    hasClient && hasTotal ? Math.max(0, clientDurationMs - totalDurationMs) : 0;
+  const showClientGap = hasClient && clientGapMs >= 500;
 
   return (
     <div className="search-stats mt-3 rounded py-2 px-3">
@@ -52,21 +62,41 @@ const SearchStats = ({ stats, totalDurationMs, hasSearched, isSearching }) => {
 
       {showStats && (
         <div className="search-stats-panel mt-2">
-          {storeStats.length === 0 && !hasTotal ? (
+          {storeStats.length === 0 && !hasTotal && !hasClient ? (
             <p className="small text-muted mb-0">
               No store timing data for this search.
             </p>
           ) : (
             <>
+              {hasClient && (
+                <p className="small text-muted mb-2 search-stats-client">
+                  Time to results:{" "}
+                  <span className="text-body fw-semibold">
+                    {formatDurationMs(clientDurationMs)}
+                  </span>
+                  {" (browser wall clock: session check, network, and API)"}
+                </p>
+              )}
               {hasTotal && (
                 <p className="small text-muted mb-2 search-stats-total">
-                  Total search time:{" "}
+                  API search time:{" "}
                   <span className="text-body fw-semibold">
                     {formatDurationMs(totalDurationMs)}
                   </span>
                   {storeStats.length > 1
                     ? " (waits for all selected stores and Card Kingdom enrichment; per-store times below)"
                     : " (includes Card Kingdom enrichment wait; per-store time below)"}
+                </p>
+              )}
+              {showClientGap && (
+                <p className="small text-muted mb-2 search-stats-gap">
+                  Outside API search:{" "}
+                  <span className="text-body fw-semibold">
+                    {formatDurationMs(clientGapMs)}
+                  </span>
+                  {
+                    " — usually session/Turnstile, Lambda cold start, or network; not counted in API search time or per-store times"
+                  }
                 </p>
               )}
               {storeStats.length > 0 && (

--- a/frontend/src/hooks/useSearch.js
+++ b/frontend/src/hooks/useSearch.js
@@ -60,6 +60,7 @@ export default function useSearch() {
   const [searchStoreErrors, setSearchStoreErrors] = useState([]);
   const [searchStoreStats, setSearchStoreStats] = useState([]);
   const [searchTotalDurationMs, setSearchTotalDurationMs] = useState(null);
+  const [searchClientDurationMs, setSearchClientDurationMs] = useState(null);
   const [cardKingdomPrice, setCardKingdomPrice] = useState(null);
   const [dismissedStoreErrorsKey, setDismissedStoreErrorsKey] = useState(null);
   const [storesWarning, setStoresWarning] = useState(null);
@@ -184,6 +185,7 @@ export default function useSearch() {
       setSearchStoreErrors([]);
       setSearchStoreStats([]);
       setSearchTotalDurationMs(null);
+      setSearchClientDurationMs(null);
       setDismissedStoreErrorsKey(null);
 
       if (window.gtag) {
@@ -191,18 +193,30 @@ export default function useSearch() {
       }
 
       const searchUrl = `${API_SEARCH_URL}?s=${encodeURIComponent(query)}&lgs=${encodeURIComponent(stores.join(","))}`;
+      const clientStartedAt =
+        typeof performance !== "undefined" &&
+        typeof performance.now === "function"
+          ? performance.now()
+          : Date.now();
 
       const progressInterval = setInterval(() => {
         setSearchProgress((prev) => {
+          const base = prev.replace(/\s*\.+$/, "") || "Searching LGS";
           const dots = (prev.match(/\./g) || []).length;
-          if (dots >= MAX_PROGRESS_DOTS) return "Searching LGS";
-          return `${prev} .`;
+          if (dots >= MAX_PROGRESS_DOTS) return base;
+          return `${base} .`;
         });
       }, SEARCH_PROGRESS_INTERVAL_MS);
       progressIntervalRef.current = progressInterval;
 
       const fetchSearchResult = async (sessionRetried) => {
+        if (requestId === activeSearchRequestIdRef.current) {
+          setSearchProgress("Checking session");
+        }
         await ensureApiSession({ forceRefresh: sessionRetried });
+        if (requestId === activeSearchRequestIdRef.current) {
+          setSearchProgress("Searching LGS");
+        }
 
         const res = await fetch(searchUrl, {
           signal: searchAbortController.signal,
@@ -252,6 +266,15 @@ export default function useSearch() {
         .then((result) => {
           if (requestId !== activeSearchRequestIdRef.current) return;
           if (result && Object.hasOwn(result, "data")) {
+            const clientEndedAt =
+              typeof performance !== "undefined" &&
+              typeof performance.now === "function"
+                ? performance.now()
+                : Date.now();
+            const clientDurationMs = Math.max(
+              0,
+              Math.round(clientEndedAt - clientStartedAt),
+            );
             // Treat null data as empty array
             setSearchResults(result.data || []);
             setCardKingdomPrice(result.cardKingdomPrice ?? null);
@@ -265,6 +288,7 @@ export default function useSearch() {
             setSearchStoreErrors(storeErrors);
             setSearchStoreStats(storeStats);
             setSearchTotalDurationMs(totalDurationMs);
+            setSearchClientDurationMs(clientDurationMs);
             setDismissedStoreErrorsKey(null);
             if (!skipHistorySyncRef.current) {
               syncSearchHistory({
@@ -274,6 +298,7 @@ export default function useSearch() {
                 storeErrors,
                 storeStats,
                 totalDurationMs,
+                clientDurationMs,
                 hasSearched: true,
                 searchError: null,
                 cardKingdomPrice: result.cardKingdomPrice ?? null,
@@ -302,6 +327,7 @@ export default function useSearch() {
               setSearchStoreErrors([]);
               setSearchStoreStats([]);
               setSearchTotalDurationMs(null);
+              setSearchClientDurationMs(null);
               setDismissedStoreErrorsKey(null);
               userCancelledRef.current = false;
             }
@@ -313,6 +339,7 @@ export default function useSearch() {
           setSearchStoreErrors([]);
           setSearchStoreStats([]);
           setSearchTotalDurationMs(null);
+          setSearchClientDurationMs(null);
           setDismissedStoreErrorsKey(null);
 
           let nextSearchError;
@@ -352,6 +379,7 @@ export default function useSearch() {
               storeErrors: [],
               storeStats: [],
               totalDurationMs: null,
+              clientDurationMs: null,
               hasSearched: true,
               searchError: nextSearchError,
               cardKingdomPrice: null,
@@ -416,6 +444,7 @@ export default function useSearch() {
         setSearchStoreErrors([]);
         setSearchStoreStats([]);
         setSearchTotalDurationMs(null);
+        setSearchClientDurationMs(null);
         setSearchError(null);
         setCardKingdomPrice(null);
         setDismissedStoreErrorsKey(null);
@@ -446,6 +475,9 @@ export default function useSearch() {
       setSearchStoreStats(state.storeStats || []);
       setSearchTotalDurationMs(
         Number.isFinite(state.totalDurationMs) ? state.totalDurationMs : null,
+      );
+      setSearchClientDurationMs(
+        Number.isFinite(state.clientDurationMs) ? state.clientDurationMs : null,
       );
       setHasSearched(!!state.hasSearched);
       setSearchError(state.searchError || null);
@@ -700,6 +732,7 @@ export default function useSearch() {
     searchStoreErrors: visibleStoreErrors,
     searchStoreStats,
     searchTotalDurationMs,
+    searchClientDurationMs,
     onDismissStoreErrors: dismissStoreErrors,
     storesWarning,
     cardKingdomPrice,

--- a/frontend/src/utils/searchUrl.js
+++ b/frontend/src/utils/searchUrl.js
@@ -13,6 +13,7 @@ import {
  *   storeErrors: object[],
  *   storeStats: object[],
  *   totalDurationMs: number | null,
+ *   clientDurationMs: number | null,
  *   hasSearched: boolean,
  *   searchError: string | null,
  *   cardKingdomPrice: object | null,
@@ -33,6 +34,11 @@ export function buildSearchHistoryState(snapshot) {
     totalDurationMs:
       Number.isFinite(snapshot.totalDurationMs) && snapshot.totalDurationMs >= 0
         ? snapshot.totalDurationMs
+        : null,
+    clientDurationMs:
+      Number.isFinite(snapshot.clientDurationMs) &&
+      snapshot.clientDurationMs >= 0
+        ? snapshot.clientDurationMs
         : null,
     hasSearched: snapshot.hasSearched,
     searchError: snapshot.searchError,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Investigated searches where stats look like:

- **API search time:** 1.00s (includes Card Kingdom enrichment wait)
- **Cards Central:** 2 items, 374ms

…yet the UI takes **>10s** to show results.

### Root cause

`totalDurationMs` / per-store times only measure work **inside** the Lambda search handler (store fan-out + 1s minimum pad + CK enrichment ≤2s). They **do not** include:

1. **Session / Turnstile** — `ensureApiSession()` runs while the search spinner is already shown (Turnstile can take many seconds; up to 3 mint attempts)
2. **Lambda cold start** — happens before handler timing starts, so it never appears in `totalDurationMs`
3. **Network / API Gateway** RTT

The **1.00s** figure matches the controller’s 1s `responseThreshold` pad after Cards Central finished in ~374ms. CK enrichment finished within that window (or was capped/disabled). So the store path was fast; the missing seconds are almost always **before** `/search` handler timing.

(Historical note: before #367, unbounded CK enrichment could also inflate wall clock while per-store stats stayed low; that path is now capped at 2s and included in `totalDurationMs`.)

### Changes

- Show **Time to results** (browser wall clock) alongside **API search time**
- When the gap is ≥500ms, explain **Outside API search** (session/Turnstile, cold start, network)
- Progress label switches to **Checking session** while minting/verifying
- Document latency layers in `docs/search-strategies-retries-timeouts.md`

### Screenshots

Desktop:

![Search stats desktop](https://cursor.com/artifacts/c/art-4118cf39-1cc1-462e-8422-c8af9104da4d)

Mobile:

![Search stats mobile](https://cursor.com/artifacts/c/art-029f789e-18b7-428d-9238-fe1e7658e3d7)

## Test plan

- [ ] Toggle search stats after a warm search — client and API times should be close
- [ ] Cold / first search (or force session remint) — client time much larger than API time; gap line appears
- [ ] Confirm FAQ modal is unchanged from master

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26148c2a-1ba6-4333-b5dc-574e7135662e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26148c2a-1ba6-4333-b5dc-574e7135662e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

