### PR TITLE
Align docs with recent API infrastructure changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,16 +110,18 @@ Proxy target: `VITE_API_PROXY_TARGET` (default `https://api.gishathfetch.com`). 
 `VITE_API_ORIGIN_VERIFY_SECRET` when testing against an environment with
 `API_ORIGIN_VERIFY_SECRET` enabled.
 
-Full reference for the three abuse-mitigation layers:
+Full reference for the two abuse-mitigation layers:
 [`docs/api-abuse-mitigation.md`](docs/api-abuse-mitigation.md).
 
 #### API abuse mitigation (overview)
 
 Two optional layers; each is **off until configured**:
 
-1. **CloudFront → API origin secret** (`API_ORIGIN_VERIFY_SECRET`): requests must send
-   matching `X-Origin-Verify` (CloudFront custom origin header or Vite dev proxy).
-   Enforced on both `/session` and `/search`.
+1. **CloudFront → API origin secret** (`API_ORIGIN_VERIFY_SECRET`): when set, requests
+   must pass origin verification — either a matching `X-Origin-Verify` header
+   (CloudFront custom origin header or Vite dev proxy) or an allowlisted `Origin`
+   on the API custom domain (`api.gishathfetch.com`, not `execute-api`). Enforced
+   on both `/session` and `/search`.
 2. **Session cookie** (`API_SESSION_SECRET`): `GET /session` mints HttpOnly `gf_api_session`
    (default TTL 15m via `API_SESSION_TTL_SECONDS`). `/search` requires a valid cookie
    (`session required` / `session expired` → 403). Frontend: `ensureApiSession()` with a

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ It aggregates listings from supported stores, normalizes results, and sorts by p
 Gishath Fetch is a static React SPA served from S3 behind CloudFront. Search and
 session use **`https://api.gishathfetch.com/search`** and **`/session`** from the
 browser (cross-origin, credentialed). API Gateway invokes a container-based Lambda
-that scrapes LGS sites in parallel. Inbound API abuse mitigation uses three
+that scrapes LGS sites in parallel. Inbound API abuse mitigation uses two
 optional layers: a CloudFront→API origin-verify secret (`X-Origin-Verify`), a
 short-lived HttpOnly session cookie (`gf_api_session`) — see
 [`docs/api-abuse-mitigation.md`](docs/api-abuse-mitigation.md). When

--- a/docs/api-abuse-mitigation.md
+++ b/docs/api-abuse-mitigation.md
@@ -24,7 +24,7 @@ sequenceDiagram
 
     Note over U: SPA load (gishathfetch.com)
     U->>API: GET /session
-    Note over API: origin check (X-Origin-Verify<br/>from CloudFront)
+    Note over API: origin check (allowlisted Origin<br/>on api.gishathfetch.com)
     API-->>U: 204 + Set-Cookie: gf_api_session=...
     U->>API: GET /search?s=... (credentials: include)
     Note over API: origin check + session cookie HMAC
@@ -40,9 +40,10 @@ CloudFront and inject the origin-verify header (see below).
 
 ## 1. CloudFront → API origin secret
 
-**Purpose:** Reject callers that do not arrive through a trusted edge hop (CloudFront
-or the Vite dev proxy) that injects a shared secret. When this layer is on, the
-execute-api URL cannot be used with a spoofed `Origin` header alone.
+**Purpose:** Reject direct `execute-api` bypass attempts and other callers that
+cannot prove an allowlisted browser origin or a shared edge secret. When this
+layer is on, the execute-api URL cannot be used with a spoofed `Origin` header
+alone.
 
 | Item | Value |
 |------|--------|
@@ -100,15 +101,18 @@ curl -i "https://api.gishathfetch.com/search?s=Opt" \
 
 **Checklist**
 
-1. `api.gishathfetch.com` DNS points to the **API CloudFront** distribution (not
-   directly to API Gateway).
-2. CloudFront origin custom header `X-Origin-Verify` matches Lambda
-   `API_ORIGIN_VERIFY_SECRET`.
-3. `API_ORIGIN_VERIFY_SECRET` is set on Lambda `mtg-price-scrapper`.
-4. Verify step 1 with the curl probes above after deploy.
+1. `api.gishathfetch.com` is mapped to the HTTP API custom domain (production
+   routes directly to API Gateway; allowlisted `Origin` satisfies origin verify
+   for browser traffic).
+2. `API_ORIGIN_VERIFY_SECRET` is set on Lambda `mtg-price-scrapper`.
+3. Verify with the curl probes above after deploy (execute-api bypass blocked;
+   custom domain + allowlisted `Origin` works).
+4. **Optional:** if CloudFront fronts the API origin, its custom header
+   `X-Origin-Verify` must match `API_ORIGIN_VERIFY_SECRET` (browsers still pass
+   via allowlisted `Origin` when using the custom domain).
 
-**Stronger options** (optional; not required when the secret + CloudFront path is
-in place):
+**Stronger options** (optional; not required when origin verify and the custom
+domain path are in place):
 
 - **Lambda authorizer** on the HTTP API that rejects requests missing the secret
   (blocks before the search Lambda runs; same check, earlier in the chain).
@@ -177,7 +181,7 @@ When `API_SESSION_SECRET` is set, `/search` requires a valid cookie:
 
 | Variable | Where | Default / off | Effect when set |
 |----------|--------|---------------|-----------------|
-| `API_ORIGIN_VERIFY_SECRET` | Lambda | unset = skip | Require matching `X-Origin-Verify` (CloudFront / Vite proxy) |
+| `API_ORIGIN_VERIFY_SECRET` | Lambda | unset = skip | Require `X-Origin-Verify` (CloudFront / Vite proxy) or allowlisted `Origin` on the API custom domain |
 | `API_ORIGIN_VERIFY_HEADER` | Lambda | `X-Origin-Verify` | Custom header name for the shared secret |
 | `API_SESSION_SECRET` | Lambda | unset = skip session on `/search`; `/session` 503 | Sign/validate `gf_api_session` |
 | `API_SESSION_TTL_SECONDS` | Lambda | `900` | Cookie / token lifetime |
@@ -196,5 +200,10 @@ Expose **`GET` + `OPTIONS`** for `/search` and `/session` only (legacy `/`,
 `/api`, and `/api/*` paths are still accepted by Lambda path routing for
 compatibility, but should be removed from the gateway once traffic has
 migrated).
+
+Lambda strips common API Gateway stage prefixes before routing (`/prod`,
+`/staging`, `/dev`, `/default`). CloudFront origins that target `execute-api`
+with origin path `/default` therefore reach `/default/search` and
+`/default/session` correctly.
 
 CORS allowlist and header policy live in `api/handler/cors.go`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Audit of documentation after recent infrastructure changes (#381–#385, Turnstile removal #382). Several docs were partially updated but still contained stale or misleading wording.

## Changes

- **README.md** — Fix leftover "three optional layers" wording (Turnstile was removed in #382).
- **AGENTS.md** — Fix "three abuse-mitigation layers" reference; clarify that origin verify accepts either `X-Origin-Verify` or allowlisted `Origin` on the API custom domain (#383).
- **docs/api-abuse-mitigation.md**:
  - Update browser sequence diagram to reflect allowlisted `Origin` on `api.gishathfetch.com` (not CloudFront header injection).
  - Rewrite origin-verify checklist for production routing directly to API Gateway custom domain (#383).
  - Clarify purpose and env-reference wording for the dual origin-verify paths.
  - Document `/default` API Gateway stage prefix stripping (#385).

## Already up to date

- Turnstile references were already removed from code and most docs in #382.
- `docs/search-strategies-retries-timeouts.md`, deploy workflow, and FAQ content do not reference the removed infrastructure.
- Frontend search stats and session mint docs match current behavior (no Turnstile timing).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ffe2d2d8-ff7b-4c52-a7d7-721ec6b146ca?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ffe2d2d8-ff7b-4c52-a7d7-721ec6b146ca&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

