### PR TITLE
Migrate backend logging from stdlib log to slog

### DIFF
--- a/api/cmd/main.go
+++ b/api/cmd/main.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"os"
 	"time"
 
 	"mtg-price-checker-sg/handler"
 	"mtg-price-checker-sg/pkg/config"
+	"mtg-price-checker-sg/pkg/logger"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
@@ -17,9 +18,10 @@ import (
 func init() {
 	// load .env file
 	err := godotenv.Load()
+	logger.Init()
 	if err != nil {
 		if os.Getenv("ENV") != config.EnvProd {
-			log.Println("No .env file found or error loading .env")
+			slog.Warn("No .env file found or error loading .env")
 		}
 	}
 }
@@ -29,7 +31,13 @@ func main() {
 		lambda.Start(handler.Handle)
 	} else {
 		start := time.Now()
-		log.Println(handler.Search(context.Background(), events.APIGatewayProxyRequest{}))
-		log.Printf("Took: %s", time.Since(start))
+		ctx := context.Background()
+		resp, err := handler.Search(ctx, events.APIGatewayProxyRequest{})
+		if err != nil {
+			slog.ErrorContext(ctx, "local search failed", "err", err)
+		} else {
+			slog.InfoContext(ctx, "local search result", "result", resp)
+		}
+		slog.InfoContext(ctx, "local search duration", "duration", time.Since(start))
 	}
 }

--- a/api/cmd/signature-directory/main.go
+++ b/api/cmd/signature-directory/main.go
@@ -3,37 +3,45 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 
+	"mtg-price-checker-sg/pkg/logger"
 	"mtg-price-checker-sg/pkg/webbotauth"
 )
 
 func main() {
+	logger.Init()
+
 	outPath := flag.String("out", "frontend/public/.well-known/http-message-signatures-directory", "output file path")
 	flag.Parse()
 
 	pemData, err := webbotauth.LoadPrivateKeyPEM()
 	if err != nil {
-		log.Fatalf("load signing key: %v", err)
+		slog.Error("load signing key", "err", err)
+		os.Exit(1)
 	}
 
 	privateKey, err := webbotauth.ParseEd25519PrivateKeyPEM(pemData)
 	if err != nil {
-		log.Fatalf("parse signing key: %v", err)
+		slog.Error("parse signing key", "err", err)
+		os.Exit(1)
 	}
 
 	body, err := webbotauth.DirectoryJSON(privateKey)
 	if err != nil {
-		log.Fatalf("build signature directory: %v", err)
+		slog.Error("build signature directory", "err", err)
+		os.Exit(1)
 	}
 
 	if err := os.MkdirAll(filepath.Dir(*outPath), 0o755); err != nil {
-		log.Fatalf("create output directory: %v", err)
+		slog.Error("create output directory", "err", err)
+		os.Exit(1)
 	}
 	if err := os.WriteFile(*outPath, body, 0o644); err != nil {
-		log.Fatalf("write %s: %v", *outPath, err)
+		slog.Error("write signature directory", "path", *outPath, "err", err)
+		os.Exit(1)
 	}
 
 	fmt.Fprintf(os.Stderr, "wrote %s (%d bytes)\n", *outPath, len(body))

--- a/api/controller/ckprice/ckprice.go
+++ b/api/controller/ckprice/ckprice.go
@@ -2,12 +2,12 @@ package ckprice
 
 import (
 	"context"
-	"log"
 	"time"
 
 	"mtg-price-checker-sg/gateway/cardkingdom"
 	"mtg-price-checker-sg/gateway/scryfall"
 	"mtg-price-checker-sg/pkg/config"
+	"mtg-price-checker-sg/pkg/logger"
 	"mtg-price-checker-sg/store/ckprices"
 )
 
@@ -84,7 +84,7 @@ type RefreshResult struct {
 
 // RefreshPrices downloads Card Kingdom retail prices from the CK pricelist API and upserts the DynamoDB index.
 func RefreshPrices(ctx context.Context, store ckprices.Store) (*RefreshResult, error) {
-	log.Printf("ck price refresh: fetching card kingdom pricelist")
+	logger.From(ctx).InfoContext(ctx, "ck price refresh: fetching card kingdom pricelist")
 	fetchStarted := time.Now()
 
 	listings, err := fetchCheapestFunc(ctx)
@@ -92,25 +92,31 @@ func RefreshPrices(ctx context.Context, store ckprices.Store) (*RefreshResult, e
 		return nil, err
 	}
 
-	log.Printf("ck price refresh: fetched card kingdom pricelist listings=%d duration=%s", len(listings), time.Since(fetchStarted).Round(time.Millisecond))
+	logger.From(ctx).InfoContext(ctx, "ck price refresh: fetched card kingdom pricelist",
+		"listings", len(listings),
+		"duration", time.Since(fetchStarted).Round(time.Millisecond),
+	)
 
-	log.Printf("ck price refresh: writing dynamodb listings=%d", len(listings))
+	logger.From(ctx).InfoContext(ctx, "ck price refresh: writing dynamodb", "listings", len(listings))
 	writeStarted := time.Now()
 	syncedAt, err := store.PutAll(ctx, listings)
 	if err != nil {
 		return nil, err
 	}
-	log.Printf("ck price refresh: wrote dynamodb listings=%d syncedAt=%s duration=%s", len(listings), syncedAt, time.Since(writeStarted).Round(time.Millisecond))
+	logger.From(ctx).InfoContext(ctx, "ck price refresh: wrote dynamodb",
+		"listings", len(listings),
+		"syncedAt", syncedAt,
+		"duration", time.Since(writeStarted).Round(time.Millisecond),
+	)
 
 	deleteStarted := time.Now()
 	deleted, err := store.DeleteListingsNotInPricelist(ctx, listings)
 	if err != nil {
 		return nil, err
 	}
-	log.Printf(
-		"ck price refresh: deleted dynamodb listings not in pricelist count=%d duration=%s",
-		deleted,
-		time.Since(deleteStarted).Round(time.Millisecond),
+	logger.From(ctx).InfoContext(ctx, "ck price refresh: deleted dynamodb listings not in pricelist",
+		"count", deleted,
+		"duration", time.Since(deleteStarted).Round(time.Millisecond),
 	)
 
 	return &RefreshResult{

--- a/api/controller/search.go
+++ b/api/controller/search.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"maps"
 	"mtg-price-checker-sg/gateway"
 	"mtg-price-checker-sg/gateway/agora"
@@ -29,6 +29,7 @@ import (
 	"mtg-price-checker-sg/gateway/util"
 	"mtg-price-checker-sg/pkg/alert"
 	"mtg-price-checker-sg/pkg/config"
+	"mtg-price-checker-sg/pkg/logger"
 	"sort"
 	"strings"
 	"sync"
@@ -132,7 +133,7 @@ func searchShops(ctx context.Context, input SearchInput, shopNameToLGSMap map[st
 	if time.Since(realStart) < responseThreshold {
 		sleepDuration := responseThreshold - time.Since(realStart)
 		time.Sleep(sleepDuration)
-		log.Printf("Sleeping for [%s]", sleepDuration)
+		logger.From(ctx).InfoContext(ctx, "Sleeping for minimum response threshold", "duration", sleepDuration)
 	}
 
 	return inStockCards, buildStoreErrors(siteErrors), buildStoreStats(shopDurations, inStockCards), nil
@@ -174,9 +175,9 @@ func fetchCardsConcurrently(ctx context.Context, searchString string, shops map[
 		go sendAlert(formatAlertErrorSummary(searchString, alertErrorMessages))
 	}
 	if len(siteErrors) > 0 {
-		log.Printf("Shops with errors for [%s]: %d", searchString, len(siteErrors))
+		logger.From(ctx).InfoContext(ctx, "Shops with errors", "search", searchString, "count", len(siteErrors))
 	}
-	log.Println(formatShopSearchSummary(searchString, time.Since(start), shopDurations))
+	logger.From(ctx).InfoContext(ctx, formatShopSearchSummary(searchString, time.Since(start), shopDurations))
 	return cards, siteErrors, shopDurations
 }
 
@@ -186,17 +187,17 @@ type shopSearchDuration struct {
 }
 
 type fetchResultAggregator struct {
-	mu                   sync.Mutex
-	cards                []gateway.Card
-	siteErrors           map[string]error
+	mu                 sync.Mutex
+	cards              []gateway.Card
+	siteErrors         map[string]error
 	alertErrorMessages []string
-	shopDurations        []shopSearchDuration
+	shopDurations      []shopSearchDuration
 }
 
 func newFetchResultAggregator(shopCount int) *fetchResultAggregator {
 	return &fetchResultAggregator{
-		cards:                []gateway.Card{},
-		siteErrors:           make(map[string]error, shopCount),
+		cards:              []gateway.Card{},
+		siteErrors:         make(map[string]error, shopCount),
 		alertErrorMessages: make([]string, 0, shopCount),
 	}
 }
@@ -359,7 +360,7 @@ func storeCardKey(card gateway.Card) string {
 func recoverShopPanic(shopName string, aggregator *fetchResultAggregator) {
 	if r := recover(); r != nil {
 		errMsg := fmt.Sprintf("Recovered from panic in shop [%s]: %v", shopName, r)
-		log.Println(errMsg)
+		slog.Error(errMsg, "shop", shopName, "panic", r)
 		aggregator.addSiteError(shopName, fmt.Errorf("panic: %v", r))
 		aggregator.addAlertErrorMessage(errMsg)
 	}
@@ -373,7 +374,7 @@ func recordShopSearchError(searchString, shopName string, err error, aggregator 
 			searchString,
 			gateway.EnsureHTTPStatusInErrorMessage(err.Error()),
 		)
-		log.Println(errMsg)
+		slog.Warn(errMsg, "shop", shopName, "search", searchString, "err", err)
 		aggregator.addAlertErrorMessage(errMsg)
 	}
 	aggregator.addSiteError(shopName, err)

--- a/api/gateway/agora/search.go
+++ b/api/gateway/agora/search.go
@@ -2,7 +2,7 @@ package agora
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"net/url"
 	"strconv"
 	"strings"
@@ -119,7 +119,7 @@ func parseStoreItem(se *goquery.Selection, storeName string, apiURL *url.URL, se
 
 	cardURL, err := buildCardURL(apiURL, searchStr)
 	if err != nil {
-		log.Printf("error parsing url for %s with value [%s]: %v", storeName, apiURL.String(), err)
+		slog.Warn("error parsing url", "store", storeName, "value", apiURL.String(), "err", err)
 		return gateway.Card{}, false
 	}
 

--- a/api/gateway/binderpos/scrap.go
+++ b/api/gateway/binderpos/scrap.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"mtg-price-checker-sg/gateway/util"
 	"net/url"
 	"strconv"
@@ -151,7 +151,7 @@ func scrapVariant3(ctx context.Context, storeName, baseUrl, searchUrl, searchStr
 						u := strings.TrimSpace(baseUrl + el.ChildAttr("a", "href"))
 						cleanPageURL, err := url.Parse(u)
 						if err != nil {
-							log.Printf("error parsing url for %s with value [%s]: %v", storeName, u, err)
+							slog.Warn("error parsing url", "store", storeName, "value", u, "err", err)
 							return
 						}
 						cleanPageURL.RawQuery = url.Values{
@@ -240,7 +240,7 @@ func scrapVariant4(ctx context.Context, storeName, baseUrl, searchUrl, searchStr
 			)
 			price, err := util.ParsePrice(priceStr)
 			if err != nil || price <= 0 {
-				log.Printf("error parsing price for %s with value [%s]: %v", storeName, priceStr, err)
+				slog.Warn("error parsing price", "store", storeName, "value", priceStr, "err", err)
 				return
 			}
 
@@ -261,7 +261,7 @@ func scrapVariant4(ctx context.Context, storeName, baseUrl, searchUrl, searchStr
 
 			cleanPageURL, err := url.Parse(strings.TrimSpace(baseUrl + link))
 			if err != nil {
-				log.Printf("error parsing url for %s with value [%s]: %v", storeName, link, err)
+				slog.Warn("error parsing url", "store", storeName, "value", link, "err", err)
 				return
 			}
 			cleanPageURL.RawQuery = url.Values{
@@ -326,7 +326,7 @@ func scrapVariant2(ctx context.Context, storeName, baseUrl, searchUrl, searchStr
 							// url with variant (quality)
 							cleanPageURL, err := url.Parse(strings.TrimSpace(baseUrl + pageUrl))
 							if err != nil {
-								log.Printf("error parsing url for %s with value [%s]: %v", storeName, pageUrl, err)
+								slog.Warn("error parsing url", "store", storeName, "value", pageUrl, "err", err)
 								return
 							}
 							cleanPageURL.RawQuery = url.Values{
@@ -399,7 +399,7 @@ func scrapVariant1(ctx context.Context, storeName, baseUrl, searchUrl, searchStr
 						u := strings.TrimSpace(baseUrl + el.ChildAttr("a", "href"))
 						cleanPageURL, err := url.Parse(u)
 						if err != nil {
-							log.Printf("error parsing url for %s with value [%s]: %v", storeName, u, err)
+							slog.Warn("error parsing url", "store", storeName, "value", u, "err", err)
 							return
 						}
 

--- a/api/gateway/bot_auth.go
+++ b/api/gateway/bot_auth.go
@@ -6,7 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"strconv"
@@ -140,16 +140,16 @@ func loadWebBotAuth() {
 	pemData, keyErr := webbotauth.LoadPrivateKeyPEM()
 	signatureAgentURL := strings.TrimSpace(os.Getenv(config.WebBotAuthSignatureAgentEnv))
 	if keyErr != nil || signatureAgentURL == "" {
-		log.Printf(
-			"%s is true but signing credentials are not fully configured; Web Bot Auth disabled",
-			config.WebBotAuthEnabledEnv,
+		slog.Warn(
+			"Web Bot Auth disabled: signing credentials not fully configured",
+			"env", config.WebBotAuthEnabledEnv,
 		)
 		return
 	}
 
 	privateKey, err := webbotauth.ParseEd25519PrivateKeyPEM(pemData)
 	if err != nil {
-		log.Printf("invalid Web Bot Auth signing key: %v; Web Bot Auth disabled", err)
+		slog.Warn("invalid Web Bot Auth signing key; Web Bot Auth disabled", "err", err)
 		return
 	}
 
@@ -168,12 +168,12 @@ func loadWebBotAuth() {
 		userAgent:         userAgent,
 		ttl:               ttl,
 	}
-	log.Printf(
-		"Web Bot Auth enabled: signature_agent=%s key_id=%s user_agent=%q ttl=%s",
-		signatureAgentURL,
-		keyID,
-		userAgent,
-		ttl,
+	slog.Info(
+		"Web Bot Auth enabled",
+		"signature_agent", signatureAgentURL,
+		"key_id", keyID,
+		"user_agent", userAgent,
+		"ttl", ttl,
 	)
 }
 

--- a/api/gateway/cardkingdom/pricelist_fetch.go
+++ b/api/gateway/cardkingdom/pricelist_fetch.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"strconv"
@@ -15,11 +15,12 @@ import (
 	"mtg-price-checker-sg/gateway"
 	"mtg-price-checker-sg/gateway/util"
 	"mtg-price-checker-sg/pkg/config"
+	"mtg-price-checker-sg/pkg/logger"
 )
 
 const (
-	defaultCKPricelistURL   = "https://api.cardkingdom.com/api/v2/pricelist"
-	ckPricelistErrorPrefix  = "ck price pricelist"
+	defaultCKPricelistURL  = "https://api.cardkingdom.com/api/v2/pricelist"
+	ckPricelistErrorPrefix = "ck price pricelist"
 	// The CK pricelist JSON is ~65MB (~150k products). When the residential proxy
 	// fallback is used, the body can take several minutes after headers return;
 	// http.Client.Timeout covers the full round trip including body read.
@@ -40,14 +41,14 @@ type ckPricelistMeta struct {
 }
 
 type ckPricelistItem struct {
-	URL              string              `json:"url"`
-	Name             string              `json:"name"`
-	Variation        string              `json:"variation"`
-	Edition          string              `json:"edition"`
-	IsFoil           jsonStringBool      `json:"is_foil"`
-	PriceRetail      jsonStringFloat     `json:"price_retail"`
-	QtyRetail        jsonStringInt       `json:"qty_retail"`
-	ConditionValues  ckConditionValues   `json:"condition_values"`
+	URL             string            `json:"url"`
+	Name            string            `json:"name"`
+	Variation       string            `json:"variation"`
+	Edition         string            `json:"edition"`
+	IsFoil          jsonStringBool    `json:"is_foil"`
+	PriceRetail     jsonStringFloat   `json:"price_retail"`
+	QtyRetail       jsonStringInt     `json:"qty_retail"`
+	ConditionValues ckConditionValues `json:"condition_values"`
 }
 
 type ckConditionValues struct {
@@ -164,18 +165,17 @@ func fetchCheapestFromCKPricelist(ctx context.Context) (map[string]Listing, erro
 	defer cancel()
 
 	downloadURL := ckPricelistURL()
-	log.Printf("ck price refresh: downloading pricelist from %s", downloadURL)
+	logger.From(ctx).InfoContext(ctx, "ck price refresh: downloading pricelist", "url", downloadURL)
 
 	downloadStarted := time.Now()
 	payload, err := downloadCKPricelist(ctx, downloadURL)
 	if err != nil {
 		return nil, err
 	}
-	log.Printf(
-		"ck price refresh: downloaded pricelist products=%d created_at=%s duration=%s",
-		len(payload.Data),
-		payload.Meta.CreatedAt,
-		time.Since(downloadStarted).Round(time.Millisecond),
+	logger.From(ctx).InfoContext(ctx, "ck price refresh: downloaded pricelist",
+		"products", len(payload.Data),
+		"created_at", payload.Meta.CreatedAt,
+		"duration", time.Since(downloadStarted).Round(time.Millisecond),
 	)
 
 	updatedAt, err := pricelistUpdatedAt(payload.Meta.CreatedAt)
@@ -220,7 +220,7 @@ func downloadCKPricelist(ctx context.Context, downloadURL string) (*ckPricelistP
 		return nil, err
 	}
 
-	log.Printf("ck price refresh: direct pricelist download failed, retrying via residential proxy")
+	logger.From(ctx).InfoContext(ctx, "ck price refresh: direct pricelist download failed, retrying via residential proxy")
 	proxyOpts := ckPricelistOutboundOptions()
 	proxyOpts.OnlyProxyURL = proxyURL
 	return downloadCKPricelistOnceFunc(ctx, downloadURL, proxyOpts)
@@ -238,7 +238,7 @@ func downloadCKPricelistOnce(ctx context.Context, downloadURL string, opts gatew
 		return nil, fmt.Errorf("%s: status %d: %s", ckPricelistErrorPrefix, resp.StatusCode, strings.TrimSpace(string(body)))
 	}
 
-	log.Printf("ck price refresh: reading pricelist body")
+	logger.From(ctx).InfoContext(ctx, "ck price refresh: reading pricelist body")
 	readStarted := time.Now()
 	bodyReader := &progressLogReader{
 		reader:     resp.Body,
@@ -250,10 +250,9 @@ func downloadCKPricelistOnce(ctx context.Context, downloadURL string, opts gatew
 	if err != nil {
 		return nil, fmt.Errorf("%s: read body: %w", ckPricelistErrorPrefix, err)
 	}
-	log.Printf(
-		"ck price refresh: read pricelist body bytes=%d duration=%s",
-		len(raw),
-		time.Since(readStarted).Round(time.Millisecond),
+	logger.From(ctx).InfoContext(ctx, "ck price refresh: read pricelist body",
+		"bytes", len(raw),
+		"duration", time.Since(readStarted).Round(time.Millisecond),
 	)
 
 	var payload ckPricelistPayload
@@ -303,18 +302,16 @@ func (r *progressLogReader) logProgress(now time.Time) {
 	elapsed := now.Sub(r.readStarted).Round(time.Millisecond)
 	if r.totalBytes > 0 {
 		pct := (float64(r.readBytes) * 100) / float64(r.totalBytes)
-		log.Printf(
-			"%s progress bytes=%d total=%d pct=%.1f%% elapsed=%s",
-			r.label,
-			r.readBytes,
-			r.totalBytes,
-			pct,
-			elapsed,
+		slog.Info(r.label+" progress",
+			"bytes", r.readBytes,
+			"total", r.totalBytes,
+			"pct", pct,
+			"elapsed", elapsed,
 		)
 		return
 	}
 
-	log.Printf("%s progress bytes=%d elapsed=%s", r.label, r.readBytes, elapsed)
+	slog.Info(r.label+" progress", "bytes", r.readBytes, "elapsed", elapsed)
 }
 
 func cheapestListingsFromPricelist(payload *ckPricelistPayload, updatedAt time.Time) map[string]Listing {

--- a/api/gateway/cardsandcollection/search.go
+++ b/api/gateway/cardsandcollection/search.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -203,7 +203,7 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 						u := fmt.Sprintf(StoreBaseURL+"/product/%s", hit.ID)
 						cleanPageURL, err := url.Parse(u)
 						if err != nil {
-							log.Printf("error parsing url for %s with value [%s]: %v", s.Name, u, err)
+							slog.Warn("error parsing url", "store", s.Name, "value", u, "err", err)
 							continue
 						}
 						cleanPageURL.RawQuery = url.Values{

--- a/api/gateway/collector.go
+++ b/api/gateway/collector.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"math/rand/v2"
 	"mtg-price-checker-sg/gateway/util"
 	"mtg-price-checker-sg/pkg/config"
@@ -263,10 +263,10 @@ func applyCollectorHTTPClient(
 	mode, proxyURL := selectOutboundProxy(leasedDedicatedProxyURL, requestDedicatedProxyURL)
 	client, err := newOutboundHTTPClient(proxyURL, config.SearchAttemptTimeout, profile)
 	if err != nil {
-		log.Printf("browser TLS client setup failed for colly (%s): %v", mode, err)
+		slog.Warn("browser TLS client setup failed for colly", "mode", mode, "err", err)
 		if proxyURL != "" {
 			if setErr := c.SetProxy(proxyURL); setErr != nil {
-				log.Printf("invalid proxy configured for colly (%s): %v", mode, setErr)
+				slog.Warn("invalid proxy configured for colly", "mode", mode, "err", setErr)
 			}
 		}
 		return
@@ -335,7 +335,7 @@ func applyInitialProxy(c *colly.Collector, leasedDedicatedProxyURL, requestDedic
 	}
 	if err := c.SetProxy(proxyURL); err != nil {
 		if mode == "dynamic" {
-			log.Printf("invalid dynamic proxy configured: %v", err)
+			slog.Warn("invalid dynamic proxy configured", "err", err)
 		}
 		return clearProxy(c)
 	}
@@ -354,7 +354,7 @@ func registerRequestHandler(
 			return
 		}
 		if err := waitForDomainRequestSlot(c.Context, r.URL); err != nil {
-			log.Printf("Skipping request pacing for %s due to context cancellation: %v", r.URL, err)
+			slog.Warn("Skipping request pacing due to context cancellation", "url", r.URL, "err", err)
 			r.Abort()
 			return
 		}
@@ -368,7 +368,7 @@ func registerRequestHandler(
 			} else {
 				r.Headers.Set("User-Agent", OutboundUserAgent())
 				if err := SignWebBotAuthCollyRequest(r); err != nil {
-					log.Printf("Web Bot Auth signing failed for %s: %v", r.URL, err)
+					slog.Warn("Web Bot Auth signing failed", "url", r.URL, "err", err)
 				}
 			}
 		}

--- a/api/gateway/duellerpoint/search.go
+++ b/api/gateway/duellerpoint/search.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/url"
 	"strconv"
 	"strings"
@@ -30,15 +30,15 @@ type searchResponse struct {
 }
 
 type searchResult struct {
-	Name              string `json:"name"`
-	Slug              string `json:"slug"`
-	Price             string `json:"price"`
-	FoilPrice         string `json:"foil_price"`
-	Quantity          int    `json:"quantity"`
-	IsActive          bool   `json:"is_active"`
-	FoilType          string `json:"foil_type"`
-	GetNameWithFoil   string `json:"get_name_with_foil"`
-	GetVariationName  string `json:"get_variation_name"`
+	Name               string `json:"name"`
+	Slug               string `json:"slug"`
+	Price              string `json:"price"`
+	FoilPrice          string `json:"foil_price"`
+	Quantity           int    `json:"quantity"`
+	IsActive           bool   `json:"is_active"`
+	FoilType           string `json:"foil_type"`
+	GetNameWithFoil    string `json:"get_name_with_foil"`
+	GetVariationName   string `json:"get_variation_name"`
 	TCGPlayerProductID string `json:"tcgplayer_product_id_ext"`
 }
 
@@ -88,7 +88,7 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 
 		cleanPageURL, err := url.Parse(card.Url)
 		if err != nil {
-			log.Printf("error parsing url for %s with value [%s]: %v", s.Name, card.Url, err)
+			slog.Warn("error parsing url", "store", s.Name, "value", card.Url, "err", err)
 			continue
 		}
 		cleanPageURL.RawQuery = url.Values{

--- a/api/gateway/fivemana/search.go
+++ b/api/gateway/fivemana/search.go
@@ -3,7 +3,7 @@ package fivemana
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/url"
 	"strings"
 
@@ -45,7 +45,7 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 		return nil, err
 	}
 
-	log.Printf("%s: graphql search failed, falling back to HTML: %v", s.Name, err)
+	slog.Warn("graphql search failed, falling back to HTML", "store", s.Name, "err", err)
 
 	htmlCards, htmlErr := s.searchHTML(ctx, searchStr)
 	if htmlErr != nil {
@@ -101,9 +101,9 @@ func (s Store) searchHTML(ctx context.Context, searchStr string) ([]gateway.Card
 
 func fiveManaOutboundOpts(storeBase *url.URL, pageURL *url.URL, style gateway.OutboundRequestStyle) gateway.OutboundRequestOptions {
 	opts := gateway.OutboundRequestOptions{
-		Style:                  style,
-		PageURL:                pageURL,
-		StoreBase:              storeBase,
+		Style:              style,
+		PageURL:            pageURL,
+		StoreBase:          storeBase,
 		ShopifySGDCurrency: true,
 		SkipDirect:         true,
 	}
@@ -139,7 +139,7 @@ func parseProductCard(se *goquery.Selection, storeName string) (gateway.Card, bo
 
 	cardURL, err := productURLWithUTM(StoreBaseURL + se.Find("h3.card__heading a").AttrOr("href", ""))
 	if err != nil {
-		log.Printf("error parsing url for %s with value [%s]: %v", storeName, heading.AttrOr("href", ""), err)
+		slog.Warn("error parsing url", "store", storeName, "value", heading.AttrOr("href", ""), "err", err)
 		return gateway.Card{}, false
 	}
 

--- a/api/gateway/moxandlotus/search.go
+++ b/api/gateway/moxandlotus/search.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/url"
 	"strconv"
 	"strings"
@@ -164,7 +164,7 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 						u := fmt.Sprintf(StoreBaseURL+"/view/%s/%v", strings.ToLower(card.ExpansionCode), card.ID)
 						cleanPageURL, err := url.Parse(u)
 						if err != nil {
-							log.Printf("error parsing url for %s with value [%s]: %v", s.Name, u, err)
+							slog.Warn("error parsing url", "store", s.Name, "value", u, "err", err)
 							continue
 						}
 						cleanPageURL.RawQuery = url.Values{

--- a/api/gateway/outbound_get.go
+++ b/api/gateway/outbound_get.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"strings"
 	"time"
 
 	"mtg-price-checker-sg/gateway/util"
+	"mtg-price-checker-sg/pkg/logger"
 )
 
 type outboundAttempt struct {
@@ -92,22 +92,26 @@ func doOutboundAttempt(
 		return nil, "", false, err
 	}
 
-	log.Printf("outbound request: trying %s url=%s", proxyDesc, outboundRequestURL(req))
+	logger.From(ctx).InfoContext(ctx, "outbound request: trying", "proxy", proxyDesc, "url", outboundRequestURL(req))
 
 	resp, err := attempt.client.Do(req)
 	if err != nil {
 		lastFailure := fmt.Sprintf("%s: %v", attempt.strategy, err)
-		log.Printf("outbound request: failed %s: %v", proxyDesc, err)
+		logger.From(ctx).WarnContext(ctx, "outbound request: failed", "proxy", proxyDesc, "err", err)
 		return nil, lastFailure, false, nil
 	}
 
 	if isOutboundClientError(resp.StatusCode) {
 		lastFailure := outboundStatusFailure(attempt.strategy, resp)
-		log.Printf("outbound request: failed %s: status %d", proxyDesc, resp.StatusCode)
+		logger.From(ctx).WarnContext(ctx, "outbound request: failed", "proxy", proxyDesc, "status", resp.StatusCode)
 		return nil, lastFailure, false, nil
 	}
 
-	log.Printf("outbound request: succeeded %s status=%d url=%s", proxyDesc, resp.StatusCode, outboundRequestURL(req))
+	logger.From(ctx).InfoContext(ctx, "outbound request: succeeded",
+		"proxy", proxyDesc,
+		"status", resp.StatusCode,
+		"url", outboundRequestURL(req),
+	)
 	return resp, "", true, nil
 }
 

--- a/api/gateway/tcgmarketplace/search.go
+++ b/api/gateway/tcgmarketplace/search.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -122,7 +122,7 @@ func (s Store) Search(ctx context.Context, searchStr string) ([]gateway.Card, er
 				u := strings.TrimSpace(card.URL)
 				cleanPageURL, err := url.Parse(u)
 				if err != nil {
-					log.Printf("error parsing url for %s with value [%s]: %v", s.Name, u, err)
+					slog.Warn("error parsing url", "store", s.Name, "value", u, "err", err)
 					continue
 				}
 				cleanPageURL.RawQuery = url.Values{

--- a/api/handler/analytics_keywords.go
+++ b/api/handler/analytics_keywords.go
@@ -2,13 +2,13 @@ package handler
 
 import (
 	"context"
-	"log"
 	"os"
 	"strings"
 
 	"mtg-price-checker-sg/controller/analyticskeywords"
 	"mtg-price-checker-sg/gateway/ga4"
 	"mtg-price-checker-sg/pkg/config"
+	"mtg-price-checker-sg/pkg/logger"
 	"mtg-price-checker-sg/store/analyticsreport"
 )
 
@@ -19,13 +19,13 @@ var (
 		return ga4.NewClient(ctx)
 	}
 	buildAnalyticsKeywordsReportFunc = analyticskeywords.BuildReport
-	newAnalyticsReportWriterFunc = func(ctx context.Context) (analyticsreport.Writer, error) {
+	newAnalyticsReportWriterFunc     = func(ctx context.Context) (analyticsreport.Writer, error) {
 		return analyticsreport.NewS3Writer(ctx)
 	}
 )
 
 func runAnalyticsKeywordsExport(ctx context.Context) (err error) {
-	log.Printf("analytics keywords export: started")
+	logger.From(ctx).InfoContext(ctx, "analytics keywords export: started")
 	var generatedAt string
 
 	defer func() {
@@ -38,29 +38,29 @@ func runAnalyticsKeywordsExport(ctx context.Context) (err error) {
 
 	reporter, err := newGA4ReporterFunc(ctx)
 	if err != nil {
-		log.Printf("analytics keywords export: failed opening ga4 client: %v", err)
+		logger.From(ctx).ErrorContext(ctx, "analytics keywords export: failed opening ga4 client", "err", err)
 		return err
 	}
 
 	propertyID := strings.TrimSpace(os.Getenv(config.GA4PropertyIDEnv))
 	report, err := buildAnalyticsKeywordsReportFunc(ctx, reporter, propertyID, analyticskeywords.TopKeywordLimit)
 	if err != nil {
-		log.Printf("analytics keywords export: failed building report: %v", err)
+		logger.From(ctx).ErrorContext(ctx, "analytics keywords export: failed building report", "err", err)
 		return err
 	}
 
 	writer, err := newAnalyticsReportWriterFunc(ctx)
 	if err != nil {
-		log.Printf("analytics keywords export: failed opening s3 writer: %v", err)
+		logger.From(ctx).ErrorContext(ctx, "analytics keywords export: failed opening s3 writer", "err", err)
 		return err
 	}
 
 	if err = writer.Write(ctx, report); err != nil {
-		log.Printf("analytics keywords export: failed writing report: %v", err)
+		logger.From(ctx).ErrorContext(ctx, "analytics keywords export: failed writing report", "err", err)
 		return err
 	}
 
 	generatedAt = report.GeneratedAt
-	log.Printf("analytics keywords export: finished generatedAt=%s", generatedAt)
+	logger.From(ctx).InfoContext(ctx, "analytics keywords export: finished", "generatedAt", generatedAt)
 	return nil
 }

--- a/api/handler/ck_refresh.go
+++ b/api/handler/ck_refresh.go
@@ -2,10 +2,10 @@ package handler
 
 import (
 	"context"
-	"log"
 	"time"
 
 	"mtg-price-checker-sg/controller/ckprice"
+	"mtg-price-checker-sg/pkg/logger"
 	"mtg-price-checker-sg/store/ckpricereport"
 	"mtg-price-checker-sg/store/ckprices"
 )
@@ -16,7 +16,7 @@ var (
 	newCKRefreshStoreFunc = func(ctx context.Context) (ckprices.Store, error) {
 		return ckprices.NewDynamoDBStore(ctx)
 	}
-	refreshCKPricesFunc = ckprice.RefreshPrices
+	refreshCKPricesFunc        = ckprice.RefreshPrices
 	newCKPriceReportWriterFunc = func(ctx context.Context) (ckpricereport.Writer, error) {
 		return ckpricereport.NewS3Writer(ctx)
 	}
@@ -24,7 +24,7 @@ var (
 )
 
 func runCKPriceRefresh(ctx context.Context) (err error) {
-	log.Printf("ck price refresh: started")
+	logger.From(ctx).InfoContext(ctx, "ck price refresh: started")
 	var refreshedCount int
 	var topCount int
 	var bottomCount int
@@ -40,40 +40,44 @@ func runCKPriceRefresh(ctx context.Context) (err error) {
 
 	store, err := newCKRefreshStoreFunc(ctx)
 	if err != nil {
-		log.Printf("ck price refresh: failed opening dynamodb store: %v", err)
+		logger.From(ctx).ErrorContext(ctx, "ck price refresh: failed opening dynamodb store", "err", err)
 		return err
 	}
 
 	refreshResult, err := refreshCKPricesFunc(ctx, store)
 	if err != nil {
-		log.Printf("ck price refresh: failed: %v", err)
+		logger.From(ctx).ErrorContext(ctx, "ck price refresh: failed", "err", err)
 		return err
 	}
 	refreshedCount = refreshResult.ListingCount
 
-	log.Printf("ck price refresh: finished refreshed=%d", refreshedCount)
+	logger.From(ctx).InfoContext(ctx, "ck price refresh: finished", "refreshed", refreshedCount)
 
 	changes, err := ckprices.TopBottomPriceChangesInPricelist(ctx, store, refreshResult.Listings)
 	if err != nil {
-		log.Printf("ck price refresh: failed reading price changes: %v", err)
+		logger.From(ctx).ErrorContext(ctx, "ck price refresh: failed reading price changes", "err", err)
 		return err
 	}
 
 	writer, err := newCKPriceReportWriterFunc(ctx)
 	if err != nil {
-		log.Printf("ck price refresh: failed opening s3 writer: %v", err)
+		logger.From(ctx).ErrorContext(ctx, "ck price refresh: failed opening s3 writer", "err", err)
 		return err
 	}
 
 	report := ckpricereport.NewReport(changes, ckPriceReportNowFunc())
 	if err = writer.Write(ctx, report); err != nil {
-		log.Printf("ck price refresh: failed writing price change report: %v", err)
+		logger.From(ctx).ErrorContext(ctx, "ck price refresh: failed writing price change report", "err", err)
 		return err
 	}
 
 	topCount = len(report.Top)
 	bottomCount = len(report.Bottom)
 	generatedAt = report.GeneratedAt
-	log.Printf("ck price refresh: exported price changes top=%d bottom=%d generatedAt=%s", topCount, bottomCount, generatedAt)
+	logger.From(ctx).InfoContext(ctx, "ck price refresh: exported price changes",
+		"top", topCount,
+		"bottom", bottomCount,
+		"generatedAt", generatedAt,
+	)
 	return nil
 }

--- a/api/handler/search.go
+++ b/api/handler/search.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -17,6 +16,7 @@ import (
 	"mtg-price-checker-sg/controller/ckprice"
 	"mtg-price-checker-sg/gateway/cardkingdom"
 	"mtg-price-checker-sg/pkg/config"
+	"mtg-price-checker-sg/pkg/logger"
 	"mtg-price-checker-sg/store/ckprices"
 
 	"github.com/aws/aws-lambda-go/events"
@@ -137,7 +137,7 @@ func Search(ctx context.Context, request events.APIGatewayProxyRequest) (events.
 
 			price, err := lookupCKPriceFunc(ckCtx, searchString)
 			if err != nil {
-				log.Printf("ck price lookup for [%s]: %v", searchString, err)
+				logger.From(ckCtx).WarnContext(ckCtx, "ck price lookup failed", "search", searchString, "err", err)
 				return
 			}
 			ckPrice = price

--- a/api/pkg/alert/webhook.go
+++ b/api/pkg/alert/webhook.go
@@ -3,7 +3,7 @@ package alert
 import (
 	"bytes"
 	"encoding/json"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 )
@@ -32,7 +32,7 @@ func SendJobAlert(message string) {
 func sendWebhookAlert(webhookURLEnv, message string) {
 	webhookURL := os.Getenv(webhookURLEnv)
 	if webhookURL == "" {
-		log.Printf("%s not set, skipping alert", webhookURLEnv)
+		slog.Warn("alert webhook not set, skipping alert", "env", webhookURLEnv)
 		return
 	}
 
@@ -42,18 +42,18 @@ func sendWebhookAlert(webhookURLEnv, message string) {
 
 	jsonPayload, err := json.Marshal(payload)
 	if err != nil {
-		log.Printf("Failed to marshal alert payload: %v", err)
+		slog.Error("failed to marshal alert payload", "err", err)
 		return
 	}
 
 	resp, err := http.Post(webhookURL, "application/json", bytes.NewBuffer(jsonPayload))
 	if err != nil {
-		log.Printf("Failed to send alert: %v", err)
+		slog.Error("failed to send alert", "err", err)
 		return
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		log.Printf("Alert webhook returned non-2xx status: %d", resp.StatusCode)
+		slog.Warn("alert webhook returned non-2xx status", "status", resp.StatusCode)
 	}
 }

--- a/api/pkg/logger/logger.go
+++ b/api/pkg/logger/logger.go
@@ -1,0 +1,32 @@
+package logger
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	"mtg-price-checker-sg/pkg/config"
+
+	"github.com/aws/aws-lambda-go/lambdacontext"
+)
+
+// Init configures the process-wide default slog logger.
+func Init() {
+	slog.SetDefault(New())
+}
+
+// New returns a logger suitable for the current environment.
+func New() *slog.Logger {
+	if os.Getenv("ENV") == config.EnvProd {
+		return lambdacontext.NewLogger()
+	}
+	return slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+}
+
+// From returns the default logger. Use context-aware methods (InfoContext, etc.)
+// so Lambda request IDs are attached when running in production.
+func From(_ context.Context) *slog.Logger {
+	return slog.Default()
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces all first-party `log` usage with Go's structured `log/slog` package.

- Adds `api/pkg/logger` with environment-aware initialization:
  - **Production** (`ENV=prod`): `lambdacontext.NewLogger()` for Lambda JSON/text formatting, log levels, and automatic `requestId` injection
  - **Local/dev**: text handler at debug level
- Migrates ~60 log call sites across handlers, controllers, gateways, and CLI tools
- Uses context-aware logging (`InfoContext`, `WarnContext`, `ErrorContext`) where `context.Context` is available for request correlation
- Assigns appropriate log levels (info for operational events, warn for recoverable issues, error for failures)

## Example

Before:
```
outbound request: trying proxy_mode=dedicated proxy=DEDICATED_PROXY_6 url=https://...
```

After (local):
```
level=INFO msg="outbound request: trying" proxy="proxy_mode=dedicated proxy=DEDICATED_PROXY_6" url=https://...
```

In Lambda with `AWS_LAMBDA_LOG_FORMAT=JSON`, logs are structured JSON with `requestId` attached automatically.

## Testing

- `go build -mod=vendor ./...` — passes
- `go fix ./...` — passes
- `make test` — live gateway tests hit transient upstream failures (Agora 429, ManaPro HTML structure change); unrelated to this change. All unit tests and non-live packages pass.

## Notes

- Also fixes a latent compile issue in `cmd/main.go` local mode where `handler.Search` returns two values but was passed to a single-value context.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04d928be-e451-4e42-be98-062016ee121d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04d928be-e451-4e42-be98-062016ee121d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

