### PR TITLE
Require CloudFront origin secret for API access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,16 +110,17 @@ Proxy target: `VITE_API_PROXY_TARGET` (default `https://api.gishathfetch.com`). 
 `VITE_API_ORIGIN_VERIFY_SECRET` when testing against an environment with
 `API_ORIGIN_VERIFY_SECRET` enabled.
 
-Full reference for the three abuse-mitigation layers:
+Full reference for the two abuse-mitigation layers:
 [`docs/api-abuse-mitigation.md`](docs/api-abuse-mitigation.md).
 
 #### API abuse mitigation (overview)
 
 Two optional layers; each is **off until configured**:
 
-1. **CloudFront → API origin secret** (`API_ORIGIN_VERIFY_SECRET`): requests must send
-   matching `X-Origin-Verify` (CloudFront custom origin header or Vite dev proxy).
-   Enforced on both `/session` and `/search`.
+1. **CloudFront → API origin secret** (`API_ORIGIN_VERIFY_SECRET`): when set, requests
+   must include a matching `X-Origin-Verify` header injected by the API CloudFront
+   distribution (origin request) or the Vite dev proxy. Allowlisted `Origin` alone
+   is not accepted. Enforced on both `/session` and `/search`.
 2. **Session cookie** (`API_SESSION_SECRET`): `GET /session` mints HttpOnly `gf_api_session`
    (default TTL 15m via `API_SESSION_TTL_SECONDS`). `/search` requires a valid cookie
    (`session required` / `session expired` → 403). Frontend: `ensureApiSession()` with a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,10 @@ Two optional layers; each is **off until configured**:
    10-minute background refresh and one retry on expiry
    (`frontend/src/utils/apiSession.js`).
 
-Production should enable both together. `make deploy` does not wire these Lambda
+Production should enable both together. Both public CloudFront distributions
+(`gishathfetch.com` and `api.gishathfetch.com`) have **AWS WAF** web ACLs
+attached; see [`docs/api-abuse-mitigation.md`](docs/api-abuse-mitigation.md) →
+*Edge protection*. `make deploy` does not wire these Lambda
 secrets — set them on `mtg-price-scrapper` manually (or via your secrets process).
 
 **API Gateway (manual):** expose `GET` + `OPTIONS` for `/search` and `/session` only; remove

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ Gishath Fetch is a static React SPA served from S3 behind CloudFront. Search and
 session use **`https://api.gishathfetch.com/search`** and **`/session`** from the
 browser (cross-origin, credentialed). That API hostname is fronted by a separate
 CloudFront distribution that injects `X-Origin-Verify` before forwarding to API
-Gateway. API Gateway invokes a container-based Lambda that scrapes LGS sites in
-parallel. Inbound API abuse mitigation uses two optional layers: a
+Gateway. Both public CloudFront distributions (`gishathfetch.com` and
+`api.gishathfetch.com`) have **AWS WAF** web ACLs attached at the edge. API
+Gateway invokes a container-based Lambda that scrapes LGS sites in parallel. Inbound API abuse mitigation uses two optional layers: a
 CloudFront→API origin-verify secret (`X-Origin-Verify`), a short-lived HttpOnly
 session cookie (`gf_api_session`) — see
 [`docs/api-abuse-mitigation.md`](docs/api-abuse-mitigation.md). When
@@ -48,6 +49,8 @@ flowchart TB
     end
 
     subgraph aws["AWS ap-southeast-1"]
+        WAFSPA[WAF web ACL]
+        WAFAPI[WAF web ACL]
         CF[CloudFront gishathfetch.com]
         APICF[CloudFront api.gishathfetch.com]
         S3[(S3 gishathfetch.com)]
@@ -68,10 +71,12 @@ flowchart TB
         GA4[Google Analytics GA4]
     end
 
-    Browser -->|HTTPS| CF
+    Browser -->|HTTPS| WAFSPA
+    WAFSPA --> CF
     CF --> S3
     Browser -->|gtag search events| GA4
-    Browser -->|GET /session, /search| APICF
+    Browser -->|GET /session, /search| WAFAPI
+    WAFAPI --> APICF
     APICF -->|+ X-Origin-Verify| AGW
     AGW --> SearchLambda
     SearchLambda -->|optional Web Bot Auth signatures| Proxies
@@ -95,9 +100,9 @@ flowchart TB
 
 | Service | Name / endpoint | Role |
 |---------|-----------------|------|
-| Frontend CDN | CloudFront → `gishathfetch.com` | Serves the React SPA from S3 |
+| Frontend CDN | WAF → CloudFront → `gishathfetch.com` | Serves the React SPA from S3 |
 | Web Bot Auth directory | `https://gishathfetch.com/.well-known/http-message-signatures-directory` | Public signing keys for verifiers; built by `make generate-signature-directory` and uploaded on frontend deploy |
-| Search API | CloudFront → `api.gishathfetch.com` → API Gateway | `GET /search`, `GET /session`; CloudFront injects origin-verify header; session cookie ([docs](docs/api-abuse-mitigation.md)) |
+| Search API | WAF → CloudFront → `api.gishathfetch.com` → API Gateway | `GET /search`, `GET /session`; CloudFront injects origin-verify header; session cookie ([docs](docs/api-abuse-mitigation.md)) |
 | Search Lambda | `mtg-price-scrapper` | Concurrent LGS scraping; optional Web Bot Auth on outbound requests; optional CK price lookup from DynamoDB |
 | CK refresh Lambda | `mtg-price-ck-refresh` | Daily Card Kingdom pricelist download, DynamoDB index rebuild, and CK price change export to S3 |
 | Analytics keywords Lambda | `mtg-analytics-keywords-export` | Daily GA4 export of top search keywords to S3 |
@@ -258,7 +263,7 @@ Example inline policy (merge with existing permissions on the role, or attach as
 ## 🛡️ API abuse mitigation
 
 Inbound `/search` and `/session` are gated by two optional layers (each off
-until configured):
+until configured), with **AWS WAF** on both CloudFront distributions at the edge:
 
 1. **CloudFront → API origin secret** — Lambda `API_ORIGIN_VERIFY_SECRET`;
    CloudFront (or the Vite dev proxy) injects `X-Origin-Verify` on origin

--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@ It aggregates listings from supported stores, normalizes results, and sorts by p
 
 Gishath Fetch is a static React SPA served from S3 behind CloudFront. Search and
 session use **`https://api.gishathfetch.com/search`** and **`/session`** from the
-browser (cross-origin, credentialed). API Gateway invokes a container-based Lambda
-that scrapes LGS sites in parallel. Inbound API abuse mitigation uses three
-optional layers: a CloudFront→API origin-verify secret (`X-Origin-Verify`), a
-short-lived HttpOnly session cookie (`gf_api_session`) — see
+browser (cross-origin, credentialed). That API hostname is fronted by a separate
+CloudFront distribution that injects `X-Origin-Verify` before forwarding to API
+Gateway. API Gateway invokes a container-based Lambda that scrapes LGS sites in
+parallel. Inbound API abuse mitigation uses two optional layers: a
+CloudFront→API origin-verify secret (`X-Origin-Verify`), a short-lived HttpOnly
+session cookie (`gf_api_session`) — see
 [`docs/api-abuse-mitigation.md`](docs/api-abuse-mitigation.md). When
 `WEB_BOT_AUTH_ENABLED` is set, outbound scraper requests
 are signed per [Web Bot Auth](https://datatracker.ietf.org/doc/draft-meunier-web-bot-auth-architecture/)
@@ -46,9 +48,10 @@ flowchart TB
     end
 
     subgraph aws["AWS ap-southeast-1"]
-        CF[CloudFront]
+        CF[CloudFront gishathfetch.com]
+        APICF[CloudFront api.gishathfetch.com]
         S3[(S3 gishathfetch.com)]
-        AGW[API Gateway api.gishathfetch.com]
+        AGW[API Gateway]
         SearchLambda[Lambda mtg-price-scrapper]
         RefreshLambda[Lambda mtg-price-ck-refresh]
         AnalyticsLambda[Lambda mtg-analytics-keywords-export]
@@ -68,7 +71,8 @@ flowchart TB
     Browser -->|HTTPS| CF
     CF --> S3
     Browser -->|gtag search events| GA4
-    Browser -->|GET /session, /search| AGW
+    Browser -->|GET /session, /search| APICF
+    APICF -->|+ X-Origin-Verify| AGW
     AGW --> SearchLambda
     SearchLambda -->|optional Web Bot Auth signatures| Proxies
     Proxies --> LGS
@@ -93,7 +97,7 @@ flowchart TB
 |---------|-----------------|------|
 | Frontend CDN | CloudFront → `gishathfetch.com` | Serves the React SPA from S3 |
 | Web Bot Auth directory | `https://gishathfetch.com/.well-known/http-message-signatures-directory` | Public signing keys for verifiers; built by `make generate-signature-directory` and uploaded on frontend deploy |
-| Search API | API Gateway `api.gishathfetch.com` | `GET /search`, `GET /session`; abuse mitigation: origin verify + session cookie ([docs](docs/api-abuse-mitigation.md)) |
+| Search API | CloudFront → `api.gishathfetch.com` → API Gateway | `GET /search`, `GET /session`; CloudFront injects origin-verify header; session cookie ([docs](docs/api-abuse-mitigation.md)) |
 | Search Lambda | `mtg-price-scrapper` | Concurrent LGS scraping; optional Web Bot Auth on outbound requests; optional CK price lookup from DynamoDB |
 | CK refresh Lambda | `mtg-price-ck-refresh` | Daily Card Kingdom pricelist download, DynamoDB index rebuild, and CK price change export to S3 |
 | Analytics keywords Lambda | `mtg-analytics-keywords-export` | Daily GA4 export of top search keywords to S3 |

--- a/api/handler/access.go
+++ b/api/handler/access.go
@@ -17,9 +17,8 @@ func enforceOriginVerify(
 	apiRes events.APIGatewayProxyResponse,
 	origin string,
 	headers map[string]string,
-	domainName string,
 ) (events.APIGatewayProxyResponse, bool) {
-	if err := apiauth.VerifyOriginHeader(headers, domainName); err != nil {
+	if err := apiauth.VerifyOriginHeader(headers); err != nil {
 		return accessDeniedResponse(apiRes, origin, "forbidden"), false
 	}
 	return apiRes, true

--- a/api/handler/search.go
+++ b/api/handler/search.go
@@ -63,7 +63,7 @@ func Search(ctx context.Context, request events.APIGatewayProxyRequest) (events.
 		return optionsResponse(origin)
 	}
 
-	if res, ok := enforceOriginVerify(apiRes, origin, request.Headers, request.RequestContext.DomainName); !ok {
+	if res, ok := enforceOriginVerify(apiRes, origin, request.Headers); !ok {
 		return res, nil
 	}
 	if res, ok := enforceSession(apiRes, origin, request.Headers); !ok {

--- a/api/handler/session.go
+++ b/api/handler/session.go
@@ -27,7 +27,7 @@ func Session(ctx context.Context, request events.APIGatewayProxyRequest) (events
 		return errorResponse(apiRes, origin, "method not allowed", http.StatusMethodNotAllowed)
 	}
 
-	if res, ok := enforceOriginVerify(apiRes, origin, request.Headers, request.RequestContext.DomainName); !ok {
+	if res, ok := enforceOriginVerify(apiRes, origin, request.Headers); !ok {
 		return res, nil
 	}
 

--- a/api/pkg/apiauth/origin.go
+++ b/api/pkg/apiauth/origin.go
@@ -3,7 +3,6 @@ package apiauth
 import (
 	"crypto/subtle"
 	"errors"
-	"slices"
 	"strings"
 
 	"mtg-price-checker-sg/pkg/config"
@@ -12,11 +11,11 @@ import (
 var errOriginVerifyFailed = errors.New("origin verification failed")
 
 // VerifyOriginHeader enforces access when API_ORIGIN_VERIFY_SECRET is set.
-// Requests with a matching X-Origin-Verify header pass (e.g. CloudFront origin or
-// the Vite dev proxy). Browser calls via the API custom domain (not execute-api)
-// may omit that header and use an allowlisted Origin instead. Allowlisted Origin
-// alone is rejected on execute-api hostnames because it is trivially spoofed.
-func VerifyOriginHeader(headers map[string]string, domainName string) error {
+// Requests must include a matching X-Origin-Verify header (injected by CloudFront
+// on the origin request, or by the Vite dev proxy). Allowlisted Origin alone is
+// not accepted: it is trivially spoofed on direct execute-api or custom-domain
+// calls that bypass CloudFront.
+func VerifyOriginHeader(headers map[string]string) error {
 	secret := config.APIOriginVerifySecret()
 	if secret == "" {
 		return nil
@@ -24,27 +23,13 @@ func VerifyOriginHeader(headers map[string]string, domainName string) error {
 
 	headerName := strings.ToLower(config.APIOriginVerifyHeader())
 	got := strings.TrimSpace(headerValue(headers, headerName))
-	if got != "" {
-		if subtle.ConstantTimeCompare([]byte(got), []byte(secret)) == 1 {
-			return nil
-		}
+	if got == "" {
 		return errOriginVerifyFailed
 	}
-
-	if isExecuteAPIGatewayDomain(domainName) {
-		return errOriginVerifyFailed
-	}
-
-	origin := strings.TrimSpace(headerValue(headers, "origin"))
-	if origin != "" && slices.Contains(config.GetAllowedOrigins(), origin) {
+	if subtle.ConstantTimeCompare([]byte(got), []byte(secret)) == 1 {
 		return nil
 	}
-
 	return errOriginVerifyFailed
-}
-
-func isExecuteAPIGatewayDomain(domainName string) bool {
-	return strings.Contains(strings.ToLower(strings.TrimSpace(domainName)), ".execute-api.")
 }
 
 func headerValue(headers map[string]string, lowerName string) string {

--- a/api/pkg/apiauth/session_test.go
+++ b/api/pkg/apiauth/session_test.go
@@ -36,24 +36,15 @@ func TestVerifyOriginHeader(t *testing.T) {
 	require.NoError(t, os.Setenv(config.APIOriginVerifySecretEnv, "cloudfront-secret"))
 	t.Cleanup(func() { _ = os.Unsetenv(config.APIOriginVerifySecretEnv) })
 
-	err := VerifyOriginHeader(map[string]string{"x-origin-verify": "cloudfront-secret"}, "")
+	err := VerifyOriginHeader(map[string]string{"x-origin-verify": "cloudfront-secret"})
 	require.NoError(t, err)
 
-	err = VerifyOriginHeader(map[string]string{"x-origin-verify": "wrong"}, "")
+	err = VerifyOriginHeader(map[string]string{"x-origin-verify": "wrong"})
 	require.ErrorIs(t, err, errOriginVerifyFailed)
 
-	err = VerifyOriginHeader(
-		map[string]string{"origin": "https://gishathfetch.com"},
-		"api.gishathfetch.com",
-	)
-	require.NoError(t, err)
-
-	err = VerifyOriginHeader(
-		map[string]string{"origin": "https://gishathfetch.com"},
-		"abc123.execute-api.ap-southeast-1.amazonaws.com",
-	)
+	err = VerifyOriginHeader(map[string]string{"origin": "https://gishathfetch.com"})
 	require.ErrorIs(t, err, errOriginVerifyFailed)
 
-	err = VerifyOriginHeader(map[string]string{}, "api.gishathfetch.com")
+	err = VerifyOriginHeader(map[string]string{})
 	require.ErrorIs(t, err, errOriginVerifyFailed)
 }

--- a/docs/api-abuse-mitigation.md
+++ b/docs/api-abuse-mitigation.md
@@ -10,6 +10,9 @@ Each layer is **off until its secret/key is configured**. With none set, `/searc
 and `/session` behave as open CORS-allowlisted endpoints (useful for local
 Lambda/`go run` testing). In production, enable both together.
 
+Production also attaches **AWS WAF** web ACLs to both public CloudFront
+distributions (see [Edge protection](#edge-protection-aws-waf) below).
+
 For agent-oriented enablement notes (env vars, Vite), see also
 [`AGENTS.md`](../AGENTS.md) → *Frontend API connection*.
 
@@ -40,6 +43,26 @@ Production SPA calls go **cross-origin** to `https://api.gishathfetch.com`
 (`credentials: "include"`). That hostname must resolve to the **API CloudFront**
 distribution, which forwards to API Gateway and injects `X-Origin-Verify` on the
 origin request. A separate CloudFront distribution serves the static SPA from S3.
+Both distributions have **AWS WAF** web ACLs attached at the edge.
+
+---
+
+## Edge protection (AWS WAF)
+
+Production attaches an **AWS WAF** web ACL to each public CloudFront
+distribution:
+
+| Distribution | Hostname | Origin | WAF scope |
+|--------------|----------|--------|-----------|
+| Frontend CDN | `gishathfetch.com` | S3 (`gishathfetch.com` bucket) | Viewer requests to the SPA |
+| API CDN | `api.gishathfetch.com` | API Gateway (`execute-api`, origin path `/default`) | Viewer requests to `/search` and `/session` |
+
+WAF evaluates traffic at the CloudFront edge before the request is forwarded to
+S3 or API Gateway. Rule groups and rate limits are configured in the AWS console
+(or your IaC process); `make deploy` does not manage WAF resources.
+
+Together with origin verify and the session cookie, WAF adds edge filtering
+against automated abuse and common web attacks before traffic reaches Lambda.
 
 ---
 
@@ -102,12 +125,13 @@ curl -i "https://api.gishathfetch.com/search?s=Opt" \
 
 1. `api.gishathfetch.com` DNS points to the **API CloudFront** distribution (not
    directly to API Gateway).
-2. CloudFront origin custom header `X-Origin-Verify` matches Lambda
+2. An **AWS WAF** web ACL is associated with the API CloudFront distribution.
+3. CloudFront origin custom header `X-Origin-Verify` matches Lambda
    `API_ORIGIN_VERIFY_SECRET`.
-3. `API_ORIGIN_VERIFY_SECRET` is set on Lambda `mtg-price-scrapper`.
-4. Remove any API Gateway **custom domain** mapping for `api.gishathfetch.com`
+4. `API_ORIGIN_VERIFY_SECRET` is set on Lambda `mtg-price-scrapper`.
+5. Remove any API Gateway **custom domain** mapping for `api.gishathfetch.com`
    that would allow callers to bypass CloudFront.
-5. Verify with the curl probes above after deploy (both bypass attempts return
+6. Verify with the curl probes above after deploy (both bypass attempts return
    403; browser search works).
 
 **Stronger options** (optional; not required when origin verify and the CloudFront

--- a/docs/api-abuse-mitigation.md
+++ b/docs/api-abuse-mitigation.md
@@ -20,21 +20,26 @@ For agent-oriented enablement notes (env vars, Vite), see also
 ```mermaid
 sequenceDiagram
     participant U as Browser
-    participant API as api.gishathfetch.com
+    participant CF as CloudFront<br/>api.gishathfetch.com
+    participant API as API Gateway
 
     Note over U: SPA load (gishathfetch.com)
-    U->>API: GET /session
-    Note over API: origin check (X-Origin-Verify<br/>from CloudFront)
-    API-->>U: 204 + Set-Cookie: gf_api_session=...
-    U->>API: GET /search?s=... (credentials: include)
+    U->>CF: GET /session
+    CF->>API: origin request + X-Origin-Verify
+    Note over API: origin check (secret header)
+    API-->>CF: 204 + Set-Cookie: gf_api_session=...
+    CF-->>U: 204 + Set-Cookie: gf_api_session=...
+    U->>CF: GET /search?s=... (credentials: include)
+    CF->>API: origin request + X-Origin-Verify + cookie
     Note over API: origin check + session cookie HMAC
-    API-->>U: search JSON
+    API-->>CF: search JSON
+    CF-->>U: search JSON
 ```
 
 Production SPA calls go **cross-origin** to `https://api.gishathfetch.com`
-(`credentials: "include"`). Frontend CDN CloudFront serves static assets from
-S3; it is not on the search path unless you also front API Gateway with
-CloudFront and inject the origin-verify header (see below).
+(`credentials: "include"`). That hostname must resolve to the **API CloudFront**
+distribution, which forwards to API Gateway and injects `X-Origin-Verify` on the
+origin request. A separate CloudFront distribution serves the static SPA from S3.
 
 ---
 
@@ -50,32 +55,24 @@ execute-api URL cannot be used with a spoofed `Origin` header alone.
 | Optional header name override | `API_ORIGIN_VERIFY_HEADER` (default `X-Origin-Verify`) |
 | Code | `api/pkg/apiauth/origin.go`, enforced in `handler/search.go` and `handler/session.go` |
 
-When `API_ORIGIN_VERIFY_SECRET` is set, a request passes origin verification when
-either:
-
-1. It includes `X-Origin-Verify` (or the configured header) equal to the secret
-   (CloudFront origin request or Vite dev proxy), or
-2. It arrives on the **API custom domain** (not `*.execute-api.*.amazonaws.com`)
-   with an allowlisted `Origin` header (normal browser traffic to
-   `api.gishathfetch.com`).
-
-Allowlisted `Origin` alone is **rejected** on execute-api hostnames because it is
-trivially spoofed on direct calls that bypass the custom domain.
+When `API_ORIGIN_VERIFY_SECRET` is set, a request passes origin verification only
+when it includes `X-Origin-Verify` (or the configured header) equal to the secret.
+Allowlisted `Origin` alone is **not** accepted — it is trivially spoofed on direct
+`execute-api` or custom-domain calls that bypass CloudFront.
 
 Otherwise the handler returns **403** (`forbidden`).
 
 ### CloudFront setup (API origin)
 
-If CloudFront is configured as a reverse proxy in front of API Gateway (or as a
-custom origin for `/api/*` / search paths), add a **custom origin header**:
+`api.gishathfetch.com` must point at a CloudFront distribution that proxies to API
+Gateway (typically `execute-api` with origin path `/default`). Add a **custom origin
+header** on that origin:
 
 - Name: `X-Origin-Verify` (unless you override `API_ORIGIN_VERIFY_HEADER`)
 - Value: the same string as Lambda `API_ORIGIN_VERIFY_SECRET`
 
-Keep the secret out of the SPA bundle. When CloudFront fronts the API, it can add
-this header on the **origin request** to API Gateway (viewers never send it).
-Browser calls to `api.gishathfetch.com` also pass via allowlisted `Origin` when
-the request hostname is the custom domain.
+Keep the secret out of the SPA bundle. CloudFront adds this header on the **origin
+request** to API Gateway; browsers never send it.
 
 ### Lock down the execute-api URL
 
@@ -84,18 +81,20 @@ support API Gateway resource policies or IP allowlists the way REST APIs do, so
 you cannot block the raw `*.execute-api.*.amazonaws.com` hostname at the gateway
 with a CloudFront managed prefix list alone.
 
-With `API_ORIGIN_VERIFY_SECRET` set, direct calls to the execute-api URL are
+With `API_ORIGIN_VERIFY_SECRET` set, direct calls that bypass CloudFront are
 rejected even with a spoofed allowlisted `Origin`:
 
 ```bash
-# Bypass attempt — should return 403 forbidden (Origin spoofing is not enough)
+# Bypass attempt — execute-api with spoofed Origin (403)
 curl -i "https://<api-id>.execute-api.ap-southeast-1.amazonaws.com/search?s=Opt" \
   -H "Origin: https://gishathfetch.com"
 
-# Legit path — should work (WAF + origin secret + session as configured)
+# Bypass attempt — API custom domain without CloudFront secret header (403)
 curl -i "https://api.gishathfetch.com/search?s=Opt" \
-  -H "Origin: https://gishathfetch.com" \
-  --cookie "gf_api_session=..."
+  -H "Origin: https://gishathfetch.com"
+
+# Legit path — browser via CloudFront (session cookie from prior GET /session)
+# Manual curl cannot reproduce this without knowing the shared secret.
 ```
 
 **Checklist**
@@ -105,7 +104,10 @@ curl -i "https://api.gishathfetch.com/search?s=Opt" \
 2. CloudFront origin custom header `X-Origin-Verify` matches Lambda
    `API_ORIGIN_VERIFY_SECRET`.
 3. `API_ORIGIN_VERIFY_SECRET` is set on Lambda `mtg-price-scrapper`.
-4. Verify step 1 with the curl probes above after deploy.
+4. Remove any API Gateway **custom domain** mapping for `api.gishathfetch.com`
+   that would allow callers to bypass CloudFront.
+5. Verify with the curl probes above after deploy (both bypass attempts return
+   403; browser search works).
 
 **Stronger options** (optional; not required when the secret + CloudFront path is
 in place):
@@ -177,7 +179,7 @@ When `API_SESSION_SECRET` is set, `/search` requires a valid cookie:
 
 | Variable | Where | Default / off | Effect when set |
 |----------|--------|---------------|-----------------|
-| `API_ORIGIN_VERIFY_SECRET` | Lambda | unset = skip | Require matching `X-Origin-Verify` (CloudFront / Vite proxy) |
+| `API_ORIGIN_VERIFY_SECRET` | Lambda | unset = skip | Require matching `X-Origin-Verify` (CloudFront origin request or Vite dev proxy) |
 | `API_ORIGIN_VERIFY_HEADER` | Lambda | `X-Origin-Verify` | Custom header name for the shared secret |
 | `API_SESSION_SECRET` | Lambda | unset = skip session on `/search`; `/session` 503 | Sign/validate `gf_api_session` |
 | `API_SESSION_TTL_SECONDS` | Lambda | `900` | Cookie / token lifetime |
@@ -196,5 +198,10 @@ Expose **`GET` + `OPTIONS`** for `/search` and `/session` only (legacy `/`,
 `/api`, and `/api/*` paths are still accepted by Lambda path routing for
 compatibility, but should be removed from the gateway once traffic has
 migrated).
+
+Lambda strips common API Gateway stage prefixes before routing (`/prod`,
+`/staging`, `/dev`, `/default`). CloudFront origins that target `execute-api`
+with origin path `/default` therefore reach `/default/search` and
+`/default/session` correctly.
 
 CORS allowlist and header policy live in `api/handler/cors.go`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Re-tightens API origin verification now that `api.gishathfetch.com` is fronted by CloudFront with `X-Origin-Verify` injected on origin requests. Removes the temporary allowlisted-`Origin` fallback added in #383 for direct API Gateway custom-domain traffic.

## Code changes

- `VerifyOriginHeader` again accepts **only** a matching `X-Origin-Verify` header (CloudFront origin request or Vite dev proxy).
- Allowlisted `Origin` alone is rejected on all hostnames, including `api.gishathfetch.com` and `execute-api`.
- Drops the unused `domainName` parameter from origin verification.

## Docs

- Updated `docs/api-abuse-mitigation.md`, `AGENTS.md`, and `README.md` for the CloudFront-only browser path.
- Added checklist item to remove any API Gateway custom-domain mapping that would bypass CloudFront.
- Documented **AWS WAF** web ACLs on both CloudFront distributions (`gishathfetch.com` SPA and `api.gishathfetch.com` API).

## Deploy prerequisites

**Deploy only after** production infra matches the checklist:

1. `api.gishathfetch.com` DNS → API CloudFront distribution (not API Gateway custom domain).
2. AWS WAF web ACL associated with the API CloudFront distribution.
3. CloudFront origin custom header `X-Origin-Verify` = Lambda `API_ORIGIN_VERIFY_SECRET`.
4. No direct API Gateway custom-domain alias for `api.gishathfetch.com`.

If deployed before CloudFront is live, browser session mint will return **403** (`forbidden`).

## Verification

- `make test` passes.
- After deploy, these should return **403**:
  - `curl` to `execute-api` with spoofed `Origin`
  - `curl` to `api.gishathfetch.com` with spoofed `Origin` only (no secret header)
- Browser search via the SPA should continue to work through CloudFront.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ffe2d2d8-ff7b-4c52-a7d7-721ec6b146ca?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ffe2d2d8-ff7b-4c52-a7d7-721ec6b146ca&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

