### PR TITLE
Extract embedded card quality from Arcane Sanctum titles

### DIFF
--- a/api/gateway/binderpos/storefront_card_helpers.go
+++ b/api/gateway/binderpos/storefront_card_helpers.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"strings"
 
+	"mtg-price-checker-sg/gateway/util"
 	"mtg-price-checker-sg/pkg/config"
 )
 
@@ -43,7 +44,7 @@ func qualityFromProductTitle(productTitle string) string {
 	}
 	quality := strings.TrimSpace(strings.ReplaceAll(segment, "Foil", ""))
 	quality = strings.Join(strings.Fields(quality), " ")
-	if !looksLikeCardQuality(quality) {
+	if !util.IsKnownQuality(quality) {
 		return ""
 	}
 	return quality
@@ -59,8 +60,8 @@ func embeddedQualitySegment(productTitle string) string {
 	if after == "" {
 		return ""
 	}
-	if bracket := strings.Index(after, "["); bracket >= 0 {
-		return strings.TrimSpace(after[:bracket])
+	if before, _, ok := strings.Cut(after, "["); ok {
+		return strings.TrimSpace(before)
 	}
 	return after
 }
@@ -81,16 +82,6 @@ func embeddedQualitySeparator(productTitle string, dash int) string {
 	return " – "
 }
 
-func looksLikeCardQuality(quality string) bool {
-	switch strings.ToUpper(strings.TrimSpace(quality)) {
-	case "NM", "NM/M", "LP", "MP", "HP", "DM", "EX/EX+",
-		"NEAR MINT", "LIGHTLY PLAYED", "MODERATELY PLAYED", "HEAVILY PLAYED", "DAMAGED", "EXCELLENT":
-		return true
-	default:
-		return false
-	}
-}
-
 func stripEmbeddedQualityFromProductTitle(productTitle string) string {
 	productTitle = strings.TrimSpace(productTitle)
 	dash := embeddedQualityDashIndex(productTitle)
@@ -103,7 +94,7 @@ func stripEmbeddedQualityFromProductTitle(productTitle string) string {
 	}
 	quality := strings.TrimSpace(strings.ReplaceAll(segment, "Foil", ""))
 	quality = strings.Join(strings.Fields(quality), " ")
-	if !looksLikeCardQuality(quality) {
+	if !util.IsKnownQuality(quality) {
 		return productTitle
 	}
 

--- a/api/gateway/binderpos/storefront_card_helpers.go
+++ b/api/gateway/binderpos/storefront_card_helpers.go
@@ -29,13 +29,110 @@ func qualityFromVariantTitle(title string) string {
 	return strings.Join(strings.Fields(quality), " ")
 }
 
+func resolveCardQuality(productTitle, variantTitle string) string {
+	if quality := qualityFromVariantTitle(variantTitle); quality != "" {
+		return quality
+	}
+	return qualityFromProductTitle(productTitle)
+}
+
+func qualityFromProductTitle(productTitle string) string {
+	segment := embeddedQualitySegment(productTitle)
+	if segment == "" {
+		return ""
+	}
+	quality := strings.TrimSpace(strings.ReplaceAll(segment, "Foil", ""))
+	quality = strings.Join(strings.Fields(quality), " ")
+	if !looksLikeCardQuality(quality) {
+		return ""
+	}
+	return quality
+}
+
+func embeddedQualitySegment(productTitle string) string {
+	productTitle = strings.TrimSpace(productTitle)
+	dash := embeddedQualityDashIndex(productTitle)
+	if dash < 0 {
+		return ""
+	}
+	after := strings.TrimSpace(productTitle[dash+len(embeddedQualitySeparator(productTitle, dash)):])
+	if after == "" {
+		return ""
+	}
+	if bracket := strings.Index(after, "["); bracket >= 0 {
+		return strings.TrimSpace(after[:bracket])
+	}
+	return after
+}
+
+func embeddedQualityDashIndex(productTitle string) int {
+	for _, sep := range []string{" — ", " – "} {
+		if i := strings.Index(productTitle, sep); i >= 0 {
+			return i
+		}
+	}
+	return -1
+}
+
+func embeddedQualitySeparator(productTitle string, dash int) string {
+	if dash >= 0 && dash+len(" — ") <= len(productTitle) && productTitle[dash:dash+len(" — ")] == " — " {
+		return " — "
+	}
+	return " – "
+}
+
+func looksLikeCardQuality(quality string) bool {
+	switch strings.ToUpper(strings.TrimSpace(quality)) {
+	case "NM", "NM/M", "LP", "MP", "HP", "DM", "EX/EX+",
+		"NEAR MINT", "LIGHTLY PLAYED", "MODERATELY PLAYED", "HEAVILY PLAYED", "DAMAGED", "EXCELLENT":
+		return true
+	default:
+		return false
+	}
+}
+
+func stripEmbeddedQualityFromProductTitle(productTitle string) string {
+	productTitle = strings.TrimSpace(productTitle)
+	dash := embeddedQualityDashIndex(productTitle)
+	if dash < 0 {
+		return productTitle
+	}
+	segment := embeddedQualitySegment(productTitle)
+	if segment == "" {
+		return productTitle
+	}
+	quality := strings.TrimSpace(strings.ReplaceAll(segment, "Foil", ""))
+	quality = strings.Join(strings.Fields(quality), " ")
+	if !looksLikeCardQuality(quality) {
+		return productTitle
+	}
+
+	name := strings.TrimSpace(productTitle[:dash])
+	after := strings.TrimSpace(productTitle[dash+len(embeddedQualitySeparator(productTitle, dash)):])
+	if bracket := strings.Index(after, "["); bracket >= 0 {
+		rest := strings.TrimSpace(after[bracket:])
+		if rest != "" {
+			return strings.TrimSpace(name + " " + rest)
+		}
+	}
+	return name
+}
+
+func productTitleIndicatesFoil(productTitle string) bool {
+	return strings.Contains(strings.ToLower(embeddedQualitySegment(productTitle)), "foil")
+}
+
 func formatCardName(scrapVariant int, productTitle, variantTitle string) string {
 	productTitle = strings.TrimSpace(productTitle)
+	rawVariantTitle := strings.TrimSpace(variantTitle)
 	variantTitle = effectiveVariantTitle(variantTitle)
 
 	switch scrapVariant {
 	case 2:
 		if variantTitle == "" {
+			if isPlaceholderVariantTitle(rawVariantTitle) {
+				return stripEmbeddedQualityFromProductTitle(productTitle)
+			}
 			return productTitle
 		}
 		return strings.TrimSpace(productTitle + " - " + variantTitle)

--- a/api/gateway/binderpos/storefront_card_helpers_test.go
+++ b/api/gateway/binderpos/storefront_card_helpers_test.go
@@ -1,0 +1,47 @@
+package binderpos
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestQualityFromProductTitle(t *testing.T) {
+	tests := []struct {
+		title string
+		want  string
+	}{
+		{"Reanimate — NM [Breaking News]", "NM"},
+		{"Intuition — LP [Tempest]", "LP"},
+		{"Subtlety — NM Foil [Secret Lair Drop]", "NM"},
+		{"Opt [Ixalan]", ""},
+		{"The Hobbit — Gift Bundle", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.title, func(t *testing.T) {
+			require.Equal(t, tt.want, qualityFromProductTitle(tt.title))
+		})
+	}
+}
+
+func TestStripEmbeddedQualityFromProductTitle(t *testing.T) {
+	tests := []struct {
+		title string
+		want  string
+	}{
+		{"Reanimate — NM [Breaking News]", "Reanimate [Breaking News]"},
+		{"Subtlety — NM Foil [Secret Lair Drop]", "Subtlety [Secret Lair Drop]"},
+		{"Opt [Ixalan]", "Opt [Ixalan]"},
+		{"The Hobbit — Gift Bundle", "The Hobbit — Gift Bundle"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.title, func(t *testing.T) {
+			require.Equal(t, tt.want, stripEmbeddedQualityFromProductTitle(tt.title))
+		})
+	}
+}
+
+func TestResolveCardQualityPrefersVariantTitle(t *testing.T) {
+	require.Equal(t, "Near Mint", resolveCardQuality("Reanimate — NM [Breaking News]", "Near Mint"))
+	require.Equal(t, "NM", resolveCardQuality("Reanimate — NM [Breaking News]", "Default Title"))
+}

--- a/api/gateway/binderpos/storefront_decklist.go
+++ b/api/gateway/binderpos/storefront_decklist.go
@@ -115,14 +115,14 @@ func mapDecklistLinesToCards(scrapVariant int, storeName, baseURL string, lines 
 					continue
 				}
 
-				quality := qualityFromVariantTitle(variant.Title)
+				quality := resolveCardQuality(productTitle, variant.Title)
 				card := gateway.Card{
 					Name:    formatCardName(scrapVariant, productTitle, variant.Title),
 					Url:     cardURL,
 					Img:     image,
 					Price:   variant.Price,
 					InStock: variant.Quantity > 0,
-					IsFoil:  strings.Contains(strings.ToLower(effectiveVariantTitle(variant.Title)), "foil"),
+					IsFoil:  strings.Contains(strings.ToLower(effectiveVariantTitle(variant.Title)), "foil") || titleIndicatesFoil(productTitle) || productTitleIndicatesFoil(productTitle),
 					Source:  storeName,
 					Quality: util.MapQuality(quality),
 				}

--- a/api/gateway/binderpos/storefront_graphql.go
+++ b/api/gateway/binderpos/storefront_graphql.go
@@ -259,14 +259,14 @@ func mapGraphQLProduct(scrapVariant int, storeName, baseURL string, product *gra
 			continue
 		}
 
-		quality := qualityFromVariantTitle(variant.Title)
+		quality := resolveCardQuality(title, variant.Title)
 		card := gateway.Card{
 			Name:    formatCardName(scrapVariant, title, variant.Title),
 			Url:     cardURL,
 			Img:     img,
 			Price:   price,
 			InStock: true,
-			IsFoil:  strings.Contains(strings.ToLower(effectiveVariantTitle(variant.Title)), "foil") || titleIndicatesFoil(title),
+			IsFoil:  strings.Contains(strings.ToLower(effectiveVariantTitle(variant.Title)), "foil") || titleIndicatesFoil(title) || productTitleIndicatesFoil(title),
 			Source:  storeName,
 			Quality: util.MapQuality(quality),
 		}

--- a/api/gateway/binderpos/storefront_graphql_test.go
+++ b/api/gateway/binderpos/storefront_graphql_test.go
@@ -111,6 +111,60 @@ func TestMapGraphQLProductDefaultTitleVariantNameForScrapVariant2(t *testing.T) 
 	require.Empty(t, cards[0].Quality)
 }
 
+func TestMapGraphQLProductEmbeddedQualityInTitle(t *testing.T) {
+	product := &graphQLProduct{
+		Title:            "Reanimate — NM [Breaking News]",
+		Handle:           "reanimate-nm-breaking-news",
+		AvailableForSale: true,
+		ProductType:      "MTG Single",
+	}
+	product.Variants.Edges = []struct {
+		Node *graphQLVariant `json:"node"`
+	}{
+		{Node: &graphQLVariant{
+			ID:               "gid://shopify/ProductVariant/555",
+			Title:            "Default Title",
+			AvailableForSale: true,
+			Price:            struct {
+				Amount string `json:"amount"`
+			}{Amount: "13.5"},
+		}},
+	}
+
+	cards := mapGraphQLProduct(2, "Arcane Sanctum", "https://arcanesanctumtcg.com", product)
+	require.Len(t, cards, 1)
+	require.Equal(t, "Reanimate [Breaking News]", cards[0].Name)
+	require.Equal(t, "Near Mint", cards[0].Quality)
+	require.False(t, cards[0].IsFoil)
+}
+
+func TestMapGraphQLProductEmbeddedQualityFoilInTitle(t *testing.T) {
+	product := &graphQLProduct{
+		Title:            "Subtlety — NM Foil [Secret Lair Drop]",
+		Handle:           "subtlety-nm-foil-secret-lair-drop",
+		AvailableForSale: true,
+		ProductType:      "MTG Single",
+	}
+	product.Variants.Edges = []struct {
+		Node *graphQLVariant `json:"node"`
+	}{
+		{Node: &graphQLVariant{
+			ID:               "gid://shopify/ProductVariant/556",
+			Title:            "Default Title",
+			AvailableForSale: true,
+			Price:            struct {
+				Amount string `json:"amount"`
+			}{Amount: "25.0"},
+		}},
+	}
+
+	cards := mapGraphQLProduct(2, "Arcane Sanctum", "https://arcanesanctumtcg.com", product)
+	require.Len(t, cards, 1)
+	require.Equal(t, "Subtlety [Secret Lair Drop]", cards[0].Name)
+	require.Equal(t, "Near Mint", cards[0].Quality)
+	require.True(t, cards[0].IsFoil)
+}
+
 func TestMapGraphQLProductSkipsNonMTG(t *testing.T) {
 	product := &graphQLProduct{
 		Title:            "Pikachu",

--- a/api/gateway/util/quality.go
+++ b/api/gateway/util/quality.go
@@ -2,21 +2,28 @@ package util
 
 import "strings"
 
+var qualityByKey = map[string]string{
+	"NM":     "Near Mint",
+	"NM/M":   "Near Mint",
+	"LP":     "Lightly Played",
+	"MP":     "Moderately Played",
+	"HP":     "Heavily Played",
+	"DM":     "Damaged",
+	"EX/EX+": "Excellent",
+}
+
+func normalizedQualityKey(quality string) string {
+	return strings.ToUpper(strings.TrimSpace(quality))
+}
+
 func MapQuality(quality string) string {
-	switch strings.ToUpper(strings.TrimSpace(quality)) {
-	case "NM", "NM/M":
-		return "Near Mint"
-	case "LP":
-		return "Lightly Played"
-	case "MP":
-		return "Moderately Played"
-	case "HP":
-		return "Heavily Played"
-	case "DM":
-		return "Damaged"
-	case "EX/EX+":
-		return "Excellent"
-	default:
-		return quality
+	if mapped, ok := qualityByKey[normalizedQualityKey(quality)]; ok {
+		return mapped
 	}
+	return quality
+}
+
+func IsKnownQuality(quality string) bool {
+	_, ok := qualityByKey[normalizedQualityKey(quality)]
+	return ok
 }

--- a/api/gateway/util/quality_test.go
+++ b/api/gateway/util/quality_test.go
@@ -2,6 +2,27 @@ package util
 
 import "testing"
 
+func TestIsKnownQuality(t *testing.T) {
+	tests := []struct {
+		quality string
+		want    bool
+	}{
+		{"NM", true},
+		{"nm", true},
+		{"LP", true},
+		{"Gift Bundle", false},
+		{"Near Mint", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.quality, func(t *testing.T) {
+			if got := IsKnownQuality(tt.quality); got != tt.want {
+				t.Errorf("IsKnownQuality(%q) = %v, want %v", tt.quality, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestMapQuality(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Arcane Sanctum encodes card condition in Shopify **product titles** (e.g. `Reanimate — NM [Breaking News]`, `Subtlety — NM Foil [Secret Lair Drop]`) while variants use the placeholder `Default Title`. Previously, `Quality` was only read from variant titles, so condition was always empty for this store.

This change adds BinderPOS parsing helpers that:

- Fall back to extracting quality from the em-dash segment in product titles when variant titles carry no condition
- Validate extracted segments with `util.IsKnownQuality` (shared alias map with `util.MapQuality`)
- Map abbreviations (`NM`, `LP`, etc.) via `util.MapQuality`
- Strip the embedded condition from displayed card names for scrap variant 2
- Detect foil from the embedded segment (e.g. `NM Foil`)

## Example

| Before | After |
|--------|-------|
| Name: `Reanimate — NM [Breaking News]`, Quality: *(empty)* | Name: `Reanimate [Breaking News]`, Quality: `Near Mint` |
| Name: `Subtlety — NM Foil [Secret Lair Drop]`, Quality: *(empty)*, IsFoil: false | Name: `Subtlety [Secret Lair Drop]`, Quality: `Near Mint`, IsFoil: true |

## Testing

- Added unit tests for product-title quality parsing and GraphQL mapping
- `make test` passes (including `gateway/arcanesanctum` live probe)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-388fd601-102b-4150-8a14-d26147307c78?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-388fd601-102b-4150-8a14-d26147307c78&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

