### PR TITLE
Fix landing URL search blocked by redundant session prefetch

### DIFF
--- a/frontend/src/hooks/useSearch.js
+++ b/frontend/src/hooks/useSearch.js
@@ -747,8 +747,9 @@ export default function useSearch() {
   }, []);
 
   // --- Initialization ---
-  // Note: performSearch is included in deps but is stable (empty dep array in useCallback)
-  // This effect should only run once on mount, not when selectedStores changes
+  // Run once on mount when the URL includes ?s=. Defer with queueMicrotask so
+  // TurnstileBootstrap's useLayoutEffect can start widget prepare first; performSearch
+  // already warms the API session before showing the searching spinner.
   const hasInitializedRef = useRef(false);
 
   useEffect(() => {
@@ -756,27 +757,20 @@ export default function useSearch() {
     hasInitializedRef.current = true;
 
     const urlParams = new URLSearchParams(window.location.search);
-    if (urlParams.has("s") && urlParams.get("s") !== "") {
-      const q = decodeURIComponent(urlParams.get("s"));
-      skipSuggestionsRef.current = true;
-
-      const urlStores = getStoresFromUrl(urlParams);
-      const stores = urlStores ?? selectedStores;
-
-      const runInitialUrlSearch = async () => {
-        if (isTurnstileConfigured()) {
-          // Warm the session before searching so Turnstile runs during page load
-          // (TurnstileBootstrap prefetch) instead of blocking the first search.
-          await ensureApiSession().catch(() => {
-            // performSearch retries session bootstrap before the API call.
-          });
-        }
-        performSearch(q, stores);
-      };
-
-      void runInitialUrlSearch();
+    if (!urlParams.has("s") || urlParams.get("s") === "") {
+      return;
     }
-  }, [performSearch, selectedStores]);
+
+    const q = decodeURIComponent(urlParams.get("s"));
+    skipSuggestionsRef.current = true;
+
+    const urlStores = getStoresFromUrl(urlParams);
+    const stores = urlStores ?? selectedStores;
+
+    queueMicrotask(() => {
+      performSearchRef.current(q, resolveStoresToSearch(stores));
+    });
+  }, [resolveStoresToSearch, selectedStores]);
 
   return {
     searchQuery,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes auto-search on landing when the URL includes a card name (`?s=...`), which regressed in #376.

## Root cause

PR #376 changed the mount effect to `await ensureApiSession()` before calling `performSearch` for URL-driven searches. That duplicated the session warm-up already performed inside `performSearch`, and could race with `TurnstileBootstrap` during page load. In some cases the query was populated from the URL but the search never started.

## Fix

- Call `performSearch` directly again for `?s=` links (via `performSearchRef` + `queueMicrotask` so `TurnstileBootstrap`'s layout effect can start widget prepare first)
- Remove the redundant `ensureApiSession` prefetch from the mount effect
- Apply `resolveStoresToSearch` so users with an empty saved store selection still search all stores (matching manual search submit behavior)

## Testing

- Manual: `http://localhost:5174/?s=Opt` — search input populated and search attempt triggered (Turnstile/API errors in cloud env are expected; the important part is the search starts)
- `npm run lint` passes
- `make test` — unrelated live Agora gateway timeout in this environment
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49ae8324-b965-47ec-97f3-4c51bdfe37f1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49ae8324-b965-47ec-97f3-4c51bdfe37f1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

