### PR TITLE
Disable Mana Pro search while storefront is password-protected

### DIFF
--- a/api/controller/search.go
+++ b/api/controller/search.go
@@ -592,6 +592,9 @@ func initAndMapShops(lgs []string) map[string]gateway.LGS {
 		if shop.name == agora.StoreName && !config.AgoraSearchEnabled {
 			continue
 		}
+		if shop.name == manapro.StoreName && !config.ManaproSearchEnabled {
+			continue
+		}
 		if len(selectedLGS) > 0 {
 			if _, exists := selectedLGS[shop.name]; !exists {
 				continue

--- a/api/gateway/manapro/search_test.go
+++ b/api/gateway/manapro/search_test.go
@@ -6,6 +6,7 @@ import (
 
 	"mtg-price-checker-sg/gateway/binderpos"
 	"mtg-price-checker-sg/gateway/gatewaytest"
+	"mtg-price-checker-sg/pkg/config"
 
 	"github.com/joho/godotenv"
 )
@@ -15,6 +16,10 @@ func init() {
 }
 
 func Test_Search(t *testing.T) {
+	if !config.ManaproSearchEnabled {
+		t.Skip("Mana Pro search is disabled while the storefront is password-protected")
+	}
+
 	s := NewLGS()
 	result, err := s.Search(context.Background(), "Abrade")
 	gatewaytest.RequireSearchOrProbe(t, err, result, gatewaytest.CardExpect{

--- a/api/pkg/config/config.go
+++ b/api/pkg/config/config.go
@@ -115,6 +115,11 @@ const UseLeasedDedicatedProxy = false
 // AgoraSearchEnabled toggles Agora Hobby search in the search Lambda.
 const AgoraSearchEnabled = true
 
+// ManaproSearchEnabled toggles Mana Pro search in the search Lambda.
+// Disabled while sg-manapro.com serves Shopify's password ("Opening Soon") page,
+// which locks the Online Store channel and breaks scrape, GraphQL, and decklist.
+const ManaproSearchEnabled = false
+
 func UseDynamicProxy() bool {
 	rawValue := strings.TrimSpace(os.Getenv(UseDynamicProxyEnv))
 	if rawValue == "" {

--- a/api/pkg/config/config_test.go
+++ b/api/pkg/config/config_test.go
@@ -10,6 +10,12 @@ func TestAgoraSearchEnabled(t *testing.T) {
 	}
 }
 
+func TestManaproSearchEnabled(t *testing.T) {
+	if ManaproSearchEnabled {
+		t.Fatalf("expected manapro search to be disabled while storefront is password-protected")
+	}
+}
+
 func TestUseDynamicProxy(t *testing.T) {
 	t.Run("defaults to disabled when unset", func(t *testing.T) {
 		t.Setenv(UseDynamicProxyEnv, "")

--- a/docs/search-strategies-retries-timeouts.md
+++ b/docs/search-strategies-retries-timeouts.md
@@ -80,7 +80,7 @@ For **field-level feature parity** between HTML scrape, Storefront GraphQL, Deck
 | GOG | Yes | 3 | 8 |
 | Hideout | Yes | 3 | 8 |
 | Hideyoshi | Yes | 2 | 8 |
-| Mana Pro | Yes | 2 | 8 |
+| Mana Pro | Yes | 2 | 8 | **Search disabled** — storefront password page locks Online Store channel |
 | MTG Asia | Yes | 2 | 8 |
 | One MTG | Yes | 2 | 8 |
 

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,9 +1,13 @@
 // --- App Constants ---
 
 const AGORA_STORE_NAME = "Agora Hobby";
+const MANAPRO_STORE_NAME = "Mana Pro";
 
 // Toggle Agora Hobby in the store list and search UI.
 export const AGORA_SEARCH_ENABLED = true;
+
+// Toggle Mana Pro while sg-manapro.com is behind Shopify's password page.
+export const MANAPRO_SEARCH_ENABLED = false;
 
 export const PAGE_TITLE =
   "Gishath Fetch: MTG Price Checker for Singapore's LGS & Online Shops";
@@ -30,9 +34,15 @@ const ALL_LGS_OPTIONS = [
   "The TCG Marketplace",
 ];
 
-export const LGS_OPTIONS = AGORA_SEARCH_ENABLED
-  ? ALL_LGS_OPTIONS
-  : ALL_LGS_OPTIONS.filter((store) => store !== AGORA_STORE_NAME);
+export const LGS_OPTIONS = ALL_LGS_OPTIONS.filter((store) => {
+  if (!AGORA_SEARCH_ENABLED && store === AGORA_STORE_NAME) {
+    return false;
+  }
+  if (!MANAPRO_SEARCH_ENABLED && store === MANAPRO_STORE_NAME) {
+    return false;
+  }
+  return true;
+});
 
 export const SITE_TAGLINE =
   "Magic: The Gathering price checker for Singapore's LGS and online shops";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Investigated failing Mana Pro live tests and upstream search behavior. This is **not** a BinderPOS HTML markup change — `sg-manapro.com` is now behind Shopify's **"Opening Soon" password page**, which blocks all search strategies:

| Strategy | Result |
|----------|--------|
| HTML scrape (variant 2) | Password page served instead of search results; no `data-product-variants` markup |
| Storefront GraphQL | `Online Store channel is locked.` |
| BinderPOS decklist API | HTTP 400 |

Until Mana Pro reopens the storefront, search is disabled using the same toggle pattern as Agora Hobby.

## Changes

- Add `ManaproSearchEnabled = false` in `api/pkg/config/config.go`
- Skip Mana Pro in `initAndMapShops` when disabled
- Hide Mana Pro from frontend `LGS_OPTIONS` via `MANAPRO_SEARCH_ENABLED`
- Skip `gateway/manapro` live test while disabled
- Document the outage in `docs/search-strategies-retries-timeouts.md`

## Re-enabling

When the store removes the password page and inventory is reachable again:

1. Set `ManaproSearchEnabled = true` in `api/pkg/config/config.go`
2. Set `MANAPRO_SEARCH_ENABLED = true` in `frontend/src/constants.js`
3. Run `go test ./gateway/manapro/...` to confirm scrape/API paths work

## Testing

- `make test` (all packages pass; manapro live test skipped)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c402d510-52e4-4ea5-ad3d-01070822b1c5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c402d510-52e4-4ea5-ad3d-01070822b1c5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

