### PR TITLE
Fix hidden ~20s Turnstile delay before search results appear

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -43,9 +43,16 @@
 
   <!-- Preconnect to external domains for better performance -->
   <link rel="preconnect" href="https://api.scryfall.com">
+  <link rel="preconnect" href="https://challenges.cloudflare.com">
   <link rel="preconnect" href="https://pagead2.googlesyndication.com">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://cdn.jsdelivr.net">
+  <link
+    rel="preload"
+    href="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit"
+    as="script"
+    crossorigin
+  >
 
   <link rel="apple-touch-icon" sizes="180x180" href="./apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="./favicon-32x32.png">

--- a/frontend/src/components/TurnstileBootstrap.jsx
+++ b/frontend/src/components/TurnstileBootstrap.jsx
@@ -1,7 +1,8 @@
-import { useEffect, useRef } from "react";
+import { useLayoutEffect, useRef } from "react";
+import { ensureApiSession } from "../utils/apiSession";
 import {
+  beginTurnstileWidgetPrepare,
   isTurnstileConfigured,
-  prepareTurnstileWidget,
   teardownTurnstileWidget,
 } from "../utils/turnstileSession";
 
@@ -10,12 +11,14 @@ const PREPARE_MAX_ATTEMPTS = 3;
 
 /**
  * Invisible Turnstile widget used to obtain tokens for GET /session on the API host.
- * Retries prepare a few times — script/challenge load is flaky under private browsing.
+ * Prepare runs in useLayoutEffect so the widget is registering before search/session
+ * effects on the parent. Retries prepare a few times — script/challenge load is flaky
+ * under private browsing.
  */
 export default function TurnstileBootstrap() {
   const containerRef = useRef(null);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!isTurnstileConfigured()) {
       return undefined;
     }
@@ -24,11 +27,20 @@ export default function TurnstileBootstrap() {
     const abort = new AbortController();
     let retryTimer = null;
 
+    const prefetchSession = () => {
+      ensureApiSession().catch(() => {
+        // Search retries session bootstrap before the first API call.
+      });
+    };
+
     const prepareWithRetry = async (attempt) => {
       try {
-        await prepareTurnstileWidget(containerRef.current, {
+        await beginTurnstileWidgetPrepare(containerRef.current, {
           signal: abort.signal,
         });
+        if (!cancelled) {
+          prefetchSession();
+        }
       } catch {
         if (cancelled || abort.signal.aborted) {
           return;

--- a/frontend/src/hooks/useSearch.js
+++ b/frontend/src/hooks/useSearch.js
@@ -22,6 +22,7 @@ import {
   persistSelectedStores,
 } from "../utils/searchUrl";
 import { applyHomeSeo, applySearchSeo } from "../utils/seo";
+import { isTurnstileConfigured } from "../utils/turnstileSession";
 
 const SEARCH_TOO_LONG_ERROR = `Card name is too long (maximum ${MAX_SEARCH_LENGTH} characters).`;
 const SEARCH_TOO_SHORT_ERROR = `Enter at least ${MIN_SEARCH_LENGTH} characters to search.`;
@@ -93,9 +94,11 @@ export default function useSearch() {
   }, [searchResults]);
 
   useEffect(() => {
-    ensureApiSession().catch(() => {
-      // Search will retry session bootstrap before the first API call.
-    });
+    if (!isTurnstileConfigured()) {
+      ensureApiSession().catch(() => {
+        // Search will retry session bootstrap before the first API call.
+      });
+    }
 
     const refreshTimer = setInterval(() => {
       ensureApiSession({ forceRefresh: true }).catch(() => {

--- a/frontend/src/utils/apiSession.js
+++ b/frontend/src/utils/apiSession.js
@@ -18,6 +18,21 @@ const NO_SESSION_WORK = Object.freeze({
   sessionMintDurationMs: 0,
 });
 
+function attributeJoinedBootstrapWait(totalWaitMs, bootstrapTiming) {
+  if (!isTurnstileConfigured()) {
+    return {
+      turnstileDurationMs: null,
+      sessionMintDurationMs: totalWaitMs,
+    };
+  }
+
+  const mintMs = bootstrapTiming.sessionMintDurationMs ?? 0;
+  return {
+    turnstileDurationMs: Math.max(0, totalWaitMs - mintMs),
+    sessionMintDurationMs: mintMs,
+  };
+}
+
 /** Refresh before default API session TTL (15m) so idle tabs stay authorized. */
 export const API_SESSION_REFRESH_INTERVAL_MS = 10 * 60 * 1000;
 
@@ -33,6 +48,7 @@ let sessionBootstrapPromise = null;
  * @returns {Promise<SessionBootstrapTiming>} Time spent in this call. Cached sessions return zeros.
  */
 export async function ensureApiSession(options = {}) {
+  const waitStart = performance.now();
   const { forceRefresh = false } = options;
 
   if (forceRefresh) {
@@ -40,18 +56,28 @@ export async function ensureApiSession(options = {}) {
     resetTurnstileChallenge();
   }
 
+  const initiatedBootstrap = !sessionBootstrapPromise;
   if (!sessionBootstrapPromise) {
     sessionBootstrapPromise = bootstrapSessionWithRetry();
-    try {
-      return await sessionBootstrapPromise;
-    } catch (err) {
-      sessionBootstrapPromise = null;
-      throw err;
-    }
   }
 
-  await sessionBootstrapPromise;
-  return NO_SESSION_WORK;
+  try {
+    const bootstrapTiming = await sessionBootstrapPromise;
+    const totalWaitMs = Math.round(performance.now() - waitStart);
+
+    if (!initiatedBootstrap && totalWaitMs > 0) {
+      return attributeJoinedBootstrapWait(totalWaitMs, bootstrapTiming);
+    }
+
+    if (!initiatedBootstrap) {
+      return NO_SESSION_WORK;
+    }
+
+    return bootstrapTiming;
+  } catch (err) {
+    sessionBootstrapPromise = null;
+    throw err;
+  }
 }
 
 async function bootstrapSessionWithRetry() {

--- a/frontend/src/utils/turnstileSession.js
+++ b/frontend/src/utils/turnstileSession.js
@@ -2,9 +2,12 @@ const TURNSTILE_SCRIPT_SRC =
   "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
 
 const TURNSTILE_TIMEOUT_MS = 30_000;
-const TURNSTILE_WIDGET_READY_TIMEOUT_MS = 20_000;
+/** Caps wait when the widget never registers (e.g. script blocked by an extension). */
+const TURNSTILE_WIDGET_READY_TIMEOUT_MS = 12_000;
+const TURNSTILE_SCRIPT_LOAD_TIMEOUT_MS = 8_000;
 
 let scriptLoadPromise = null;
+let widgetPreparePromise = null;
 let widgetId = null;
 let widgetContainer = null;
 
@@ -44,14 +47,27 @@ function loadTurnstileScript() {
   }
 
   scriptLoadPromise = new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error("turnstile script timeout"));
+    }, TURNSTILE_SCRIPT_LOAD_TIMEOUT_MS);
+
+    const finish = (handler) => {
+      clearTimeout(timeout);
+      handler();
+    };
+
     const existing = document.querySelector(
       `script[src^="https://challenges.cloudflare.com/turnstile/"]`,
     );
     if (existing) {
-      existing.addEventListener("load", () => resolve(), { once: true });
+      if (window.turnstile) {
+        finish(resolve);
+        return;
+      }
+      existing.addEventListener("load", () => finish(resolve), { once: true });
       existing.addEventListener(
         "error",
-        () => reject(new Error("turnstile script failed")),
+        () => finish(() => reject(new Error("turnstile script failed"))),
         { once: true },
       );
       return;
@@ -61,8 +77,9 @@ function loadTurnstileScript() {
     script.src = TURNSTILE_SCRIPT_SRC;
     script.async = true;
     script.defer = true;
-    script.onload = () => resolve();
-    script.onerror = () => reject(new Error("turnstile script failed"));
+    script.onload = () => finish(resolve);
+    script.onerror = () =>
+      finish(() => reject(new Error("turnstile script failed")));
     document.head.appendChild(script);
   });
 
@@ -113,12 +130,35 @@ export function onTurnstileError() {
 export function teardownTurnstileWidget() {
   rejectPendingTokenWaiters(new Error("turnstile widget teardown"));
   cachedToken = "";
+  widgetPreparePromise = null;
   if (widgetId != null && window.turnstile?.remove) {
     window.turnstile.remove(widgetId);
   }
   widgetId = null;
   widgetContainer = null;
   failWidgetReady(new Error("turnstile widget teardown"));
+}
+
+/**
+ * Starts widget preparation once; concurrent callers share the same promise.
+ * TurnstileBootstrap should call this as early as possible on mount.
+ */
+export function beginTurnstileWidgetPrepare(container, options = {}) {
+  if (!isTurnstileConfigured() || !container) {
+    return Promise.resolve();
+  }
+
+  if (widgetPreparePromise) {
+    return widgetPreparePromise;
+  }
+
+  widgetPreparePromise = prepareTurnstileWidget(container, options).catch(
+    (err) => {
+      widgetPreparePromise = null;
+      throw err;
+    },
+  );
+  return widgetPreparePromise;
 }
 
 export async function prepareTurnstileWidget(container, options = {}) {
@@ -215,12 +255,19 @@ function waitForWidgetReady() {
   });
 }
 
+async function ensureTurnstileWidgetReady() {
+  if (widgetPreparePromise) {
+    await widgetPreparePromise;
+  }
+  await waitForWidgetReady();
+}
+
 export async function obtainTurnstileToken() {
   if (!isTurnstileConfigured()) {
     return "";
   }
 
-  await waitForWidgetReady();
+  await ensureTurnstileWidgetReady();
   if (widgetId == null || !window.turnstile) {
     throw new Error("turnstile widget not ready");
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Investigation

The search stats you shared show the **API is fast** (~2.7s server total, ~3.1s client search response) across 17 stores. The ~20s wait before results appear is **not** store scraping — it happens **before** `/search` is called.

### Root cause

Production enables Cloudflare Turnstile for session minting (`GET /session`). Before a search can run, the client must:

1. Load the Turnstile script from `challenges.cloudflare.com`
2. Register the invisible widget
3. Obtain a challenge token and mint the HttpOnly session cookie

`obtainTurnstileToken()` waits up to **20 seconds** for the widget to register (`TURNSTILE_WIDGET_READY_TIMEOUT_MS` in `frontend/src/utils/turnstileSession.js`). If the script is slow to load (cold cache, network, ad blocker, private browsing), the search sits in the "Searching LGS" state until this completes.

### Why stats showed Turnstile/Session as 0ms

`useSearch` called `ensureApiSession()` on mount to prefetch the session. When the user searched, `performSearch` joined that **in-flight** bootstrap promise and received `NO_SESSION_WORK` (`turnstileDurationMs: 0`, `sessionMintDurationMs: 0`) even though it blocked for the full wait. Only the `/search` fetch time (~3s) was recorded — hiding the ~17–20s Turnstile bootstrap.

There was also a race: session bootstrap could start before `TurnstileBootstrap` had begun preparing the widget.

## Fix

- **Prepare Turnstile earlier**: use `useLayoutEffect` and a shared `beginTurnstileWidgetPrepare()` promise; prefetch session only after the widget is ready
- **Preload Turnstile**: add `preconnect` + `preload` for `challenges.cloudflare.com` in `index.html`
- **Fail faster on hung script**: 8s script load timeout; reduce widget-ready cap from 20s → 12s
- **Accurate timing**: when a search awaits an in-flight bootstrap, attribute the wall-clock wait to Turnstile/session in stats

## Expected impact

- First search on a cold visit should start sooner (script download begins before React boots)
- Search stats should now show the Turnstile wait when it was the bottleneck
- Users with Turnstile fully blocked will see an error sooner instead of waiting the full 20s

No backend changes; store fan-out timing is unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c82557a-9b33-4d46-82bb-37261af7efd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c82557a-9b33-4d46-82bb-37261af7efd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

