### PR TITLE
Sort search store stats by time taken (descending)

### DIFF
--- a/api/controller/search.go
+++ b/api/controller/search.go
@@ -401,6 +401,9 @@ func buildStoreStats(shopDurations []shopSearchDuration, cards []Card) []StoreSt
 
 	sortedDurations := append([]shopSearchDuration(nil), shopDurations...)
 	sort.Slice(sortedDurations, func(i, j int) bool {
+		if sortedDurations[i].duration != sortedDurations[j].duration {
+			return sortedDurations[i].duration > sortedDurations[j].duration
+		}
 		return sortedDurations[i].name < sortedDurations[j].name
 	})
 

--- a/api/controller/search_test.go
+++ b/api/controller/search_test.go
@@ -417,10 +417,10 @@ func TestBuildStoreStats(t *testing.T) {
 	if len(stats) != 2 {
 		t.Fatalf("expected 2 stats, got %d", len(stats))
 	}
-	if stats[0].Store != "Alpha Games" || stats[0].ItemCount != 2 || stats[0].DurationMs != 120 {
+	if stats[0].Store != "Zebra Games" || stats[0].ItemCount != 1 || stats[0].DurationMs != 2500 {
 		t.Fatalf("unexpected first stat: %+v", stats[0])
 	}
-	if stats[1].Store != "Zebra Games" || stats[1].ItemCount != 1 || stats[1].DurationMs != 2500 {
+	if stats[1].Store != "Alpha Games" || stats[1].ItemCount != 2 || stats[1].DurationMs != 120 {
 		t.Fatalf("unexpected second stat: %+v", stats[1])
 	}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Search stats for stores are now sorted by **time taken** (descending) instead of alphabetically by store name. Slowest stores appear first in the stats table; equal durations fall back to store name for a stable order.

## Changes

- `api/controller/search.go`: `buildStoreStats` sorts by `duration` descending, then `name` ascending as tiebreaker.
- `api/controller/search_test.go`: Updated `TestBuildStoreStats` expectations.

## Testing

- `go test ./controller/... -run TestBuildStoreStats`
- `make test` (full suite)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-667d6893-9721-41e2-9387-d61fa060f240?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-667d6893-9721-41e2-9387-d61fa060f240&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

