### PR TITLE
Move search stats below bottom ad space

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -261,20 +261,21 @@ export default function App() {
         baseUrl={BASE_URL}
       />
 
-      <SearchStats
-        stats={searchStoreStats}
-        totalDurationMs={searchTotalDurationMs}
-        sessionMintDurationMs={sessionMintDurationMs}
-        searchResponseDurationMs={searchResponseDurationMs}
-        hasSearched={hasSearched}
-        isSearching={isSearching}
-      />
-
       <Footer
         cartCount={cart.length}
         onShowCart={() => setShowCart(true)}
         onShowMap={() => setModalType("MAP")}
         onShowFaq={() => setModalType("FAQ")}
+        searchStatsSlot={
+          <SearchStats
+            stats={searchStoreStats}
+            totalDurationMs={searchTotalDurationMs}
+            sessionMintDurationMs={sessionMintDurationMs}
+            searchResponseDurationMs={searchResponseDurationMs}
+            hasSearched={hasSearched}
+            isSearching={isSearching}
+          />
+        }
       />
 
       <CartActionFeedback

--- a/frontend/src/components/AdComponent.jsx
+++ b/frontend/src/components/AdComponent.jsx
@@ -231,7 +231,7 @@ const AdComponent = memo(
         style={{ overflow: "hidden" }}
       >
         {isFilled && (
-          <div className="text-center mb-2" style={{ fontSize: "11px" }}>
+          <div className="text-center mb-2" style={{ fontSize: "12px" }}>
             <a
               href="https://www.patreon.com/GishathFetch"
               target="_blank"

--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -6,13 +6,20 @@ const scrollToTop = () => {
   window.scrollTo({ top: 0, behavior: "smooth" });
 };
 
-const Footer = ({ cartCount, onShowCart, onShowMap, onShowFaq }) => {
+const Footer = ({
+  cartCount,
+  onShowCart,
+  onShowMap,
+  onShowFaq,
+  searchStatsSlot,
+}) => {
   useBottomChromeLayout();
 
   return (
     <>
       <div className="mt-4 site-footer-spacer">
         <AdComponent />
+        {searchStatsSlot}
       </div>
 
       {/* Fixed Bottom Navigation */}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -714,10 +714,6 @@ ins.adsbygoogle.adsbygoogle-noablate {
   margin-bottom: 1rem;
 }
 
-.search-stats + .site-footer-spacer {
-  margin-top: 0;
-}
-
 .search-stats-toggle {
   font-size: 0.875rem;
   color: var(--bs-secondary-color);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Moves the search stats toggle and panel below the bottom ad slot so ads sit closer to the search results and stats appear just above the fixed bottom navigation.

## Changes

- Render `SearchStats` inside the footer spacer, after `AdComponent`
- Remove obsolete CSS rule for the old `search-stats + .site-footer-spacer` sibling order

## Layout order (bottom of page)

1. Search results
2. Bottom ad
3. Search stats
4. Fixed bottom nav

## Screenshots

### Desktop
![Search stats below ad — desktop](https://cursor.com/artifacts/c/art-88ab7011-0c2f-43f0-a938-678fb9961247)

### Mobile
![Search stats below ad — mobile](https://cursor.com/artifacts/c/art-2e1022a7-928c-4aa3-8b05-e111ff5625cd)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4eeceb8b-1806-4611-b2e1-fcfe53a74430?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4eeceb8b-1806-4611-b2e1-fcfe53a74430&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

