### PR TITLE
Remove redundant IAM account ID substitution note from docs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -332,8 +332,5 @@ is gitignored.
 |------|------------------|
 | GA4 measurement ID (`G-…` in `frontend/index.html`) | Embedded in the browser for analytics |
 | Shopify **Storefront** access tokens in `api/gateway/*/search.go` | Shopify publishes these for client-side Storefront API use; they grant read-only storefront access, not admin |
-| AWS account ID / resource ARNs in `Makefile` and IAM examples below | Identifiers, not credentials — substitute your account ID when copying policies |
+| AWS account ID / resource ARNs in `Makefile` and IAM examples | Identifiers, not credentials |
 | `api.gishathfetch.com`, bucket names, Lambda function names | Public infrastructure endpoints |
-
-When copying IAM policies below, replace `206363131200` with your AWS account ID (see
-`AWS_ACCOUNT_ID` in the root `Makefile`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the standalone paragraph in `docs/architecture.md` that told readers to replace `206363131200` with their AWS account ID when copying IAM policies. That instruction duplicated the "Intentionally public" table row directly above it.

Also simplifies that table row: fixes "IAM examples below" → "IAM examples" (the CK refresh IAM section is above the Secrets section) and drops the redundant substitution guidance.

## Test plan

- [x] Docs-only change; no code or tests affected
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9440eb44-c642-4a33-a03c-52681f2c7070?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9440eb44-c642-4a33-a03c-52681f2c7070&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

