### PR TITLE
Hide Turnstile timing in search stats when disabled

### DIFF
--- a/frontend/src/components/SearchStats.jsx
+++ b/frontend/src/components/SearchStats.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Form } from "react-bootstrap";
+import { isTurnstileConfigured } from "../utils/turnstileSession";
 
 const SEARCH_STATS_STORAGE_KEY = "gishathfetch-show-search-stats";
 
@@ -46,7 +47,8 @@ const SearchStats = ({
 
   const storeStats = Array.isArray(stats) ? stats : [];
   const hasTotal = Number.isFinite(totalDurationMs) && totalDurationMs >= 0;
-  const hasTurnstileTiming = sessionTurnstileDurationMs !== null;
+  const hasTurnstileTiming =
+    isTurnstileConfigured() && sessionTurnstileDurationMs !== null;
   const hasSessionMintTiming =
     Number.isFinite(sessionMintDurationMs) && sessionMintDurationMs >= 0;
   const hasSearchResponseTiming =

--- a/frontend/src/utils/apiSession.js
+++ b/frontend/src/utils/apiSession.js
@@ -13,10 +13,12 @@ import {
  */
 
 /** @type {SessionBootstrapTiming} */
-const NO_SESSION_WORK = Object.freeze({
-  turnstileDurationMs: 0,
-  sessionMintDurationMs: 0,
-});
+function noSessionWork() {
+  return {
+    turnstileDurationMs: isTurnstileConfigured() ? 0 : null,
+    sessionMintDurationMs: 0,
+  };
+}
 
 function attributeJoinedBootstrapWait(totalWaitMs, bootstrapTiming) {
   if (!isTurnstileConfigured()) {
@@ -70,7 +72,7 @@ export async function ensureApiSession(options = {}) {
     }
 
     if (!initiatedBootstrap) {
-      return NO_SESSION_WORK;
+      return noSessionWork();
     }
 
     return bootstrapTiming;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hides the Turnstile row from search stats when Turnstile is not configured (follow-up to #379).

## Changes

- Return `null` (not `0`) for `turnstileDurationMs` from cached session bootstrap when the site key is unset
- Only render the Turnstile row in search stats when `isTurnstileConfigured()`

## Testing

- `cd frontend && npm run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a78bd2dc-1e97-4b53-9528-74e6468fa167?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a78bd2dc-1e97-4b53-9528-74e6468fa167&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

