### PR TITLE
Start Turnstile challenge early and warm session before search

### DIFF
--- a/frontend/src/components/SearchStats.jsx
+++ b/frontend/src/components/SearchStats.jsx
@@ -53,6 +53,14 @@ const SearchStats = ({
     Number.isFinite(searchResponseDurationMs) && searchResponseDurationMs >= 0;
   const hasClientTiming =
     hasTurnstileTiming || hasSessionMintTiming || hasSearchResponseTiming;
+  const clientSetupMs =
+    (hasTurnstileTiming ? sessionTurnstileDurationMs : 0) +
+    (hasSessionMintTiming ? sessionMintDurationMs : 0);
+  const showClientSetupNote =
+    hasTotal &&
+    hasClientTiming &&
+    clientSetupMs > totalDurationMs &&
+    clientSetupMs >= 1000;
 
   return (
     <div className="search-stats mt-3 rounded py-2 px-3">
@@ -82,6 +90,13 @@ const SearchStats = ({
                   {storeStats.length > 1
                     ? " (waits for all selected stores and Card Kingdom enrichment; per-store times below)"
                     : " (includes Card Kingdom enrichment wait; per-store time below)"}
+                </p>
+              )}
+              {showClientSetupNote && (
+                <p className="small text-muted mb-2">
+                  Browser session setup (Turnstile and session mint) can take
+                  longer than the server search total below; that work runs in
+                  the browser before the API request.
                 </p>
               )}
               {hasClientTiming && (

--- a/frontend/src/hooks/useSearch.js
+++ b/frontend/src/hooks/useSearch.js
@@ -183,235 +183,254 @@ export default function useSearch() {
       resultsBeforeSearchRef.current = searchResultsRef.current;
       lastSearchRef.current = { query, stores };
 
-      setIsSearching(true);
-      setSearchProgress("Searching LGS");
-      setSearchResults([]);
-      setCardKingdomPrice(null);
-      setHasSearched(true);
-      setSearchError(null);
-      setSearchStoreErrors([]);
-      setSearchStoreStats([]);
-      setSearchTotalDurationMs(null);
-      setSessionTurnstileDurationMs(null);
-      setSessionMintDurationMs(null);
-      setSearchResponseDurationMs(null);
-      setDismissedStoreErrorsKey(null);
-
-      if (window.gtag) {
-        window.gtag("event", "search", { search_term: query });
-      }
-
       const searchUrl = `${API_SEARCH_URL}?s=${encodeURIComponent(query)}&lgs=${encodeURIComponent(stores.join(","))}`;
 
-      const progressInterval = setInterval(() => {
-        setSearchProgress((prev) => {
-          const dots = (prev.match(/\./g) || []).length;
-          if (dots >= MAX_PROGRESS_DOTS) return "Searching LGS";
-          return `${prev} .`;
-        });
-      }, SEARCH_PROGRESS_INTERVAL_MS);
-      progressIntervalRef.current = progressInterval;
-
-      const fetchSearchResult = async (sessionRetried) => {
-        const sessionTiming = await ensureApiSession({
-          forceRefresh: sessionRetried,
-        });
-        setSessionTurnstileDurationMs(sessionTiming.turnstileDurationMs);
-        setSessionMintDurationMs(sessionTiming.sessionMintDurationMs);
-
-        const searchFetchStart = performance.now();
-        const res = await fetch(searchUrl, {
-          signal: searchAbortController.signal,
-          credentials: "include",
-        });
-
-        if (!res.ok) {
-          let errorBody = null;
+      const runSearch = async () => {
+        let prefetchedSessionTiming = null;
+        if (isTurnstileConfigured()) {
           try {
-            errorBody = await res.json();
+            prefetchedSessionTiming = await ensureApiSession();
           } catch {
-            // Ignore malformed error responses.
+            // fetchSearchResult retries session bootstrap before the API call.
           }
+        }
 
-          const validationMessage =
-            typeof errorBody?.error === "string" && errorBody.error
-              ? errorBody.error
-              : null;
-          const statusCode = errorBody?.statusCode || res.status;
+        if (requestId !== activeSearchRequestIdRef.current) {
+          return;
+        }
 
-          if (
-            !sessionRetried &&
-            isApiSessionAccessDenied(validationMessage, statusCode)
-          ) {
-            resetApiSessionCache();
-            return fetchSearchResult(true);
-          }
+        setIsSearching(true);
+        setSearchProgress("Searching LGS");
+        setSearchResults([]);
+        setCardKingdomPrice(null);
+        setHasSearched(true);
+        setSearchError(null);
+        setSearchStoreErrors([]);
+        setSearchStoreStats([]);
+        setSearchTotalDurationMs(null);
+        setSessionTurnstileDurationMs(null);
+        setSessionMintDurationMs(null);
+        setSearchResponseDurationMs(null);
+        setDismissedStoreErrorsKey(null);
 
-          if (validationMessage) {
+        if (window.gtag) {
+          window.gtag("event", "search", { search_term: query });
+        }
+
+        const progressInterval = setInterval(() => {
+          setSearchProgress((prev) => {
+            const dots = (prev.match(/\./g) || []).length;
+            if (dots >= MAX_PROGRESS_DOTS) return "Searching LGS";
+            return `${prev} .`;
+          });
+        }, SEARCH_PROGRESS_INTERVAL_MS);
+        progressIntervalRef.current = progressInterval;
+
+        const fetchSearchResult = async (sessionRetried) => {
+          const sessionTiming = sessionRetried
+            ? await ensureApiSession({ forceRefresh: true })
+            : (prefetchedSessionTiming ?? (await ensureApiSession()));
+          setSessionTurnstileDurationMs(sessionTiming.turnstileDurationMs);
+          setSessionMintDurationMs(sessionTiming.sessionMintDurationMs);
+
+          const searchFetchStart = performance.now();
+          const res = await fetch(searchUrl, {
+            signal: searchAbortController.signal,
+            credentials: "include",
+          });
+
+          if (!res.ok) {
+            let errorBody = null;
+            try {
+              errorBody = await res.json();
+            } catch {
+              // Ignore malformed error responses.
+            }
+
+            const validationMessage =
+              typeof errorBody?.error === "string" && errorBody.error
+                ? errorBody.error
+                : null;
+            const statusCode = errorBody?.statusCode || res.status;
+
+            if (
+              !sessionRetried &&
+              isApiSessionAccessDenied(validationMessage, statusCode)
+            ) {
+              resetApiSessionCache();
+              return fetchSearchResult(true);
+            }
+
+            if (validationMessage) {
+              throw new Error(
+                formatErrorWithStatusCode(validationMessage, statusCode),
+              );
+            }
+
             throw new Error(
-              formatErrorWithStatusCode(validationMessage, statusCode),
+              formatErrorWithStatusCode(
+                res.statusText || "The server returned an error.",
+                statusCode,
+              ),
             );
           }
 
-          throw new Error(
-            formatErrorWithStatusCode(
-              res.statusText || "The server returned an error.",
-              statusCode,
-            ),
+          const result = await res.json();
+          const searchResponseDurationMs = Math.round(
+            performance.now() - searchFetchStart,
           );
-        }
 
-        const result = await res.json();
-        const searchResponseDurationMs = Math.round(
-          performance.now() - searchFetchStart,
-        );
-
-        return {
-          result,
-          sessionTiming,
-          searchResponseDurationMs,
+          return {
+            result,
+            sessionTiming,
+            searchResponseDurationMs,
+          };
         };
-      };
 
-      fetchSearchResult(false)
-        .then(({ result, sessionTiming, searchResponseDurationMs }) => {
-          if (requestId !== activeSearchRequestIdRef.current) return;
-          if (result && Object.hasOwn(result, "data")) {
-            // Treat null data as empty array
-            setSearchResults(result.data || []);
-            setCardKingdomPrice(result.cardKingdomPrice ?? null);
-            const storeErrors = Array.isArray(result.errors)
-              ? result.errors
-              : [];
-            const storeStats = Array.isArray(result.stats) ? result.stats : [];
-            const totalDurationMs = Number.isFinite(result.totalDurationMs)
-              ? result.totalDurationMs
-              : null;
-            setSearchStoreErrors(storeErrors);
-            setSearchStoreStats(storeStats);
-            setSearchTotalDurationMs(totalDurationMs);
-            setSearchResponseDurationMs(searchResponseDurationMs);
+        fetchSearchResult(false)
+          .then(({ result, sessionTiming, searchResponseDurationMs }) => {
+            if (requestId !== activeSearchRequestIdRef.current) return;
+            if (result && Object.hasOwn(result, "data")) {
+              // Treat null data as empty array
+              setSearchResults(result.data || []);
+              setCardKingdomPrice(result.cardKingdomPrice ?? null);
+              const storeErrors = Array.isArray(result.errors)
+                ? result.errors
+                : [];
+              const storeStats = Array.isArray(result.stats)
+                ? result.stats
+                : [];
+              const totalDurationMs = Number.isFinite(result.totalDurationMs)
+                ? result.totalDurationMs
+                : null;
+              setSearchStoreErrors(storeErrors);
+              setSearchStoreStats(storeStats);
+              setSearchTotalDurationMs(totalDurationMs);
+              setSearchResponseDurationMs(searchResponseDurationMs);
+              setDismissedStoreErrorsKey(null);
+              if (!skipHistorySyncRef.current) {
+                syncSearchHistory({
+                  query,
+                  stores,
+                  results: result.data || [],
+                  storeErrors,
+                  storeStats,
+                  totalDurationMs,
+                  sessionTurnstileDurationMs: sessionTiming.turnstileDurationMs,
+                  sessionMintDurationMs: sessionTiming.sessionMintDurationMs,
+                  searchResponseDurationMs,
+                  hasSearched: true,
+                  searchError: null,
+                  cardKingdomPrice: result.cardKingdomPrice ?? null,
+                });
+              }
+              skipHistorySyncRef.current = false;
+              if (window.gtag) {
+                window.gtag("event", "view_search_results", {
+                  search_term: query,
+                });
+              }
+            } else {
+              throw new Error("Invalid response format from server");
+            }
+          })
+          .catch((err) => {
+            if (err.name === "AbortError") {
+              if (
+                userCancelledRef.current &&
+                requestId === activeSearchRequestIdRef.current
+              ) {
+                const previousResults = resultsBeforeSearchRef.current;
+                setSearchResults(previousResults);
+                setHasSearched(previousResults.length > 0);
+                setSearchError(null);
+                setSearchStoreErrors([]);
+                setSearchStoreStats([]);
+                setSearchTotalDurationMs(null);
+                setSessionTurnstileDurationMs(null);
+                setSessionMintDurationMs(null);
+                setSearchResponseDurationMs(null);
+                setDismissedStoreErrorsKey(null);
+                userCancelledRef.current = false;
+              }
+              return;
+            }
+            if (requestId !== activeSearchRequestIdRef.current) return;
+            console.error("Search error:", err);
+            setSearchResults([]);
+            setSearchStoreErrors([]);
+            setSearchStoreStats([]);
+            setSearchTotalDurationMs(null);
+            setSessionTurnstileDurationMs(null);
+            setSessionMintDurationMs(null);
+            setSearchResponseDurationMs(null);
             setDismissedStoreErrorsKey(null);
+
+            let nextSearchError;
+            // Set user-friendly error message
+            if (
+              err.message.includes("Failed to fetch") ||
+              err.name === "TypeError"
+            ) {
+              nextSearchError =
+                "Unable to connect to the server. Please check your internet connection and try again.";
+            } else if (
+              typeof err.message === "string" &&
+              (err.message.includes("turnstile") ||
+                err.message.includes("API session verification"))
+            ) {
+              nextSearchError =
+                "Could not verify this browser session. Please refresh the page and try again.";
+            } else if (err.message.includes("API session failed")) {
+              nextSearchError =
+                "The server is experiencing issues. Please try again later.";
+            } else if (err.message.startsWith("Error (")) {
+              nextSearchError = err.message;
+            } else if (err.message.includes("Server error")) {
+              nextSearchError =
+                "The server is experiencing issues. Please try again later.";
+            } else {
+              nextSearchError =
+                "An error occurred while searching. Please try again.";
+            }
+            setSearchError(nextSearchError);
+
             if (!skipHistorySyncRef.current) {
               syncSearchHistory({
                 query,
                 stores,
-                results: result.data || [],
-                storeErrors,
-                storeStats,
-                totalDurationMs,
-                sessionTurnstileDurationMs: sessionTiming.turnstileDurationMs,
-                sessionMintDurationMs: sessionTiming.sessionMintDurationMs,
-                searchResponseDurationMs,
+                results: [],
+                storeErrors: [],
+                storeStats: [],
+                totalDurationMs: null,
+                sessionTurnstileDurationMs: null,
+                sessionMintDurationMs: null,
+                searchResponseDurationMs: null,
                 hasSearched: true,
-                searchError: null,
-                cardKingdomPrice: result.cardKingdomPrice ?? null,
+                searchError: nextSearchError,
+                cardKingdomPrice: null,
               });
             }
             skipHistorySyncRef.current = false;
-            if (window.gtag) {
-              window.gtag("event", "view_search_results", {
-                search_term: query,
-              });
+          })
+          .finally(() => {
+            clearInterval(progressInterval);
+            if (progressIntervalRef.current === progressInterval) {
+              progressIntervalRef.current = null;
             }
-          } else {
-            throw new Error("Invalid response format from server");
-          }
-        })
-        .catch((err) => {
-          if (err.name === "AbortError") {
-            if (
-              userCancelledRef.current &&
-              requestId === activeSearchRequestIdRef.current
-            ) {
-              const previousResults = resultsBeforeSearchRef.current;
-              setSearchResults(previousResults);
-              setHasSearched(previousResults.length > 0);
-              setSearchError(null);
-              setSearchStoreErrors([]);
-              setSearchStoreStats([]);
-              setSearchTotalDurationMs(null);
-              setSessionTurnstileDurationMs(null);
-              setSessionMintDurationMs(null);
-              setSearchResponseDurationMs(null);
-              setDismissedStoreErrorsKey(null);
-              userCancelledRef.current = false;
+
+            if (searchAbortControllerRef.current === searchAbortController) {
+              searchAbortControllerRef.current = null;
             }
-            return;
-          }
-          if (requestId !== activeSearchRequestIdRef.current) return;
-          console.error("Search error:", err);
-          setSearchResults([]);
-          setSearchStoreErrors([]);
-          setSearchStoreStats([]);
-          setSearchTotalDurationMs(null);
-          setSessionTurnstileDurationMs(null);
-          setSessionMintDurationMs(null);
-          setSearchResponseDurationMs(null);
-          setDismissedStoreErrorsKey(null);
 
-          let nextSearchError;
-          // Set user-friendly error message
-          if (
-            err.message.includes("Failed to fetch") ||
-            err.name === "TypeError"
-          ) {
-            nextSearchError =
-              "Unable to connect to the server. Please check your internet connection and try again.";
-          } else if (
-            typeof err.message === "string" &&
-            (err.message.includes("turnstile") ||
-              err.message.includes("API session verification"))
-          ) {
-            nextSearchError =
-              "Could not verify this browser session. Please refresh the page and try again.";
-          } else if (err.message.includes("API session failed")) {
-            nextSearchError =
-              "The server is experiencing issues. Please try again later.";
-          } else if (err.message.startsWith("Error (")) {
-            nextSearchError = err.message;
-          } else if (err.message.includes("Server error")) {
-            nextSearchError =
-              "The server is experiencing issues. Please try again later.";
-          } else {
-            nextSearchError =
-              "An error occurred while searching. Please try again.";
-          }
-          setSearchError(nextSearchError);
+            if (requestId !== activeSearchRequestIdRef.current) return;
+            setIsSearching(false);
+            setSearchProgress("Search");
+            skipSuggestionsRef.current = false;
+          });
+      };
 
-          if (!skipHistorySyncRef.current) {
-            syncSearchHistory({
-              query,
-              stores,
-              results: [],
-              storeErrors: [],
-              storeStats: [],
-              totalDurationMs: null,
-              sessionTurnstileDurationMs: null,
-              sessionMintDurationMs: null,
-              searchResponseDurationMs: null,
-              hasSearched: true,
-              searchError: nextSearchError,
-              cardKingdomPrice: null,
-            });
-          }
-          skipHistorySyncRef.current = false;
-        })
-        .finally(() => {
-          clearInterval(progressInterval);
-          if (progressIntervalRef.current === progressInterval) {
-            progressIntervalRef.current = null;
-          }
-
-          if (searchAbortControllerRef.current === searchAbortController) {
-            searchAbortControllerRef.current = null;
-          }
-
-          if (requestId !== activeSearchRequestIdRef.current) return;
-          setIsSearching(false);
-          setSearchProgress("Search");
-          skipSuggestionsRef.current = false;
-        });
+      void runSearch();
     },
     [syncSearchHistory],
   );
@@ -744,7 +763,18 @@ export default function useSearch() {
       const urlStores = getStoresFromUrl(urlParams);
       const stores = urlStores ?? selectedStores;
 
-      setTimeout(() => performSearch(q, stores), 100);
+      const runInitialUrlSearch = async () => {
+        if (isTurnstileConfigured()) {
+          // Warm the session before searching so Turnstile runs during page load
+          // (TurnstileBootstrap prefetch) instead of blocking the first search.
+          await ensureApiSession().catch(() => {
+            // performSearch retries session bootstrap before the API call.
+          });
+        }
+        performSearch(q, stores);
+      };
+
+      void runInitialUrlSearch();
     }
   }, [performSearch, selectedStores]);
 

--- a/frontend/src/utils/turnstileSession.js
+++ b/frontend/src/utils/turnstileSession.js
@@ -309,3 +309,9 @@ export function resetTurnstileChallenge() {
   }
   startTurnstileChallenge();
 }
+
+if (isTurnstileConfigured()) {
+  loadTurnstileScript().catch(() => {
+    // TurnstileBootstrap / session mint will retry on prepare.
+  });
+}

--- a/frontend/src/utils/turnstileSession.js
+++ b/frontend/src/utils/turnstileSession.js
@@ -25,6 +25,8 @@ let widgetReady = createDeferred();
 
 let cachedToken = "";
 let pendingTokenPromise = null;
+/** True after execute() until token, error, expiry, reset, or teardown. */
+let challengeInFlight = false;
 
 function siteKey() {
   const key = import.meta.env.VITE_TURNSTILE_SITE_KEY;
@@ -112,6 +114,7 @@ export function registerTurnstileWidget(id) {
 
 export function onTurnstileToken(token) {
   cachedToken = token;
+  challengeInFlight = false;
   if (pendingTokenPromise) {
     pendingTokenPromise.resolve(token);
     pendingTokenPromise = null;
@@ -120,16 +123,20 @@ export function onTurnstileToken(token) {
 
 export function onTurnstileExpired() {
   cachedToken = "";
+  challengeInFlight = false;
+  startTurnstileChallenge();
 }
 
 export function onTurnstileError() {
   cachedToken = "";
+  challengeInFlight = false;
   rejectPendingTokenWaiters(new Error("turnstile challenge failed"));
 }
 
 export function teardownTurnstileWidget() {
   rejectPendingTokenWaiters(new Error("turnstile widget teardown"));
   cachedToken = "";
+  challengeInFlight = false;
   widgetPreparePromise = null;
   if (widgetId != null && window.turnstile?.remove) {
     window.turnstile.remove(widgetId);
@@ -180,6 +187,7 @@ export async function prepareTurnstileWidget(container, options = {}) {
 
   if (widgetId != null) {
     if (widgetContainer === container && container.isConnected) {
+      startTurnstileChallenge();
       return;
     }
     teardownTurnstileWidget();
@@ -193,7 +201,7 @@ export async function prepareTurnstileWidget(container, options = {}) {
 
   try {
     // Widget mode (Invisible / Managed / …) is chosen in the Cloudflare dashboard for the
-    // sitekey. execution: "execute" defers the challenge until obtainTurnstileToken().
+    // sitekey. execution: "execute" defers the challenge until startTurnstileChallenge().
     const id = window.turnstile.render(container, {
       sitekey: siteKey(),
       execution: "execute",
@@ -203,6 +211,7 @@ export async function prepareTurnstileWidget(container, options = {}) {
     });
     widgetContainer = container;
     registerTurnstileWidget(id);
+    startTurnstileChallenge();
   } catch (err) {
     failWidgetReady(err);
     throw err;
@@ -262,6 +271,17 @@ async function ensureTurnstileWidgetReady() {
   await waitForWidgetReady();
 }
 
+function startTurnstileChallenge() {
+  if (widgetId == null || !window.turnstile?.execute) {
+    return;
+  }
+  if (cachedToken || challengeInFlight) {
+    return;
+  }
+  challengeInFlight = true;
+  window.turnstile.execute(widgetId);
+}
+
 export async function obtainTurnstileToken() {
   if (!isTurnstileConfigured()) {
     return "";
@@ -276,14 +296,16 @@ export async function obtainTurnstileToken() {
     return cachedToken;
   }
 
-  window.turnstile.execute(widgetId);
+  startTurnstileChallenge();
   return waitForTurnstileToken();
 }
 
 export function resetTurnstileChallenge() {
   cachedToken = "";
+  challengeInFlight = false;
   rejectPendingTokenWaiters(new Error("turnstile challenge reset"));
   if (widgetId != null && window.turnstile) {
     window.turnstile.reset(widgetId);
   }
+  startTurnstileChallenge();
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Session bootstrap is warmed **before** the first search blocks on it, building on the early Turnstile challenge work already merged in #375. This addresses cases where search stats showed ~15s Turnstile time while the server search only took ~1s.

## Root cause

Searches could start (especially from `?s=` URL params after only 100ms) while the Turnstile widget was still loading. The search then blocked on session mint and attributed the full wall-clock wait to "Turnstile" in search stats.

## Changes

- Eager-load Turnstile script on module init when configured
- Warm API session before showing the searching spinner
- URL-driven searches await session bootstrap instead of a fixed 100ms timeout
- Search stats note when browser session setup exceeds server total time
- Rebased on master (includes #375 early `execute()` after widget render)

## Testing

- `cd frontend && npm run lint`
- Merge conflict with master resolved in `turnstileSession.js`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a78bd2dc-1e97-4b53-9528-74e6468fa167?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a78bd2dc-1e97-4b53-9528-74e6468fa167&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

