### PR TITLE
Fix origin verify for browser traffic on api custom domain

### DIFF
--- a/api/handler/access.go
+++ b/api/handler/access.go
@@ -17,8 +17,9 @@ func enforceOriginVerify(
 	apiRes events.APIGatewayProxyResponse,
 	origin string,
 	headers map[string]string,
+	domainName string,
 ) (events.APIGatewayProxyResponse, bool) {
-	if err := apiauth.VerifyOriginHeader(headers); err != nil {
+	if err := apiauth.VerifyOriginHeader(headers, domainName); err != nil {
 		return accessDeniedResponse(apiRes, origin, "forbidden"), false
 	}
 	return apiRes, true

--- a/api/handler/search.go
+++ b/api/handler/search.go
@@ -63,7 +63,7 @@ func Search(ctx context.Context, request events.APIGatewayProxyRequest) (events.
 		return optionsResponse(origin)
 	}
 
-	if res, ok := enforceOriginVerify(apiRes, origin, request.Headers); !ok {
+	if res, ok := enforceOriginVerify(apiRes, origin, request.Headers, request.RequestContext.DomainName); !ok {
 		return res, nil
 	}
 	if res, ok := enforceSession(apiRes, origin, request.Headers); !ok {

--- a/api/handler/session.go
+++ b/api/handler/session.go
@@ -30,7 +30,7 @@ func Session(ctx context.Context, request events.APIGatewayProxyRequest) (events
 		return errorResponse(apiRes, origin, "method not allowed", http.StatusMethodNotAllowed)
 	}
 
-	if res, ok := enforceOriginVerify(apiRes, origin, request.Headers); !ok {
+	if res, ok := enforceOriginVerify(apiRes, origin, request.Headers, request.RequestContext.DomainName); !ok {
 		return res, nil
 	}
 

--- a/api/pkg/apiauth/origin.go
+++ b/api/pkg/apiauth/origin.go
@@ -3,6 +3,7 @@ package apiauth
 import (
 	"crypto/subtle"
 	"errors"
+	"slices"
 	"strings"
 
 	"mtg-price-checker-sg/pkg/config"
@@ -11,11 +12,11 @@ import (
 var errOriginVerifyFailed = errors.New("origin verification failed")
 
 // VerifyOriginHeader enforces access when API_ORIGIN_VERIFY_SECRET is set.
-// Requests must include a matching X-Origin-Verify header (injected by CloudFront
-// on the origin request, or by the Vite dev proxy). Allowlisted Origin alone is
-// not accepted: it is trivially spoofed on direct execute-api calls that bypass
-// CloudFront and WAF.
-func VerifyOriginHeader(headers map[string]string) error {
+// Requests with a matching X-Origin-Verify header pass (e.g. CloudFront origin or
+// the Vite dev proxy). Browser calls via the API custom domain (not execute-api)
+// may omit that header and use an allowlisted Origin instead. Allowlisted Origin
+// alone is rejected on execute-api hostnames because it is trivially spoofed.
+func VerifyOriginHeader(headers map[string]string, domainName string) error {
 	secret := config.APIOriginVerifySecret()
 	if secret == "" {
 		return nil
@@ -23,13 +24,27 @@ func VerifyOriginHeader(headers map[string]string) error {
 
 	headerName := strings.ToLower(config.APIOriginVerifyHeader())
 	got := strings.TrimSpace(headerValue(headers, headerName))
-	if got == "" {
+	if got != "" {
+		if subtle.ConstantTimeCompare([]byte(got), []byte(secret)) == 1 {
+			return nil
+		}
 		return errOriginVerifyFailed
 	}
-	if subtle.ConstantTimeCompare([]byte(got), []byte(secret)) == 1 {
+
+	if isExecuteAPIGatewayDomain(domainName) {
+		return errOriginVerifyFailed
+	}
+
+	origin := strings.TrimSpace(headerValue(headers, "origin"))
+	if origin != "" && slices.Contains(config.GetAllowedOrigins(), origin) {
 		return nil
 	}
+
 	return errOriginVerifyFailed
+}
+
+func isExecuteAPIGatewayDomain(domainName string) bool {
+	return strings.Contains(strings.ToLower(strings.TrimSpace(domainName)), ".execute-api.")
 }
 
 func headerValue(headers map[string]string, lowerName string) string {

--- a/api/pkg/apiauth/session_test.go
+++ b/api/pkg/apiauth/session_test.go
@@ -36,15 +36,24 @@ func TestVerifyOriginHeader(t *testing.T) {
 	require.NoError(t, os.Setenv(config.APIOriginVerifySecretEnv, "cloudfront-secret"))
 	t.Cleanup(func() { _ = os.Unsetenv(config.APIOriginVerifySecretEnv) })
 
-	err := VerifyOriginHeader(map[string]string{"x-origin-verify": "cloudfront-secret"})
+	err := VerifyOriginHeader(map[string]string{"x-origin-verify": "cloudfront-secret"}, "")
 	require.NoError(t, err)
 
-	err = VerifyOriginHeader(map[string]string{"x-origin-verify": "wrong"})
+	err = VerifyOriginHeader(map[string]string{"x-origin-verify": "wrong"}, "")
 	require.ErrorIs(t, err, errOriginVerifyFailed)
 
-	err = VerifyOriginHeader(map[string]string{"origin": "https://gishathfetch.com"})
+	err = VerifyOriginHeader(
+		map[string]string{"origin": "https://gishathfetch.com"},
+		"api.gishathfetch.com",
+	)
+	require.NoError(t, err)
+
+	err = VerifyOriginHeader(
+		map[string]string{"origin": "https://gishathfetch.com"},
+		"abc123.execute-api.ap-southeast-1.amazonaws.com",
+	)
 	require.ErrorIs(t, err, errOriginVerifyFailed)
 
-	err = VerifyOriginHeader(map[string]string{})
+	err = VerifyOriginHeader(map[string]string{}, "api.gishathfetch.com")
 	require.ErrorIs(t, err, errOriginVerifyFailed)
 }

--- a/docs/api-abuse-mitigation.md
+++ b/docs/api-abuse-mitigation.md
@@ -57,10 +57,17 @@ execute-api URL cannot be used with a spoofed `Origin` header alone.
 | Optional header name override | `API_ORIGIN_VERIFY_HEADER` (default `X-Origin-Verify`) |
 | Code | `api/pkg/apiauth/origin.go`, enforced in `handler/search.go` and `handler/session.go` |
 
-When `API_ORIGIN_VERIFY_SECRET` is set, a request passes origin verification only
-when it includes `X-Origin-Verify` (or the configured header) equal to the secret.
-Allowlisted `Origin` alone is **not** accepted (it is trivially spoofed on direct
-`execute-api` calls that bypass CloudFront and WAF).
+When `API_ORIGIN_VERIFY_SECRET` is set, a request passes origin verification when
+either:
+
+1. It includes `X-Origin-Verify` (or the configured header) equal to the secret
+   (CloudFront origin request or Vite dev proxy), or
+2. It arrives on the **API custom domain** (not `*.execute-api.*.amazonaws.com`)
+   with an allowlisted `Origin` header (normal browser traffic to
+   `api.gishathfetch.com`).
+
+Allowlisted `Origin` alone is **rejected** on execute-api hostnames because it is
+trivially spoofed on direct calls that bypass the custom domain.
 
 Otherwise the handler returns **403** (`forbidden`).
 
@@ -72,9 +79,10 @@ custom origin for `/api/*` / search paths), add a **custom origin header**:
 - Name: `X-Origin-Verify` (unless you override `API_ORIGIN_VERIFY_HEADER`)
 - Value: the same string as Lambda `API_ORIGIN_VERIFY_SECRET`
 
-Keep the secret out of the SPA bundle. Browsers reach `api.gishathfetch.com`
-through CloudFront; CloudFront adds this header on the **origin request** to API
-Gateway (viewers never send it).
+Keep the secret out of the SPA bundle. When CloudFront fronts the API, it can add
+this header on the **origin request** to API Gateway (viewers never send it).
+Browser calls to `api.gishathfetch.com` also pass via allowlisted `Origin` when
+the request hostname is the custom domain.
 
 ### Lock down the execute-api URL
 
@@ -83,9 +91,8 @@ support API Gateway resource policies or IP allowlists the way REST APIs do, so
 you cannot block the raw `*.execute-api.*.amazonaws.com` hostname at the gateway
 with a CloudFront managed prefix list alone.
 
-With `API_ORIGIN_VERIFY_SECRET` set and CloudFront injecting `X-Origin-Verify`,
-direct calls to the execute-api URL are rejected unless the caller also knows the
-secret:
+With `API_ORIGIN_VERIFY_SECRET` set, direct calls to the execute-api URL are
+rejected even with a spoofed allowlisted `Origin`:
 
 ```bash
 # Bypass attempt — should return 403 forbidden (Origin spoofing is not enough)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After #381, users see **"Could not verify this browser session. Please refresh the page and try again."** when searching.

That message is shown when `GET /session` returns 403 during session bootstrap. I confirmed production currently rejects browser traffic:

```bash
curl -si "https://api.gishathfetch.com/session" -H "Origin: https://gishathfetch.com"
# → 403 {"error":"forbidden","statusCode":403}
```

#381 tightened origin verification to require `X-Origin-Verify` only. Production routes `api.gishathfetch.com` directly to API Gateway (response includes `apigw-requestid`), so CloudFront never injects that header. Legitimate browser requests only send an allowlisted `Origin` header.

## Fix

Accept origin verification when **either**:

1. `X-Origin-Verify` matches the secret (CloudFront / Vite proxy path), or
2. The request hostname is the API **custom domain** (not `*.execute-api.*.amazonaws.com`) **and** `Origin` is allowlisted.

This restores normal browser traffic on `api.gishathfetch.com` while still blocking execute-api bypass attempts that spoof `Origin`.

## Testing

- `go test -mod=vendor ./pkg/apiauth/... ./handler/...`
- `make test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5b5d344-e174-4055-b8cd-b4f919069d4d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5b5d344-e174-4055-b8cd-b4f919069d4d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

