### PR TITLE
Keep Default Title variants but leave quality blank

### DIFF
--- a/api/gateway/binderpos/storefront_card_helpers.go
+++ b/api/gateway/binderpos/storefront_card_helpers.go
@@ -8,13 +8,30 @@ import (
 	"mtg-price-checker-sg/pkg/config"
 )
 
-func isUnusableVariantTitle(title string) bool {
+func isPlaceholderVariantTitle(title string) bool {
 	return strings.EqualFold(strings.TrimSpace(title), "Default Title")
+}
+
+func effectiveVariantTitle(title string) string {
+	title = strings.TrimSpace(title)
+	if isPlaceholderVariantTitle(title) {
+		return ""
+	}
+	return title
+}
+
+func qualityFromVariantTitle(title string) string {
+	title = effectiveVariantTitle(title)
+	if title == "" {
+		return ""
+	}
+	quality := strings.TrimSpace(strings.ReplaceAll(title, "Foil", ""))
+	return strings.Join(strings.Fields(quality), " ")
 }
 
 func formatCardName(scrapVariant int, productTitle, variantTitle string) string {
 	productTitle = strings.TrimSpace(productTitle)
-	variantTitle = strings.TrimSpace(variantTitle)
+	variantTitle = effectiveVariantTitle(variantTitle)
 
 	switch scrapVariant {
 	case 2:

--- a/api/gateway/binderpos/storefront_decklist.go
+++ b/api/gateway/binderpos/storefront_decklist.go
@@ -103,7 +103,7 @@ func mapDecklistLinesToCards(scrapVariant int, storeName, baseURL string, lines 
 
 			image := buildCardImageURL(product.Image, productTitle)
 			for _, variant := range product.Variants {
-				if variant.Price <= 0 || variant.Quantity <= 0 || isUnusableVariantTitle(variant.Title) {
+				if variant.Price <= 0 || variant.Quantity <= 0 {
 					continue
 				}
 				if variant.ShopifyID <= 0 || productPath == "" {
@@ -115,14 +115,14 @@ func mapDecklistLinesToCards(scrapVariant int, storeName, baseURL string, lines 
 					continue
 				}
 
-				quality := strings.TrimSpace(strings.ReplaceAll(variant.Title, "Foil", ""))
+				quality := qualityFromVariantTitle(variant.Title)
 				card := gateway.Card{
 					Name:    formatCardName(scrapVariant, productTitle, variant.Title),
 					Url:     cardURL,
 					Img:     image,
 					Price:   variant.Price,
 					InStock: variant.Quantity > 0,
-					IsFoil:  strings.Contains(strings.ToLower(variant.Title), "foil"),
+					IsFoil:  strings.Contains(strings.ToLower(effectiveVariantTitle(variant.Title)), "foil"),
 					Source:  storeName,
 					Quality: util.MapQuality(quality),
 				}

--- a/api/gateway/binderpos/storefront_graphql.go
+++ b/api/gateway/binderpos/storefront_graphql.go
@@ -243,7 +243,7 @@ func mapGraphQLProduct(scrapVariant int, storeName, baseURL string, product *gra
 	var cards []gateway.Card
 	for _, edge := range product.Variants.Edges {
 		variant := edge.Node
-		if variant == nil || !variant.AvailableForSale || isUnusableVariantTitle(variant.Title) {
+		if variant == nil || !variant.AvailableForSale {
 			continue
 		}
 		price, err := strconv.ParseFloat(strings.TrimSpace(variant.Price.Amount), 64)
@@ -259,15 +259,14 @@ func mapGraphQLProduct(scrapVariant int, storeName, baseURL string, product *gra
 			continue
 		}
 
-		quality := strings.TrimSpace(strings.ReplaceAll(variant.Title, "Foil", ""))
-		quality = strings.Join(strings.Fields(quality), " ")
+		quality := qualityFromVariantTitle(variant.Title)
 		card := gateway.Card{
 			Name:    formatCardName(scrapVariant, title, variant.Title),
 			Url:     cardURL,
 			Img:     img,
 			Price:   price,
 			InStock: true,
-			IsFoil:  strings.Contains(strings.ToLower(variant.Title), "foil") || titleIndicatesFoil(title),
+			IsFoil:  strings.Contains(strings.ToLower(effectiveVariantTitle(variant.Title)), "foil") || titleIndicatesFoil(title),
 			Source:  storeName,
 			Quality: util.MapQuality(quality),
 		}

--- a/api/gateway/binderpos/storefront_graphql_test.go
+++ b/api/gateway/binderpos/storefront_graphql_test.go
@@ -70,7 +70,7 @@ func TestMapGraphQLProduct(t *testing.T) {
 	}
 
 	cards := mapGraphQLProduct(3, "Hideout", "https://hideoutcg.com", product)
-	require.Len(t, cards, 1)
+	require.Len(t, cards, 2)
 	require.Equal(t, "Abrade", cards[0].Name)
 	require.Equal(t, "Near Mint", cards[0].Quality)
 	require.False(t, cards[0].IsFoil)
@@ -78,6 +78,37 @@ func TestMapGraphQLProduct(t *testing.T) {
 	require.Equal(t, []string{"Foundations"}, cards[0].ExtraInfo)
 	require.Contains(t, cards[0].Url, "variant=111")
 	require.Contains(t, cards[0].Url, "utm_source=")
+
+	require.Equal(t, "Abrade", cards[1].Name)
+	require.Empty(t, cards[1].Quality)
+	require.Equal(t, 1.00, cards[1].Price)
+	require.Contains(t, cards[1].Url, "variant=444")
+}
+
+func TestMapGraphQLProductDefaultTitleVariantNameForScrapVariant2(t *testing.T) {
+	product := &graphQLProduct{
+		Title:            "Opt [Ixalan]",
+		Handle:           "opt-ixalan",
+		AvailableForSale: true,
+		ProductType:      "MTG Single",
+	}
+	product.Variants.Edges = []struct {
+		Node *graphQLVariant `json:"node"`
+	}{
+		{Node: &graphQLVariant{
+			ID:               "gid://shopify/ProductVariant/555",
+			Title:            "Default Title",
+			AvailableForSale: true,
+			Price:            struct {
+				Amount string `json:"amount"`
+			}{Amount: "0.25"},
+		}},
+	}
+
+	cards := mapGraphQLProduct(2, "Arcane Sanctum", "https://arcanesanctumtcg.com", product)
+	require.Len(t, cards, 1)
+	require.Equal(t, "Opt [Ixalan]", cards[0].Name)
+	require.Empty(t, cards[0].Quality)
 }
 
 func TestMapGraphQLProductSkipsNonMTG(t *testing.T) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #390, which merged the first pass that **excluded** variants with Shopify's placeholder title `"Default Title"` entirely.

This PR corrects that behavior: keep the card result, but ignore the placeholder for display.

## Behavior

When `variant.title` is `"Default Title"`:

- **Quality** is left blank (not shown as `"Default Title"`)
- **Card name** for scrap variant 2 (e.g. Arcane Sanctum) no longer appends ` - Default Title`
- The listing is still returned with price, URL, and stock

## Changes

- Replace `isUnusableVariantTitle` skip logic with `effectiveVariantTitle()` / `qualityFromVariantTitle()` helpers
- Apply in GraphQL and decklist mapping
- Update/add unit tests

## Testing

- `go test -mod=vendor ./gateway/binderpos/...`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cbaed1a4-9881-44f7-9475-3f1583b34b58?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cbaed1a4-9881-44f7-9475-3f1583b34b58&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

