### PR TITLE
Add Postman collections for API-based LGS search endpoints

### DIFF
--- a/postman/collections/all-lgs.postman_collection.json
+++ b/postman/collections/all-lgs.postman_collection.json
@@ -1,0 +1,1318 @@
+{
+  "info": {
+    "name": "GishathFetch - All LGS Search APIs",
+    "description": "Combined Postman collection for all API-based LGS integrations in gishathfetch. Excludes HTML-only stores (Agora Hobby). Each folder mirrors an individual per-store collection in postman/collections/.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "search_query",
+      "value": "Opt"
+    }
+  ],
+  "item": [
+    {
+      "name": "Cards Central",
+      "item": [
+        {
+          "name": "LGS Search",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/lgs/search?q={{search_query}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "lgs",
+                "search"
+              ],
+              "query": [
+                {
+                  "key": "q",
+                  "value": "{{search_query}}"
+                }
+              ]
+            },
+            "description": "GET /api/lgs/search?q={card name}. Returns JSON array of in-stock MTG singles."
+          }
+        }
+      ],
+      "description": "Custom LGS search API at /api/lgs/search. No authentication required."
+    },
+    {
+      "name": "Cards & Collections",
+      "item": [
+        {
+          "name": "Catalog Search",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/catalog/",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "catalog",
+                ""
+              ]
+            },
+            "description": "POST Elasticsearch query to /api/catalog/. Filters to MTG and accessories.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"query\": {\n    \"bool\": {\n      \"should\": [\n        {\n          \"simple_query_string\": {\n            \"query\": \"{{search_query}}\",\n            \"fields\": [\n              \"name\",\n              \"setCode\",\n              \"setName\"\n            ],\n            \"default_operator\": \"AND\"\n          }\n        },\n        {\n          \"multi_match\": {\n            \"query\": \"{{search_query}}\",\n            \"type\": \"phrase_prefix\",\n            \"fields\": [\n              \"name\",\n              \"setCode\",\n              \"setName\"\n            ]\n          }\n        }\n      ]\n    }\n  },\n  \"post_filter\": {\n    \"bool\": {\n      \"must\": {\n        \"terms\": {\n          \"collectableContext.raw\": [\n            \"MTG\",\n            \"ACCESSORY\"\n          ]\n        }\n      }\n    }\n  },\n  \"aggs\": {\n    \"productCategory4\": {\n      \"filter\": {\n        \"bool\": {\n          \"must\": {\n            \"terms\": {\n              \"collectableContext.raw\": [\n                \"MTG\",\n                \"ACCESSORY\"\n              ]\n            }\n          }\n        }\n      },\n      \"aggs\": {\n        \"productCategory.raw\": {\n          \"terms\": {\n            \"field\": \"productCategory.raw\",\n            \"size\": 50\n          }\n        },\n        \"productCategory.raw_count\": {\n          \"cardinality\": {\n            \"field\": \"productCategory.raw\"\n          }\n        }\n      }\n    }\n  },\n  \"size\": 20,\n  \"sort\": [\n    {\n      \"quantityOnSale\": \"desc\"\n    }\n  ]\n}"
+            }
+          }
+        }
+      ],
+      "description": "Elasticsearch-style catalog API at POST /api/catalog/. No authentication required."
+    },
+    {
+      "name": "Dueller's Point",
+      "item": [
+        {
+          "name": "Product Search",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/products/search?search_text={{search_query}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "products",
+                "search"
+              ],
+              "query": [
+                {
+                  "key": "search_text",
+                  "value": "{{search_query}}"
+                }
+              ]
+            },
+            "description": "GET /products/search?search_text={card name}. Returns JSON with results array."
+          }
+        }
+      ],
+      "description": "REST search API at GET /products/search. No authentication required."
+    },
+    {
+      "name": "Mox & Lotus",
+      "item": [
+        {
+          "name": "Product Search",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/products?limit=24&full_search=true&showStatus=false&is_paginated=true&in_stock=true&sortVariation=true&category_id=1&variation_code=all&order_by=Price Low to High&search={{search_query}}",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "products"
+              ],
+              "query": [
+                {
+                  "key": "limit",
+                  "value": "24"
+                },
+                {
+                  "key": "full_search",
+                  "value": "true"
+                },
+                {
+                  "key": "showStatus",
+                  "value": "false"
+                },
+                {
+                  "key": "is_paginated",
+                  "value": "true"
+                },
+                {
+                  "key": "in_stock",
+                  "value": "true"
+                },
+                {
+                  "key": "sortVariation",
+                  "value": "true"
+                },
+                {
+                  "key": "category_id",
+                  "value": "1"
+                },
+                {
+                  "key": "variation_code",
+                  "value": "all"
+                },
+                {
+                  "key": "order_by",
+                  "value": "Price Low to High"
+                },
+                {
+                  "key": "search",
+                  "value": "{{search_query}}"
+                }
+              ]
+            },
+            "description": "GET /api/products with MTG category filters and in_stock=true."
+          }
+        }
+      ],
+      "description": "REST product API at GET /api/products. No authentication required."
+    },
+    {
+      "name": "The TCG Marketplace",
+      "item": [
+        {
+          "name": "Advanced Search",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{api_url}}/encoder/advancedsearch",
+              "host": [
+                "{{api_url}}"
+              ],
+              "path": [
+                "encoder",
+                "advancedsearch"
+              ]
+            },
+            "description": "POST /encoder/advancedsearch. category=3 is MTG. Set access_token collection variable before sending.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"access_token\": \"{{access_token}}\",\n  \"name\": \"{{search_query}}\",\n  \"category\": 3,\n  \"order\": \"name_asc\"\n}"
+            }
+          }
+        }
+      ],
+      "description": "Advanced search API on port 3501. Requires access_token (set TCG_MARKETPLACE_ACCESS_TOKEN env var in production)."
+    },
+    {
+      "name": "5 Mana",
+      "item": [
+        {
+          "name": "Shopify Storefront GraphQL Search",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-Shopify-Storefront-Access-Token",
+                "value": "{{storefront_access_token}}"
+              },
+              {
+                "key": "Cookie",
+                "value": "cart_currency=SGD; localization=SG"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/2024-10/graphql.json",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "2024-10",
+                "graphql.json"
+              ]
+            },
+            "description": "POST /api/2024-10/graphql.json with MTG Single product filter.",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"query\": \"query SearchCards($q: String!) {\\n  search(\\n    query: $q\\n    first: 25\\n    types: PRODUCT\\n    productFilters: [{ available: true }, { productType: \\\"MTG Single\\\" }]\\n  ) {\\n    edges {\\n      node {\\n        ... on Product {\\n          title\\n          handle\\n          availableForSale\\n          productType\\n          tags\\n          featuredImage { url }\\n          variants(first: 20) {\\n            edges {\\n              node {\\n                title\\n                availableForSale\\n                price { amount }\\n              }\\n            }\\n          }\\n        }\\n      }\\n    }\\n  }\\n}\",\n  \"variables\": {\n    \"q\": \"{{search_query}}\"\n  }\n}"
+            }
+          }
+        }
+      ],
+      "description": "Shopify Storefront GraphQL (primary path). Filters to available MTG Single products."
+    },
+    {
+      "name": "Arcane Sanctum",
+      "item": [
+        {
+          "name": "Shopify Storefront GraphQL Search",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-Shopify-Storefront-Access-Token",
+                "value": "228ce7e7cffe6623f36634d0ca085e9e"
+              },
+              {
+                "key": "Cookie",
+                "value": "cart_currency=SGD; localization=SG"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/2024-10/graphql.json",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "2024-10",
+                "graphql.json"
+              ]
+            },
+            "description": "Search Arcane Sanctum inventory via Shopify Storefront API (same path used by gishathfetch gateway).",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"query\": \"query SearchCards($q: String!) {\\n  search(\\n    query: $q\\n    first: 25\\n    types: PRODUCT\\n    productFilters: [{ available: true }]\\n  ) {\\n    edges {\\n      node {\\n        ... on Product {\\n          title\\n          handle\\n          availableForSale\\n          productType\\n          tags\\n          featuredImage { url }\\n          variants(first: 20) {\\n            edges {\\n              node {\\n                id\\n                title\\n                availableForSale\\n                price { amount }\\n              }\\n            }\\n          }\\n        }\\n      }\\n    }\\n  }\\n}\",\n  \"variables\": {\n    \"q\": \"{{search_query}}\"\n  }\n}"
+            }
+          }
+        },
+        {
+          "name": "BinderPOS Decklist API Search",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "https://portal.binderpos.com/external/shopify/decklist?storeUrl={{shopify_domain}}&type=mtg",
+              "protocol": "https",
+              "host": [
+                "portal",
+                "binderpos",
+                "com"
+              ],
+              "path": [
+                "external",
+                "shopify",
+                "decklist"
+              ],
+              "query": [
+                {
+                  "key": "storeUrl",
+                  "value": "{{shopify_domain}}"
+                },
+                {
+                  "key": "type",
+                  "value": "mtg"
+                }
+              ]
+            },
+            "description": "Search Arcane Sanctum via BinderPOS portal decklist API (storeUrl=30uetm-1y.myshopify.com).",
+            "body": {
+              "mode": "raw",
+              "raw": "[\n  {\n    \"card\": \"{{search_query}}\",\n    \"quantity\": 1\n  }\n]"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Card Affinity",
+      "item": [
+        {
+          "name": "BinderPOS Decklist API Search",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "https://portal.binderpos.com/external/shopify/decklist?storeUrl={{shopify_domain}}&type=mtg",
+              "protocol": "https",
+              "host": [
+                "portal",
+                "binderpos",
+                "com"
+              ],
+              "path": [
+                "external",
+                "shopify",
+                "decklist"
+              ],
+              "query": [
+                {
+                  "key": "storeUrl",
+                  "value": "{{shopify_domain}}"
+                },
+                {
+                  "key": "type",
+                  "value": "mtg"
+                }
+              ]
+            },
+            "description": "Search Card Affinity via BinderPOS portal decklist API (storeUrl=563304-2.myshopify.com).",
+            "body": {
+              "mode": "raw",
+              "raw": "[\n  {\n    \"card\": \"{{search_query}}\",\n    \"quantity\": 1\n  }\n]"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Cards Citadel",
+      "item": [
+        {
+          "name": "Shopify Storefront GraphQL Search",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-Shopify-Storefront-Access-Token",
+                "value": "b68bd33b7d819fc110eb25a07988cc8e"
+              },
+              {
+                "key": "Cookie",
+                "value": "cart_currency=SGD; localization=SG"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/2024-10/graphql.json",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "2024-10",
+                "graphql.json"
+              ]
+            },
+            "description": "Search Cards Citadel inventory via Shopify Storefront API (same path used by gishathfetch gateway).",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"query\": \"query SearchCards($q: String!) {\\n  search(\\n    query: $q\\n    first: 25\\n    types: PRODUCT\\n    productFilters: [{ available: true }]\\n  ) {\\n    edges {\\n      node {\\n        ... on Product {\\n          title\\n          handle\\n          availableForSale\\n          productType\\n          tags\\n          featuredImage { url }\\n          variants(first: 20) {\\n            edges {\\n              node {\\n                id\\n                title\\n                availableForSale\\n                price { amount }\\n              }\\n            }\\n          }\\n        }\\n      }\\n    }\\n  }\\n}\",\n  \"variables\": {\n    \"q\": \"{{search_query}}\"\n  }\n}"
+            }
+          }
+        },
+        {
+          "name": "BinderPOS Decklist API Search",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "https://portal.binderpos.com/external/shopify/decklist?storeUrl={{shopify_domain}}&type=mtg",
+              "protocol": "https",
+              "host": [
+                "portal",
+                "binderpos",
+                "com"
+              ],
+              "path": [
+                "external",
+                "shopify",
+                "decklist"
+              ],
+              "query": [
+                {
+                  "key": "storeUrl",
+                  "value": "{{shopify_domain}}"
+                },
+                {
+                  "key": "type",
+                  "value": "mtg"
+                }
+              ]
+            },
+            "description": "Search Cards Citadel via BinderPOS portal decklist API (storeUrl=card-citadel.myshopify.com).",
+            "body": {
+              "mode": "raw",
+              "raw": "[\n  {\n    \"card\": \"{{search_query}}\",\n    \"quantity\": 1\n  }\n]"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Flagship Games",
+      "item": [
+        {
+          "name": "Shopify Storefront GraphQL Search",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-Shopify-Storefront-Access-Token",
+                "value": "e08d01a75c052a2ba9e40b5cfa5b0e36"
+              },
+              {
+                "key": "Cookie",
+                "value": "cart_currency=SGD; localization=SG"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/2024-10/graphql.json",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "2024-10",
+                "graphql.json"
+              ]
+            },
+            "description": "Search Flagship Games inventory via Shopify Storefront API (same path used by gishathfetch gateway).",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"query\": \"query SearchCards($q: String!) {\\n  search(\\n    query: $q\\n    first: 25\\n    types: PRODUCT\\n    productFilters: [{ available: true }]\\n  ) {\\n    edges {\\n      node {\\n        ... on Product {\\n          title\\n          handle\\n          availableForSale\\n          productType\\n          tags\\n          featuredImage { url }\\n          variants(first: 20) {\\n            edges {\\n              node {\\n                id\\n                title\\n                availableForSale\\n                price { amount }\\n              }\\n            }\\n          }\\n        }\\n      }\\n    }\\n  }\\n}\",\n  \"variables\": {\n    \"q\": \"{{search_query}}\"\n  }\n}"
+            }
+          }
+        },
+        {
+          "name": "BinderPOS Decklist API Search",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "https://portal.binderpos.com/external/shopify/decklist?storeUrl={{shopify_domain}}&type=mtg",
+              "protocol": "https",
+              "host": [
+                "portal",
+                "binderpos",
+                "com"
+              ],
+              "path": [
+                "external",
+                "shopify",
+                "decklist"
+              ],
+              "query": [
+                {
+                  "key": "storeUrl",
+                  "value": "{{shopify_domain}}"
+                },
+                {
+                  "key": "type",
+                  "value": "mtg"
+                }
+              ]
+            },
+            "description": "Search Flagship Games via BinderPOS portal decklist API (storeUrl=flagship-games.myshopify.com).",
+            "body": {
+              "mode": "raw",
+              "raw": "[\n  {\n    \"card\": \"{{search_query}}\",\n    \"quantity\": 1\n  }\n]"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Fyendal Hobby",
+      "item": [
+        {
+          "name": "Shopify Storefront GraphQL Search",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-Shopify-Storefront-Access-Token",
+                "value": "62ebf8066d0372bca57bb96d7a009a79"
+              },
+              {
+                "key": "Cookie",
+                "value": "cart_currency=SGD; localization=SG"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/2024-10/graphql.json",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "2024-10",
+                "graphql.json"
+              ]
+            },
+            "description": "Search Fyendal Hobby inventory via Shopify Storefront API (same path used by gishathfetch gateway).",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"query\": \"query SearchCards($q: String!) {\\n  search(\\n    query: $q\\n    first: 25\\n    types: PRODUCT\\n    productFilters: [{ available: true }]\\n  ) {\\n    edges {\\n      node {\\n        ... on Product {\\n          title\\n          handle\\n          availableForSale\\n          productType\\n          tags\\n          featuredImage { url }\\n          variants(first: 20) {\\n            edges {\\n              node {\\n                id\\n                title\\n                availableForSale\\n                price { amount }\\n              }\\n            }\\n          }\\n        }\\n      }\\n    }\\n  }\\n}\",\n  \"variables\": {\n    \"q\": \"{{search_query}}\"\n  }\n}"
+            }
+          }
+        },
+        {
+          "name": "BinderPOS Decklist API Search",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "https://portal.binderpos.com/external/shopify/decklist?storeUrl={{shopify_domain}}&type=mtg",
+              "protocol": "https",
+              "host": [
+                "portal",
+                "binderpos",
+                "com"
+              ],
+              "path": [
+                "external",
+                "shopify",
+                "decklist"
+              ],
+              "query": [
+                {
+                  "key": "storeUrl",
+                  "value": "{{shopify_domain}}"
+                },
+                {
+                  "key": "type",
+                  "value": "mtg"
+                }
+              ]
+            },
+            "description": "Search Fyendal Hobby via BinderPOS portal decklist API (storeUrl=fyendal-hobby.myshopify.com).",
+            "body": {
+              "mode": "raw",
+              "raw": "[\n  {\n    \"card\": \"{{search_query}}\",\n    \"quantity\": 1\n  }\n]"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Games Haven",
+      "item": [
+        {
+          "name": "Shopify Storefront GraphQL Search",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-Shopify-Storefront-Access-Token",
+                "value": "5938b052bbbd595d317fdeb5464a6733"
+              },
+              {
+                "key": "Cookie",
+                "value": "cart_currency=SGD; localization=SG"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/2024-10/graphql.json",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "2024-10",
+                "graphql.json"
+              ]
+            },
+            "description": "Search Games Haven inventory via Shopify Storefront API (same path used by gishathfetch gateway).",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"query\": \"query SearchCards($q: String!) {\\n  search(\\n    query: $q\\n    first: 25\\n    types: PRODUCT\\n    productFilters: [{ available: true }]\\n  ) {\\n    edges {\\n      node {\\n        ... on Product {\\n          title\\n          handle\\n          availableForSale\\n          productType\\n          tags\\n          featuredImage { url }\\n          variants(first: 20) {\\n            edges {\\n              node {\\n                id\\n                title\\n                availableForSale\\n                price { amount }\\n              }\\n            }\\n          }\\n        }\\n      }\\n    }\\n  }\\n}\",\n  \"variables\": {\n    \"q\": \"{{search_query}}\"\n  }\n}"
+            }
+          }
+        },
+        {
+          "name": "BinderPOS Decklist API Search",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "https://portal.binderpos.com/external/shopify/decklist?storeUrl={{shopify_domain}}&type=mtg",
+              "protocol": "https",
+              "host": [
+                "portal",
+                "binderpos",
+                "com"
+              ],
+              "path": [
+                "external",
+                "shopify",
+                "decklist"
+              ],
+              "query": [
+                {
+                  "key": "storeUrl",
+                  "value": "{{shopify_domain}}"
+                },
+                {
+                  "key": "type",
+                  "value": "mtg"
+                }
+              ]
+            },
+            "description": "Search Games Haven via BinderPOS portal decklist API (storeUrl=games-haven-sg.myshopify.com).",
+            "body": {
+              "mode": "raw",
+              "raw": "[\n  {\n    \"card\": \"{{search_query}}\",\n    \"quantity\": 1\n  }\n]"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Grey Ogre Games",
+      "item": [
+        {
+          "name": "Shopify Storefront GraphQL Search",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-Shopify-Storefront-Access-Token",
+                "value": "80c454d63abad6ad0ebb6b3aaf649fcd"
+              },
+              {
+                "key": "Cookie",
+                "value": "cart_currency=SGD; localization=SG"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/2024-10/graphql.json",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "2024-10",
+                "graphql.json"
+              ]
+            },
+            "description": "Search Grey Ogre Games inventory via Shopify Storefront API (same path used by gishathfetch gateway).",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"query\": \"query SearchCards($q: String!) {\\n  search(\\n    query: $q\\n    first: 25\\n    types: PRODUCT\\n    productFilters: [{ available: true }]\\n  ) {\\n    edges {\\n      node {\\n        ... on Product {\\n          title\\n          handle\\n          availableForSale\\n          productType\\n          tags\\n          featuredImage { url }\\n          variants(first: 20) {\\n            edges {\\n              node {\\n                id\\n                title\\n                availableForSale\\n                price { amount }\\n              }\\n            }\\n          }\\n        }\\n      }\\n    }\\n  }\\n}\",\n  \"variables\": {\n    \"q\": \"{{search_query}}\"\n  }\n}"
+            }
+          }
+        },
+        {
+          "name": "BinderPOS Decklist API Search",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "https://portal.binderpos.com/external/shopify/decklist?storeUrl={{shopify_domain}}&type=mtg",
+              "protocol": "https",
+              "host": [
+                "portal",
+                "binderpos",
+                "com"
+              ],
+              "path": [
+                "external",
+                "shopify",
+                "decklist"
+              ],
+              "query": [
+                {
+                  "key": "storeUrl",
+                  "value": "{{shopify_domain}}"
+                },
+                {
+                  "key": "type",
+                  "value": "mtg"
+                }
+              ]
+            },
+            "description": "Search Grey Ogre Games via BinderPOS portal decklist API (storeUrl=grey-ogre-games-singapore.myshopify.com).",
+            "body": {
+              "mode": "raw",
+              "raw": "[\n  {\n    \"card\": \"{{search_query}}\",\n    \"quantity\": 1\n  }\n]"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Hideout",
+      "item": [
+        {
+          "name": "Shopify Storefront GraphQL Search",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-Shopify-Storefront-Access-Token",
+                "value": "986e6f452e7b632be7a14cba965f64a8"
+              },
+              {
+                "key": "Cookie",
+                "value": "cart_currency=SGD; localization=SG"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/2024-10/graphql.json",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "2024-10",
+                "graphql.json"
+              ]
+            },
+            "description": "Search Hideout inventory via Shopify Storefront API (same path used by gishathfetch gateway).",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"query\": \"query SearchCards($q: String!) {\\n  search(\\n    query: $q\\n    first: 25\\n    types: PRODUCT\\n    productFilters: [{ available: true }]\\n  ) {\\n    edges {\\n      node {\\n        ... on Product {\\n          title\\n          handle\\n          availableForSale\\n          productType\\n          tags\\n          featuredImage { url }\\n          variants(first: 20) {\\n            edges {\\n              node {\\n                id\\n                title\\n                availableForSale\\n                price { amount }\\n              }\\n            }\\n          }\\n        }\\n      }\\n    }\\n  }\\n}\",\n  \"variables\": {\n    \"q\": \"{{search_query}}\"\n  }\n}"
+            }
+          }
+        },
+        {
+          "name": "BinderPOS Decklist API Search",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "https://portal.binderpos.com/external/shopify/decklist?storeUrl={{shopify_domain}}&type=mtg",
+              "protocol": "https",
+              "host": [
+                "portal",
+                "binderpos",
+                "com"
+              ],
+              "path": [
+                "external",
+                "shopify",
+                "decklist"
+              ],
+              "query": [
+                {
+                  "key": "storeUrl",
+                  "value": "{{shopify_domain}}"
+                },
+                {
+                  "key": "type",
+                  "value": "mtg"
+                }
+              ]
+            },
+            "description": "Search Hideout via BinderPOS portal decklist API (storeUrl=220022-20.myshopify.com).",
+            "body": {
+              "mode": "raw",
+              "raw": "[\n  {\n    \"card\": \"{{search_query}}\",\n    \"quantity\": 1\n  }\n]"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Hideyoshi",
+      "item": [
+        {
+          "name": "Shopify Storefront GraphQL Search",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-Shopify-Storefront-Access-Token",
+                "value": "08d34daee87c87da96bab125075f193a"
+              },
+              {
+                "key": "Cookie",
+                "value": "cart_currency=SGD; localization=SG"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/2024-10/graphql.json",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "2024-10",
+                "graphql.json"
+              ]
+            },
+            "description": "Search Hideyoshi inventory via Shopify Storefront API (same path used by gishathfetch gateway).",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"query\": \"query SearchCards($q: String!) {\\n  search(\\n    query: $q\\n    first: 25\\n    types: PRODUCT\\n    productFilters: [{ available: true }]\\n  ) {\\n    edges {\\n      node {\\n        ... on Product {\\n          title\\n          handle\\n          availableForSale\\n          productType\\n          tags\\n          featuredImage { url }\\n          variants(first: 20) {\\n            edges {\\n              node {\\n                id\\n                title\\n                availableForSale\\n                price { amount }\\n              }\\n            }\\n          }\\n        }\\n      }\\n    }\\n  }\\n}\",\n  \"variables\": {\n    \"q\": \"{{search_query}}\"\n  }\n}"
+            }
+          }
+        },
+        {
+          "name": "BinderPOS Decklist API Search",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "https://portal.binderpos.com/external/shopify/decklist?storeUrl={{shopify_domain}}&type=mtg",
+              "protocol": "https",
+              "host": [
+                "portal",
+                "binderpos",
+                "com"
+              ],
+              "path": [
+                "external",
+                "shopify",
+                "decklist"
+              ],
+              "query": [
+                {
+                  "key": "storeUrl",
+                  "value": "{{shopify_domain}}"
+                },
+                {
+                  "key": "type",
+                  "value": "mtg"
+                }
+              ]
+            },
+            "description": "Search Hideyoshi via BinderPOS portal decklist API (storeUrl=bposacct-9.myshopify.com).",
+            "body": {
+              "mode": "raw",
+              "raw": "[\n  {\n    \"card\": \"{{search_query}}\",\n    \"quantity\": 1\n  }\n]"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Mana Pro",
+      "item": [
+        {
+          "name": "Shopify Storefront GraphQL Search",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-Shopify-Storefront-Access-Token",
+                "value": "ba695fbdd730f9fa7b1e8f32e36691cf"
+              },
+              {
+                "key": "Cookie",
+                "value": "cart_currency=SGD; localization=SG"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/2024-10/graphql.json",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "2024-10",
+                "graphql.json"
+              ]
+            },
+            "description": "Search Mana Pro inventory via Shopify Storefront API (same path used by gishathfetch gateway).",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"query\": \"query SearchCards($q: String!) {\\n  search(\\n    query: $q\\n    first: 25\\n    types: PRODUCT\\n    productFilters: [{ available: true }]\\n  ) {\\n    edges {\\n      node {\\n        ... on Product {\\n          title\\n          handle\\n          availableForSale\\n          productType\\n          tags\\n          featuredImage { url }\\n          variants(first: 20) {\\n            edges {\\n              node {\\n                id\\n                title\\n                availableForSale\\n                price { amount }\\n              }\\n            }\\n          }\\n        }\\n      }\\n    }\\n  }\\n}\",\n  \"variables\": {\n    \"q\": \"{{search_query}}\"\n  }\n}"
+            }
+          }
+        },
+        {
+          "name": "BinderPOS Decklist API Search",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "https://portal.binderpos.com/external/shopify/decklist?storeUrl={{shopify_domain}}&type=mtg",
+              "protocol": "https",
+              "host": [
+                "portal",
+                "binderpos",
+                "com"
+              ],
+              "path": [
+                "external",
+                "shopify",
+                "decklist"
+              ],
+              "query": [
+                {
+                  "key": "storeUrl",
+                  "value": "{{shopify_domain}}"
+                },
+                {
+                  "key": "type",
+                  "value": "mtg"
+                }
+              ]
+            },
+            "description": "Search Mana Pro via BinderPOS portal decklist API (storeUrl=mana-pro-sg.myshopify.com).",
+            "body": {
+              "mode": "raw",
+              "raw": "[\n  {\n    \"card\": \"{{search_query}}\",\n    \"quantity\": 1\n  }\n]"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "MTG Asia",
+      "item": [
+        {
+          "name": "Shopify Storefront GraphQL Search",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-Shopify-Storefront-Access-Token",
+                "value": "199d9ab7d26aaba337bd43110a51265f"
+              },
+              {
+                "key": "Cookie",
+                "value": "cart_currency=SGD; localization=SG"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/2024-10/graphql.json",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "2024-10",
+                "graphql.json"
+              ]
+            },
+            "description": "Search MTG Asia inventory via Shopify Storefront API (same path used by gishathfetch gateway).",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"query\": \"query SearchCards($q: String!) {\\n  search(\\n    query: $q\\n    first: 25\\n    types: PRODUCT\\n    productFilters: [{ available: true }]\\n  ) {\\n    edges {\\n      node {\\n        ... on Product {\\n          title\\n          handle\\n          availableForSale\\n          productType\\n          tags\\n          featuredImage { url }\\n          variants(first: 20) {\\n            edges {\\n              node {\\n                id\\n                title\\n                availableForSale\\n                price { amount }\\n              }\\n            }\\n          }\\n        }\\n      }\\n    }\\n  }\\n}\",\n  \"variables\": {\n    \"q\": \"{{search_query}}\"\n  }\n}"
+            }
+          }
+        },
+        {
+          "name": "BinderPOS Decklist API Search",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "https://portal.binderpos.com/external/shopify/decklist?storeUrl={{shopify_domain}}&type=mtg",
+              "protocol": "https",
+              "host": [
+                "portal",
+                "binderpos",
+                "com"
+              ],
+              "path": [
+                "external",
+                "shopify",
+                "decklist"
+              ],
+              "query": [
+                {
+                  "key": "storeUrl",
+                  "value": "{{shopify_domain}}"
+                },
+                {
+                  "key": "type",
+                  "value": "mtg"
+                }
+              ]
+            },
+            "description": "Search MTG Asia via BinderPOS portal decklist API (storeUrl=mtgasia.myshopify.com).",
+            "body": {
+              "mode": "raw",
+              "raw": "[\n  {\n    \"card\": \"{{search_query}}\",\n    \"quantity\": 1\n  }\n]"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "OneMtg",
+      "item": [
+        {
+          "name": "Shopify Storefront GraphQL Search",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "X-Shopify-Storefront-Access-Token",
+                "value": "84d91e8d0ae281e71b204f4c5a8101df"
+              },
+              {
+                "key": "Cookie",
+                "value": "cart_currency=SGD; localization=SG"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/2024-10/graphql.json",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "2024-10",
+                "graphql.json"
+              ]
+            },
+            "description": "Search OneMtg inventory via Shopify Storefront API (same path used by gishathfetch gateway).",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"query\": \"query SearchCards($q: String!) {\\n  search(\\n    query: $q\\n    first: 25\\n    types: PRODUCT\\n    productFilters: [{ available: true }]\\n  ) {\\n    edges {\\n      node {\\n        ... on Product {\\n          title\\n          handle\\n          availableForSale\\n          productType\\n          tags\\n          featuredImage { url }\\n          variants(first: 20) {\\n            edges {\\n              node {\\n                id\\n                title\\n                availableForSale\\n                price { amount }\\n              }\\n            }\\n          }\\n        }\\n      }\\n    }\\n  }\\n}\",\n  \"variables\": {\n    \"q\": \"{{search_query}}\"\n  }\n}"
+            }
+          }
+        },
+        {
+          "name": "BinderPOS Decklist API Search",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "https://portal.binderpos.com/external/shopify/decklist?storeUrl={{shopify_domain}}&type=mtg",
+              "protocol": "https",
+              "host": [
+                "portal",
+                "binderpos",
+                "com"
+              ],
+              "path": [
+                "external",
+                "shopify",
+                "decklist"
+              ],
+              "query": [
+                {
+                  "key": "storeUrl",
+                  "value": "{{shopify_domain}}"
+                },
+                {
+                  "key": "type",
+                  "value": "mtg"
+                }
+              ]
+            },
+            "description": "Search OneMtg via BinderPOS portal decklist API (storeUrl=one-mtg.myshopify.com).",
+            "body": {
+              "mode": "raw",
+              "raw": "[\n  {\n    \"card\": \"{{search_query}}\",\n    \"quantity\": 1\n  }\n]"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/postman/collections/arcanesanctum.postman_collection.json
+++ b/postman/collections/arcanesanctum.postman_collection.json
@@ -1,0 +1,112 @@
+{
+  "info": {
+    "name": "Arcane Sanctum - LGS Search API",
+    "description": "Includes Shopify Storefront GraphQL and BinderPOS Decklist API requests.\n\nGenerated from gishathfetch gateway definitions. API paths only (no HTML scrape fallbacks).",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "https://arcanesanctumtcg.com"
+    },
+    {
+      "key": "shopify_domain",
+      "value": "30uetm-1y.myshopify.com"
+    },
+    {
+      "key": "search_query",
+      "value": "Opt"
+    },
+    {
+      "key": "storefront_access_token",
+      "value": "228ce7e7cffe6623f36634d0ca085e9e"
+    }
+  ],
+  "item": [
+    {
+      "name": "Shopify Storefront GraphQL Search",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "X-Shopify-Storefront-Access-Token",
+            "value": "{{storefront_access_token}}"
+          },
+          {
+            "key": "Cookie",
+            "value": "cart_currency=SGD; localization=SG"
+          }
+        ],
+        "url": {
+          "raw": "{{base_url}}/api/2024-10/graphql.json",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "2024-10",
+            "graphql.json"
+          ]
+        },
+        "description": "Search Arcane Sanctum inventory via Shopify Storefront API (same path used by gishathfetch gateway).",
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"query\": \"query SearchCards($q: String!) {\\n  search(\\n    query: $q\\n    first: 25\\n    types: PRODUCT\\n    productFilters: [{ available: true }]\\n  ) {\\n    edges {\\n      node {\\n        ... on Product {\\n          title\\n          handle\\n          availableForSale\\n          productType\\n          tags\\n          featuredImage { url }\\n          variants(first: 20) {\\n            edges {\\n              node {\\n                id\\n                title\\n                availableForSale\\n                price { amount }\\n              }\\n            }\\n          }\\n        }\\n      }\\n    }\\n  }\\n}\",\n  \"variables\": {\n    \"q\": \"{{search_query}}\"\n  }\n}"
+        }
+      }
+    },
+    {
+      "name": "BinderPOS Decklist API Search",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "https://portal.binderpos.com/external/shopify/decklist?storeUrl={{shopify_domain}}&type=mtg",
+          "protocol": "https",
+          "host": [
+            "portal",
+            "binderpos",
+            "com"
+          ],
+          "path": [
+            "external",
+            "shopify",
+            "decklist"
+          ],
+          "query": [
+            {
+              "key": "storeUrl",
+              "value": "{{shopify_domain}}"
+            },
+            {
+              "key": "type",
+              "value": "mtg"
+            }
+          ]
+        },
+        "description": "Search Arcane Sanctum via BinderPOS portal decklist API (storeUrl=30uetm-1y.myshopify.com).",
+        "body": {
+          "mode": "raw",
+          "raw": "[\n  {\n    \"card\": \"{{search_query}}\",\n    \"quantity\": 1\n  }\n]"
+        }
+      }
+    }
+  ]
+}

--- a/postman/collections/cardaffinity.postman_collection.json
+++ b/postman/collections/cardaffinity.postman_collection.json
@@ -1,0 +1,68 @@
+{
+  "info": {
+    "name": "Card Affinity - LGS Search API",
+    "description": "Card Affinity has no public Storefront token; only the BinderPOS Decklist API is available.\n\nGenerated from gishathfetch gateway definitions. API paths only (no HTML scrape fallbacks).",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "https://card-affinity.com"
+    },
+    {
+      "key": "shopify_domain",
+      "value": "563304-2.myshopify.com"
+    },
+    {
+      "key": "search_query",
+      "value": "Opt"
+    }
+  ],
+  "item": [
+    {
+      "name": "BinderPOS Decklist API Search",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "https://portal.binderpos.com/external/shopify/decklist?storeUrl={{shopify_domain}}&type=mtg",
+          "protocol": "https",
+          "host": [
+            "portal",
+            "binderpos",
+            "com"
+          ],
+          "path": [
+            "external",
+            "shopify",
+            "decklist"
+          ],
+          "query": [
+            {
+              "key": "storeUrl",
+              "value": "{{shopify_domain}}"
+            },
+            {
+              "key": "type",
+              "value": "mtg"
+            }
+          ]
+        },
+        "description": "Search Card Affinity via BinderPOS portal decklist API (storeUrl=563304-2.myshopify.com).",
+        "body": {
+          "mode": "raw",
+          "raw": "[\n  {\n    \"card\": \"{{search_query}}\",\n    \"quantity\": 1\n  }\n]"
+        }
+      }
+    }
+  ]
+}

--- a/postman/collections/cardsandcollection.postman_collection.json
+++ b/postman/collections/cardsandcollection.postman_collection.json
@@ -1,0 +1,51 @@
+{
+  "info": {
+    "name": "Cards & Collections - LGS Search API",
+    "description": "Elasticsearch-style catalog API at POST /api/catalog/. No authentication required.\n\nGenerated from gishathfetch gateway definitions. API paths only (no HTML scrape fallbacks).",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "https://cardsandcollections.com"
+    },
+    {
+      "key": "search_query",
+      "value": "Counterspell"
+    }
+  ],
+  "item": [
+    {
+      "name": "Catalog Search",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "{{base_url}}/api/catalog/",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "catalog",
+            ""
+          ]
+        },
+        "description": "POST Elasticsearch query to /api/catalog/. Filters to MTG and accessories.",
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"query\": {\n    \"bool\": {\n      \"should\": [\n        {\n          \"simple_query_string\": {\n            \"query\": \"{{search_query}}\",\n            \"fields\": [\n              \"name\",\n              \"setCode\",\n              \"setName\"\n            ],\n            \"default_operator\": \"AND\"\n          }\n        },\n        {\n          \"multi_match\": {\n            \"query\": \"{{search_query}}\",\n            \"type\": \"phrase_prefix\",\n            \"fields\": [\n              \"name\",\n              \"setCode\",\n              \"setName\"\n            ]\n          }\n        }\n      ]\n    }\n  },\n  \"post_filter\": {\n    \"bool\": {\n      \"must\": {\n        \"terms\": {\n          \"collectableContext.raw\": [\n            \"MTG\",\n            \"ACCESSORY\"\n          ]\n        }\n      }\n    }\n  },\n  \"aggs\": {\n    \"productCategory4\": {\n      \"filter\": {\n        \"bool\": {\n          \"must\": {\n            \"terms\": {\n              \"collectableContext.raw\": [\n                \"MTG\",\n                \"ACCESSORY\"\n              ]\n            }\n          }\n        }\n      },\n      \"aggs\": {\n        \"productCategory.raw\": {\n          \"terms\": {\n            \"field\": \"productCategory.raw\",\n            \"size\": 50\n          }\n        },\n        \"productCategory.raw_count\": {\n          \"cardinality\": {\n            \"field\": \"productCategory.raw\"\n          }\n        }\n      }\n    }\n  },\n  \"size\": 20,\n  \"sort\": [\n    {\n      \"quantityOnSale\": \"desc\"\n    }\n  ]\n}"
+        }
+      }
+    }
+  ]
+}

--- a/postman/collections/cardscentral.postman_collection.json
+++ b/postman/collections/cardscentral.postman_collection.json
@@ -1,0 +1,49 @@
+{
+  "info": {
+    "name": "Cards Central - LGS Search API",
+    "description": "Custom LGS search API at /api/lgs/search. No authentication required.\n\nGenerated from gishathfetch gateway definitions. API paths only (no HTML scrape fallbacks).",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "https://cardscentral.com"
+    },
+    {
+      "key": "search_query",
+      "value": "Lightning Bolt"
+    }
+  ],
+  "item": [
+    {
+      "name": "LGS Search",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "{{base_url}}/api/lgs/search?q={{search_query}}",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "lgs",
+            "search"
+          ],
+          "query": [
+            {
+              "key": "q",
+              "value": "{{search_query}}"
+            }
+          ]
+        },
+        "description": "GET /api/lgs/search?q={card name}. Returns JSON array of in-stock MTG singles."
+      }
+    }
+  ]
+}

--- a/postman/collections/cardscitadel.postman_collection.json
+++ b/postman/collections/cardscitadel.postman_collection.json
@@ -1,0 +1,112 @@
+{
+  "info": {
+    "name": "Cards Citadel - LGS Search API",
+    "description": "Includes Shopify Storefront GraphQL and BinderPOS Decklist API requests.\n\nGenerated from gishathfetch gateway definitions. API paths only (no HTML scrape fallbacks).",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "https://cardscitadel.com"
+    },
+    {
+      "key": "shopify_domain",
+      "value": "card-citadel.myshopify.com"
+    },
+    {
+      "key": "search_query",
+      "value": "Opt"
+    },
+    {
+      "key": "storefront_access_token",
+      "value": "b68bd33b7d819fc110eb25a07988cc8e"
+    }
+  ],
+  "item": [
+    {
+      "name": "Shopify Storefront GraphQL Search",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "X-Shopify-Storefront-Access-Token",
+            "value": "{{storefront_access_token}}"
+          },
+          {
+            "key": "Cookie",
+            "value": "cart_currency=SGD; localization=SG"
+          }
+        ],
+        "url": {
+          "raw": "{{base_url}}/api/2024-10/graphql.json",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "2024-10",
+            "graphql.json"
+          ]
+        },
+        "description": "Search Cards Citadel inventory via Shopify Storefront API (same path used by gishathfetch gateway).",
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"query\": \"query SearchCards($q: String!) {\\n  search(\\n    query: $q\\n    first: 25\\n    types: PRODUCT\\n    productFilters: [{ available: true }]\\n  ) {\\n    edges {\\n      node {\\n        ... on Product {\\n          title\\n          handle\\n          availableForSale\\n          productType\\n          tags\\n          featuredImage { url }\\n          variants(first: 20) {\\n            edges {\\n              node {\\n                id\\n                title\\n                availableForSale\\n                price { amount }\\n              }\\n            }\\n          }\\n        }\\n      }\\n    }\\n  }\\n}\",\n  \"variables\": {\n    \"q\": \"{{search_query}}\"\n  }\n}"
+        }
+      }
+    },
+    {
+      "name": "BinderPOS Decklist API Search",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "https://portal.binderpos.com/external/shopify/decklist?storeUrl={{shopify_domain}}&type=mtg",
+          "protocol": "https",
+          "host": [
+            "portal",
+            "binderpos",
+            "com"
+          ],
+          "path": [
+            "external",
+            "shopify",
+            "decklist"
+          ],
+          "query": [
+            {
+              "key": "storeUrl",
+              "value": "{{shopify_domain}}"
+            },
+            {
+              "key": "type",
+              "value": "mtg"
+            }
+          ]
+        },
+        "description": "Search Cards Citadel via BinderPOS portal decklist API (storeUrl=card-citadel.myshopify.com).",
+        "body": {
+          "mode": "raw",
+          "raw": "[\n  {\n    \"card\": \"{{search_query}}\",\n    \"quantity\": 1\n  }\n]"
+        }
+      }
+    }
+  ]
+}

--- a/postman/collections/duellerpoint.postman_collection.json
+++ b/postman/collections/duellerpoint.postman_collection.json
@@ -1,0 +1,48 @@
+{
+  "info": {
+    "name": "Dueller's Point - LGS Search API",
+    "description": "REST search API at GET /products/search. No authentication required.\n\nGenerated from gishathfetch gateway definitions. API paths only (no HTML scrape fallbacks).",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "https://www.duellerspoint.com"
+    },
+    {
+      "key": "search_query",
+      "value": "Lightning Bolt"
+    }
+  ],
+  "item": [
+    {
+      "name": "Product Search",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "{{base_url}}/products/search?search_text={{search_query}}",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "products",
+            "search"
+          ],
+          "query": [
+            {
+              "key": "search_text",
+              "value": "{{search_query}}"
+            }
+          ]
+        },
+        "description": "GET /products/search?search_text={card name}. Returns JSON with results array."
+      }
+    }
+  ]
+}

--- a/postman/collections/fivemana.postman_collection.json
+++ b/postman/collections/fivemana.postman_collection.json
@@ -1,0 +1,63 @@
+{
+  "info": {
+    "name": "5 Mana - LGS Search API",
+    "description": "Shopify Storefront GraphQL (primary path). Filters to available MTG Single products.\n\nGenerated from gishathfetch gateway definitions. API paths only (no HTML scrape fallbacks).",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "https://5-mana.sg"
+    },
+    {
+      "key": "storefront_access_token",
+      "value": "9e4cb078af6a814458ce898eb9631fe6"
+    },
+    {
+      "key": "search_query",
+      "value": "Abrade"
+    }
+  ],
+  "item": [
+    {
+      "name": "Shopify Storefront GraphQL Search",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "X-Shopify-Storefront-Access-Token",
+            "value": "{{storefront_access_token}}"
+          },
+          {
+            "key": "Cookie",
+            "value": "cart_currency=SGD; localization=SG"
+          }
+        ],
+        "url": {
+          "raw": "{{base_url}}/api/2024-10/graphql.json",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "2024-10",
+            "graphql.json"
+          ]
+        },
+        "description": "POST /api/2024-10/graphql.json with MTG Single product filter.",
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"query\": \"query SearchCards($q: String!) {\\n  search(\\n    query: $q\\n    first: 25\\n    types: PRODUCT\\n    productFilters: [{ available: true }, { productType: \\\"MTG Single\\\" }]\\n  ) {\\n    edges {\\n      node {\\n        ... on Product {\\n          title\\n          handle\\n          availableForSale\\n          productType\\n          tags\\n          featuredImage { url }\\n          variants(first: 20) {\\n            edges {\\n              node {\\n                title\\n                availableForSale\\n                price { amount }\\n              }\\n            }\\n          }\\n        }\\n      }\\n    }\\n  }\\n}\",\n  \"variables\": {\n    \"q\": \"{{search_query}}\"\n  }\n}"
+        }
+      }
+    }
+  ]
+}

--- a/postman/collections/flagship.postman_collection.json
+++ b/postman/collections/flagship.postman_collection.json
@@ -1,0 +1,112 @@
+{
+  "info": {
+    "name": "Flagship Games - LGS Search API",
+    "description": "Includes Shopify Storefront GraphQL and BinderPOS Decklist API requests.\n\nGenerated from gishathfetch gateway definitions. API paths only (no HTML scrape fallbacks).",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "https://www.flagshipgames.sg"
+    },
+    {
+      "key": "shopify_domain",
+      "value": "flagship-games.myshopify.com"
+    },
+    {
+      "key": "search_query",
+      "value": "Opt"
+    },
+    {
+      "key": "storefront_access_token",
+      "value": "e08d01a75c052a2ba9e40b5cfa5b0e36"
+    }
+  ],
+  "item": [
+    {
+      "name": "Shopify Storefront GraphQL Search",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "X-Shopify-Storefront-Access-Token",
+            "value": "{{storefront_access_token}}"
+          },
+          {
+            "key": "Cookie",
+            "value": "cart_currency=SGD; localization=SG"
+          }
+        ],
+        "url": {
+          "raw": "{{base_url}}/api/2024-10/graphql.json",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "2024-10",
+            "graphql.json"
+          ]
+        },
+        "description": "Search Flagship Games inventory via Shopify Storefront API (same path used by gishathfetch gateway).",
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"query\": \"query SearchCards($q: String!) {\\n  search(\\n    query: $q\\n    first: 25\\n    types: PRODUCT\\n    productFilters: [{ available: true }]\\n  ) {\\n    edges {\\n      node {\\n        ... on Product {\\n          title\\n          handle\\n          availableForSale\\n          productType\\n          tags\\n          featuredImage { url }\\n          variants(first: 20) {\\n            edges {\\n              node {\\n                id\\n                title\\n                availableForSale\\n                price { amount }\\n              }\\n            }\\n          }\\n        }\\n      }\\n    }\\n  }\\n}\",\n  \"variables\": {\n    \"q\": \"{{search_query}}\"\n  }\n}"
+        }
+      }
+    },
+    {
+      "name": "BinderPOS Decklist API Search",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "https://portal.binderpos.com/external/shopify/decklist?storeUrl={{shopify_domain}}&type=mtg",
+          "protocol": "https",
+          "host": [
+            "portal",
+            "binderpos",
+            "com"
+          ],
+          "path": [
+            "external",
+            "shopify",
+            "decklist"
+          ],
+          "query": [
+            {
+              "key": "storeUrl",
+              "value": "{{shopify_domain}}"
+            },
+            {
+              "key": "type",
+              "value": "mtg"
+            }
+          ]
+        },
+        "description": "Search Flagship Games via BinderPOS portal decklist API (storeUrl=flagship-games.myshopify.com).",
+        "body": {
+          "mode": "raw",
+          "raw": "[\n  {\n    \"card\": \"{{search_query}}\",\n    \"quantity\": 1\n  }\n]"
+        }
+      }
+    }
+  ]
+}

--- a/postman/collections/fyendalhobby.postman_collection.json
+++ b/postman/collections/fyendalhobby.postman_collection.json
@@ -1,0 +1,112 @@
+{
+  "info": {
+    "name": "Fyendal Hobby - LGS Search API",
+    "description": "Includes Shopify Storefront GraphQL and BinderPOS Decklist API requests.\n\nGenerated from gishathfetch gateway definitions. API paths only (no HTML scrape fallbacks).",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "https://fyendalhobby.com"
+    },
+    {
+      "key": "shopify_domain",
+      "value": "fyendal-hobby.myshopify.com"
+    },
+    {
+      "key": "search_query",
+      "value": "Opt"
+    },
+    {
+      "key": "storefront_access_token",
+      "value": "62ebf8066d0372bca57bb96d7a009a79"
+    }
+  ],
+  "item": [
+    {
+      "name": "Shopify Storefront GraphQL Search",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "X-Shopify-Storefront-Access-Token",
+            "value": "{{storefront_access_token}}"
+          },
+          {
+            "key": "Cookie",
+            "value": "cart_currency=SGD; localization=SG"
+          }
+        ],
+        "url": {
+          "raw": "{{base_url}}/api/2024-10/graphql.json",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "2024-10",
+            "graphql.json"
+          ]
+        },
+        "description": "Search Fyendal Hobby inventory via Shopify Storefront API (same path used by gishathfetch gateway).",
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"query\": \"query SearchCards($q: String!) {\\n  search(\\n    query: $q\\n    first: 25\\n    types: PRODUCT\\n    productFilters: [{ available: true }]\\n  ) {\\n    edges {\\n      node {\\n        ... on Product {\\n          title\\n          handle\\n          availableForSale\\n          productType\\n          tags\\n          featuredImage { url }\\n          variants(first: 20) {\\n            edges {\\n              node {\\n                id\\n                title\\n                availableForSale\\n                price { amount }\\n              }\\n            }\\n          }\\n        }\\n      }\\n    }\\n  }\\n}\",\n  \"variables\": {\n    \"q\": \"{{search_query}}\"\n  }\n}"
+        }
+      }
+    },
+    {
+      "name": "BinderPOS Decklist API Search",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "https://portal.binderpos.com/external/shopify/decklist?storeUrl={{shopify_domain}}&type=mtg",
+          "protocol": "https",
+          "host": [
+            "portal",
+            "binderpos",
+            "com"
+          ],
+          "path": [
+            "external",
+            "shopify",
+            "decklist"
+          ],
+          "query": [
+            {
+              "key": "storeUrl",
+              "value": "{{shopify_domain}}"
+            },
+            {
+              "key": "type",
+              "value": "mtg"
+            }
+          ]
+        },
+        "description": "Search Fyendal Hobby via BinderPOS portal decklist API (storeUrl=fyendal-hobby.myshopify.com).",
+        "body": {
+          "mode": "raw",
+          "raw": "[\n  {\n    \"card\": \"{{search_query}}\",\n    \"quantity\": 1\n  }\n]"
+        }
+      }
+    }
+  ]
+}

--- a/postman/collections/gameshaven.postman_collection.json
+++ b/postman/collections/gameshaven.postman_collection.json
@@ -1,0 +1,112 @@
+{
+  "info": {
+    "name": "Games Haven - LGS Search API",
+    "description": "Includes Shopify Storefront GraphQL and BinderPOS Decklist API requests.\n\nGenerated from gishathfetch gateway definitions. API paths only (no HTML scrape fallbacks).",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "https://www.gameshaventcg.com"
+    },
+    {
+      "key": "shopify_domain",
+      "value": "games-haven-sg.myshopify.com"
+    },
+    {
+      "key": "search_query",
+      "value": "Opt"
+    },
+    {
+      "key": "storefront_access_token",
+      "value": "5938b052bbbd595d317fdeb5464a6733"
+    }
+  ],
+  "item": [
+    {
+      "name": "Shopify Storefront GraphQL Search",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "X-Shopify-Storefront-Access-Token",
+            "value": "{{storefront_access_token}}"
+          },
+          {
+            "key": "Cookie",
+            "value": "cart_currency=SGD; localization=SG"
+          }
+        ],
+        "url": {
+          "raw": "{{base_url}}/api/2024-10/graphql.json",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "2024-10",
+            "graphql.json"
+          ]
+        },
+        "description": "Search Games Haven inventory via Shopify Storefront API (same path used by gishathfetch gateway).",
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"query\": \"query SearchCards($q: String!) {\\n  search(\\n    query: $q\\n    first: 25\\n    types: PRODUCT\\n    productFilters: [{ available: true }]\\n  ) {\\n    edges {\\n      node {\\n        ... on Product {\\n          title\\n          handle\\n          availableForSale\\n          productType\\n          tags\\n          featuredImage { url }\\n          variants(first: 20) {\\n            edges {\\n              node {\\n                id\\n                title\\n                availableForSale\\n                price { amount }\\n              }\\n            }\\n          }\\n        }\\n      }\\n    }\\n  }\\n}\",\n  \"variables\": {\n    \"q\": \"{{search_query}}\"\n  }\n}"
+        }
+      }
+    },
+    {
+      "name": "BinderPOS Decklist API Search",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "https://portal.binderpos.com/external/shopify/decklist?storeUrl={{shopify_domain}}&type=mtg",
+          "protocol": "https",
+          "host": [
+            "portal",
+            "binderpos",
+            "com"
+          ],
+          "path": [
+            "external",
+            "shopify",
+            "decklist"
+          ],
+          "query": [
+            {
+              "key": "storeUrl",
+              "value": "{{shopify_domain}}"
+            },
+            {
+              "key": "type",
+              "value": "mtg"
+            }
+          ]
+        },
+        "description": "Search Games Haven via BinderPOS portal decklist API (storeUrl=games-haven-sg.myshopify.com).",
+        "body": {
+          "mode": "raw",
+          "raw": "[\n  {\n    \"card\": \"{{search_query}}\",\n    \"quantity\": 1\n  }\n]"
+        }
+      }
+    }
+  ]
+}

--- a/postman/collections/gog.postman_collection.json
+++ b/postman/collections/gog.postman_collection.json
@@ -1,0 +1,112 @@
+{
+  "info": {
+    "name": "Grey Ogre Games - LGS Search API",
+    "description": "Includes Shopify Storefront GraphQL and BinderPOS Decklist API requests.\n\nGenerated from gishathfetch gateway definitions. API paths only (no HTML scrape fallbacks).",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "https://www.greyogregames.com"
+    },
+    {
+      "key": "shopify_domain",
+      "value": "grey-ogre-games-singapore.myshopify.com"
+    },
+    {
+      "key": "search_query",
+      "value": "Opt"
+    },
+    {
+      "key": "storefront_access_token",
+      "value": "80c454d63abad6ad0ebb6b3aaf649fcd"
+    }
+  ],
+  "item": [
+    {
+      "name": "Shopify Storefront GraphQL Search",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "X-Shopify-Storefront-Access-Token",
+            "value": "{{storefront_access_token}}"
+          },
+          {
+            "key": "Cookie",
+            "value": "cart_currency=SGD; localization=SG"
+          }
+        ],
+        "url": {
+          "raw": "{{base_url}}/api/2024-10/graphql.json",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "2024-10",
+            "graphql.json"
+          ]
+        },
+        "description": "Search Grey Ogre Games inventory via Shopify Storefront API (same path used by gishathfetch gateway).",
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"query\": \"query SearchCards($q: String!) {\\n  search(\\n    query: $q\\n    first: 25\\n    types: PRODUCT\\n    productFilters: [{ available: true }]\\n  ) {\\n    edges {\\n      node {\\n        ... on Product {\\n          title\\n          handle\\n          availableForSale\\n          productType\\n          tags\\n          featuredImage { url }\\n          variants(first: 20) {\\n            edges {\\n              node {\\n                id\\n                title\\n                availableForSale\\n                price { amount }\\n              }\\n            }\\n          }\\n        }\\n      }\\n    }\\n  }\\n}\",\n  \"variables\": {\n    \"q\": \"{{search_query}}\"\n  }\n}"
+        }
+      }
+    },
+    {
+      "name": "BinderPOS Decklist API Search",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "https://portal.binderpos.com/external/shopify/decklist?storeUrl={{shopify_domain}}&type=mtg",
+          "protocol": "https",
+          "host": [
+            "portal",
+            "binderpos",
+            "com"
+          ],
+          "path": [
+            "external",
+            "shopify",
+            "decklist"
+          ],
+          "query": [
+            {
+              "key": "storeUrl",
+              "value": "{{shopify_domain}}"
+            },
+            {
+              "key": "type",
+              "value": "mtg"
+            }
+          ]
+        },
+        "description": "Search Grey Ogre Games via BinderPOS portal decklist API (storeUrl=grey-ogre-games-singapore.myshopify.com).",
+        "body": {
+          "mode": "raw",
+          "raw": "[\n  {\n    \"card\": \"{{search_query}}\",\n    \"quantity\": 1\n  }\n]"
+        }
+      }
+    }
+  ]
+}

--- a/postman/collections/hideout.postman_collection.json
+++ b/postman/collections/hideout.postman_collection.json
@@ -1,0 +1,112 @@
+{
+  "info": {
+    "name": "Hideout - LGS Search API",
+    "description": "Includes Shopify Storefront GraphQL and BinderPOS Decklist API requests.\n\nGenerated from gishathfetch gateway definitions. API paths only (no HTML scrape fallbacks).",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "https://hideoutcg.com"
+    },
+    {
+      "key": "shopify_domain",
+      "value": "220022-20.myshopify.com"
+    },
+    {
+      "key": "search_query",
+      "value": "Opt"
+    },
+    {
+      "key": "storefront_access_token",
+      "value": "986e6f452e7b632be7a14cba965f64a8"
+    }
+  ],
+  "item": [
+    {
+      "name": "Shopify Storefront GraphQL Search",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "X-Shopify-Storefront-Access-Token",
+            "value": "{{storefront_access_token}}"
+          },
+          {
+            "key": "Cookie",
+            "value": "cart_currency=SGD; localization=SG"
+          }
+        ],
+        "url": {
+          "raw": "{{base_url}}/api/2024-10/graphql.json",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "2024-10",
+            "graphql.json"
+          ]
+        },
+        "description": "Search Hideout inventory via Shopify Storefront API (same path used by gishathfetch gateway).",
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"query\": \"query SearchCards($q: String!) {\\n  search(\\n    query: $q\\n    first: 25\\n    types: PRODUCT\\n    productFilters: [{ available: true }]\\n  ) {\\n    edges {\\n      node {\\n        ... on Product {\\n          title\\n          handle\\n          availableForSale\\n          productType\\n          tags\\n          featuredImage { url }\\n          variants(first: 20) {\\n            edges {\\n              node {\\n                id\\n                title\\n                availableForSale\\n                price { amount }\\n              }\\n            }\\n          }\\n        }\\n      }\\n    }\\n  }\\n}\",\n  \"variables\": {\n    \"q\": \"{{search_query}}\"\n  }\n}"
+        }
+      }
+    },
+    {
+      "name": "BinderPOS Decklist API Search",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "https://portal.binderpos.com/external/shopify/decklist?storeUrl={{shopify_domain}}&type=mtg",
+          "protocol": "https",
+          "host": [
+            "portal",
+            "binderpos",
+            "com"
+          ],
+          "path": [
+            "external",
+            "shopify",
+            "decklist"
+          ],
+          "query": [
+            {
+              "key": "storeUrl",
+              "value": "{{shopify_domain}}"
+            },
+            {
+              "key": "type",
+              "value": "mtg"
+            }
+          ]
+        },
+        "description": "Search Hideout via BinderPOS portal decklist API (storeUrl=220022-20.myshopify.com).",
+        "body": {
+          "mode": "raw",
+          "raw": "[\n  {\n    \"card\": \"{{search_query}}\",\n    \"quantity\": 1\n  }\n]"
+        }
+      }
+    }
+  ]
+}

--- a/postman/collections/hideyoshi.postman_collection.json
+++ b/postman/collections/hideyoshi.postman_collection.json
@@ -1,0 +1,112 @@
+{
+  "info": {
+    "name": "Hideyoshi - LGS Search API",
+    "description": "Includes Shopify Storefront GraphQL and BinderPOS Decklist API requests.\n\nGenerated from gishathfetch gateway definitions. API paths only (no HTML scrape fallbacks).",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "https://hideyoshitcg.com"
+    },
+    {
+      "key": "shopify_domain",
+      "value": "bposacct-9.myshopify.com"
+    },
+    {
+      "key": "search_query",
+      "value": "Opt"
+    },
+    {
+      "key": "storefront_access_token",
+      "value": "08d34daee87c87da96bab125075f193a"
+    }
+  ],
+  "item": [
+    {
+      "name": "Shopify Storefront GraphQL Search",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "X-Shopify-Storefront-Access-Token",
+            "value": "{{storefront_access_token}}"
+          },
+          {
+            "key": "Cookie",
+            "value": "cart_currency=SGD; localization=SG"
+          }
+        ],
+        "url": {
+          "raw": "{{base_url}}/api/2024-10/graphql.json",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "2024-10",
+            "graphql.json"
+          ]
+        },
+        "description": "Search Hideyoshi inventory via Shopify Storefront API (same path used by gishathfetch gateway).",
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"query\": \"query SearchCards($q: String!) {\\n  search(\\n    query: $q\\n    first: 25\\n    types: PRODUCT\\n    productFilters: [{ available: true }]\\n  ) {\\n    edges {\\n      node {\\n        ... on Product {\\n          title\\n          handle\\n          availableForSale\\n          productType\\n          tags\\n          featuredImage { url }\\n          variants(first: 20) {\\n            edges {\\n              node {\\n                id\\n                title\\n                availableForSale\\n                price { amount }\\n              }\\n            }\\n          }\\n        }\\n      }\\n    }\\n  }\\n}\",\n  \"variables\": {\n    \"q\": \"{{search_query}}\"\n  }\n}"
+        }
+      }
+    },
+    {
+      "name": "BinderPOS Decklist API Search",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "https://portal.binderpos.com/external/shopify/decklist?storeUrl={{shopify_domain}}&type=mtg",
+          "protocol": "https",
+          "host": [
+            "portal",
+            "binderpos",
+            "com"
+          ],
+          "path": [
+            "external",
+            "shopify",
+            "decklist"
+          ],
+          "query": [
+            {
+              "key": "storeUrl",
+              "value": "{{shopify_domain}}"
+            },
+            {
+              "key": "type",
+              "value": "mtg"
+            }
+          ]
+        },
+        "description": "Search Hideyoshi via BinderPOS portal decklist API (storeUrl=bposacct-9.myshopify.com).",
+        "body": {
+          "mode": "raw",
+          "raw": "[\n  {\n    \"card\": \"{{search_query}}\",\n    \"quantity\": 1\n  }\n]"
+        }
+      }
+    }
+  ]
+}

--- a/postman/collections/manapro.postman_collection.json
+++ b/postman/collections/manapro.postman_collection.json
@@ -1,0 +1,112 @@
+{
+  "info": {
+    "name": "Mana Pro - LGS Search API",
+    "description": "Includes Shopify Storefront GraphQL and BinderPOS Decklist API requests.\n\nGenerated from gishathfetch gateway definitions. API paths only (no HTML scrape fallbacks).",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "https://sg-manapro.com"
+    },
+    {
+      "key": "shopify_domain",
+      "value": "mana-pro-sg.myshopify.com"
+    },
+    {
+      "key": "search_query",
+      "value": "Opt"
+    },
+    {
+      "key": "storefront_access_token",
+      "value": "ba695fbdd730f9fa7b1e8f32e36691cf"
+    }
+  ],
+  "item": [
+    {
+      "name": "Shopify Storefront GraphQL Search",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "X-Shopify-Storefront-Access-Token",
+            "value": "{{storefront_access_token}}"
+          },
+          {
+            "key": "Cookie",
+            "value": "cart_currency=SGD; localization=SG"
+          }
+        ],
+        "url": {
+          "raw": "{{base_url}}/api/2024-10/graphql.json",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "2024-10",
+            "graphql.json"
+          ]
+        },
+        "description": "Search Mana Pro inventory via Shopify Storefront API (same path used by gishathfetch gateway).",
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"query\": \"query SearchCards($q: String!) {\\n  search(\\n    query: $q\\n    first: 25\\n    types: PRODUCT\\n    productFilters: [{ available: true }]\\n  ) {\\n    edges {\\n      node {\\n        ... on Product {\\n          title\\n          handle\\n          availableForSale\\n          productType\\n          tags\\n          featuredImage { url }\\n          variants(first: 20) {\\n            edges {\\n              node {\\n                id\\n                title\\n                availableForSale\\n                price { amount }\\n              }\\n            }\\n          }\\n        }\\n      }\\n    }\\n  }\\n}\",\n  \"variables\": {\n    \"q\": \"{{search_query}}\"\n  }\n}"
+        }
+      }
+    },
+    {
+      "name": "BinderPOS Decklist API Search",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "https://portal.binderpos.com/external/shopify/decklist?storeUrl={{shopify_domain}}&type=mtg",
+          "protocol": "https",
+          "host": [
+            "portal",
+            "binderpos",
+            "com"
+          ],
+          "path": [
+            "external",
+            "shopify",
+            "decklist"
+          ],
+          "query": [
+            {
+              "key": "storeUrl",
+              "value": "{{shopify_domain}}"
+            },
+            {
+              "key": "type",
+              "value": "mtg"
+            }
+          ]
+        },
+        "description": "Search Mana Pro via BinderPOS portal decklist API (storeUrl=mana-pro-sg.myshopify.com).",
+        "body": {
+          "mode": "raw",
+          "raw": "[\n  {\n    \"card\": \"{{search_query}}\",\n    \"quantity\": 1\n  }\n]"
+        }
+      }
+    }
+  ]
+}

--- a/postman/collections/moxandlotus.postman_collection.json
+++ b/postman/collections/moxandlotus.postman_collection.json
@@ -1,0 +1,84 @@
+{
+  "info": {
+    "name": "Mox & Lotus - LGS Search API",
+    "description": "REST product API at GET /api/products. No authentication required.\n\nGenerated from gishathfetch gateway definitions. API paths only (no HTML scrape fallbacks).",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "https://moxandlotus.sg"
+    },
+    {
+      "key": "search_query",
+      "value": "Abrade"
+    }
+  ],
+  "item": [
+    {
+      "name": "Product Search",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "{{base_url}}/api/products?limit=24&full_search=true&showStatus=false&is_paginated=true&in_stock=true&sortVariation=true&category_id=1&variation_code=all&order_by=Price Low to High&search={{search_query}}",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "products"
+          ],
+          "query": [
+            {
+              "key": "limit",
+              "value": "24"
+            },
+            {
+              "key": "full_search",
+              "value": "true"
+            },
+            {
+              "key": "showStatus",
+              "value": "false"
+            },
+            {
+              "key": "is_paginated",
+              "value": "true"
+            },
+            {
+              "key": "in_stock",
+              "value": "true"
+            },
+            {
+              "key": "sortVariation",
+              "value": "true"
+            },
+            {
+              "key": "category_id",
+              "value": "1"
+            },
+            {
+              "key": "variation_code",
+              "value": "all"
+            },
+            {
+              "key": "order_by",
+              "value": "Price Low to High"
+            },
+            {
+              "key": "search",
+              "value": "{{search_query}}"
+            }
+          ]
+        },
+        "description": "GET /api/products with MTG category filters and in_stock=true."
+      }
+    }
+  ]
+}

--- a/postman/collections/mtgasia.postman_collection.json
+++ b/postman/collections/mtgasia.postman_collection.json
@@ -1,0 +1,112 @@
+{
+  "info": {
+    "name": "MTG Asia - LGS Search API",
+    "description": "Includes Shopify Storefront GraphQL and BinderPOS Decklist API requests.\n\nGenerated from gishathfetch gateway definitions. API paths only (no HTML scrape fallbacks).",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "https://www.mtg-asia.com"
+    },
+    {
+      "key": "shopify_domain",
+      "value": "mtgasia.myshopify.com"
+    },
+    {
+      "key": "search_query",
+      "value": "Opt"
+    },
+    {
+      "key": "storefront_access_token",
+      "value": "199d9ab7d26aaba337bd43110a51265f"
+    }
+  ],
+  "item": [
+    {
+      "name": "Shopify Storefront GraphQL Search",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "X-Shopify-Storefront-Access-Token",
+            "value": "{{storefront_access_token}}"
+          },
+          {
+            "key": "Cookie",
+            "value": "cart_currency=SGD; localization=SG"
+          }
+        ],
+        "url": {
+          "raw": "{{base_url}}/api/2024-10/graphql.json",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "2024-10",
+            "graphql.json"
+          ]
+        },
+        "description": "Search MTG Asia inventory via Shopify Storefront API (same path used by gishathfetch gateway).",
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"query\": \"query SearchCards($q: String!) {\\n  search(\\n    query: $q\\n    first: 25\\n    types: PRODUCT\\n    productFilters: [{ available: true }]\\n  ) {\\n    edges {\\n      node {\\n        ... on Product {\\n          title\\n          handle\\n          availableForSale\\n          productType\\n          tags\\n          featuredImage { url }\\n          variants(first: 20) {\\n            edges {\\n              node {\\n                id\\n                title\\n                availableForSale\\n                price { amount }\\n              }\\n            }\\n          }\\n        }\\n      }\\n    }\\n  }\\n}\",\n  \"variables\": {\n    \"q\": \"{{search_query}}\"\n  }\n}"
+        }
+      }
+    },
+    {
+      "name": "BinderPOS Decklist API Search",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "https://portal.binderpos.com/external/shopify/decklist?storeUrl={{shopify_domain}}&type=mtg",
+          "protocol": "https",
+          "host": [
+            "portal",
+            "binderpos",
+            "com"
+          ],
+          "path": [
+            "external",
+            "shopify",
+            "decklist"
+          ],
+          "query": [
+            {
+              "key": "storeUrl",
+              "value": "{{shopify_domain}}"
+            },
+            {
+              "key": "type",
+              "value": "mtg"
+            }
+          ]
+        },
+        "description": "Search MTG Asia via BinderPOS portal decklist API (storeUrl=mtgasia.myshopify.com).",
+        "body": {
+          "mode": "raw",
+          "raw": "[\n  {\n    \"card\": \"{{search_query}}\",\n    \"quantity\": 1\n  }\n]"
+        }
+      }
+    }
+  ]
+}

--- a/postman/collections/onemtg.postman_collection.json
+++ b/postman/collections/onemtg.postman_collection.json
@@ -1,0 +1,112 @@
+{
+  "info": {
+    "name": "OneMtg - LGS Search API",
+    "description": "Includes Shopify Storefront GraphQL and BinderPOS Decklist API requests.\n\nGenerated from gishathfetch gateway definitions. API paths only (no HTML scrape fallbacks).",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "https://onemtg.com.sg"
+    },
+    {
+      "key": "shopify_domain",
+      "value": "one-mtg.myshopify.com"
+    },
+    {
+      "key": "search_query",
+      "value": "Opt"
+    },
+    {
+      "key": "storefront_access_token",
+      "value": "84d91e8d0ae281e71b204f4c5a8101df"
+    }
+  ],
+  "item": [
+    {
+      "name": "Shopify Storefront GraphQL Search",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "X-Shopify-Storefront-Access-Token",
+            "value": "{{storefront_access_token}}"
+          },
+          {
+            "key": "Cookie",
+            "value": "cart_currency=SGD; localization=SG"
+          }
+        ],
+        "url": {
+          "raw": "{{base_url}}/api/2024-10/graphql.json",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "2024-10",
+            "graphql.json"
+          ]
+        },
+        "description": "Search OneMtg inventory via Shopify Storefront API (same path used by gishathfetch gateway).",
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"query\": \"query SearchCards($q: String!) {\\n  search(\\n    query: $q\\n    first: 25\\n    types: PRODUCT\\n    productFilters: [{ available: true }]\\n  ) {\\n    edges {\\n      node {\\n        ... on Product {\\n          title\\n          handle\\n          availableForSale\\n          productType\\n          tags\\n          featuredImage { url }\\n          variants(first: 20) {\\n            edges {\\n              node {\\n                id\\n                title\\n                availableForSale\\n                price { amount }\\n              }\\n            }\\n          }\\n        }\\n      }\\n    }\\n  }\\n}\",\n  \"variables\": {\n    \"q\": \"{{search_query}}\"\n  }\n}"
+        }
+      }
+    },
+    {
+      "name": "BinderPOS Decklist API Search",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "https://portal.binderpos.com/external/shopify/decklist?storeUrl={{shopify_domain}}&type=mtg",
+          "protocol": "https",
+          "host": [
+            "portal",
+            "binderpos",
+            "com"
+          ],
+          "path": [
+            "external",
+            "shopify",
+            "decklist"
+          ],
+          "query": [
+            {
+              "key": "storeUrl",
+              "value": "{{shopify_domain}}"
+            },
+            {
+              "key": "type",
+              "value": "mtg"
+            }
+          ]
+        },
+        "description": "Search OneMtg via BinderPOS portal decklist API (storeUrl=one-mtg.myshopify.com).",
+        "body": {
+          "mode": "raw",
+          "raw": "[\n  {\n    \"card\": \"{{search_query}}\",\n    \"quantity\": 1\n  }\n]"
+        }
+      }
+    }
+  ]
+}

--- a/postman/collections/tcgmarketplace.postman_collection.json
+++ b/postman/collections/tcgmarketplace.postman_collection.json
@@ -1,0 +1,54 @@
+{
+  "info": {
+    "name": "The TCG Marketplace - LGS Search API",
+    "description": "Advanced search API on port 3501. Requires access_token (set TCG_MARKETPLACE_ACCESS_TOKEN env var in production).\n\nGenerated from gishathfetch gateway definitions. API paths only (no HTML scrape fallbacks).",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "api_url",
+      "value": "https://thetcgmarketplace.com:3501"
+    },
+    {
+      "key": "access_token",
+      "value": ""
+    },
+    {
+      "key": "search_query",
+      "value": "Abrade"
+    }
+  ],
+  "item": [
+    {
+      "name": "Advanced Search",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Accept",
+            "value": "application/json"
+          },
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "url": {
+          "raw": "{{api_url}}/encoder/advancedsearch",
+          "host": [
+            "{{api_url}}"
+          ],
+          "path": [
+            "encoder",
+            "advancedsearch"
+          ]
+        },
+        "description": "POST /encoder/advancedsearch. category=3 is MTG. Set access_token collection variable before sending.",
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"access_token\": \"{{access_token}}\",\n  \"name\": \"{{search_query}}\",\n  \"category\": 3,\n  \"order\": \"name_asc\"\n}"
+        }
+      }
+    }
+  ]
+}

--- a/postman/generate-collections.mjs
+++ b/postman/generate-collections.mjs
@@ -1,0 +1,484 @@
+#!/usr/bin/env node
+/**
+ * Generates Postman v2.1 collections for each LGS that uses JSON/GraphQL APIs
+ * (excludes HTML-only scrapers like Agora Hobby).
+ */
+
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const OUT_DIR = join(import.meta.dirname, 'collections');
+mkdirSync(OUT_DIR, { recursive: true });
+
+const BINDERPOS_GRAPHQL_QUERY = `query SearchCards($q: String!) {
+  search(
+    query: $q
+    first: 25
+    types: PRODUCT
+    productFilters: [{ available: true }]
+  ) {
+    edges {
+      node {
+        ... on Product {
+          title
+          handle
+          availableForSale
+          productType
+          tags
+          featuredImage { url }
+          variants(first: 20) {
+            edges {
+              node {
+                id
+                title
+                availableForSale
+                price { amount }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+const FIVEMANA_GRAPHQL_QUERY = `query SearchCards($q: String!) {
+  search(
+    query: $q
+    first: 25
+    types: PRODUCT
+    productFilters: [{ available: true }, { productType: "MTG Single" }]
+  ) {
+    edges {
+      node {
+        ... on Product {
+          title
+          handle
+          availableForSale
+          productType
+          tags
+          featuredImage { url }
+          variants(first: 20) {
+            edges {
+              node {
+                title
+                availableForSale
+                price { amount }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+const CARDS_AND_COLLECTIONS_BODY = {
+  query: {
+    bool: {
+      should: [
+        {
+          simple_query_string: {
+            query: '{{search_query}}',
+            fields: ['name', 'setCode', 'setName'],
+            default_operator: 'AND',
+          },
+        },
+        {
+          multi_match: {
+            query: '{{search_query}}',
+            type: 'phrase_prefix',
+            fields: ['name', 'setCode', 'setName'],
+          },
+        },
+      ],
+    },
+  },
+  post_filter: {
+    bool: {
+      must: {
+        terms: {
+          'collectableContext.raw': ['MTG', 'ACCESSORY'],
+        },
+      },
+    },
+  },
+  aggs: {
+    productCategory4: {
+      filter: {
+        bool: {
+          must: {
+            terms: {
+              'collectableContext.raw': ['MTG', 'ACCESSORY'],
+            },
+          },
+        },
+      },
+      aggs: {
+        'productCategory.raw': {
+          terms: { field: 'productCategory.raw', size: 50 },
+        },
+        'productCategory.raw_count': {
+          cardinality: { field: 'productCategory.raw' },
+        },
+      },
+    },
+  },
+  size: 20,
+  sort: [{ quantityOnSale: 'desc' }],
+};
+
+function collection(info, variables, items) {
+  return {
+    info: {
+      name: info.name,
+      description: info.description,
+      schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json',
+    },
+    variable: variables,
+    item: items,
+  };
+}
+
+function getRequest(name, description, method, url, headers, body) {
+  const req = {
+    name,
+    request: {
+      method,
+      header: headers,
+      url,
+      description,
+    },
+  };
+  if (body !== undefined) {
+    req.request.body = body;
+  }
+  return req;
+}
+
+function jsonHeaders(extra = []) {
+  return [
+    { key: 'Accept', value: 'application/json' },
+    { key: 'Content-Type', value: 'application/json' },
+    ...extra,
+  ];
+}
+
+function shopifyGraphQLRequest(storeName, baseUrl, token, query) {
+  const headers = jsonHeaders([
+  { key: 'X-Shopify-Storefront-Access-Token', value: token },
+  { key: 'Cookie', value: 'cart_currency=SGD; localization=SG' },
+  ]);
+  return getRequest(
+    'Shopify Storefront GraphQL Search',
+    `Search ${storeName} inventory via Shopify Storefront API (same path used by gishathfetch gateway).`,
+    'POST',
+    {
+      raw: '{{base_url}}/api/2024-10/graphql.json',
+      host: ['{{base_url}}'],
+      path: ['api', '2024-10', 'graphql.json'],
+    },
+    headers,
+    {
+      mode: 'raw',
+      raw: JSON.stringify({ query, variables: { q: '{{search_query}}' } }, null, 2),
+    },
+  );
+}
+
+function decklistRequest(storeName, shopifyDomain) {
+  return getRequest(
+    'BinderPOS Decklist API Search',
+    `Search ${storeName} via BinderPOS portal decklist API (storeUrl=${shopifyDomain}).`,
+    'POST',
+    {
+      raw: 'https://portal.binderpos.com/external/shopify/decklist?storeUrl={{shopify_domain}}&type=mtg',
+      protocol: 'https',
+      host: ['portal', 'binderpos', 'com'],
+      path: ['external', 'shopify', 'decklist'],
+      query: [
+        { key: 'storeUrl', value: '{{shopify_domain}}' },
+        { key: 'type', value: 'mtg' },
+      ],
+    },
+    jsonHeaders(),
+    {
+      mode: 'raw',
+      raw: JSON.stringify([{ card: '{{search_query}}', quantity: 1 }], null, 2),
+    },
+  );
+}
+
+const binderposStores = [
+  { id: 'arcanesanctum', name: 'Arcane Sanctum', baseUrl: 'https://arcanesanctumtcg.com', token: '228ce7e7cffe6623f36634d0ca085e9e', shopifyDomain: '30uetm-1y.myshopify.com' },
+  { id: 'cardaffinity', name: 'Card Affinity', baseUrl: 'https://card-affinity.com', token: null, shopifyDomain: '563304-2.myshopify.com' },
+  { id: 'cardscitadel', name: 'Cards Citadel', baseUrl: 'https://cardscitadel.com', token: 'b68bd33b7d819fc110eb25a07988cc8e', shopifyDomain: 'card-citadel.myshopify.com' },
+  { id: 'flagship', name: 'Flagship Games', baseUrl: 'https://www.flagshipgames.sg', token: 'e08d01a75c052a2ba9e40b5cfa5b0e36', shopifyDomain: 'flagship-games.myshopify.com' },
+  { id: 'fyendalhobby', name: 'Fyendal Hobby', baseUrl: 'https://fyendalhobby.com', token: '62ebf8066d0372bca57bb96d7a009a79', shopifyDomain: 'fyendal-hobby.myshopify.com' },
+  { id: 'gameshaven', name: 'Games Haven', baseUrl: 'https://www.gameshaventcg.com', token: '5938b052bbbd595d317fdeb5464a6733', shopifyDomain: 'games-haven-sg.myshopify.com' },
+  { id: 'gog', name: 'Grey Ogre Games', baseUrl: 'https://www.greyogregames.com', token: '80c454d63abad6ad0ebb6b3aaf649fcd', shopifyDomain: 'grey-ogre-games-singapore.myshopify.com' },
+  { id: 'hideout', name: 'Hideout', baseUrl: 'https://hideoutcg.com', token: '986e6f452e7b632be7a14cba965f64a8', shopifyDomain: '220022-20.myshopify.com' },
+  { id: 'hideyoshi', name: 'Hideyoshi', baseUrl: 'https://hideyoshitcg.com', token: '08d34daee87c87da96bab125075f193a', shopifyDomain: 'bposacct-9.myshopify.com' },
+  { id: 'manapro', name: 'Mana Pro', baseUrl: 'https://sg-manapro.com', token: 'ba695fbdd730f9fa7b1e8f32e36691cf', shopifyDomain: 'mana-pro-sg.myshopify.com' },
+  { id: 'mtgasia', name: 'MTG Asia', baseUrl: 'https://www.mtg-asia.com', token: '199d9ab7d26aaba337bd43110a51265f', shopifyDomain: 'mtgasia.myshopify.com' },
+  { id: 'onemtg', name: 'OneMtg', baseUrl: 'https://onemtg.com.sg', token: '84d91e8d0ae281e71b204f4c5a8101df', shopifyDomain: 'one-mtg.myshopify.com' },
+];
+
+const customStores = [
+  {
+    id: 'cardscentral',
+    name: 'Cards Central',
+    description: 'Custom LGS search API at /api/lgs/search. No authentication required.',
+    variables: [
+      { key: 'base_url', value: 'https://cardscentral.com' },
+      { key: 'search_query', value: 'Lightning Bolt' },
+    ],
+    items: [
+      getRequest(
+        'LGS Search',
+        'GET /api/lgs/search?q={card name}. Returns JSON array of in-stock MTG singles.',
+        'GET',
+        {
+          raw: '{{base_url}}/api/lgs/search?q={{search_query}}',
+          host: ['{{base_url}}'],
+          path: ['api', 'lgs', 'search'],
+          query: [{ key: 'q', value: '{{search_query}}' }],
+        },
+        [{ key: 'Accept', value: 'application/json' }],
+      ),
+    ],
+  },
+  {
+    id: 'cardsandcollection',
+    name: 'Cards & Collections',
+    description: 'Elasticsearch-style catalog API at POST /api/catalog/. No authentication required.',
+    variables: [
+      { key: 'base_url', value: 'https://cardsandcollections.com' },
+      { key: 'search_query', value: 'Counterspell' },
+    ],
+    items: [
+      getRequest(
+        'Catalog Search',
+        'POST Elasticsearch query to /api/catalog/. Filters to MTG and accessories.',
+        'POST',
+        {
+          raw: '{{base_url}}/api/catalog/',
+          host: ['{{base_url}}'],
+          path: ['api', 'catalog', ''],
+        },
+        jsonHeaders(),
+        { mode: 'raw', raw: JSON.stringify(CARDS_AND_COLLECTIONS_BODY, null, 2) },
+      ),
+    ],
+  },
+  {
+    id: 'duellerpoint',
+    name: "Dueller's Point",
+    description: 'REST search API at GET /products/search. No authentication required.',
+    variables: [
+      { key: 'base_url', value: 'https://www.duellerspoint.com' },
+      { key: 'search_query', value: 'Lightning Bolt' },
+    ],
+    items: [
+      getRequest(
+        'Product Search',
+        'GET /products/search?search_text={card name}. Returns JSON with results array.',
+        'GET',
+        {
+          raw: '{{base_url}}/products/search?search_text={{search_query}}',
+          host: ['{{base_url}}'],
+          path: ['products', 'search'],
+          query: [{ key: 'search_text', value: '{{search_query}}' }],
+        },
+        [{ key: 'Accept', value: 'application/json' }],
+      ),
+    ],
+  },
+  {
+    id: 'moxandlotus',
+    name: 'Mox & Lotus',
+    description: 'REST product API at GET /api/products. No authentication required.',
+    variables: [
+      { key: 'base_url', value: 'https://moxandlotus.sg' },
+      { key: 'search_query', value: 'Abrade' },
+    ],
+    items: [
+      getRequest(
+        'Product Search',
+        'GET /api/products with MTG category filters and in_stock=true.',
+        'GET',
+        {
+          raw: '{{base_url}}/api/products?limit=24&full_search=true&showStatus=false&is_paginated=true&in_stock=true&sortVariation=true&category_id=1&variation_code=all&order_by=Price Low to High&search={{search_query}}',
+          host: ['{{base_url}}'],
+          path: ['api', 'products'],
+          query: [
+            { key: 'limit', value: '24' },
+            { key: 'full_search', value: 'true' },
+            { key: 'showStatus', value: 'false' },
+            { key: 'is_paginated', value: 'true' },
+            { key: 'in_stock', value: 'true' },
+            { key: 'sortVariation', value: 'true' },
+            { key: 'category_id', value: '1' },
+            { key: 'variation_code', value: 'all' },
+            { key: 'order_by', value: 'Price Low to High' },
+            { key: 'search', value: '{{search_query}}' },
+          ],
+        },
+        [{ key: 'Accept', value: 'application/json' }],
+      ),
+    ],
+  },
+  {
+    id: 'tcgmarketplace',
+    name: 'The TCG Marketplace',
+    description: 'Advanced search API on port 3501. Requires access_token (set TCG_MARKETPLACE_ACCESS_TOKEN env var in production).',
+    variables: [
+      { key: 'api_url', value: 'https://thetcgmarketplace.com:3501' },
+      { key: 'access_token', value: '' },
+      { key: 'search_query', value: 'Abrade' },
+    ],
+    items: [
+      getRequest(
+        'Advanced Search',
+        'POST /encoder/advancedsearch. category=3 is MTG. Set access_token collection variable before sending.',
+        'POST',
+        {
+          raw: '{{api_url}}/encoder/advancedsearch',
+          host: ['{{api_url}}'],
+          path: ['encoder', 'advancedsearch'],
+        },
+        jsonHeaders(),
+        {
+          mode: 'raw',
+          raw: JSON.stringify(
+            {
+              access_token: '{{access_token}}',
+              name: '{{search_query}}',
+              category: 3,
+              order: 'name_asc',
+            },
+            null,
+            2,
+          ),
+        },
+      ),
+    ],
+  },
+  {
+    id: 'fivemana',
+    name: '5 Mana',
+    description: 'Shopify Storefront GraphQL (primary path). Filters to available MTG Single products.',
+    variables: [
+      { key: 'base_url', value: 'https://5-mana.sg' },
+      { key: 'storefront_access_token', value: '9e4cb078af6a814458ce898eb9631fe6' },
+      { key: 'search_query', value: 'Abrade' },
+    ],
+    items: [
+      getRequest(
+        'Shopify Storefront GraphQL Search',
+        'POST /api/2024-10/graphql.json with MTG Single product filter.',
+        'POST',
+        {
+          raw: '{{base_url}}/api/2024-10/graphql.json',
+          host: ['{{base_url}}'],
+          path: ['api', '2024-10', 'graphql.json'],
+        },
+        jsonHeaders([
+          { key: 'X-Shopify-Storefront-Access-Token', value: '{{storefront_access_token}}' },
+          { key: 'Cookie', value: 'cart_currency=SGD; localization=SG' },
+        ]),
+        {
+          mode: 'raw',
+          raw: JSON.stringify({ query: FIVEMANA_GRAPHQL_QUERY, variables: { q: '{{search_query}}' } }, null, 2),
+        },
+      ),
+    ],
+  },
+];
+
+function writeCollection(filename, data) {
+  const path = join(OUT_DIR, filename);
+  writeFileSync(path, JSON.stringify(data, null, 2) + '\n');
+  return path;
+}
+
+const written = [];
+
+for (const store of customStores) {
+  const c = collection(
+    {
+      name: `${store.name} - LGS Search API`,
+      description: store.description + '\n\nGenerated from gishathfetch gateway definitions. API paths only (no HTML scrape fallbacks).',
+    },
+    store.variables,
+    store.items,
+  );
+  written.push(writeCollection(`${store.id}.postman_collection.json`, c));
+}
+
+for (const store of binderposStores) {
+  const variables = [
+    { key: 'base_url', value: store.baseUrl },
+    { key: 'shopify_domain', value: store.shopifyDomain },
+    { key: 'search_query', value: 'Opt' },
+  ];
+  if (store.token) {
+    variables.push({ key: 'storefront_access_token', value: store.token });
+  }
+
+  const items = [];
+  if (store.token) {
+    items.push(
+      shopifyGraphQLRequest(store.name, store.baseUrl, '{{storefront_access_token}}', BINDERPOS_GRAPHQL_QUERY),
+    );
+  }
+  items.push(decklistRequest(store.name, store.shopifyDomain));
+
+  const apiNote = store.token
+    ? 'Includes Shopify Storefront GraphQL and BinderPOS Decklist API requests.'
+    : 'Card Affinity has no public Storefront token; only the BinderPOS Decklist API is available.';
+
+  const c = collection(
+    {
+      name: `${store.name} - LGS Search API`,
+      description: `${apiNote}\n\nGenerated from gishathfetch gateway definitions. API paths only (no HTML scrape fallbacks).`,
+    },
+    variables,
+    items,
+  );
+  written.push(writeCollection(`${store.id}.postman_collection.json`, c));
+}
+
+// Master collection with folders per store
+const masterItems = [
+  ...customStores.map((s) => ({
+    name: s.name,
+    item: s.items,
+    description: s.description,
+  })),
+  ...binderposStores.map((s) => {
+    const subItems = [];
+    if (s.token) {
+      subItems.push(shopifyGraphQLRequest(s.name, s.baseUrl, s.token, BINDERPOS_GRAPHQL_QUERY));
+    }
+    subItems.push(decklistRequest(s.name, s.shopifyDomain));
+    return { name: s.name, item: subItems };
+  }),
+];
+
+const master = collection(
+  {
+    name: 'GishathFetch - All LGS Search APIs',
+    description:
+      'Combined Postman collection for all API-based LGS integrations in gishathfetch. Excludes HTML-only stores (Agora Hobby). Each folder mirrors an individual per-store collection in postman/collections/.',
+  },
+  [{ key: 'search_query', value: 'Opt' }],
+  masterItems,
+);
+
+written.push(writeCollection('all-lgs.postman_collection.json', master));
+
+console.log(`Wrote ${written.length} Postman collections to ${OUT_DIR}:`);
+for (const p of written) {
+  console.log('  -', p.split('/').pop());
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds importable Postman v2.1 collections for every LGS integration that uses JSON/GraphQL APIs (no HTML scrape fallbacks).

## What's included

- **18 per-store collections** in `postman/collections/` (one JSON file per store)
- **1 combined collection** (`all-lgs.postman_collection.json`) with a folder per store
- **Generator script** (`postman/generate-collections.mjs`) synced to gateway definitions — re-run after gateway changes

## Stores covered

| Type | Stores |
|------|--------|
| Custom REST | Cards Central, Cards & Collections, Dueller's Point, Mox & Lotus, The TCG Marketplace |
| Shopify GraphQL | 5 Mana |
| BinderPOS (GraphQL + Decklist) | Arcane Sanctum, Cards Citadel, Flagship, Fyendal Hobby, Games Haven, Grey Ogre Games, Hideout, Hideyoshi, Mana Pro, MTG Asia, OneMtg |
| BinderPOS (Decklist only) | Card Affinity (no public Storefront token) |

**Excluded:** Agora Hobby (HTML scrape only).

## Import

In Postman: **Import** → select one or more `*.postman_collection.json` files from `postman/collections/`.

## Notes

- **TCG Marketplace** requires setting the `access_token` collection variable (same as `TCG_MARKETPLACE_ACCESS_TOKEN` env var in production).
- **Shopify/BinderPOS** collections include the public Storefront access tokens already used by the gateway.
- Collection variables `search_query` default to common test card names; change before sending.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-167834a5-d267-43b1-899d-f82ecdad8eb4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-167834a5-d267-43b1-899d-f82ecdad8eb4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

