### PR TITLE
Add Turnstile and session mint timings to search stats

### DIFF
--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -129,9 +129,27 @@ Constants live in `frontend/src/hooks/useSearch.js` (and related).
 | Item | Value | Notes |
 |------|--------|--------|
 | Autocomplete debounce | 300ms | `AUTOCOMPLETE_DEBOUNCE_MS`; delays Scryfall autocomplete fetches after typing. |
-| Search progress UI tick | 1000ms | `SEARCH_PROGRESS_INTERVAL_MS`; animates the “Searching LGS . . .” label. |
+| Search progress UI tick | 1000ms | `SEARCH_PROGRESS_INTERVAL_MS`; animates the “Searching LGS . . .” / “Checking session . . .” label. |
 | Programmatic search delay on load (URL with `?s=`) | 100ms | `setTimeout` before `performSearch` in the mount `useEffect`. |
 | API `fetch` timeout / retries | None in code | Uses browser `fetch` with `AbortController` only; no app-level timeout or automatic retry. |
+| Session before `/search` | `ensureApiSession()` | Awaited inside the search spinner; may run Turnstile + `GET /session` (up to 3 mint attempts). Not included in API `totalDurationMs`. |
+| Client wall clock in SearchStats | `clientDurationMs` | Measured from search start to JSON response. |
+| Turnstile / session mint in SearchStats | `sessionTiming` | Client breakdown from `ensureApiSession`: `turnstileMs` + `sessionFetchMs` when this search started the mint; wait-only when joining an in-flight bootstrap. |
+
+## End-to-end latency vs search stats
+
+`totalDurationMs` / per-store `durationMs` only cover work **inside** the Lambda search handler after auth checks (store fan-out, 1s minimum response pad, CK enrichment capped at 2s). Wall-clock time until the UI shows results can be much larger when any of these run first:
+
+| Layer | Typical when slow | Included in `totalDurationMs`? | SearchStats field |
+|-------|-------------------|--------------------------------|-------------------|
+| Turnstile challenge | First visit, expired cookie, forced remint after 403 | No | `sessionTiming.turnstileMs` |
+| `GET /session` mint | Same as Turnstile (runs after challenge) | No | `sessionTiming.sessionFetchMs` |
+| Lambda cold start | Idle API after scale-to-zero | No (starts before handler timing) | Remainder under “Other (network / cold start)” |
+| API Gateway / network RTT | Distant client, congested path | No | Same “Other” remainder |
+| Store scrape + 1s pad + CK ≤2s | Measured API search | Yes | `totalDurationMs` / per-store `durationMs` |
+| React render of results | Rarely material for small result sets | No (after fetch) | Not measured |
+
+Example: Cards Central finishes in ~374ms, API pads to ~1.00s, stats show that 1.00s — while the browser may still have spent several seconds on Turnstile/session or cold start before `/search` returned.
 
 ---
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -57,6 +57,8 @@ export default function App() {
     searchStoreErrors,
     searchStoreStats,
     searchTotalDurationMs,
+    searchClientDurationMs,
+    searchSessionTiming,
     onDismissStoreErrors,
     storesWarning,
     cardKingdomPrice,
@@ -264,6 +266,8 @@ export default function App() {
       <SearchStats
         stats={searchStoreStats}
         totalDurationMs={searchTotalDurationMs}
+        clientDurationMs={searchClientDurationMs}
+        sessionTiming={searchSessionTiming}
         hasSearched={hasSearched}
         isSearching={isSearching}
       />

--- a/frontend/src/components/SearchStats.jsx
+++ b/frontend/src/components/SearchStats.jsx
@@ -21,7 +21,33 @@ function readShowStatsPreference() {
   }
 }
 
-const SearchStats = ({ stats, totalDurationMs, hasSearched, isSearching }) => {
+function sessionAccountedMs(sessionTiming) {
+  if (!sessionTiming || sessionTiming.reused) {
+    return 0;
+  }
+  if (sessionTiming.joinedInFlight) {
+    return Number.isFinite(sessionTiming.totalMs) ? sessionTiming.totalMs : 0;
+  }
+  const turnstile =
+    Number.isFinite(sessionTiming.turnstileMs) && sessionTiming.turnstileMs > 0
+      ? sessionTiming.turnstileMs
+      : 0;
+  const sessionFetch =
+    Number.isFinite(sessionTiming.sessionFetchMs) &&
+    sessionTiming.sessionFetchMs > 0
+      ? sessionTiming.sessionFetchMs
+      : 0;
+  return turnstile + sessionFetch;
+}
+
+const SearchStats = ({
+  stats,
+  totalDurationMs,
+  clientDurationMs,
+  sessionTiming,
+  hasSearched,
+  isSearching,
+}) => {
   const [showStats, setShowStats] = useState(readShowStatsPreference);
 
   useEffect(() => {
@@ -38,6 +64,29 @@ const SearchStats = ({ stats, totalDurationMs, hasSearched, isSearching }) => {
 
   const storeStats = Array.isArray(stats) ? stats : [];
   const hasTotal = Number.isFinite(totalDurationMs) && totalDurationMs >= 0;
+  const hasClient = Number.isFinite(clientDurationMs) && clientDurationMs >= 0;
+  const showMintBreakdown =
+    !!sessionTiming && !sessionTiming.reused && !sessionTiming.joinedInFlight;
+  const showSessionWait =
+    !!sessionTiming &&
+    !sessionTiming.reused &&
+    sessionTiming.joinedInFlight &&
+    Number.isFinite(sessionTiming.totalMs) &&
+    sessionTiming.totalMs > 0;
+  const showTurnstile =
+    showMintBreakdown &&
+    Number.isFinite(sessionTiming.turnstileMs) &&
+    sessionTiming.turnstileMs > 0;
+  const showSessionFetch =
+    showMintBreakdown &&
+    Number.isFinite(sessionTiming.sessionFetchMs) &&
+    sessionTiming.sessionFetchMs > 0;
+  const accountedSessionMs = sessionAccountedMs(sessionTiming);
+  const otherMs =
+    hasClient && hasTotal
+      ? Math.max(0, clientDurationMs - accountedSessionMs - totalDurationMs)
+      : 0;
+  const showOtherGap = hasClient && otherMs >= 500;
 
   return (
     <div className="search-stats mt-3 rounded py-2 px-3">
@@ -52,21 +101,74 @@ const SearchStats = ({ stats, totalDurationMs, hasSearched, isSearching }) => {
 
       {showStats && (
         <div className="search-stats-panel mt-2">
-          {storeStats.length === 0 && !hasTotal ? (
+          {storeStats.length === 0 &&
+          !hasTotal &&
+          !hasClient &&
+          !showMintBreakdown &&
+          !showSessionWait ? (
             <p className="small text-muted mb-0">
               No store timing data for this search.
             </p>
           ) : (
             <>
+              {hasClient && (
+                <p className="small text-muted mb-2 search-stats-client">
+                  Time to results:{" "}
+                  <span className="text-body fw-semibold">
+                    {formatDurationMs(clientDurationMs)}
+                  </span>
+                  {" (browser wall clock: session check, network, and API)"}
+                </p>
+              )}
+              {showTurnstile && (
+                <p className="small text-muted mb-2 search-stats-turnstile">
+                  Turnstile:{" "}
+                  <span className="text-body fw-semibold">
+                    {formatDurationMs(sessionTiming.turnstileMs)}
+                  </span>
+                  {" — Cloudflare challenge before session mint"}
+                </p>
+              )}
+              {showSessionFetch && (
+                <p className="small text-muted mb-2 search-stats-session">
+                  Session mint:{" "}
+                  <span className="text-body fw-semibold">
+                    {formatDurationMs(sessionTiming.sessionFetchMs)}
+                  </span>
+                  {" — GET /session (not included in API search time)"}
+                </p>
+              )}
+              {showSessionWait && (
+                <p className="small text-muted mb-2 search-stats-session-wait">
+                  Session check:{" "}
+                  <span className="text-body fw-semibold">
+                    {formatDurationMs(sessionTiming.totalMs)}
+                  </span>
+                  {
+                    " — waited on an in-flight Turnstile/session mint (breakdown unavailable)"
+                  }
+                </p>
+              )}
               {hasTotal && (
                 <p className="small text-muted mb-2 search-stats-total">
-                  Total search time:{" "}
+                  API search time:{" "}
                   <span className="text-body fw-semibold">
                     {formatDurationMs(totalDurationMs)}
                   </span>
                   {storeStats.length > 1
                     ? " (waits for all selected stores and Card Kingdom enrichment; per-store times below)"
                     : " (includes Card Kingdom enrichment wait; per-store time below)"}
+                </p>
+              )}
+              {showOtherGap && (
+                <p className="small text-muted mb-2 search-stats-gap">
+                  Other (network / cold start):{" "}
+                  <span className="text-body fw-semibold">
+                    {formatDurationMs(otherMs)}
+                  </span>
+                  {
+                    " — Lambda cold start or network RTT; not counted in API search time or per-store times"
+                  }
                 </p>
               )}
               {storeStats.length > 0 && (

--- a/frontend/src/components/searchStatsTiming.test.js
+++ b/frontend/src/components/searchStatsTiming.test.js
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+
+/**
+ * Mirrors SearchStats sessionAccountedMs so the accounting stays covered without a DOM test runner.
+ * @param {{
+ *   turnstileMs?: number | null,
+ *   sessionFetchMs?: number | null,
+ *   totalMs?: number,
+ *   reused?: boolean,
+ *   joinedInFlight?: boolean,
+ * } | null} sessionTiming
+ */
+function sessionAccountedMs(sessionTiming) {
+  if (!sessionTiming || sessionTiming.reused) {
+    return 0;
+  }
+  if (sessionTiming.joinedInFlight) {
+    return Number.isFinite(sessionTiming.totalMs) ? sessionTiming.totalMs : 0;
+  }
+  const turnstile =
+    Number.isFinite(sessionTiming.turnstileMs) && sessionTiming.turnstileMs > 0
+      ? sessionTiming.turnstileMs
+      : 0;
+  const sessionFetch =
+    Number.isFinite(sessionTiming.sessionFetchMs) &&
+    sessionTiming.sessionFetchMs > 0
+      ? sessionTiming.sessionFetchMs
+      : 0;
+  return turnstile + sessionFetch;
+}
+
+assert.equal(sessionAccountedMs(null), 0);
+assert.equal(
+  sessionAccountedMs({
+    reused: true,
+    turnstileMs: 5000,
+    sessionFetchMs: 200,
+    totalMs: 5200,
+  }),
+  0,
+);
+assert.equal(
+  sessionAccountedMs({
+    reused: false,
+    joinedInFlight: true,
+    turnstileMs: null,
+    sessionFetchMs: null,
+    totalMs: 1200,
+  }),
+  1200,
+);
+assert.equal(
+  sessionAccountedMs({
+    reused: false,
+    joinedInFlight: false,
+    turnstileMs: 8000,
+    sessionFetchMs: 350,
+    totalMs: 8350,
+  }),
+  8350,
+);
+assert.equal(
+  sessionAccountedMs({
+    reused: false,
+    joinedInFlight: false,
+    turnstileMs: 0,
+    sessionFetchMs: 120,
+    totalMs: 120,
+  }),
+  120,
+);
+
+const clientDurationMs = 12400;
+const totalDurationMs = 1000;
+const accounted = sessionAccountedMs({
+  reused: false,
+  joinedInFlight: false,
+  turnstileMs: 8200,
+  sessionFetchMs: 350,
+  totalMs: 8550,
+});
+const otherMs = Math.max(0, clientDurationMs - accounted - totalDurationMs);
+assert.equal(otherMs, 2850);
+
+console.log("searchStatsTiming.test.js: ok");

--- a/frontend/src/hooks/useSearch.js
+++ b/frontend/src/hooks/useSearch.js
@@ -9,6 +9,7 @@ import {
 } from "../constants";
 import {
   API_SESSION_REFRESH_INTERVAL_MS,
+  emptySessionTiming,
   ensureApiSession,
   isApiSessionAccessDenied,
   resetApiSessionCache,
@@ -60,6 +61,8 @@ export default function useSearch() {
   const [searchStoreErrors, setSearchStoreErrors] = useState([]);
   const [searchStoreStats, setSearchStoreStats] = useState([]);
   const [searchTotalDurationMs, setSearchTotalDurationMs] = useState(null);
+  const [searchClientDurationMs, setSearchClientDurationMs] = useState(null);
+  const [searchSessionTiming, setSearchSessionTiming] = useState(null);
   const [cardKingdomPrice, setCardKingdomPrice] = useState(null);
   const [dismissedStoreErrorsKey, setDismissedStoreErrorsKey] = useState(null);
   const [storesWarning, setStoresWarning] = useState(null);
@@ -184,6 +187,8 @@ export default function useSearch() {
       setSearchStoreErrors([]);
       setSearchStoreStats([]);
       setSearchTotalDurationMs(null);
+      setSearchClientDurationMs(null);
+      setSearchSessionTiming(null);
       setDismissedStoreErrorsKey(null);
 
       if (window.gtag) {
@@ -191,18 +196,32 @@ export default function useSearch() {
       }
 
       const searchUrl = `${API_SEARCH_URL}?s=${encodeURIComponent(query)}&lgs=${encodeURIComponent(stores.join(","))}`;
+      const clientStartedAt =
+        typeof performance !== "undefined" &&
+        typeof performance.now === "function"
+          ? performance.now()
+          : Date.now();
 
       const progressInterval = setInterval(() => {
         setSearchProgress((prev) => {
+          const base = prev.replace(/\s*\.+$/, "") || "Searching LGS";
           const dots = (prev.match(/\./g) || []).length;
-          if (dots >= MAX_PROGRESS_DOTS) return "Searching LGS";
-          return `${prev} .`;
+          if (dots >= MAX_PROGRESS_DOTS) return base;
+          return `${base} .`;
         });
       }, SEARCH_PROGRESS_INTERVAL_MS);
       progressIntervalRef.current = progressInterval;
 
       const fetchSearchResult = async (sessionRetried) => {
-        await ensureApiSession({ forceRefresh: sessionRetried });
+        if (requestId === activeSearchRequestIdRef.current) {
+          setSearchProgress("Checking session");
+        }
+        const sessionTiming = await ensureApiSession({
+          forceRefresh: sessionRetried,
+        });
+        if (requestId === activeSearchRequestIdRef.current) {
+          setSearchProgress("Searching LGS");
+        }
 
         const res = await fetch(searchUrl, {
           signal: searchAbortController.signal,
@@ -245,13 +264,22 @@ export default function useSearch() {
           );
         }
 
-        return res.json();
+        return { result: await res.json(), sessionTiming };
       };
 
       fetchSearchResult(false)
-        .then((result) => {
+        .then(({ result, sessionTiming }) => {
           if (requestId !== activeSearchRequestIdRef.current) return;
           if (result && Object.hasOwn(result, "data")) {
+            const clientEndedAt =
+              typeof performance !== "undefined" &&
+              typeof performance.now === "function"
+                ? performance.now()
+                : Date.now();
+            const clientDurationMs = Math.max(
+              0,
+              Math.round(clientEndedAt - clientStartedAt),
+            );
             // Treat null data as empty array
             setSearchResults(result.data || []);
             setCardKingdomPrice(result.cardKingdomPrice ?? null);
@@ -262,9 +290,12 @@ export default function useSearch() {
             const totalDurationMs = Number.isFinite(result.totalDurationMs)
               ? result.totalDurationMs
               : null;
+            const nextSessionTiming = sessionTiming ?? emptySessionTiming();
             setSearchStoreErrors(storeErrors);
             setSearchStoreStats(storeStats);
             setSearchTotalDurationMs(totalDurationMs);
+            setSearchClientDurationMs(clientDurationMs);
+            setSearchSessionTiming(nextSessionTiming);
             setDismissedStoreErrorsKey(null);
             if (!skipHistorySyncRef.current) {
               syncSearchHistory({
@@ -274,6 +305,8 @@ export default function useSearch() {
                 storeErrors,
                 storeStats,
                 totalDurationMs,
+                clientDurationMs,
+                sessionTiming: nextSessionTiming,
                 hasSearched: true,
                 searchError: null,
                 cardKingdomPrice: result.cardKingdomPrice ?? null,
@@ -302,6 +335,8 @@ export default function useSearch() {
               setSearchStoreErrors([]);
               setSearchStoreStats([]);
               setSearchTotalDurationMs(null);
+              setSearchClientDurationMs(null);
+              setSearchSessionTiming(null);
               setDismissedStoreErrorsKey(null);
               userCancelledRef.current = false;
             }
@@ -313,6 +348,8 @@ export default function useSearch() {
           setSearchStoreErrors([]);
           setSearchStoreStats([]);
           setSearchTotalDurationMs(null);
+          setSearchClientDurationMs(null);
+          setSearchSessionTiming(null);
           setDismissedStoreErrorsKey(null);
 
           let nextSearchError;
@@ -352,6 +389,8 @@ export default function useSearch() {
               storeErrors: [],
               storeStats: [],
               totalDurationMs: null,
+              clientDurationMs: null,
+              sessionTiming: null,
               hasSearched: true,
               searchError: nextSearchError,
               cardKingdomPrice: null,
@@ -416,6 +455,8 @@ export default function useSearch() {
         setSearchStoreErrors([]);
         setSearchStoreStats([]);
         setSearchTotalDurationMs(null);
+        setSearchClientDurationMs(null);
+        setSearchSessionTiming(null);
         setSearchError(null);
         setCardKingdomPrice(null);
         setDismissedStoreErrorsKey(null);
@@ -446,6 +487,14 @@ export default function useSearch() {
       setSearchStoreStats(state.storeStats || []);
       setSearchTotalDurationMs(
         Number.isFinite(state.totalDurationMs) ? state.totalDurationMs : null,
+      );
+      setSearchClientDurationMs(
+        Number.isFinite(state.clientDurationMs) ? state.clientDurationMs : null,
+      );
+      setSearchSessionTiming(
+        state.sessionTiming && typeof state.sessionTiming === "object"
+          ? state.sessionTiming
+          : null,
       );
       setHasSearched(!!state.hasSearched);
       setSearchError(state.searchError || null);
@@ -700,6 +749,8 @@ export default function useSearch() {
     searchStoreErrors: visibleStoreErrors,
     searchStoreStats,
     searchTotalDurationMs,
+    searchClientDurationMs,
+    searchSessionTiming,
     onDismissStoreErrors: dismissStoreErrors,
     storesWarning,
     cardKingdomPrice,

--- a/frontend/src/utils/apiSession.js
+++ b/frontend/src/utils/apiSession.js
@@ -10,11 +10,49 @@ export const API_SESSION_REFRESH_INTERVAL_MS = 10 * 60 * 1000;
 /** Turnstile / network blips are common in private browsing; retry with a fresh token. */
 const SESSION_MINT_MAX_ATTEMPTS = 3;
 
+/** Treat near-instant awaits as a warm (already-minted) session. */
+const WARM_SESSION_WAIT_MS = 2;
+
 let sessionBootstrapPromise = null;
+
+function nowMs() {
+  return typeof performance !== "undefined" &&
+    typeof performance.now === "function"
+    ? performance.now()
+    : Date.now();
+}
+
+/**
+ * @typedef {{
+ *   turnstileMs: number | null,
+ *   sessionFetchMs: number | null,
+ *   totalMs: number,
+ *   attempts: number,
+ *   reused: boolean,
+ *   joinedInFlight: boolean,
+ * }} SessionTiming
+ */
+
+/** @returns {SessionTiming} */
+export function emptySessionTiming() {
+  return {
+    turnstileMs: 0,
+    sessionFetchMs: 0,
+    totalMs: 0,
+    attempts: 0,
+    reused: true,
+    joinedInFlight: false,
+  };
+}
 
 /**
  * Ensures the browser holds a valid HttpOnly API session cookie (minted by GET /session on the API host).
  * Safe to call repeatedly; concurrent callers share one in-flight request unless forceRefresh.
+ *
+ * Returns client-side timing for Turnstile + session mint so SearchStats can break down waits
+ * that sit outside API `totalDurationMs`.
+ *
+ * @returns {Promise<SessionTiming>}
  */
 export async function ensureApiSession(options = {}) {
   const { forceRefresh = false } = options;
@@ -24,12 +62,42 @@ export async function ensureApiSession(options = {}) {
     resetTurnstileChallenge();
   }
 
+  const callStarted = nowMs();
+  const startedMint = !sessionBootstrapPromise;
+
   if (!sessionBootstrapPromise) {
     sessionBootstrapPromise = bootstrapSessionWithRetry();
   }
 
   try {
-    await sessionBootstrapPromise;
+    const mintTiming = await sessionBootstrapPromise;
+    const waitedMs = Math.max(0, Math.round(nowMs() - callStarted));
+
+    // Warm cookie / already-resolved bootstrap: do not attribute prior mint cost to this call.
+    if (waitedMs <= WARM_SESSION_WAIT_MS) {
+      return emptySessionTiming();
+    }
+
+    if (startedMint) {
+      return {
+        turnstileMs: mintTiming.turnstileMs,
+        sessionFetchMs: mintTiming.sessionFetchMs,
+        totalMs: mintTiming.totalMs,
+        attempts: mintTiming.attempts,
+        reused: false,
+        joinedInFlight: false,
+      };
+    }
+
+    // Joined an in-flight bootstrap (e.g. mount refresh still running): report wait only.
+    return {
+      turnstileMs: null,
+      sessionFetchMs: null,
+      totalMs: waitedMs,
+      attempts: mintTiming.attempts,
+      reused: false,
+      joinedInFlight: true,
+    };
   } catch (err) {
     sessionBootstrapPromise = null;
     throw err;
@@ -38,47 +106,99 @@ export async function ensureApiSession(options = {}) {
 
 async function bootstrapSessionWithRetry() {
   let lastError = null;
+  let turnstileMs = 0;
+  let sessionFetchMs = 0;
 
   for (let attempt = 1; attempt <= SESSION_MINT_MAX_ATTEMPTS; attempt += 1) {
-    try {
-      await mintApiSession();
-      return;
-    } catch (err) {
-      lastError = err;
-      // Drop any pending/used token so the next attempt runs a fresh challenge.
-      resetTurnstileChallenge();
+    const attemptTiming = await mintApiSession();
+    turnstileMs += attemptTiming.turnstileMs;
+    sessionFetchMs += attemptTiming.sessionFetchMs;
+
+    if (attemptTiming.ok) {
+      return {
+        turnstileMs,
+        sessionFetchMs,
+        totalMs: turnstileMs + sessionFetchMs,
+        attempts: attempt,
+      };
     }
+
+    lastError = attemptTiming.error;
+    // Drop any pending/used token so the next attempt runs a fresh challenge.
+    resetTurnstileChallenge();
   }
 
   throw lastError ?? new Error("API session failed");
 }
 
+/**
+ * @returns {Promise<{
+ *   ok: boolean,
+ *   turnstileMs: number,
+ *   sessionFetchMs: number,
+ *   error?: Error,
+ * }>}
+ */
 async function mintApiSession() {
   const headers = {};
-  const turnstileToken = await obtainTurnstileToken();
-  if (turnstileToken) {
-    headers["CF-Turnstile-Response"] = turnstileToken;
+  let turnstileMs = 0;
+  let sessionFetchMs = 0;
+
+  const turnstileStarted = nowMs();
+  try {
+    const turnstileToken = await obtainTurnstileToken();
+    turnstileMs = Math.max(0, Math.round(nowMs() - turnstileStarted));
+    if (turnstileToken) {
+      headers["CF-Turnstile-Response"] = turnstileToken;
+    }
+  } catch (err) {
+    turnstileMs = Math.max(0, Math.round(nowMs() - turnstileStarted));
+    return {
+      ok: false,
+      turnstileMs,
+      sessionFetchMs: 0,
+      error: err instanceof Error ? err : new Error("turnstile failed"),
+    };
   }
 
   // Network failures surface as TypeError; rethrow as-is so the UI keeps the
   // accurate "unable to connect" copy instead of blaming session verification.
-  const res = await fetch(API_SESSION_URL, {
-    method: "GET",
-    credentials: "include",
-    headers,
-  });
+  const fetchStarted = nowMs();
+  let res;
+  try {
+    res = await fetch(API_SESSION_URL, {
+      method: "GET",
+      credentials: "include",
+      headers,
+    });
+  } catch (err) {
+    sessionFetchMs = Math.max(0, Math.round(nowMs() - fetchStarted));
+    // Tokens are single-use; never reuse after a mint attempt.
+    resetTurnstileChallenge();
+    return {
+      ok: false,
+      turnstileMs,
+      sessionFetchMs,
+      error: err instanceof Error ? err : new Error("API session failed"),
+    };
+  }
 
-  // Tokens are single-use; never reuse after a mint attempt.
+  sessionFetchMs = Math.max(0, Math.round(nowMs() - fetchStarted));
   resetTurnstileChallenge();
 
   if (!res.ok) {
+    let error;
     if (res.status === 403) {
-      throw new Error(
+      error = new Error(
         "API session verification failed. Please try searching again.",
       );
+    } else {
+      error = new Error(`API session failed (${res.status})`);
     }
-    throw new Error(`API session failed (${res.status})`);
+    return { ok: false, turnstileMs, sessionFetchMs, error };
   }
+
+  return { ok: true, turnstileMs, sessionFetchMs };
 }
 
 /** True when search API rejected the request for missing or expired session cookie. */

--- a/frontend/src/utils/searchUrl.js
+++ b/frontend/src/utils/searchUrl.js
@@ -13,6 +13,8 @@ import {
  *   storeErrors: object[],
  *   storeStats: object[],
  *   totalDurationMs: number | null,
+ *   clientDurationMs: number | null,
+ *   sessionTiming: object | null,
  *   hasSearched: boolean,
  *   searchError: string | null,
  *   cardKingdomPrice: object | null,
@@ -33,6 +35,15 @@ export function buildSearchHistoryState(snapshot) {
     totalDurationMs:
       Number.isFinite(snapshot.totalDurationMs) && snapshot.totalDurationMs >= 0
         ? snapshot.totalDurationMs
+        : null,
+    clientDurationMs:
+      Number.isFinite(snapshot.clientDurationMs) &&
+      snapshot.clientDurationMs >= 0
+        ? snapshot.clientDurationMs
+        : null,
+    sessionTiming:
+      snapshot.sessionTiming && typeof snapshot.sessionTiming === "object"
+        ? snapshot.sessionTiming
         : null,
     hasSearched: snapshot.hasSearched,
     searchError: snapshot.searchError,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Search stats previously only showed API `totalDurationMs` / per-store times, so a search that felt like 10s+ could still report ~1s when the wait was Turnstile or session minting (outside the Lambda search handler).

This change measures those client-side waits and surfaces them in Search Stats:

- **Time to results** — browser wall clock from search start to JSON response
- **Turnstile** — Cloudflare challenge time when this search started the mint
- **Session mint** — `GET /session` fetch time
- **API search time** — existing `totalDurationMs` (stores + CK enrichment)
- **Other (network / cold start)** — remainder when ≥500ms after subtracting the above

Also shows **Checking session** while `ensureApiSession` runs. Warm sessions omit Turnstile/session lines (already minted). Joining an in-flight bootstrap reports a combined session-check wait without a misleading split.

## Test plan

- [ ] Toggle search stats after a warm search — time to results ≈ API search; no Turnstile/session lines
- [ ] Force session remint (clear cookies / 403 retry) with Turnstile enabled — Turnstile and Session mint lines appear
- [ ] Cold first search while mount bootstrap still runs — Session check wait line may appear
- [ ] `node frontend/src/components/searchStatsTiming.test.js`
- [ ] `cd frontend && npm run lint`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09f75a11-dcdb-4ec1-be1b-1f27cab93389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09f75a11-dcdb-4ec1-be1b-1f27cab93389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

