### PR TITLE
Strip /default API Gateway stage prefix for CloudFront origin path

### DIFF
--- a/api/handler/path.go
+++ b/api/handler/path.go
@@ -17,7 +17,7 @@ func normalizeAPIPath(request events.APIGatewayProxyRequest) string {
 		path = "/"
 	}
 
-	for _, prefix := range []string{"/prod", "/staging", "/dev"} {
+	for _, prefix := range []string{"/prod", "/staging", "/dev", "/default"} {
 		if strings.HasPrefix(path, prefix+"/") || path == prefix {
 			path = strings.TrimPrefix(path, prefix)
 			if path == "" {

--- a/api/handler/path_test.go
+++ b/api/handler/path_test.go
@@ -19,6 +19,8 @@ func Test_normalizeAPIPath(t *testing.T) {
 		{"/api/search", "search"},
 		{"/api/session", "session"},
 		{"/prod/search", "search"},
+		{"/default/search", "search"},
+		{"/default/session", "session"},
 		{"/prod/api/search", "search"},
 		{"/prod/api", ""},
 		{"/", ""},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

API CloudFront (`d3rsi676nigizy.cloudfront.net`) uses execute-api as origin with **origin path `/default`**. Requests reach Lambda as `/default/session` and `/default/search`, but `normalizeAPIPath` only stripped `/prod`, `/staging`, and `/dev`, so routes returned `404 not found`.

Custom domain traffic (`api.gishathfetch.com/session`) is unaffected — API Gateway maps those paths without a stage prefix.

## Fix

Add `/default` to the stage prefix list in `normalizeAPIPath`.

## Safety

- Existing paths `/session`, `/search`, `/api/search`, `/prod/search` behave exactly as before.
- Only requests that include a `/default/` prefix are newly normalized.

## Testing

- `go test ./handler/...` (includes `/default/search` and `/default/session` cases)
- `make test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5b5d344-e174-4055-b8cd-b4f919069d4d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5b5d344-e174-4055-b8cd-b4f919069d4d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

