### PR TITLE
Add search response time to search stats

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -59,6 +59,7 @@ export default function App() {
     searchTotalDurationMs,
     sessionTurnstileDurationMs,
     sessionMintDurationMs,
+    searchResponseDurationMs,
     onDismissStoreErrors,
     storesWarning,
     cardKingdomPrice,
@@ -268,6 +269,7 @@ export default function App() {
         totalDurationMs={searchTotalDurationMs}
         sessionTurnstileDurationMs={sessionTurnstileDurationMs}
         sessionMintDurationMs={sessionMintDurationMs}
+        searchResponseDurationMs={searchResponseDurationMs}
         hasSearched={hasSearched}
         isSearching={isSearching}
       />

--- a/frontend/src/components/SearchStats.jsx
+++ b/frontend/src/components/SearchStats.jsx
@@ -26,6 +26,7 @@ const SearchStats = ({
   totalDurationMs,
   sessionTurnstileDurationMs,
   sessionMintDurationMs,
+  searchResponseDurationMs,
   hasSearched,
   isSearching,
 }) => {
@@ -48,7 +49,10 @@ const SearchStats = ({
   const hasTurnstileTiming = sessionTurnstileDurationMs !== null;
   const hasSessionMintTiming =
     Number.isFinite(sessionMintDurationMs) && sessionMintDurationMs >= 0;
-  const hasBootstrapTiming = hasTurnstileTiming || hasSessionMintTiming;
+  const hasSearchResponseTiming =
+    Number.isFinite(searchResponseDurationMs) && searchResponseDurationMs >= 0;
+  const hasClientTiming =
+    hasTurnstileTiming || hasSessionMintTiming || hasSearchResponseTiming;
 
   return (
     <div className="search-stats mt-3 rounded py-2 px-3">
@@ -63,7 +67,7 @@ const SearchStats = ({
 
       {showStats && (
         <div className="search-stats-panel mt-2">
-          {storeStats.length === 0 && !hasTotal && !hasBootstrapTiming ? (
+          {storeStats.length === 0 && !hasTotal && !hasClientTiming ? (
             <p className="small text-muted mb-0">
               No store timing data for this search.
             </p>
@@ -80,12 +84,12 @@ const SearchStats = ({
                     : " (includes Card Kingdom enrichment wait; per-store time below)"}
                 </p>
               )}
-              {hasBootstrapTiming && (
+              {hasClientTiming && (
                 <div className="table-responsive mb-2">
                   <table className="table table-sm table-borderless mb-0 search-stats-table">
                     <thead>
                       <tr>
-                        <th scope="col">Session bootstrap</th>
+                        <th scope="col">Client timing</th>
                         <th scope="col" className="text-end">
                           Time
                         </th>
@@ -105,6 +109,14 @@ const SearchStats = ({
                           <td>Session mint</td>
                           <td className="text-end text-nowrap">
                             {formatDurationMs(sessionMintDurationMs)}
+                          </td>
+                        </tr>
+                      )}
+                      {hasSearchResponseTiming && (
+                        <tr>
+                          <td>Search response</td>
+                          <td className="text-end text-nowrap">
+                            {formatDurationMs(searchResponseDurationMs)}
                           </td>
                         </tr>
                       )}

--- a/frontend/src/hooks/useSearch.js
+++ b/frontend/src/hooks/useSearch.js
@@ -63,6 +63,8 @@ export default function useSearch() {
   const [sessionTurnstileDurationMs, setSessionTurnstileDurationMs] =
     useState(null);
   const [sessionMintDurationMs, setSessionMintDurationMs] = useState(null);
+  const [searchResponseDurationMs, setSearchResponseDurationMs] =
+    useState(null);
   const [cardKingdomPrice, setCardKingdomPrice] = useState(null);
   const [dismissedStoreErrorsKey, setDismissedStoreErrorsKey] = useState(null);
   const [storesWarning, setStoresWarning] = useState(null);
@@ -189,6 +191,7 @@ export default function useSearch() {
       setSearchTotalDurationMs(null);
       setSessionTurnstileDurationMs(null);
       setSessionMintDurationMs(null);
+      setSearchResponseDurationMs(null);
       setDismissedStoreErrorsKey(null);
 
       if (window.gtag) {
@@ -213,6 +216,7 @@ export default function useSearch() {
         setSessionTurnstileDurationMs(sessionTiming.turnstileDurationMs);
         setSessionMintDurationMs(sessionTiming.sessionMintDurationMs);
 
+        const searchFetchStart = performance.now();
         const res = await fetch(searchUrl, {
           signal: searchAbortController.signal,
           credentials: "include",
@@ -254,14 +258,20 @@ export default function useSearch() {
           );
         }
 
+        const result = await res.json();
+        const searchResponseDurationMs = Math.round(
+          performance.now() - searchFetchStart,
+        );
+
         return {
-          result: await res.json(),
+          result,
           sessionTiming,
+          searchResponseDurationMs,
         };
       };
 
       fetchSearchResult(false)
-        .then(({ result, sessionTiming }) => {
+        .then(({ result, sessionTiming, searchResponseDurationMs }) => {
           if (requestId !== activeSearchRequestIdRef.current) return;
           if (result && Object.hasOwn(result, "data")) {
             // Treat null data as empty array
@@ -277,6 +287,7 @@ export default function useSearch() {
             setSearchStoreErrors(storeErrors);
             setSearchStoreStats(storeStats);
             setSearchTotalDurationMs(totalDurationMs);
+            setSearchResponseDurationMs(searchResponseDurationMs);
             setDismissedStoreErrorsKey(null);
             if (!skipHistorySyncRef.current) {
               syncSearchHistory({
@@ -288,6 +299,7 @@ export default function useSearch() {
                 totalDurationMs,
                 sessionTurnstileDurationMs: sessionTiming.turnstileDurationMs,
                 sessionMintDurationMs: sessionTiming.sessionMintDurationMs,
+                searchResponseDurationMs,
                 hasSearched: true,
                 searchError: null,
                 cardKingdomPrice: result.cardKingdomPrice ?? null,
@@ -318,6 +330,7 @@ export default function useSearch() {
               setSearchTotalDurationMs(null);
               setSessionTurnstileDurationMs(null);
               setSessionMintDurationMs(null);
+              setSearchResponseDurationMs(null);
               setDismissedStoreErrorsKey(null);
               userCancelledRef.current = false;
             }
@@ -331,6 +344,7 @@ export default function useSearch() {
           setSearchTotalDurationMs(null);
           setSessionTurnstileDurationMs(null);
           setSessionMintDurationMs(null);
+          setSearchResponseDurationMs(null);
           setDismissedStoreErrorsKey(null);
 
           let nextSearchError;
@@ -372,6 +386,7 @@ export default function useSearch() {
               totalDurationMs: null,
               sessionTurnstileDurationMs: null,
               sessionMintDurationMs: null,
+              searchResponseDurationMs: null,
               hasSearched: true,
               searchError: nextSearchError,
               cardKingdomPrice: null,
@@ -438,6 +453,7 @@ export default function useSearch() {
         setSearchTotalDurationMs(null);
         setSessionTurnstileDurationMs(null);
         setSessionMintDurationMs(null);
+        setSearchResponseDurationMs(null);
         setSearchError(null);
         setCardKingdomPrice(null);
         setDismissedStoreErrorsKey(null);
@@ -479,6 +495,12 @@ export default function useSearch() {
         Number.isFinite(state.sessionMintDurationMs) &&
           state.sessionMintDurationMs >= 0
           ? state.sessionMintDurationMs
+          : null,
+      );
+      setSearchResponseDurationMs(
+        Number.isFinite(state.searchResponseDurationMs) &&
+          state.searchResponseDurationMs >= 0
+          ? state.searchResponseDurationMs
           : null,
       );
       setHasSearched(!!state.hasSearched);
@@ -736,6 +758,7 @@ export default function useSearch() {
     searchTotalDurationMs,
     sessionTurnstileDurationMs,
     sessionMintDurationMs,
+    searchResponseDurationMs,
     onDismissStoreErrors: dismissStoreErrors,
     storesWarning,
     cardKingdomPrice,

--- a/frontend/src/utils/searchUrl.js
+++ b/frontend/src/utils/searchUrl.js
@@ -15,6 +15,7 @@ import {
  *   totalDurationMs: number | null,
  *   sessionTurnstileDurationMs: number | null,
  *   sessionMintDurationMs: number | null,
+ *   searchResponseDurationMs: number | null,
  *   hasSearched: boolean,
  *   searchError: string | null,
  *   cardKingdomPrice: object | null,
@@ -46,6 +47,11 @@ export function buildSearchHistoryState(snapshot) {
       Number.isFinite(snapshot.sessionMintDurationMs) &&
       snapshot.sessionMintDurationMs >= 0
         ? snapshot.sessionMintDurationMs
+        : null,
+    searchResponseDurationMs:
+      Number.isFinite(snapshot.searchResponseDurationMs) &&
+      snapshot.searchResponseDurationMs >= 0
+        ? snapshot.searchResponseDurationMs
         : null,
     hasSearched: snapshot.hasSearched,
     searchError: snapshot.searchError,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds client-side **Search response** timing to the search stats panel. This measures the full `/search` HTTP round-trip from the browser: request start through JSON parse, using `performance.now()` (same approach as session mint timing).

The value appears in the **Client timing** table alongside Turnstile and Session mint, and is persisted in browser history state for back/forward navigation.

## Test plan

- [x] `make test`
- [x] `cd frontend && npm run lint`
- [x] Manual check with mocked search API: Search response row appears with a plausible duration

## Screenshots

### Desktop

![Search stats with search response timing (desktop)](https://cursor.com/artifacts/c/art-f037bb51-b375-4be7-8f45-1e28fb32bd4f)

### Mobile

![Search stats with search response timing (mobile)](https://cursor.com/artifacts/c/art-b4751d34-f5d2-4943-964c-2ac75e1b4231)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a0c957f-0768-49b8-a14f-cdf52b40b7b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a0c957f-0768-49b8-a14f-cdf52b40b7b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

