### PR TITLE
Start Turnstile challenge immediately after widget render

### DIFF
--- a/frontend/src/utils/turnstileSession.js
+++ b/frontend/src/utils/turnstileSession.js
@@ -25,6 +25,8 @@ let widgetReady = createDeferred();
 
 let cachedToken = "";
 let pendingTokenPromise = null;
+/** True after execute() until token, error, expiry, reset, or teardown. */
+let challengeInFlight = false;
 
 function siteKey() {
   const key = import.meta.env.VITE_TURNSTILE_SITE_KEY;
@@ -112,6 +114,7 @@ export function registerTurnstileWidget(id) {
 
 export function onTurnstileToken(token) {
   cachedToken = token;
+  challengeInFlight = false;
   if (pendingTokenPromise) {
     pendingTokenPromise.resolve(token);
     pendingTokenPromise = null;
@@ -120,16 +123,20 @@ export function onTurnstileToken(token) {
 
 export function onTurnstileExpired() {
   cachedToken = "";
+  challengeInFlight = false;
+  startTurnstileChallenge();
 }
 
 export function onTurnstileError() {
   cachedToken = "";
+  challengeInFlight = false;
   rejectPendingTokenWaiters(new Error("turnstile challenge failed"));
 }
 
 export function teardownTurnstileWidget() {
   rejectPendingTokenWaiters(new Error("turnstile widget teardown"));
   cachedToken = "";
+  challengeInFlight = false;
   widgetPreparePromise = null;
   if (widgetId != null && window.turnstile?.remove) {
     window.turnstile.remove(widgetId);
@@ -180,6 +187,7 @@ export async function prepareTurnstileWidget(container, options = {}) {
 
   if (widgetId != null) {
     if (widgetContainer === container && container.isConnected) {
+      startTurnstileChallenge();
       return;
     }
     teardownTurnstileWidget();
@@ -193,7 +201,7 @@ export async function prepareTurnstileWidget(container, options = {}) {
 
   try {
     // Widget mode (Invisible / Managed / …) is chosen in the Cloudflare dashboard for the
-    // sitekey. execution: "execute" defers the challenge until obtainTurnstileToken().
+    // sitekey. execution: "execute" defers the challenge until startTurnstileChallenge().
     const id = window.turnstile.render(container, {
       sitekey: siteKey(),
       execution: "execute",
@@ -203,6 +211,7 @@ export async function prepareTurnstileWidget(container, options = {}) {
     });
     widgetContainer = container;
     registerTurnstileWidget(id);
+    startTurnstileChallenge();
   } catch (err) {
     failWidgetReady(err);
     throw err;
@@ -262,6 +271,17 @@ async function ensureTurnstileWidgetReady() {
   await waitForWidgetReady();
 }
 
+function startTurnstileChallenge() {
+  if (widgetId == null || !window.turnstile?.execute) {
+    return;
+  }
+  if (cachedToken || challengeInFlight) {
+    return;
+  }
+  challengeInFlight = true;
+  window.turnstile.execute(widgetId);
+}
+
 export async function obtainTurnstileToken() {
   if (!isTurnstileConfigured()) {
     return "";
@@ -276,14 +296,16 @@ export async function obtainTurnstileToken() {
     return cachedToken;
   }
 
-  window.turnstile.execute(widgetId);
+  startTurnstileChallenge();
   return waitForTurnstileToken();
 }
 
 export function resetTurnstileChallenge() {
   cachedToken = "";
+  challengeInFlight = false;
   rejectPendingTokenWaiters(new Error("turnstile challenge reset"));
   if (widgetId != null && window.turnstile) {
     window.turnstile.reset(widgetId);
   }
+  startTurnstileChallenge();
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Turnstile challenges now start as soon as the invisible widget finishes rendering, instead of waiting until the first `obtainTurnstileToken()` call during session mint. This lets the Cloudflare challenge run in parallel with page load so the token is more likely to be cached before the user's first search.

## Changes

- Add `startTurnstileChallenge()` with an in-flight guard to avoid duplicate `execute()` calls
- Kick off the challenge right after widget render in `prepareTurnstileWidget`
- Re-start the challenge after `resetTurnstileChallenge()` and on token expiry so a fresh token is prefetched for the next session mint

## Testing

- `cd frontend && npm run lint`
- `make test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a78bd2dc-1e97-4b53-9528-74e6468fa167?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a78bd2dc-1e97-4b53-9528-74e6468fa167&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

